### PR TITLE
[codex] Harden start flow and model runtime metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bash install_preview_global.sh ./mtplx-0.1.0rc1-py3-none-any.whl
 mtplx quickstart       # interactive: pick model → mode → web/CLI, then chat
 ```
 
-That's it. The wizard handles model selection, runtime mode, and surface (browser chat at `127.0.0.1:8000` or terminal chat) on first run. On every subsequent run it asks "same as last time?" so you're one keypress from chatting.
+That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`), runtime mode, and surface (browser chat at `127.0.0.1:8000/` or terminal chat) on first run. On every subsequent run it asks "same as last time?" so you're one keypress from chatting.
 
 ---
 
@@ -49,8 +49,8 @@ That's it. The wizard handles model selection, runtime mode, and surface (browse
 - **In-browser chat UI** with auto-detected model context (256k for Qwen3.6), live tokens-per-second, markdown rendering, code-block copy buttons, a stop button, and a settings sidebar that persists per-machine.
 - **Interactive quickstart wizard.** Pick model, mode, and surface in three numbered prompts. Returning users get "same as last time?". No flag-soup required.
 - **Honest profile names that tell you what they do.**
-  - `Safe` — conservative MTP path, no fan changes, predictable on long replies.
-  - `Fast` — opt-in cold-speed path, snappy on short replies, decays on long contexts.
+  - `Fast` — default first-run path (`performance-cold`), snappy on short replies, decays on long contexts.
+  - `Stable` — conservative compatibility alias, no fan changes, predictable on long replies.
   - `Max` — Fast + ThermalForge fans pinned at 100%, sustained max throughput. Auto-installs ThermalForge with one prompt and one sudo password if you opt in.
 - **Crash-safe fan control.** When Max is on, MTPLX spawns a detached watchdog that restores fans to auto if the parent dies for any reason — including `kill -9` and "I closed the terminal". Verified live on hardware.
 - **Idle-aware Max mode.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
@@ -86,6 +86,7 @@ mtplx quickstart --fresh                    # re-run the wizard from scratch
 mtplx quickstart cli                        # terminal chat directly
 mtplx quickstart --max                      # browser chat with fan boost
 mtplx quickstart --model /path/to/model     # use a specific local or HF model
+mtplx pull Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed
 mtplx start --port 8000                     # API server only, no chat
 ```
 
@@ -141,8 +142,8 @@ Picked by the quickstart wizard, or set explicitly via `--profile`. Every mode p
 
 | Mode | Profile | Fan control | Cold | Sustained | Best for |
 |---|---|---|---|---|---|
-| **Safe** | `safe` | None (Apple defaults) | ~37 tok/s | ~37 tok/s, holds steady | Long answers, predictable speed |
-| **Fast** | `performance-cold` | None | ~60 tok/s | Decays on long contexts | Short replies, snappy chat |
+| **Fast** | `performance-cold` | None | ~60 tok/s | Decays on long contexts | Default first run, short replies, snappy chat |
+| **Stable** | `stable` / `safe` | None (Apple defaults) | ~37 tok/s | ~37 tok/s, holds steady | Long answers, predictable speed |
 | **Max** | `performance-cold` + `--max` | ThermalForge pinned to 100% | ~60 tok/s | ~60 tok/s, no decay | Sustained workloads, you don't mind fans |
 
 `Max` requires ThermalForge. `mtplx max --install` installs it from source into `~/.mtplx/bin/thermalforge`, sets up a passwordless sudoers rule scoped to that one binary, and verifies fans actually ramp before declaring success. One sudo prompt, end-to-end. Crash safety covers SIGINT, SIGTERM, SIGHUP, terminal close, and `kill -9` via a detached sidecar process.
@@ -162,7 +163,21 @@ mtplx inspect <model-path-or-hf-repo> --json
 | **Incompatible architecture** | MTP exists but not Qwen3-Next | Clear error, roadmap pointer |
 | **No MTP** | No MTP head detected | Clear error, no garbage runs |
 
-v0.1 ships verified Qwen3.6-27B (`mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP`). The compatibility registry already detects DeepSeek V3 / V3.2, GLM-4 MoE / MoE-Lite, MiMo, and MiniMax M2 — they currently report as "architecture-compatible, backend pending" and run when v0.2 lands those backends.
+v0.1 ships verified Qwen3.6-27B via `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`, with public served model id `mtplx-qwen36-27b-optimized-speed`. The compatibility registry already detects DeepSeek V3 / V3.2, GLM-4 MoE / MoE-Lite, MiMo, and MiniMax M2 — unsupported runtime families stay behind explicit compatibility gates rather than silently running.
+
+### Support matrix
+
+| Area | Preview support |
+|---|---|
+| Mac | Apple Silicon only (`arm64`) |
+| macOS | 14.0+; Sequoia is supported |
+| Python | native arm64 Python 3.10+ |
+| MLX | `python3 -m pip install mlx` in the same native environment |
+| Memory | dynamic preflight; warns below 48 GiB, fails when the selected model/profile estimate exceeds 80% of unified memory |
+| Storage | first download requires `max(model_size * 2.5, model_size + 20 GiB)` free on the model-cache filesystem |
+| Docker/Open WebUI | Docker Desktop current plus previous two macOS major releases |
+
+Run `mtplx doctor --summary`, `mtplx doctor --deep --json`, or `mtplx doctor --bundle` before filing a bug. Bundles are redacted by default under `~/.mtplx/reports/`.
 
 ---
 
@@ -175,10 +190,13 @@ mtplx doctor                # install + model + integration health
 mtplx inspect <model>       # four-tier compatibility report
 mtplx init                  # write ~/.mtplx/config.toml
 mtplx setup                 # download verified model, prepare cache
+mtplx pull                  # download the default HF model safely
+mtplx models                # cached models, validation, size, delete command
 mtplx run "..."             # one-shot ask
 mtplx chat                  # terminal chat
 mtplx start                 # OpenAI/Anthropic-compatible server
 mtplx connect openwebui     # paste settings for Open WebUI
+mtplx openwebui docker-command
 mtplx bench run --suite cold-long-code-192
 mtplx max --install         # install ThermalForge for Max mode
 mtplx max --status          # fan / thermal state

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gh release download v0.1.0-preview.1 --repo youssofal/mtplx \
   --pattern 'install_preview_global.sh'
 bash install_preview_global.sh ./mtplx-0.1.0rc1-py3-none-any.whl
 
-mtplx quickstart       # interactive: pick model → mode → web/CLI, then chat
+mtplx start            # interactive: pick model → mode → web/CLI, then chat
 ```
 
 That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`), runtime mode, and surface (browser chat at `127.0.0.1:8000/` or terminal chat) on first run. On every subsequent run it asks "same as last time?" so you're one keypress from chatting.
@@ -47,16 +47,16 @@ That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MT
 - **60+ tok/s cold on a 27B-class model.** Verified D3/192 long-code at 60.169 tok/s (Apple Silicon M5 Max, no fan boost, MLX-native, 2026-04-29).
 - **Real serving surface.** OpenAI-compatible `/v1/chat/completions` + `/v1/completions` + `/v1/models`, Anthropic-compatible `/v1/messages` (streaming SSE), `/health`, `/metrics`. Plug it into Open WebUI, Claude Code, Cline, Continue, or anything that speaks OpenAI.
 - **In-browser chat UI** with auto-detected model context (256k for Qwen3.6), live tokens-per-second, markdown rendering, code-block copy buttons, a stop button, and a settings sidebar that persists per-machine.
-- **Interactive quickstart wizard.** Pick model, mode, and surface in three numbered prompts. Returning users get "same as last time?". No flag-soup required.
+- **Interactive start wizard.** Pick model, mode, and surface in three numbered prompts. Returning users get "same as last time?". No flag-soup required.
 - **Honest profile names that tell you what they do.**
-  - `Fast` — default first-run path (`performance-cold`), snappy on short replies, decays on long contexts.
-  - `Stable` — conservative compatibility alias, no fan changes, predictable on long replies.
-  - `Max` — Fast + ThermalForge fans pinned at 100%, sustained max throughput. Auto-installs ThermalForge with one prompt and one sudo password if you opt in.
+  - `Medium` — default native-MTP speed path (`performance-cold`), about 2.2× burst over the same model with MTP off, not sustained without fan control.
+  - `Max` — Medium + ThermalForge fans pinned at 100%, about 2.24× in the measured speed lane, loud by design.
+  - `Stable` — hidden compatibility flag (`--profile stable` / `--profile safe`) for the exact/staged long-reply path.
 - **Crash-safe fan control.** When Max is on, MTPLX spawns a detached watchdog that restores fans to auto if the parent dies for any reason — including `kill -9` and "I closed the terminal". Verified live on hardware.
 - **Idle-aware Max mode.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
 - **Four-tier model compatibility contract.** `mtplx inspect <model>` reports: verified / arch-compatible-unverified / incompatible-architecture / no-MTP. No silent garbage runs.
 - **Lazy imports.** `mtplx --help`, `doctor`, `inspect`, `init`, `setup` work on a fresh venv *without MLX installed*. Generation and serving pull in MLX only when needed.
-- **Preview status: 414 tests passing**, including end-to-end onboarding, fan-control crash safety, OpenAI server fake-state, lazy-import survival, exactness gates.
+- **Preview status: 350-test suite green**, including end-to-end onboarding, fan-control crash safety, OpenAI server fake-state, lazy-import survival, exactness gates.
 
 > **Preview honesty.** The cold path is verified at 60+ tok/s. *Sustained* no-fan long-context throughput is currently ~37 tok/s on Flappy 10k versus a ≥50 tok/s target — the v0.1 release ships with this gap explicit. Closing it is the v0.2 deliverable; see [Roadmap](#roadmap).
 
@@ -76,18 +76,18 @@ mtplx help
 mtplx doctor --json
 
 # 3. Chat (the wizard does everything)
-mtplx quickstart
+mtplx start
 ```
 
 Power-user shortcuts (any of these skip the wizard):
 
 ```bash
-mtplx quickstart --fresh                    # re-run the wizard from scratch
-mtplx quickstart cli                        # terminal chat directly
-mtplx quickstart --max                      # browser chat with fan boost
-mtplx quickstart --model /path/to/model     # use a specific local or HF model
+mtplx start --fresh                         # re-run the wizard from scratch
+mtplx start cli                             # terminal chat directly
+mtplx start --max                           # browser chat with fan boost
+mtplx start --model /path/to/model          # use a specific local or HF model
 mtplx pull Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed
-mtplx start --port 8000                     # API server only, no chat
+mtplx quickstart --port 8000                # API server only, no chat
 ```
 
 OpenAI-compatible smoke test:
@@ -138,13 +138,13 @@ No second model, no greedy hack, no external drafter, no silent distribution dri
 
 ## Modes
 
-Picked by the quickstart wizard, or set explicitly via `--profile`. Every mode preserves exactness; the difference is the throughput envelope and whether MTPLX touches your fans.
+Picked by `mtplx start`, or set explicitly via `--profile`. Every mode preserves exactness; the difference is the runtime path and whether MTPLX touches your fans.
 
-| Mode | Profile | Fan control | Cold | Sustained | Best for |
-|---|---|---|---|---|---|
-| **Fast** | `performance-cold` | None | ~60 tok/s | Decays on long contexts | Default first run, short replies, snappy chat |
-| **Stable** | `stable` / `safe` | None (Apple defaults) | ~37 tok/s | ~37 tok/s, holds steady | Long answers, predictable speed |
-| **Max** | `performance-cold` + `--max` | ThermalForge pinned to 100% | ~60 tok/s | ~60 tok/s, no decay | Sustained workloads, you don't mind fans |
+| Mode | Profile | Mechanics | Speed lane | Best for |
+|---|---|---|---|---|
+| **Medium** | `performance-cold` | Native-MTP speed path, Apple fan curve | ~2.2× burst, not sustained | Default first run, short replies, snappy chat |
+| **Max** | `performance-cold` + `--max` | Medium path plus ThermalForge pinned to 100% | ~2.24× in the measured lane | Sustained workloads, you don't mind fans |
+| **Stable** | `stable` / `safe` | Exact/staged long-reply path, hidden from onboarding | Lower peak speed, steadier shape | Compatibility and conservative long replies |
 
 `Max` requires ThermalForge. `mtplx max --install` installs it from source into `~/.mtplx/bin/thermalforge`, sets up a passwordless sudoers rule scoped to that one binary, and verifies fans actually ramp before declaring success. One sudo prompt, end-to-end. Crash safety covers SIGINT, SIGTERM, SIGHUP, terminal close, and `kill -9` via a detached sidecar process.
 
@@ -184,7 +184,7 @@ Run `mtplx doctor --summary`, `mtplx doctor --deep --json`, or `mtplx doctor --b
 ## CLI surface
 
 ```bash
-mtplx quickstart            # interactive setup, then chat
+mtplx start                 # interactive setup, then chat
 mtplx help                  # detailed help; `mtplx help <command>` for any
 mtplx doctor                # install + model + integration health
 mtplx inspect <model>       # four-tier compatibility report
@@ -210,9 +210,9 @@ Every command has `--json` for machine-readable output and `--help` for context-
 
 ```mermaid
 flowchart TB
-    cli["CLI surface<br/>quickstart · run · chat · start · bench · inspect · init · setup · max"]
+    cli["CLI surface<br/>start · quickstart · run · chat · serve · bench · inspect · init · setup · max"]
     onboarding["Onboarding wizard<br/>~/.mtplx/quickstart.json"]
-    profiles["Profiles<br/>safe · performance-cold · exact · max-diagnostic"]
+    profiles["Profiles<br/>stable/safe · performance-cold · exact · max-diagnostic"]
     speculative["Speculative sampling<br/>p/q acceptance + residual correction"]
     registry["Architecture registry<br/>4-tier compatibility contract"]
     backends["MTP backends<br/>Qwen3-Next (verified) · DeepSeek V3 · GLM · MiMo (registered)"]
@@ -236,7 +236,7 @@ flowchart TB
 
 ## Roadmap
 
-**v0.1.0-preview.1 (today).** Verified Qwen3-Next-MTP cold path, OpenAI/Anthropic-compatible serving, in-browser chat, interactive quickstart wizard, four-tier compatibility, crash-safe Max mode, lazy-import CLI surface, 414 tests.
+**v0.1.0-preview.1 (today).** Verified Qwen3-Next-MTP cold path, OpenAI/Anthropic-compatible serving, in-browser chat, interactive `mtplx start` wizard, four-tier compatibility, crash-safe Max mode, lazy-import CLI surface, 350-test suite green.
 
 **v0.2 — sustained throughput.** Diagnostic-gated kernel ladder targeting `last64/first64 ≥ 0.90` no-fan on 10k generations while preserving the 60 tok/s class. Mechanism-driven: lazy-graph severance + output narrowing if graph history is the bottleneck; MLX-primitive-registered cache-update + `mx.compile` if dispatch tax dominates; an owned GDN+MLP verify-cycle kernel via `mx.fast.metal_kernel` only if the cheaper paths don't close the gap.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MT
 - **Idle-aware Max mode.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
 - **Four-tier model compatibility contract.** `mtplx inspect <model>` reports: verified / arch-compatible-unverified / incompatible-architecture / no-MTP. No silent garbage runs.
 - **Lazy imports.** `mtplx --help`, `doctor`, `inspect`, `init`, `setup` work on a fresh venv *without MLX installed*. Generation and serving pull in MLX only when needed.
-- **Preview status: 350-test suite green**, including end-to-end onboarding, fan-control crash safety, OpenAI server fake-state, lazy-import survival, exactness gates.
+- **Preview status: 354-test suite green**, including end-to-end onboarding, fan-control crash safety, OpenAI server fake-state, lazy-import survival, exactness gates.
 
 > **Preview honesty.** The cold path is verified at 60+ tok/s. *Sustained* no-fan long-context throughput is currently ~37 tok/s on Flappy 10k versus a ≥50 tok/s target — the v0.1 release ships with this gap explicit. Closing it is the v0.2 deliverable; see [Roadmap](#roadmap).
 
@@ -236,7 +236,7 @@ flowchart TB
 
 ## Roadmap
 
-**v0.1.0-preview.1 (today).** Verified Qwen3-Next-MTP cold path, OpenAI/Anthropic-compatible serving, in-browser chat, interactive `mtplx start` wizard, four-tier compatibility, crash-safe Max mode, lazy-import CLI surface, 350-test suite green.
+**v0.1.0-preview.1 (today).** Verified Qwen3-Next-MTP cold path, OpenAI/Anthropic-compatible serving, in-browser chat, interactive `mtplx start` wizard, four-tier compatibility, crash-safe Max mode, lazy-import CLI surface, 354-test suite green.
 
 **v0.2 — sustained throughput.** Diagnostic-gated kernel ladder targeting `last64/first64 ≥ 0.90` no-fan on 10k generations while preserving the 60 tok/s class. Mechanism-driven: lazy-graph severance + output narrowing if graph history is the bottleneck; MLX-primitive-registered cache-update + `mx.compile` if dispatch tax dominates; an owned GDN+MLP verify-cycle kernel via `mx.fast.metal_kernel` only if the cheaper paths don't close the gap.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,6 +2,13 @@
 
 See [INSTALL.md](../INSTALL.md) for the short path.
 
-MTPLX v0.1 uses vanilla MLX by default. The opt-in `performance-cold` profile may require the MTPLX MLX fork until the kernel work is extracted or upstreamed.
+MTPLX v0.1-preview is Apple-Silicon-first:
+
+- macOS 14.0 or newer
+- native arm64 Python 3.10 or newer
+- `python3 -m pip install mlx` in that same environment
+- enough unified memory and disk for the selected model/profile, checked by `mtplx doctor`
+
+The first-run default model is `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed` and the first-run default profile is `performance-cold`. `stable` remains available as the conservative compatibility alias.
 
 Do not install model weights into the source checkout. Use the MTPLX model cache or a Hugging Face cache.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,9 +2,9 @@
 
 | Profile | Purpose |
 |---|---|
-| `performance-cold` | Default first-run profile. Preserves the verified 60 tok/s class for short/cold replies without fan control. |
-| `stable` | Public conservative alias for predictable long replies and compatibility fallback. |
+| `performance-cold` | Medium mode: native-MTP speed path, about 2.2x burst over the same model with MTP off, not sustained without fan control. |
+| `stable` | Hidden conservative alias for the exact/staged long-reply path and compatibility fallback. |
 | `exact` | QA and release exactness checks. |
-| `max-diagnostic` | Fan-controlled diagnostics only. Not a product headline mode. |
+| `max-diagnostic` | Max-style fan-controlled diagnostics. Product Max is `performance-cold` plus explicit `--max`. |
 
 `--max` is separate from profiles. It is opt-in and must restore fan state on exit when supported.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,8 +2,8 @@
 
 | Profile | Purpose |
 |---|---|
-| `stable` | Default profile. Chosen for predictable first-run behavior. |
-| `performance-cold` | Opt-in cold throughput path. Preserves the verified 60+ tok/s short/cold result. |
+| `performance-cold` | Default first-run profile. Preserves the verified 60 tok/s class for short/cold replies without fan control. |
+| `stable` | Public conservative alias for predictable long replies and compatibility fallback. |
 | `exact` | QA and release exactness checks. |
 | `max-diagnostic` | Fan-controlled diagnostics only. Not a product headline mode. |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,19 +5,21 @@ gh release download v0.1.0-preview.1 --repo youssofal/mtplx --pattern 'mtplx-0.1
 bash install_preview_global.sh ./mtplx-0.1.0rc1-py3-none-any.whl
 
 mtplx help
-mtplx doctor --json
-mtplx init --model /path/to/verified/model --write
-mtplx inspect /path/to/verified/model --json
+mtplx doctor --summary
+mtplx pull Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed
+mtplx inspect Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed --json
 ```
 
 Public `pip install mtplx` is the Stage C target after PyPI Trusted Publishing is configured. The current private preview path uses the GitHub release wheel plus `install_preview_global.sh` so `mtplx` works from a normal Terminal without activating a project venv.
 
 The commands above are no-MLX-safe except generation and serving. A missing MLX runtime should appear in `doctor` as an actionable dependency issue, not a traceback.
 
-After a verified model is available:
+After the verified model is available:
 
 ```bash
 mtplx run "hello"
 mtplx chat
 mtplx serve --port 8000 --no-stats-footer
 ```
+
+Use `mtplx doctor --deep --json` for exhaustive diagnostics and `mtplx doctor --bundle` to create a redacted support bundle.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,9 +17,9 @@ The commands above are no-MLX-safe except generation and serving. A missing MLX 
 After the verified model is available:
 
 ```bash
-mtplx run "hello"
-mtplx chat
-mtplx serve --port 8000 --no-stats-footer
+mtplx start
+mtplx start cli
+mtplx quickstart --port 8000 --no-stats-footer
 ```
 
 Use `mtplx doctor --deep --json` for exhaustive diagnostics and `mtplx doctor --bundle` to create a redacted support bundle.

--- a/docs/server.md
+++ b/docs/server.md
@@ -30,6 +30,12 @@ For Open WebUI, set the OpenAI-compatible base URL to:
 http://127.0.0.1:8000/v1
 ```
 
+For Dockerized Open WebUI, the container must use the host gateway URL, not the host's loopback URL:
+
+```bash
+mtplx openwebui docker-command
+```
+
 For Anthropic Messages-compatible clients, point the client base URL at the
 same local server root:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,3 +1,22 @@
 # Troubleshooting
 
-See [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).
+Start with:
+
+```bash
+mtplx doctor --summary
+mtplx doctor --deep --json
+mtplx doctor --bundle
+```
+
+Expected production failures should be actionable, not tracebacks:
+
+| Symptom | Repair |
+|---|---|
+| MLX missing | `python3 -m pip install mlx` from native arm64 Python |
+| Rosetta Python | switch to native arm64 Python and rerun `mtplx doctor` |
+| default model missing | `mtplx pull Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed` |
+| Open WebUI cannot connect | use `http://127.0.0.1:8000/v1` on the host, or `http://host.docker.internal:8000/v1` inside Docker |
+| Docker daemon stopped | start Docker Desktop |
+| low disk/RAM | change `MTPLX_MODEL_DIR`, free storage, lower context/profile, or use a smaller model |
+
+See [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for the wider table.

--- a/examples/cli-chat.sh
+++ b/examples/cli-chat.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mtplx chat --model "${MTPLX_MODEL:-mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP}"
+mtplx chat --model "${MTPLX_MODEL:-Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed}"

--- a/examples/openwebui.md
+++ b/examples/openwebui.md
@@ -14,6 +14,12 @@ http://127.0.0.1:8000/v1
 
 Use a local API key only if you started the server with `--api-key`.
 
+Dockerized Open WebUI must talk back to MTPLX through the host gateway:
+
+```bash
+mtplx openwebui docker-command
+```
+
 For an isolated smoke test with the Open WebUI Python package:
 
 ```bash
@@ -25,7 +31,7 @@ ENABLE_SIGNUP=True \
 ENABLE_OPENAI_API=True \
 OPENAI_API_BASE_URLS=http://127.0.0.1:8000/v1 \
 OPENAI_API_KEYS=local-test \
-DEFAULT_MODELS=mtplx-qwen36-27b-native-mtp \
+DEFAULT_MODELS=mtplx-qwen36-27b-optimized-speed \
 uvx --python 3.11 --from open-webui open-webui serve --host 127.0.0.1 --port 8080
 ```
 

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from .constants import (
+    EXPECTED_ALL_PREQUANTIZED_MTP_KEYS,
+    EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT,
     EXPECTED_MTP_KEYS,
     EXPECTED_PREQUANTIZED_MTP_KEYS,
     EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT,
@@ -170,10 +172,16 @@ def inspect_mtp_tensors(model_dir: Path | str, config: dict[str, Any] | None = N
     mtp_path = expected_mtp_file(model_dir, config)
     mtp_quant = (config or {}).get("mtplx_mtp_quantization", {})
     prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
-    expected_keys = set(EXPECTED_PREQUANTIZED_MTP_KEYS if prequantized else EXPECTED_MTP_KEYS)
-    expected_count = (
-        EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT if prequantized else EXPECTED_MTP_TENSOR_COUNT
-    )
+    quant_policy = str(mtp_quant.get("policy") or "") if isinstance(mtp_quant, dict) else ""
+    if prequantized and quant_policy == "all":
+        expected_keys = set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS)
+        expected_count = EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT
+    elif prequantized:
+        expected_keys = set(EXPECTED_PREQUANTIZED_MTP_KEYS)
+        expected_count = EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT
+    else:
+        expected_keys = set(EXPECTED_MTP_KEYS)
+        expected_count = EXPECTED_MTP_TENSOR_COUNT
     sidecar_format = "prequantized-mlx-affine" if prequantized else "bf16"
     if not mtp_path.exists():
         return MTPInspection(

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -126,7 +126,7 @@ class ModelInspection:
     @property
     def passes_primary_gate(self) -> bool:
         if self.compatibility:
-            return self.compatibility.get("tier") == "verified"
+            return bool(self.compatibility.get("can_run"))
         return (
             self.config_exists
             and (self.model_type or "").startswith("qwen3_5")

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -20,6 +20,57 @@ from .constants import (
     MULTIMODAL_SIDECARS,
 )
 
+MTP_KEY_PREFIXES = ("mtp.", "language_model.mtp.")
+
+
+def normalize_mtp_key(key: str) -> str:
+    text = str(key)
+    for prefix in MTP_KEY_PREFIXES:
+        if text.startswith(prefix):
+            return "mtp." + text[len(prefix) :]
+    return text
+
+
+def is_mtp_key(key: str) -> bool:
+    text = str(key)
+    return any(text.startswith(prefix) for prefix in MTP_KEY_PREFIXES)
+
+
+def _mtp_expected_key_set(
+    config: dict[str, Any],
+    *,
+    keys: tuple[str, ...] = (),
+) -> tuple[set[str], int, str]:
+    mtp_quant = config.get("mtplx_mtp_quantization", {})
+    prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
+    quant_policy = str(mtp_quant.get("policy") or "") if isinstance(mtp_quant, dict) else ""
+    normalized = {normalize_mtp_key(key) for key in keys}
+    if prequantized and quant_policy == "all":
+        return (
+            set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS),
+            EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT,
+            "prequantized-mlx-affine",
+        )
+    if prequantized:
+        return (
+            set(EXPECTED_PREQUANTIZED_MTP_KEYS),
+            EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT,
+            "prequantized-mlx-affine",
+        )
+    if normalized == set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS):
+        return (
+            set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS),
+            EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT,
+            "prequantized-mlx-affine",
+        )
+    if normalized == set(EXPECTED_PREQUANTIZED_MTP_KEYS):
+        return (
+            set(EXPECTED_PREQUANTIZED_MTP_KEYS),
+            EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT,
+            "prequantized-mlx-affine",
+        )
+    return set(EXPECTED_MTP_KEYS), EXPECTED_MTP_TENSOR_COUNT, "bf16"
+
 
 def load_config(model_dir: Path | str) -> dict[str, Any]:
     path = Path(model_dir) / "config.json"
@@ -113,10 +164,12 @@ class ModelInspection:
     hidden_size: int | None
     num_hidden_layers: int | None
     vocab_size: int | None
+    mtp_pattern: str | None = None
     source: str = "local"
     quantization: dict[str, Any] = field(default_factory=dict)
     sidecars: dict[str, bool] = field(default_factory=dict)
     model_files: tuple[str, ...] = ()
+    weight_keys: tuple[str, ...] = field(default_factory=tuple, repr=False)
     mtp: MTPInspection | None = None
     runtime_contract_data: dict[str, Any] | None = None
     runtime_contract_error: str | None = None
@@ -136,6 +189,10 @@ class ModelInspection:
         )
 
     def to_dict(self) -> dict[str, Any]:
+        runtime_contract_path = (
+            self.runtime_contract_path
+            or self.compatibility.get("runtime_contract_path")
+        )
         return {
             "model_dir": self.model_dir,
             "source": self.source,
@@ -143,6 +200,7 @@ class ModelInspection:
             "architecture": self.architecture,
             "model_type": self.model_type,
             "mtp_num_hidden_layers": self.mtp_num_hidden_layers,
+            "mtp_pattern": self.mtp_pattern,
             "hidden_size": self.hidden_size,
             "num_hidden_layers": self.num_hidden_layers,
             "vocab_size": self.vocab_size,
@@ -151,7 +209,7 @@ class ModelInspection:
             "model_files": list(self.model_files),
             "passes_primary_gate": self.passes_primary_gate,
             "mtp": self.mtp.to_dict() if self.mtp else None,
-            "runtime_contract_path": self.runtime_contract_path,
+            "runtime_contract_path": runtime_contract_path,
             "compatibility": self.compatibility,
             "mtp_supported": self.compatibility.get("mtp_supported"),
             "mtp_arch": self.compatibility.get("arch_id"),
@@ -170,19 +228,7 @@ class ModelInspection:
 
 def inspect_mtp_tensors(model_dir: Path | str, config: dict[str, Any] | None = None) -> MTPInspection:
     mtp_path = expected_mtp_file(model_dir, config)
-    mtp_quant = (config or {}).get("mtplx_mtp_quantization", {})
-    prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
-    quant_policy = str(mtp_quant.get("policy") or "") if isinstance(mtp_quant, dict) else ""
-    if prequantized and quant_policy == "all":
-        expected_keys = set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS)
-        expected_count = EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT
-    elif prequantized:
-        expected_keys = set(EXPECTED_PREQUANTIZED_MTP_KEYS)
-        expected_count = EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT
-    else:
-        expected_keys = set(EXPECTED_MTP_KEYS)
-        expected_count = EXPECTED_MTP_TENSOR_COUNT
-    sidecar_format = "prequantized-mlx-affine" if prequantized else "bf16"
+    expected_keys, expected_count, sidecar_format = _mtp_expected_key_set(config or {})
     if not mtp_path.exists():
         return MTPInspection(
             mtp_file=str(mtp_path),
@@ -206,7 +252,11 @@ def inspect_mtp_tensors(model_dir: Path | str, config: dict[str, Any] | None = N
                 )
             )
 
-    key_set = {t.key for t in tensors}
+    key_set = {normalize_mtp_key(t.key) for t in tensors}
+    expected_keys, expected_count, sidecar_format = _mtp_expected_key_set(
+        config or {},
+        keys=tuple(key_set),
+    )
     return MTPInspection(
         mtp_file=str(mtp_path),
         exists=True,
@@ -358,6 +408,76 @@ def _remote_safetensors_keys(repo_id: str, filename: str) -> tuple[tuple[str, ..
         return (), str(exc)
 
 
+def _safetensors_header_keys(path: Path) -> tuple[tuple[str, ...], str | None]:
+    try:
+        with path.open("rb") as handle:
+            prefix = handle.read(8)
+            if len(prefix) < 8:
+                return (), "safetensors header is shorter than 8 bytes"
+            header_len = int.from_bytes(prefix, "little")
+            if header_len > 1_000_000:
+                return (), f"safetensors header too large for metadata-only inspect: {header_len + 8} bytes"
+            header = json.loads(handle.read(header_len).decode("utf-8"))
+        return tuple(sorted(key for key in header if key != "__metadata__")), None
+    except Exception as exc:
+        return (), str(exc)
+
+
+def _weight_keys_from_index_payload(payload: dict[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(payload, dict):
+        return ()
+    weight_map = payload.get("weight_map")
+    if not isinstance(weight_map, dict):
+        return ()
+    return tuple(sorted(str(key) for key in weight_map))
+
+
+def _local_model_weight_keys(model_path: Path) -> tuple[tuple[str, ...], str | None]:
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            return _weight_keys_from_index_payload(
+                json.loads(index_path.read_text(encoding="utf-8"))
+            ), None
+        except Exception as exc:
+            return (), str(exc)
+
+    keys: set[str] = set()
+    errors: list[str] = []
+    for shard in sorted(model_path.glob("model*.safetensors")):
+        shard_keys, error = _safetensors_header_keys(shard)
+        keys.update(shard_keys)
+        if error:
+            errors.append(f"{shard.name}: {error}")
+    return tuple(sorted(keys)), "; ".join(errors) if errors else None
+
+
+def _hf_model_weight_keys(repo_id: str, files: set[str]) -> tuple[tuple[str, ...], str | None]:
+    if "model.safetensors.index.json" in files:
+        index, _path, error = _hf_download_json(repo_id, "model.safetensors.index.json")
+        if index is not None:
+            return _weight_keys_from_index_payload(index), None
+        if error:
+            return (), error
+
+    keys: set[str] = set()
+    errors: list[str] = []
+    for filename in sorted(
+        name
+        for name in files
+        if Path(name).name.startswith("model") and name.endswith(".safetensors")
+    ):
+        shard_keys, error = _remote_safetensors_keys(repo_id, filename)
+        keys.update(shard_keys)
+        if error:
+            errors.append(f"{filename}: {error}")
+    return tuple(sorted(keys)), "; ".join(errors) if errors else None
+
+
+def _embedded_mtp_keys(weight_keys: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted(normalize_mtp_key(key) for key in weight_keys if is_mtp_key(key)))
+
+
 def _inspect_mtp_tensors_from_keys(
     mtp_file: str,
     *,
@@ -365,24 +485,45 @@ def _inspect_mtp_tensors_from_keys(
     exists: bool,
     keys: tuple[str, ...] = (),
 ) -> MTPInspection:
-    mtp_quant = config.get("mtplx_mtp_quantization", {})
-    prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
-    expected_keys = set(EXPECTED_PREQUANTIZED_MTP_KEYS if prequantized else EXPECTED_MTP_KEYS)
-    expected_count = (
-        EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT if prequantized else EXPECTED_MTP_TENSOR_COUNT
+    normalized_keys = tuple(sorted(normalize_mtp_key(key) for key in keys))
+    expected_keys, expected_count, sidecar_format = _mtp_expected_key_set(
+        config,
+        keys=normalized_keys,
     )
-    sidecar_format = "prequantized-mlx-affine" if prequantized else "bf16"
-    key_set = set(keys)
+    key_set = set(normalized_keys)
     return MTPInspection(
         mtp_file=mtp_file,
         exists=exists,
-        tensor_count=len(keys),
+        tensor_count=len(normalized_keys),
         sidecar_format=sidecar_format,
         expected_tensor_count=expected_count,
         metadata_only=True,
         missing_expected_keys=tuple(sorted(expected_keys - key_set)) if keys else (),
         extra_keys=tuple(sorted(key_set - expected_keys)) if keys else (),
     )
+
+
+def _mtp_pattern_from_config(config: dict[str, Any]) -> str | None:
+    tcfg = text_config(config)
+    raw = (
+        tcfg.get("mtp_hybrid_override_pattern")
+        or config.get("mtp_hybrid_override_pattern")
+        or tcfg.get("hybrid_override_pattern")
+        or config.get("hybrid_override_pattern")
+        or tcfg.get("layers_block_type")
+        or config.get("layers_block_type")
+    )
+    if raw is None:
+        return None
+    mapping = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
+    if isinstance(raw, str):
+        if "," in raw:
+            parts = [part.strip().lower() for part in raw.split(",") if part.strip()]
+            return "".join(mapping.get(part, part) for part in parts)
+        return raw
+    if isinstance(raw, list):
+        return "".join(mapping.get(str(part).lower(), str(part)) for part in raw)
+    return str(raw)
 
 
 def _inspect_hf_model(repo_id: str) -> ModelInspection:
@@ -408,21 +549,50 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
     quant = config.get("quantization_config") or config.get("quantization") or {}
     if not quant:
         quant = tcfg.get("quantization_config") or tcfg.get("quantization") or {}
+    model_files = tuple(
+        sorted(
+            name
+            for name in files
+            if Path(name).name.startswith("model") and name.endswith(".safetensors")
+        )
+    )
     mtp_file = str(expected_mtp_file(Path("."), config))
     if mtp_file.startswith("./"):
         mtp_file = mtp_file[2:]
     mtp_file = mtp_file.lstrip("/")
     mtp_exists = mtp_file in files if files else False
+    weight_keys: tuple[str, ...] = ()
+    config_declares_mtp = bool(
+        tcfg.get("mtp_num_hidden_layers")
+        or tcfg.get("num_nextn_predict_layers")
+        or tcfg.get("num_mtp_modules")
+        or config.get("num_nextn_predict_layers")
+        or config.get("num_mtp_modules")
+        or "mtp" in str(architecture or "").lower()
+        or "nextn" in str(architecture or "").lower()
+    )
+    if not mtp_exists and config_declares_mtp:
+        weight_keys, _weight_keys_error = _hf_model_weight_keys(repo_id, files)
     mtp_keys: tuple[str, ...] = ()
     mtp_error = None
     if mtp_exists and mtp_file.endswith(".safetensors"):
         mtp_keys, mtp_error = _remote_safetensors_keys(repo_id, mtp_file)
-    mtp = _inspect_mtp_tensors_from_keys(
-        mtp_file,
-        config=config,
-        exists=mtp_exists,
-        keys=mtp_keys,
-    )
+    combined_weight_keys = tuple(sorted(set(weight_keys).union(mtp_keys)))
+    if mtp_exists:
+        mtp = _inspect_mtp_tensors_from_keys(
+            mtp_file,
+            config=config,
+            exists=True,
+            keys=mtp_keys,
+        )
+    else:
+        embedded = _embedded_mtp_keys(weight_keys)
+        mtp = _inspect_mtp_tensors_from_keys(
+            "model.safetensors.index.json::embedded",
+            config=config,
+            exists=bool(embedded),
+            keys=embedded,
+        )
     if mtp_error and not mtp_keys:
         mtp = MTPInspection(
             mtp_file=mtp_file,
@@ -448,15 +618,11 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         hidden_size=tcfg.get("hidden_size"),
         num_hidden_layers=tcfg.get("num_hidden_layers"),
         vocab_size=tcfg.get("vocab_size"),
+        mtp_pattern=_mtp_pattern_from_config(config),
         quantization=quant,
         sidecars={name: name in files for name in MULTIMODAL_SIDECARS},
-        model_files=tuple(
-            sorted(
-                name
-                for name in files
-                if Path(name).name.startswith("model") and name.endswith(".safetensors")
-            )
-        ),
+        model_files=model_files,
+        weight_keys=combined_weight_keys,
         mtp=mtp,
         runtime_contract_data=runtime_contract_data,
         runtime_contract_error=runtime_contract_error,
@@ -477,9 +643,11 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         hidden_size=inspection.hidden_size,
         num_hidden_layers=inspection.num_hidden_layers,
         vocab_size=inspection.vocab_size,
+        mtp_pattern=inspection.mtp_pattern,
         quantization=inspection.quantization,
         sidecars=inspection.sidecars,
         model_files=inspection.model_files,
+        weight_keys=inspection.weight_keys,
         mtp=inspection.mtp,
         runtime_contract_data=inspection.runtime_contract_data,
         runtime_contract_error=inspection.runtime_contract_error,
@@ -503,7 +671,26 @@ def inspect_model(model_dir: Path | str) -> ModelInspection:
     if not quant:
         quant = tcfg.get("quantization_config") or tcfg.get("quantization") or {}
 
-    mtp = inspect_mtp_tensors(model_path, config) if config_exists else None
+    weight_keys, _weight_keys_error = (
+        _local_model_weight_keys(model_path) if config_exists else ((), None)
+    )
+    if config_exists:
+        sidecar_mtp = inspect_mtp_tensors(model_path, config)
+        if sidecar_mtp.exists:
+            mtp = sidecar_mtp
+            weight_keys = tuple(
+                sorted(set(weight_keys).union(tensor.key for tensor in sidecar_mtp.tensors))
+            )
+        else:
+            embedded = _embedded_mtp_keys(weight_keys)
+            mtp = _inspect_mtp_tensors_from_keys(
+                "model.safetensors.index.json::embedded",
+                config=config,
+                exists=bool(embedded),
+                keys=embedded,
+            )
+    else:
+        mtp = None
     inspection = ModelInspection(
         model_dir=str(model_path),
         source="local",
@@ -521,9 +708,11 @@ def inspect_model(model_dir: Path | str) -> ModelInspection:
         hidden_size=tcfg.get("hidden_size"),
         num_hidden_layers=tcfg.get("num_hidden_layers"),
         vocab_size=tcfg.get("vocab_size"),
+        mtp_pattern=_mtp_pattern_from_config(config),
         quantization=quant,
         sidecars={name: (model_path / name).exists() for name in MULTIMODAL_SIDECARS},
         model_files=tuple(sorted(p.name for p in model_path.glob("model*.safetensors"))),
+        weight_keys=weight_keys,
         mtp=mtp,
     )
     from mtplx.backends.registry import compatibility_for_inspection
@@ -539,9 +728,11 @@ def inspect_model(model_dir: Path | str) -> ModelInspection:
         hidden_size=inspection.hidden_size,
         num_hidden_layers=inspection.num_hidden_layers,
         vocab_size=inspection.vocab_size,
+        mtp_pattern=inspection.mtp_pattern,
         quantization=inspection.quantization,
         sidecars=inspection.sidecars,
         model_files=inspection.model_files,
+        weight_keys=inspection.weight_keys,
         mtp=inspection.mtp,
         runtime_contract_data=inspection.runtime_contract_data,
         runtime_contract_error=inspection.runtime_contract_error,

--- a/mtplx/backends/nemotron_h_mtp.py
+++ b/mtplx/backends/nemotron_h_mtp.py
@@ -1,0 +1,47 @@
+"""Nemotron-H native MTP backend facade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import DraftTokens, ModelState, MTPBackend, VerifyOutput
+from mtplx.profiles import DEFAULT_PROFILE_NAME
+
+
+class NemotronHMTPBackend(MTPBackend):
+    arch_id = "nemotron-h-mtp"
+
+    def load(self, model_path: Path) -> ModelState:
+        from mtplx.mtp_patch import MTPContract
+        from mtplx.runtime import load
+
+        runtime = load(model_path, mtp=True, contract=MTPContract())
+        return ModelState(
+            model_path=Path(model_path),
+            runtime=runtime,
+            metadata={"arch_id": self.arch_id, "contract_gated": True},
+        )
+
+    def verify(self, state: ModelState, draft_tokens: DraftTokens, hidden: Any) -> VerifyOutput:
+        raise NotImplementedError("NemotronHMTPBackend.verify is wired through generation.py")
+
+    def propose(self, state: ModelState, hidden: Any) -> DraftTokens:
+        raise NotImplementedError("NemotronHMTPBackend.propose is wired through generation.py")
+
+    def recommended_profile(self) -> str:
+        return DEFAULT_PROFILE_NAME
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "arch_id": self.arch_id,
+            "runtime_path": "mtplx.runtime + mtplx.nemotron_h_mtp_patch + mtplx.generation",
+            "support_level": "experimental-native-contract-gated",
+            "contract_required": True,
+            "supported_model_types": ["nemotron_h", "nemotron_h_puzzle"],
+            "limits": {"num_nextn_predict_layers": 1, "mtp_pattern_chars": ["*", "E"]},
+            "references": [
+                "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/nemotron_h_mtp.py",
+                "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/nemotron_h.py",
+            ],
+        }

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -357,6 +357,8 @@ class RuntimeContract:
     recommended_profile: str
     exactness_baseline: dict[str, Any]
     verified_on: dict[str, Any]
+    recommended_draft_lm_head: dict[str, Any] | None = None
+    recommended_draft_sampler: dict[str, Any] | None = None
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -381,6 +383,20 @@ class RuntimeContract:
         depth = int(data["mtp_depth_max"])
         if depth <= 0:
             raise ValueError("runtime contract mtp_depth_max must be positive")
+        recommended_draft_lm_head = None
+        if data.get("recommended_draft_lm_head") is not None:
+            from mtplx.draft_lm_head import normalize_draft_lm_head_spec
+
+            recommended_draft_lm_head = normalize_draft_lm_head_spec(
+                data.get("recommended_draft_lm_head")
+            )
+        recommended_draft_sampler = None
+        if data.get("recommended_draft_sampler") is not None:
+            from mtplx.draft_sampling import normalize_draft_sampler_spec
+
+            recommended_draft_sampler = normalize_draft_sampler_spec(
+                data.get("recommended_draft_sampler")
+            )
         return cls(
             mtplx_version=str(data["mtplx_version"]),
             arch_id=str(data["arch_id"]),
@@ -388,11 +404,13 @@ class RuntimeContract:
             recommended_profile=profile,
             exactness_baseline=dict(data["exactness_baseline"]),
             verified_on=dict(data["verified_on"]),
+            recommended_draft_lm_head=recommended_draft_lm_head,
+            recommended_draft_sampler=recommended_draft_sampler,
             raw=dict(data),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        out = {
             "mtplx_version": self.mtplx_version,
             "arch_id": self.arch_id,
             "mtp_depth_max": self.mtp_depth_max,
@@ -400,6 +418,11 @@ class RuntimeContract:
             "exactness_baseline": self.exactness_baseline,
             "verified_on": self.verified_on,
         }
+        if self.recommended_draft_lm_head is not None:
+            out["recommended_draft_lm_head"] = dict(self.recommended_draft_lm_head)
+        if self.recommended_draft_sampler is not None:
+            out["recommended_draft_sampler"] = dict(self.recommended_draft_sampler)
+        return out
 
 
 @dataclass(frozen=True)

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -805,7 +805,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                 can_run=False,
                 exit_code=EXIT_UNVERIFIED,
                 message=(
-                    f"{support.display_name} MTP markers recognized and a native "
+                    f"{support.display_name} markers recognized and a native "
                     "backend exists, but no verified mtplx_runtime.json contract "
                     "is present for this artifact."
                 ),

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from mtplx.profiles import DEFAULT_PROFILE_NAME, PROFILE_CHOICES
+from mtplx.profiles import DEFAULT_PROFILE_NAME, PROFILE_CHOICES, resolve_profile_name
 
 
 RUNTIME_CONTRACT_FILE = "mtplx_runtime.json"
@@ -18,6 +18,7 @@ SUPPORTED_ARCH_IDS = {
     "glm4-moe-mtp",
     "glm4-moe-lite-mtp",
     "mimo-mtp",
+    "nemotron-h-mtp",
 }
 
 TIER_VERIFIED = "verified"
@@ -59,6 +60,7 @@ class ArchitectureSupport:
     can_run_verified: bool = False
     aliases: tuple[str, ...] = ()
     config_markers: tuple[str, ...] = ("mtp_num_hidden_layers", "num_nextn_predict_layers")
+    family_gate: str = "none"
     references: tuple[str, ...] = ()
     notes: str = ""
 
@@ -73,6 +75,7 @@ class ArchitectureSupport:
             "can_run_verified": self.can_run_verified,
             "aliases": list(self.aliases),
             "config_markers": list(self.config_markers),
+            "family_gate": self.family_gate,
             "references": list(self.references),
             "notes": self.notes,
         }
@@ -88,6 +91,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native",
         can_run_verified=True,
         aliases=("qwen3_5_mtp", "qwen3_6_mtp", "qwen3-next", "qwen3_5"),
+        family_gate="qwen-mtp-sidecar-or-embedded",
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/qwen3_next_mtp.py",
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/qwen3_5_mtp.py",
@@ -105,6 +109,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
         aliases=("deepseek_mtp", "deepseek_v3", "deepseek_v32"),
+        family_gate="appended-layer-mtp-markers",
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/config/speculative.py",
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/deepseek_mtp.py",
@@ -122,6 +127,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
         aliases=("glm_moe_dsa", "glm_moe_dsa_mtp"),
+        family_gate="appended-layer-mtp-markers",
         references=(
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/glm_moe_dsa.py",
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/deepseek_v32.py",
@@ -154,6 +160,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
         aliases=("glm4_moe_mtp", "glm4_moe"),
+        family_gate="appended-layer-mtp-markers",
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/glm4_moe_mtp.py",
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/glm4_moe.py",
@@ -169,6 +176,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
         aliases=("glm4_moe_lite_mtp", "glm4_moe_lite"),
+        family_gate="appended-layer-mtp-markers",
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/glm4_moe_lite_mtp.py",
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/glm4_moe_lite.py",
@@ -195,16 +203,26 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         backend="minimax_m2",
         support_level="recognized-backend-pending",
         runtime_compatibility="recognized-backend-pending",
-        aliases=("minimax_m2", "MiniMaxM2ForCausalLM"),
+        aliases=(
+            "minimax_m2",
+            "minimax_m2_5",
+            "minimax_m25",
+            "minimax_m2_6",
+            "minimax_m26",
+            "MiniMaxM2ForCausalLM",
+            "MiniMaxM25ForCausalLM",
+            "MiniMaxM26ForCausalLM",
+        ),
         config_markers=("num_mtp_modules", "num_nextn_predict_layers", "mtp_num_hidden_layers"),
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/minimax_m2.py",
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/minimax.py",
+            "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/llama_eagle3.py",
         ),
         notes=(
-            "Base architecture is recognized; vLLM exposes MiniMax M2 speculative "
-            "layers through num_mtp_modules, but the native MLX runtime backend is "
-            "not implemented yet."
+            "MiniMax M2-family speculative support in vLLM is EAGLE3-style "
+            "auxiliary-hidden drafting, not the native MTP proposer contract MTPLX "
+            "uses for Qwen/DeepSeek/GLM/MiMo/Nemotron-H."
         ),
     ),
     "mimo-mtp": ArchitectureSupport(
@@ -215,7 +233,8 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         support_level="experimental-native-contract-gated",
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
-        aliases=("mimo_mtp", "MiMoForCausalLM"),
+        aliases=("mimo_mtp", "MiMoForCausalLM", "mimo"),
+        family_gate="mimo-layer0-mtp-markers",
         references=(
             "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/mimo_mtp.py",
             "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/mimo.py",
@@ -251,10 +270,20 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         display_name="Nemotron-H MTP",
         family="nemotron",
         backend="nemotron_h_mtp",
-        support_level="recognized-backend-pending",
-        runtime_compatibility="recognized-backend-pending",
+        support_level="experimental-native-contract-gated",
+        runtime_compatibility="native-contract-gated",
+        can_run_verified=True,
         aliases=("nemotron_h_mtp", "nemotron_h", "nemotron_h_puzzle"),
-        references=("REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/nemotron_h_mtp.py",),
+        family_gate="nemotron-h-pattern-mtp-markers",
+        references=(
+            "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/nemotron_h_mtp.py",
+            "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/nemotron_h.py",
+        ),
+        notes=(
+            "Experimental native backend for vLLM-style Nemotron-H MTP predictor "
+            "artifacts. Supports the one-step MTP path whose pattern contains "
+            "attention/MoE blocks only."
+        ),
     ),
     "exaone-moe-mtp": ArchitectureSupport(
         arch_id="exaone-moe-mtp",
@@ -293,7 +322,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         backend="pangu_ultra_moe_mtp",
         support_level="recognized-backend-pending",
         runtime_compatibility="recognized-backend-pending",
-        aliases=("pangu_ultra_moe_mtp", "pangu_ultra_moe", "openpangu_mtp"),
+        aliases=("pangu_ultra_moe_mtp", "pangu_ultra_moe", "openpangu_mtp", "openpangu"),
         references=("REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/openpangu_mtp.py",),
     ),
     "step3p5-mtp": ArchitectureSupport(
@@ -378,7 +407,8 @@ class RuntimeContract:
         ]
         if missing:
             raise ValueError(f"runtime contract missing required keys: {', '.join(missing)}")
-        profile = str(data["recommended_profile"])
+        raw_profile = str(data["recommended_profile"])
+        profile = resolve_profile_name(raw_profile)
         if profile not in PROFILE_CHOICES:
             raise ValueError(f"runtime contract has invalid recommended_profile: {profile}")
         depth = int(data["mtp_depth_max"])
@@ -491,63 +521,48 @@ def _text(value: Any) -> str:
     return str(value or "").lower().replace("-", "_")
 
 
+def _compact(value: str) -> str:
+    return _text(value).replace("_", "").replace(" ", "")
+
+
+def _alias_matches(combined: str, alias: str) -> bool:
+    alias_text = _text(alias)
+    if not alias_text:
+        return False
+    return alias_text in combined or _compact(alias_text) in _compact(combined)
+
+
+def _support_alias_matches(support: ArchitectureSupport, combined: str) -> bool:
+    aliases = (support.arch_id, *support.aliases)
+    return any(_alias_matches(combined, alias) for alias in aliases)
+
+
 def _detect_arch_id(inspection: Any) -> str | None:
     architecture = _text(getattr(inspection, "architecture", None))
     model_type = _text(getattr(inspection, "model_type", None))
     combined = f"{architecture} {model_type}"
     has_config_mtp = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
     has_explicit_mtp = has_config_mtp or "mtp" in combined or "nextn" in combined
-    if "qwen3_next" in combined or "qwen3_5" in combined or "qwen3_6" in combined:
+
+    qwen_support = ARCHITECTURE_CATALOG["qwen3-next-mtp"]
+    if _support_alias_matches(qwen_support, combined):
         return "qwen3-next-mtp"
-    if "deepseek_v4" in combined and has_explicit_mtp:
-        return "deepseek-v4-mtp"
-    if (
-        "deepseek_mtp" in combined
-        or "deepseek_v3" in combined
-        or "deepseek_v32" in combined
-        or "deepseekv3" in combined
-        or "deepseekv32" in combined
-    ) and has_explicit_mtp:
-        return "deepseek-v3-mtp"
-    if "glm_moe_dsa" in combined and has_explicit_mtp:
-        return "glm-moe-dsa-mtp"
-    if (
-        "glm4_moe_lite_mtp" in combined
-        or "glm4_moe_lite" in combined
-        or "glm4moelite" in combined
-    ) and has_explicit_mtp:
-        return "glm4-moe-lite-mtp"
-    if (
-        "glm4_moe_mtp" in combined
-        or "glm4_moe" in combined
-        or "glm4moe" in combined
-        or "glm_moe_dsa" in combined
-    ) and has_explicit_mtp:
-        return "glm4-moe-mtp"
-    if ("glm_ocr_mtp" in combined or "glm_ocr" in combined or "glmocr" in combined) and has_explicit_mtp:
-        return "glm-ocr-mtp"
-    if ("minimax_m2" in combined or "minimaxm2" in combined) and has_explicit_mtp:
-        return "minimax-m2-mtp"
-    if ("mimo_mtp" in combined or "mimoforcausallm" in combined or model_type == "mimo") and has_explicit_mtp:
-        return "mimo-mtp"
-    if ("gemma" in combined) and has_explicit_mtp:
-        return "gemma-mtp"
-    if ("ernie_mtp" in combined or "ernie4_5_moe" in combined) and has_explicit_mtp:
-        return "ernie-mtp"
-    if ("nemotron_h_mtp" in combined or "nemotron_h" in combined) and has_explicit_mtp:
-        return "nemotron-h-mtp"
-    if ("exaone4_5" in combined) and has_explicit_mtp:
-        return "exaone4-5-mtp"
-    if ("exaone_moe" in combined) and has_explicit_mtp:
-        return "exaone-moe-mtp"
-    if ("longcat_flash" in combined) and has_explicit_mtp:
-        return "longcat-flash-mtp"
-    if ("pangu_ultra_moe" in combined or "openpangu" in combined) and has_explicit_mtp:
-        return "pangu-ultra-moe-mtp"
-    if ("step3p5" in combined) and has_explicit_mtp:
-        return "step3p5-mtp"
-    if ("hy_v3" in combined or "hyv3" in combined) and has_explicit_mtp:
-        return "hy-v3-mtp"
+
+    supports = [
+        support
+        for support in ARCHITECTURE_CATALOG.values()
+        if support.arch_id not in {"qwen3-next-mtp", "generic-mtp"}
+    ]
+    supports.sort(
+        key=lambda row: max(
+            (len(_compact(alias)) for alias in (row.arch_id, *row.aliases)),
+            default=0,
+        ),
+        reverse=True,
+    )
+    for support in supports:
+        if has_explicit_mtp and _support_alias_matches(support, combined):
+            return support.arch_id
     if "mtp" in combined or "nextn" in combined:
         return "generic-mtp"
     return None
@@ -562,19 +577,176 @@ def _has_mtp_markers(inspection: Any) -> bool:
 
 
 def _passes_verified_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool) -> bool:
+    return _passes_family_runtime_gate(arch_id, inspection, tensor_gate)
+
+
+def _weight_keys(inspection: Any) -> tuple[str, ...]:
+    return tuple(str(key) for key in (getattr(inspection, "weight_keys", ()) or ()))
+
+
+_APPENDED_LAYER_MARKER_SUFFIXES = (
+    "enorm.weight",
+    "hnorm.weight",
+    "eh_proj.weight",
+    "shared_head.norm.weight",
+    "shared_head.head.weight",
+)
+
+
+def _has_marker_under_prefixes(
+    keys: tuple[str, ...],
+    prefixes: tuple[str, ...],
+    suffixes: tuple[str, ...],
+    substrings: tuple[str, ...] = (),
+) -> bool:
+    for key in keys:
+        for prefix in prefixes:
+            if not key.startswith(prefix):
+                continue
+            suffix = key.removeprefix(prefix)
+            if suffix.endswith(suffixes) or any(marker in suffix for marker in substrings):
+                return True
+    return False
+
+
+def _has_all_suffixes_under_prefixes(
+    keys: tuple[str, ...],
+    prefixes: tuple[str, ...],
+    suffixes: tuple[str, ...],
+) -> bool:
+    for suffix in suffixes:
+        if not any(key.startswith(prefix) and key.removeprefix(prefix).endswith(suffix) for key in keys for prefix in prefixes):
+            return False
+    return True
+
+
+def _passes_appended_layer_gate(inspection: Any) -> bool:
+    keys = _weight_keys(inspection)
+    if not keys:
+        return False
+    start = int(getattr(inspection, "num_hidden_layers", 0) or 0)
+    count = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
+    if start <= 0 or count <= 0:
+        return False
+    for local_idx in range(count):
+        layer_idx = start + local_idx
+        prefixes = (
+            f"model.layers.{layer_idx}.",
+            f"mtp.layers.{local_idx}.",
+            f"layers.{local_idx}.",
+        )
+        if not _has_marker_under_prefixes(
+            keys,
+            prefixes,
+            _APPENDED_LAYER_MARKER_SUFFIXES,
+            ("mtp_block.",),
+        ):
+            return False
+    return True
+
+
+def _passes_mimo_layer_gate(inspection: Any) -> bool:
+    keys = _weight_keys(inspection)
+    if not keys:
+        return False
+    start = int(getattr(inspection, "num_hidden_layers", 0) or 0)
+    count = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
+    if start <= 0 or count <= 0:
+        return False
+    # The current MiMo proposer path is one-token MTP; gate the layer it can
+    # actually execute while keeping deeper configured layers unpromoted.
+    prefixes = (
+        "model.mtp_layers.0.",
+        f"model.mtp_layers.{start}.",
+        f"model.layers.{start}.",
+        "mtp.layers.0.",
+        "layers.0.",
+    )
+    return _has_marker_under_prefixes(
+        keys,
+        prefixes,
+        (
+            "token_layernorm.weight",
+            "hidden_layernorm.weight",
+            "input_proj.weight",
+            "final_layernorm.weight",
+        ),
+        ("mtp_block.",),
+    )
+
+
+def _passes_nemotron_h_gate(inspection: Any) -> bool:
+    keys = _weight_keys(inspection)
+    if not keys:
+        return False
+    if int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) != 1:
+        return False
+    pattern = str(getattr(inspection, "mtp_pattern", None) or "")
+    if not pattern or not set(pattern).issubset({"*", "E"}):
+        return False
+    start = int(getattr(inspection, "num_hidden_layers", 0) or 0)
+    if start <= 0:
+        return False
+    physical_layers = len(pattern)
+    for local_idx in range(physical_layers):
+        prefixes = (
+            f"mtp.layers.{local_idx}.",
+            f"layers.{local_idx}.",
+            f"model.layers.{start + local_idx}.",
+            f"backbone.layers.{start + local_idx}.",
+        )
+        has_layer_body = False
+        for key in keys:
+            for prefix in prefixes:
+                if not key.startswith(prefix):
+                    continue
+                suffix = key.removeprefix(prefix)
+                if suffix == "norm.weight" or suffix.startswith("mixer."):
+                    has_layer_body = True
+                    break
+            if has_layer_body:
+                break
+        if not has_layer_body:
+            return False
+    first_prefixes = (
+        "mtp.layers.0.",
+        "layers.0.",
+        f"model.layers.{start}.",
+        f"backbone.layers.{start}.",
+    )
+    if not _has_all_suffixes_under_prefixes(
+        keys,
+        first_prefixes,
+        ("enorm.weight", "hnorm.weight", "eh_proj.weight"),
+    ):
+        return False
+    last_idx = physical_layers - 1
+    last_prefixes = (
+        f"mtp.layers.{last_idx}.",
+        f"layers.{last_idx}.",
+        f"model.layers.{start + last_idx}.",
+        f"backbone.layers.{start + last_idx}.",
+    )
+    return _has_marker_under_prefixes(keys, last_prefixes, ("final_layernorm.weight",))
+
+
+def _passes_family_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool) -> bool:
     if arch_id == "qwen3-next-mtp":
-        return bool(tensor_gate)
+        return bool(
+            tensor_gate
+            and int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
+        )
     if arch_id in {
         "deepseek-v3-mtp",
         "glm-moe-dsa-mtp",
         "glm4-moe-mtp",
         "glm4-moe-lite-mtp",
-        "mimo-mtp",
     }:
-        return bool(
-            int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
-            and tuple(getattr(inspection, "model_files", ()) or ())
-        )
+        return _passes_appended_layer_gate(inspection)
+    if arch_id == "mimo-mtp":
+        return _passes_mimo_layer_gate(inspection)
+    if arch_id == "nemotron-h-mtp":
+        return _passes_nemotron_h_gate(inspection)
     return False
 
 
@@ -721,11 +893,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             if has_mtp
             else "Qwen3-Next architecture detected"
         )
-        if (
-            support is not None
-            and tensor_gate
-            and int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
-        ):
+        if support is not None and _passes_family_runtime_gate(detected_arch_id, inspection, tensor_gate):
             return CompatibilityVerdict(
                 tier=TIER_FAMILY_COMPATIBLE_UNVERIFIED,
                 arch_id=detected_arch_id,
@@ -735,9 +903,9 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                 exit_code=EXIT_VERIFIED,
                 message=(
                     f"{marker_text}; native MTP tensors match the supported "
-                    "Qwen family layout. mtplx_runtime.json is optional "
-                    "verification metadata, so this run will be marked "
-                    "unverified until an exactness baseline is recorded."
+                    "Qwen family layout. No mtplx_runtime.json exactness "
+                    "baseline is present, so runs are marked unverified until "
+                    "a first-load smoke baseline is recorded."
                 ),
                 recommended_backend="qwen3_next",
                 recommended_profile=DEFAULT_PROFILE_NAME,
@@ -760,7 +928,8 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                     f"{marker_text}, but this folder does not contain runnable "
                     "Qwen MTP tensors. mtplx_runtime.json is optional metadata; "
                     "the blocker is missing MTP weights. Use a model with "
-                    "mtp.safetensors, or graft an MTP sidecar into this base model."
+                    "mtp.safetensors, embedded mtp.* / language_model.mtp.* "
+                    "weights, or graft an MTP sidecar into this base model."
                 ),
                 recommended_backend="qwen3_next",
                 recommended_profile=DEFAULT_PROFILE_NAME,
@@ -782,7 +951,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                 f"{marker_text}, and an MTP artifact is present, but its tensor "
                 "layout does not match the Qwen native MTP runtime gate. "
                 "mtplx_runtime.json is optional metadata; repair or regenerate "
-                "the MTP sidecar so the tensor gate passes."
+                "the MTP sidecar/embedded weights so the tensor gate passes."
             ),
             recommended_backend="qwen3_next",
             recommended_profile=DEFAULT_PROFILE_NAME,
@@ -796,6 +965,34 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
 
     support = architecture_support_for(detected_arch_id)
     if support is not None and has_mtp:
+        family_gate = _passes_family_runtime_gate(
+            support.arch_id,
+            inspection,
+            tensor_gate,
+        )
+        if support.can_run_verified and family_gate:
+            return CompatibilityVerdict(
+                tier=TIER_FAMILY_COMPATIBLE_UNVERIFIED,
+                arch_id=support.arch_id,
+                supported=True,
+                recognized=True,
+                can_run=True,
+                exit_code=EXIT_VERIFIED,
+                message=(
+                    f"{support.display_name} MTP markers and tensor layout "
+                    "match a supported native backend. No mtplx_runtime.json "
+                    "exactness baseline is present, so runs are marked "
+                    "unverified until a first-load smoke baseline is recorded."
+                ),
+                recommended_backend=support.backend,
+                recommended_profile=DEFAULT_PROFILE_NAME,
+                unsafe_force_required=False,
+                unverified_model=True,
+                mtp_supported="yes",
+                runtime_compatibility="native-family-gated",
+                support_level="native-family-auto-smoke",
+                support_notes=support.notes,
+            )
         if support.can_run_verified:
             return CompatibilityVerdict(
                 tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,
@@ -862,7 +1059,8 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
         exit_code=EXIT_INCOMPATIBLE_ARCHITECTURE,
         message=(
             f"{detected_arch_id or 'generic MTP'} detected; not supported in "
-            "v0.1.0-preview. Qwen3-Next MTP is the only running backend."
+            "v0.1.0-preview because no supported native MLX runtime family "
+            "matched this artifact."
         ),
         mtp_supported="partial",
         runtime_compatibility="unsupported",

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -21,6 +21,7 @@ SUPPORTED_ARCH_IDS = {
 }
 
 TIER_VERIFIED = "verified"
+TIER_FAMILY_COMPATIBLE_UNVERIFIED = "family-compatible-unverified"
 TIER_ARCH_COMPATIBLE_UNVERIFIED = "architecture-compatible-but-unverified"
 TIER_INCOMPATIBLE_ARCHITECTURE = "incompatible-architecture"
 TIER_NO_MTP = "no-MTP"
@@ -593,7 +594,9 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
         contract_error = contract_error or local_contract_error
     detected_arch_id = _detect_arch_id(inspection)
     has_mtp = _has_mtp_markers(inspection)
-    tensor_gate = bool(getattr(getattr(inspection, "mtp", None), "passes_tensor_gate", False))
+    mtp_artifact = getattr(inspection, "mtp", None)
+    tensor_gate = bool(getattr(mtp_artifact, "passes_tensor_gate", False))
+    mtp_artifact_exists = bool(getattr(mtp_artifact, "exists", False))
     contract_path = getattr(inspection, "runtime_contract_path", None)
     if not contract_path:
         contract_path = str(_contract_path(model_dir)) if _contract_path(model_dir).exists() else None
@@ -718,6 +721,56 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             if has_mtp
             else "Qwen3-Next architecture detected"
         )
+        if (
+            support is not None
+            and tensor_gate
+            and int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
+        ):
+            return CompatibilityVerdict(
+                tier=TIER_FAMILY_COMPATIBLE_UNVERIFIED,
+                arch_id=detected_arch_id,
+                supported=True,
+                recognized=True,
+                can_run=True,
+                exit_code=EXIT_VERIFIED,
+                message=(
+                    f"{marker_text}; native MTP tensors match the supported "
+                    "Qwen family layout. mtplx_runtime.json is optional "
+                    "verification metadata, so this run will be marked "
+                    "unverified until an exactness baseline is recorded."
+                ),
+                recommended_backend="qwen3_next",
+                recommended_profile=DEFAULT_PROFILE_NAME,
+                unsafe_force_required=False,
+                unverified_model=True,
+                mtp_supported="yes",
+                runtime_compatibility="native-family-gated",
+                support_level="native-family-auto-smoke",
+                support_notes=(support.notes if support else None),
+            )
+        if not mtp_artifact_exists:
+            return CompatibilityVerdict(
+                tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,
+                arch_id=detected_arch_id,
+                supported=False,
+                recognized=True,
+                can_run=False,
+                exit_code=EXIT_UNVERIFIED,
+                message=(
+                    f"{marker_text}, but this folder does not contain runnable "
+                    "Qwen MTP tensors. mtplx_runtime.json is optional metadata; "
+                    "the blocker is missing MTP weights. Use a model with "
+                    "mtp.safetensors, or graft an MTP sidecar into this base model."
+                ),
+                recommended_backend="qwen3_next",
+                recommended_profile=DEFAULT_PROFILE_NAME,
+                unsafe_force_required=False,
+                unverified_model=True,
+                mtp_supported="no",
+                runtime_compatibility="missing-mtp-weights",
+                support_level="native-backend-missing-mtp-weights",
+                support_notes=(support.notes if support else None),
+            )
         return CompatibilityVerdict(
             tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,
             arch_id=detected_arch_id,
@@ -726,17 +779,18 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             can_run=False,
             exit_code=EXIT_UNVERIFIED,
             message=(
-                f"{marker_text}, but no mtplx_runtime.json "
-                "verified contract is present. Use --unsafe-force-unverified "
-                "--yes to proceed without support guarantees."
+                f"{marker_text}, and an MTP artifact is present, but its tensor "
+                "layout does not match the Qwen native MTP runtime gate. "
+                "mtplx_runtime.json is optional metadata; repair or regenerate "
+                "the MTP sidecar so the tensor gate passes."
             ),
             recommended_backend="qwen3_next",
             recommended_profile=DEFAULT_PROFILE_NAME,
-            unsafe_force_required=True,
+            unsafe_force_required=False,
             unverified_model=True,
             mtp_supported="partial",
-            runtime_compatibility="needs-grafting",
-            support_level="native-backend-needs-contract",
+            runtime_compatibility="invalid-mtp-tensor-layout",
+            support_level="native-backend-invalid-mtp-tensors",
             support_notes=(support.notes if support else None),
         )
 

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -15,6 +15,7 @@ from .profiles import (
     DEFAULT_HF_MODEL_ID,
     DEFAULT_MODEL_ID,
     DEFAULT_PROFILE_NAME,
+    DEFAULT_PUBLIC_MODEL_ID,
     PROFILE_CHOICES,
     get_profile,
     list_profiles,
@@ -69,6 +70,7 @@ PUBLIC_COMMANDS = (
     ("status", "Check install, model, and integration health"),
     ("inspect", "Check whether a model is MTPLX-compatible"),
     ("models", "List models in the local MTPLX cache"),
+    ("report", "Create a redacted support bundle"),
 )
 
 ADVANCED_COMMANDS = {
@@ -277,8 +279,9 @@ def _format_verbose_help() -> str:
   mtplx quickstart --download       Pull the verified model from Hugging Face
   mtplx start --port 8000           Run the OpenAI/Anthropic server only
   mtplx connect openwebui           Print Open WebUI integration settings
+  mtplx report                      Create a redacted support bundle
   mtplx ask "Write a tiny FastAPI app"
-  mtplx inspect mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP
+  mtplx inspect Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed
 
 {_heading("Help subtopics")}
 
@@ -559,6 +562,12 @@ def cmd_debug_public(args: argparse.Namespace) -> int:
     return handler(args)
 
 
+def cmd_openwebui_public(args: argparse.Namespace) -> int:
+    from .commands.public import cmd_openwebui_public as handler
+
+    return handler(args)
+
+
 def cmd_metrics_public(args: argparse.Namespace) -> int:
     from .commands.public import cmd_metrics_public as handler
 
@@ -630,6 +639,7 @@ def _cmd_inspect_model(args: argparse.Namespace) -> int:
 def _cmd_init(args: argparse.Namespace) -> int:
     from .hf_loader import model_cache_dir, pull_model
     from .thermal import detect_thermal_control
+    from .diagnostics import host_report, required_download_free_bytes, estimate_runtime_memory_bytes
 
     config_path = Path(args.config).expanduser()
     model_dir = model_cache_dir(args.model_dir)
@@ -643,6 +653,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "is_macos": platform.system() == "Darwin",
         "is_apple_silicon": platform.system() == "Darwin" and platform.machine() == "arm64",
     }
+    host = host_report(model_cache=model_dir)
     profile = get_profile(args.profile)
     commands = {
         "doctor": "mtplx doctor --json",
@@ -659,6 +670,11 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "model_dir": str(model_dir),
         "profile": profile.to_dict(),
         "hardware": hardware,
+        "host": host,
+        "resources": {
+            "estimated_runtime_memory_bytes": estimate_runtime_memory_bytes(profile=profile.name),
+            "required_download_free_bytes": required_download_free_bytes(),
+        },
         "thermal_control": {
             "requested": args.thermal_control,
             "detected": thermal_tool,
@@ -1455,7 +1471,7 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"mtplx {DISPLAY_VERSION} ({__version__})",
     )
     sub = parser.add_subparsers(dest="command", required=True)
-    default_model = str(DEFAULT_RUNTIME_MODEL_DIR)
+    default_model = DEFAULT_HF_MODEL_ID
 
     help_p = sub.add_parser("help", help=argparse.SUPPRESS)
     help_p.add_argument("topic", nargs="?")
@@ -1511,7 +1527,7 @@ def build_parser() -> argparse.ArgumentParser:
     quickstart_p.add_argument("--no-stats", action="store_false", dest="show_stats", default=True, help="Hide speed stats after responses")
     quickstart_p.add_argument("--host", default="127.0.0.1", help="Open WebUI server host for `mtplx quickstart openwebui`")
     quickstart_p.add_argument("--port", type=int, default=8000, help="Open WebUI server port for `mtplx quickstart openwebui`")
-    quickstart_p.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp", help="Model id to select in Open WebUI")
+    quickstart_p.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID, help="Model id to select in Open WebUI")
     quickstart_p.add_argument("--api-key", help="Optional API key for non-localhost Open WebUI serving")
     quickstart_p.add_argument("--warmup-tokens", type=int, default=16, help="Warmup tokens for Open WebUI server startup")
     quickstart_p.add_argument("--stream-interval", type=int, default=1, help="Streaming chunk size for Open WebUI server")
@@ -1554,6 +1570,7 @@ def build_parser() -> argparse.ArgumentParser:
     status_p.add_argument("--model-cache")
     status_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     status_p.add_argument("--deep", action="store_true", help="Include launchers, config, staging, release, and integration checks")
+    status_p.add_argument("--summary", action="store_true", help="Print a compact check summary")
     status_p.set_defaults(func=cmd_doctor)
 
     ask_p = sub.add_parser("ask", help="Ask the verified local MTPLX model one question")
@@ -1637,12 +1654,26 @@ def build_parser() -> argparse.ArgumentParser:
     connect_p.add_argument("integration", nargs="?", choices=["openwebui", "claude-code"])
     connect_p.add_argument("--host", default="127.0.0.1")
     connect_p.add_argument("--port", type=int, default=8000)
-    connect_p.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp")
+    connect_p.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID)
     connect_p.add_argument("--api-key-env", default="MTPLX_AUTH")
+    connect_p.add_argument("--docker", action="store_true", help="Include the Dockerized Open WebUI host.docker.internal command")
+    connect_p.add_argument("--webui-port", type=int, default=3000)
+    connect_p.add_argument("--single-user", action="store_true", help="Emit WEBUI_AUTH=False for a new single-user Open WebUI data volume")
+    connect_p.add_argument("--api-key", default="mtplx-local", help="OpenAI-compatible API key value for generated Docker command")
     connect_p.add_argument("--smoke", action="store_true")
     connect_p.add_argument("--timeout", type=float, default=5.0)
     connect_p.add_argument("--json", action="store_true")
     connect_p.set_defaults(func=_cmd_connect)
+
+    openwebui_p = sub.add_parser("openwebui", help="Open WebUI integration helpers")
+    openwebui_sub = openwebui_p.add_subparsers(dest="openwebui_action", required=True)
+    openwebui_docker_p = openwebui_sub.add_parser("docker-command", help="Print the production Open WebUI Docker command")
+    openwebui_docker_p.add_argument("--mtplx-port", type=int, default=8000)
+    openwebui_docker_p.add_argument("--webui-port", type=int, default=3000)
+    openwebui_docker_p.add_argument("--single-user", action="store_true", help="Add WEBUI_AUTH=False for a fresh single-user volume")
+    openwebui_docker_p.add_argument("--api-key", default="mtplx-local")
+    openwebui_docker_p.add_argument("--json", action="store_true")
+    openwebui_docker_p.set_defaults(func=cmd_openwebui_public)
 
     models_p = sub.add_parser("models", help="List locally cached MTPLX models")
     models_p.add_argument("--cache-dir")
@@ -1660,7 +1691,23 @@ def build_parser() -> argparse.ArgumentParser:
     doctor_p.add_argument("--model-cache")
     doctor_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     doctor_p.add_argument("--deep", action="store_true", help="Include launchers, config, staging, release, and integration checks")
+    doctor_p.add_argument("--summary", action="store_true", help="Print a compact check summary")
+    doctor_p.add_argument("--bundle", action="store_true", help="Write a redacted doctor bundle under ~/.mtplx/reports")
+    doctor_p.add_argument("--output-dir", help="Directory for --bundle output")
+    doctor_p.add_argument("--include-paths", action="store_true", help="Keep local paths in --bundle output")
     doctor_p.set_defaults(func=cmd_doctor)
+
+    report_p = sub.add_parser("report", help="Create a redacted MTPLX support bundle")
+    report_p.add_argument("--project-root", default=".")
+    report_p.add_argument("--smc-path", default=os.environ.get("MTPLX_SMC_PATH") or shutil.which("smc") or "")
+    report_p.add_argument("--sovereign-path", default=os.environ.get("MTPLX_SOVEREIGN_PATH") or shutil.which("sovereign") or "")
+    report_p.add_argument("--model-cache")
+    report_p.add_argument("--output-dir", help="Directory for the report bundle")
+    report_p.add_argument("--include-paths", action="store_true", help="Keep local paths in the report")
+    report_p.add_argument("--deep", action="store_true", default=True, help="Include deep integration checks")
+    report_p.add_argument("--summary", action="store_true", help="Print compact check summary instead of JSON")
+    report_p.add_argument("--json", action="store_true", default=True, help="Emit machine-readable JSON")
+    report_p.set_defaults(func=cmd_doctor, bundle=True)
 
     inspect_public_p = sub.add_parser("inspect", help="Inspect a model and auto-check MTP support")
     inspect_public_p.add_argument(
@@ -1698,7 +1745,12 @@ def build_parser() -> argparse.ArgumentParser:
     profiles_p.set_defaults(func=_cmd_profiles)
 
     pull_p = sub.add_parser("pull", help="Download a Hugging Face model into the MTPLX cache")
-    pull_p.add_argument("model", help="Hugging Face repo id or URL")
+    pull_p.add_argument(
+        "model",
+        nargs="?",
+        default=DEFAULT_HF_MODEL_ID,
+        help="Hugging Face repo id or URL. Defaults to the preview speed model.",
+    )
     pull_p.add_argument("--cache-dir")
     pull_p.add_argument("--revision")
     pull_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
@@ -1862,7 +1914,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--profile",
         choices=(*PROFILE_CHOICES, "native-mtp-60"),
         help=(
-            "Runtime profile for product benchmark actions. Defaults to stable; "
+            "Runtime profile for product benchmark actions. Defaults to performance-cold; "
             "native-mtp-60 is a legacy alias for performance-cold."
         ),
     )
@@ -1910,7 +1962,7 @@ def build_parser() -> argparse.ArgumentParser:
     bench_p.add_argument("--exactness-partition-size", type=int, default=512)
     bench_p.add_argument("--models", nargs="+")
     bench_p.add_argument("--record-champion", action="store_true")
-    bench_p.add_argument("--champion", default="models/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP")
+    bench_p.add_argument("--champion", default=DEFAULT_HF_MODEL_ID)
     bench_p.add_argument("--references", nargs="+", default=["stock_mlx_lm", "llama_cpp"])
     bench_p.add_argument("--url", default="http://127.0.0.1:8000")
     bench_p.add_argument("--port", type=int, default=8041)
@@ -2111,8 +2163,12 @@ def build_parser() -> argparse.ArgumentParser:
         integration_p = integrate_sub.add_parser(integration_name)
         integration_p.add_argument("--host", default="127.0.0.1")
         integration_p.add_argument("--port", type=int, default=8000)
-        integration_p.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp")
+        integration_p.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID)
         integration_p.add_argument("--api-key-env", default="MTPLX_AUTH")
+        integration_p.add_argument("--docker", action="store_true", help="Include Dockerized Open WebUI command")
+        integration_p.add_argument("--webui-port", type=int, default=3000)
+        integration_p.add_argument("--single-user", action="store_true")
+        integration_p.add_argument("--api-key", default="mtplx-local")
         integration_p.add_argument("--smoke", action="store_true")
         integration_p.add_argument("--timeout", type=float, default=5.0)
         integration_p.add_argument("--json", action="store_true")
@@ -2138,7 +2194,7 @@ def build_parser() -> argparse.ArgumentParser:
     publish_check_p = model_sub.add_parser("publish-check", help="Validate HF staging readiness without upload")
     publish_check_p.add_argument(
         "--staging-dir",
-        default="hf-staging/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP",
+        default="hf-staging/Qwen3.6-27B-MTPLX-Optimized-Speed",
     )
     publish_check_p.add_argument("--repo-id")
     publish_check_p.set_defaults(func=cmd_model_public)
@@ -2716,8 +2772,41 @@ def main(argv: list[str] | None = None) -> int:
     args._cli_flags = _explicit_cli_flags(raw_args)
     from .config import apply_user_config
 
-    apply_user_config(args)
-    return int(args.func(args))
+    try:
+        apply_user_config(args)
+        return int(args.func(args))
+    except ModuleNotFoundError as exc:
+        if str(getattr(exc, "name", "")).startswith("mlx"):
+            from .errors import MissingMLXError
+
+            return _print_cli_error(MissingMLXError(detail=str(exc)), json_mode="--json" in raw_args)
+        raise
+    except Exception as exc:
+        from .errors import MTPLXError
+
+        if isinstance(exc, MTPLXError):
+            return _print_cli_error(exc, json_mode="--json" in raw_args)
+        raise
+
+
+def _print_cli_error(exc: Exception, *, json_mode: bool) -> int:
+    from .errors import MTPLXError
+
+    if isinstance(exc, MTPLXError):
+        payload = exc.to_dict()
+        code = exc.code
+    else:
+        payload = {"error": exc.__class__.__name__, "message": str(exc), "exit_code": 1}
+        code = 1
+    if json_mode:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"error: {payload['message']}", file=sys.stderr)
+        if payload.get("fix"):
+            print(f"fix: {payload['fix']}", file=sys.stderr)
+        if payload.get("command"):
+            print(f"try: {payload['command']}", file=sys.stderr)
+    return int(code)
 
 
 def _explicit_cli_flags(raw_args: list[str]) -> set[str]:

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -61,10 +61,10 @@ NATIVE_MTP_60_MODEL = DEFAULT_MODEL_ID
 
 
 PUBLIC_COMMANDS = (
-    ("quickstart", "Interactive setup → chat (model · mode · web/CLI)"),
+    ("start", "Interactive setup → chat (model · mode · web/CLI)"),
     ("help", "Detailed help; `help commands` / `help flags` / `help <name>`"),
     ("setup", "Prepare config and the model cache"),
-    ("start", "Run the local OpenAI/Anthropic server"),
+    ("quickstart", "Run the local OpenAI/Anthropic server"),
     ("connect", "Copy settings for Open WebUI or Claude Code"),
     ("ask", "Ask the verified local model once"),
     ("status", "Check install, model, and integration health"),
@@ -164,9 +164,9 @@ def _format_public_help() -> str:
 {command_lines}
 
 {_heading("Examples")}
-  mtplx quickstart                  Interactive setup, then chat
-  mtplx quickstart --fresh          Re-run the onboarding (new model/mode/surface)
-  mtplx start --max --port 8000     Server with ThermalForge fan boost (Max)
+  mtplx start                       Interactive setup, then chat
+  mtplx start --fresh               Re-run the onboarding (new model/mode/surface)
+  mtplx quickstart --max --port 8000  Server with ThermalForge fan boost (Max)
 
   {footer}
 """
@@ -184,7 +184,7 @@ def _format_advanced_help() -> str:
 Usage: mtplx <command> [options]
 
 Commands suffixed with * have subcommands. Run `mtplx help <command>` for details.
-The everyday path is quickstart first. Servers, integrations, QA, and kernels live here when needed.
+The everyday path is start first. Servers, integrations, QA, and kernels live here when needed.
 
 """ + "\n".join(sections) + """
 
@@ -198,8 +198,8 @@ Docs: README.md
 """
 
 
-def _format_quickstart_help() -> str:
-    return f"""{_heading("MTPLX quickstart")}
+def _format_start_help() -> str:
+    return f"""{_heading("MTPLX start")}
 
 Interactive end-to-end setup. On first run MTPLX walks you through three
 quick choices: model, runtime mode, and where to chat (browser or terminal).
@@ -207,21 +207,21 @@ On later runs it offers "same as last time?" so the chat is one keypress away.
 
 What gets asked:
   1. Model — your configured model, the verified default, custom HF, or local
-  2. Mode  — Stable, Cold-Speed, or Max (Max auto-installs ThermalForge)
+  2. Mode  — Medium or Max (Stable remains available via --profile stable)
   3. Where — Web UI (default) or terminal CLI
 
 Power-user shortcuts (any of these skip the onboarding wizard):
-  mtplx quickstart --fresh            Walk the onboarding again from scratch
-  mtplx quickstart cli                Skip onboarding; terminal chat directly
-  mtplx quickstart --max              Run with ThermalForge fan boost on
-  mtplx quickstart --download         Pull the verified model from HF first
-  mtplx quickstart --model /path/...  Use a specific local or HF model
-  mtplx quickstart --prompt "hi"      One-shot ask and exit (non-interactive)
+  mtplx start --fresh                 Walk the onboarding again from scratch
+  mtplx start cli                     Skip onboarding; terminal chat directly
+  mtplx start --max                   Run with ThermalForge fan boost on
+  mtplx start --download              Pull the verified model from HF first
+  mtplx start --model /path/...       Use a specific local or HF model
+  mtplx start --prompt "hi"           One-shot ask and exit (non-interactive)
 
 Useful controls:
   --download       Download the selected/default model if missing
   --model PATH     Use a local model folder or HF repo id
-  --profile stable Use the conservative long-response profile
+  --profile stable Use the hidden conservative long-response profile
   --prompt TEXT    (cli) Ask once and exit instead of opening chat
   --max-tokens N   (cli) Optional response cap; default uses remaining context
   --no-stats       Hide the TPS footer
@@ -274,10 +274,10 @@ def _format_verbose_help() -> str:
 
 {_heading("Examples")}
 
-  mtplx quickstart                  Open the local chat in your browser
-  mtplx quickstart cli              Chat in this terminal instead
-  mtplx quickstart --download       Pull the verified model from Hugging Face
-  mtplx start --port 8000           Run the OpenAI/Anthropic server only
+  mtplx start                       Open the local chat in your browser
+  mtplx start cli                   Chat in this terminal instead
+  mtplx start --download            Pull the verified model from Hugging Face
+  mtplx quickstart --port 8000      Run the OpenAI/Anthropic server only
   mtplx connect openwebui           Print Open WebUI integration settings
   mtplx report                      Create a redacted support bundle
   mtplx ask "Write a tiny FastAPI app"
@@ -289,7 +289,7 @@ def _format_verbose_help() -> str:
   mtplx help flags            Every flag, grouped by command
   mtplx help advanced         Benchmarks, QA, publishing, and kernel tools
   mtplx help <command>        Detailed flags for one command (argparse view)
-  mtplx help quickstart       The quickstart user journey
+  mtplx help start            The start user journey
 
   Docs: README.md
 """
@@ -406,8 +406,8 @@ def _print_help_topic(topic: str | None, parser: argparse.ArgumentParser) -> int
     if topic in ("flags", "options", "all-flags"):
         print(_format_flags_help())
         return 0
-    if topic in ("quickstart", "quick-start"):
-        print(_format_quickstart_help())
+    if topic == "start":
+        print(_format_start_help())
         return 0
     if topic in ("advanced", "expert", "lab"):
         print(_format_advanced_help())
@@ -754,7 +754,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             "config_path": str(config_path),
             "next_steps": [
                 "mtplx status",
-                "mtplx start --port 8000",
+                "mtplx quickstart --port 8000",
                 "mtplx connect openwebui",
             ],
         }
@@ -764,7 +764,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             print("MTPLX setup")
             print(f"config already exists: {config_path}")
             print("next: mtplx status")
-            print("next: mtplx start --port 8000")
+            print("next: mtplx quickstart --port 8000")
             print("Use --force to rewrite the config.")
         return 0
     args.write = True
@@ -787,13 +787,13 @@ def _cmd_connect(args: argparse.Namespace) -> int:
                     "purpose": "Use MTPLX through the Anthropic-compatible Claude Code path.",
                 },
             ],
-            "server": "mtplx start --port 8000",
+            "server": "mtplx quickstart --port 8000",
         }
         if args.json:
             print(json.dumps(payload, indent=2, sort_keys=True))
         else:
             print("Connect MTPLX")
-            print("1. Start the server: mtplx start --port 8000")
+            print("1. Start the server: mtplx quickstart --port 8000")
             print("2. Pick a client:")
             print("   mtplx connect openwebui")
             print("   mtplx connect claude-code")
@@ -1480,76 +1480,75 @@ def build_parser() -> argparse.ArgumentParser:
     advanced_p = sub.add_parser("advanced", help=argparse.SUPPRESS)
     advanced_p.set_defaults(func=lambda _args: (print(_format_advanced_help()) or 0))
 
-    quickstart_p = sub.add_parser(
-        "quickstart",
-        aliases=["quick-start"],
+    start_flow_p = sub.add_parser(
+        "start",
         help="Interactive setup → chat (model · mode · web/CLI)",
-        usage="mtplx quickstart [cli|web] [--fresh] [--max] [--model PATH_OR_REPO] [--prompt TEXT]",
-        description="Walk through model / mode / surface in three quick steps, then chat. Returning users get a 'same as last time?' prompt. Use --fresh to redo the onboarding, or pass any of --model / --max / cli|web to skip it entirely.",
+        usage="mtplx start [cli|web] [--fresh] [--max] [--profile stable] [--model PATH_OR_REPO] [--prompt TEXT]",
+        description="Walk through model / mode / surface in three quick steps, then chat. Returning users get a 'same as last time?' prompt. Use --fresh to redo the onboarding, or pass any of --model / --profile / --max / cli|web to skip it entirely.",
     )
-    quickstart_p.add_argument(
+    start_flow_p.add_argument(
         "target",
         nargs="?",
         choices=["web", "openwebui", "open-webui", "cli", "terminal"],
         default=None,
         help="Web chat or terminal chat. Without this argument, MTPLX runs an interactive onboarding (or the 'same as last time?' prompt) on first run.",
     )
-    quickstart_p.add_argument(
+    start_flow_p.add_argument(
         "--fresh",
         action="store_true",
         help="Skip the 'same as last time?' prompt and walk through the full onboarding again",
     )
-    quickstart_p.add_argument("--model", help="Verified model path or Hugging Face repo id")
-    quickstart_p.add_argument("--cache-dir")
-    quickstart_p.add_argument(
+    start_flow_p.add_argument("--model", help="Verified model path or Hugging Face repo id")
+    start_flow_p.add_argument("--cache-dir")
+    start_flow_p.add_argument(
         "--profile",
         choices=PROFILE_CHOICES,
         default="performance-cold",
-        help="Runtime profile; quickstart defaults to the fast cold-speed demo path",
+        help="Runtime profile; start defaults to Medium. Use stable for the hidden conservative path.",
     )
-    quickstart_p.add_argument("--download", action="store_true", help="Download the selected/default model if it is missing")
-    quickstart_p.add_argument("--yes", action="store_true", help="Use defaults without interactive model prompts")
-    quickstart_p.add_argument("--unsafe-force-unverified", action="store_true")
-    quickstart_p.add_argument("--prompt", help="Run one prompt and exit instead of entering the chat loop")
-    quickstart_p.add_argument("--system", help="Optional system prompt")
-    quickstart_p.add_argument(
+    start_flow_p.add_argument("--download", action="store_true", help="Download the selected/default model if it is missing")
+    start_flow_p.add_argument("--yes", action="store_true", help="Use defaults without interactive model prompts")
+    start_flow_p.add_argument("--unsafe-force-unverified", action="store_true")
+    start_flow_p.add_argument("--prompt", help="Run one prompt and exit instead of entering the chat loop")
+    start_flow_p.add_argument("--system", help="Optional system prompt")
+    start_flow_p.add_argument(
         "--max-tokens",
         type=_positive_int,
         default=None,
         help="Terminal response-token cap. Omit to use the model's remaining context.",
     )
-    quickstart_p.add_argument("--temperature", type=float, default=0.6)
-    quickstart_p.add_argument("--top-p", type=float, default=0.95)
-    quickstart_p.add_argument("--top-k", type=int, default=20)
-    quickstart_p.add_argument("--depth", type=int, default=3)
-    quickstart_p.add_argument("--seed", type=int, default=0)
-    _add_reasoning_arg(quickstart_p)
-    quickstart_p.add_argument("--no-stats", action="store_false", dest="show_stats", default=True, help="Hide speed stats after responses")
-    quickstart_p.add_argument("--host", default="127.0.0.1", help="Open WebUI server host for `mtplx quickstart openwebui`")
-    quickstart_p.add_argument("--port", type=int, default=8000, help="Open WebUI server port for `mtplx quickstart openwebui`")
-    quickstart_p.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID, help="Model id to select in Open WebUI")
-    quickstart_p.add_argument("--api-key", help="Optional API key for non-localhost Open WebUI serving")
-    quickstart_p.add_argument("--warmup-tokens", type=int, default=16, help="Warmup tokens for Open WebUI server startup")
-    quickstart_p.add_argument("--stream-interval", type=int, default=1, help="Streaming chunk size for Open WebUI server")
-    quickstart_p.add_argument("--rate-limit", type=int, default=0, help="Server request rate limit for Open WebUI path")
-    quickstart_p.add_argument("--max-response-tokens", type=int, help="Server response token cap for Open WebUI path")
-    quickstart_p.add_argument("--reasoning-parser", default="qwen3", help="Reasoning parser for Open WebUI server streaming")
-    quickstart_p.add_argument("--strict-warmup", action="store_true", help="Fail Open WebUI startup if warmup fails")
-    quickstart_p.add_argument(
+    start_flow_p.add_argument("--temperature", type=float, default=0.6)
+    start_flow_p.add_argument("--top-p", type=float, default=0.95)
+    start_flow_p.add_argument("--top-k", type=int, default=20)
+    start_flow_p.add_argument("--depth", type=int, default=3)
+    start_flow_p.add_argument("--seed", type=int, default=0)
+    _add_reasoning_arg(start_flow_p)
+    start_flow_p.add_argument("--no-stats", action="store_false", dest="show_stats", default=True, help="Hide speed stats after responses")
+    start_flow_p.add_argument("--host", default="127.0.0.1", help="Open WebUI server host for `mtplx start openwebui`")
+    start_flow_p.add_argument("--port", type=int, default=8000, help="Open WebUI server port for `mtplx start openwebui`")
+    start_flow_p.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID, help="Model id to select in Open WebUI")
+    start_flow_p.add_argument("--api-key", help="Optional API key for non-localhost Open WebUI serving")
+    start_flow_p.add_argument("--warmup-tokens", type=int, default=16, help="Warmup tokens for Open WebUI server startup")
+    start_flow_p.add_argument("--stream-interval", type=int, default=1, help="Streaming chunk size for Open WebUI server")
+    start_flow_p.add_argument("--rate-limit", type=int, default=0, help="Server request rate limit for Open WebUI path")
+    start_flow_p.add_argument("--max-response-tokens", type=int, help="Server response token cap for Open WebUI path")
+    start_flow_p.add_argument("--reasoning-parser", default="qwen3", help="Reasoning parser for Open WebUI server streaming")
+    start_flow_p.add_argument("--strict-warmup", action="store_true", help="Fail Open WebUI startup if warmup fails")
+    start_flow_p.add_argument(
         "--strict-fast-path",
         action="store_true",
         help="Fail Open WebUI startup if the optional fast MLX fork is not active",
     )
-    quickstart_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for Open WebUI server")
-    quickstart_p.add_argument(
+    start_flow_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for Open WebUI server")
+    start_flow_p.add_argument(
         "--max-idle-min",
         type=int,
         default=15,
         help="Minutes of chat inactivity before --max drops fans back to auto (default: 15; ramps back up on next request)",
     )
-    quickstart_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON for --dry-run")
-    quickstart_p.add_argument("--dry-run", action="store_true", help="Show what quickstart will do without loading MLX")
-    quickstart_p.set_defaults(func=cmd_quickstart_public)
+    start_flow_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON for --dry-run")
+    start_flow_p.add_argument("--dry-run", action="store_true", help="Show what start will do without loading MLX")
+    start_flow_p.set_defaults(func=cmd_quickstart_public)
 
     setup_p = sub.add_parser("setup", help="Set up MTPLX with a friendly guided default")
     setup_p.add_argument("--config", default="~/.mtplx/config.toml")
@@ -1600,55 +1599,60 @@ def build_parser() -> argparse.ArgumentParser:
     ask_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for this run")
     ask_p.set_defaults(func=cmd_run_public)
 
-    start_p = sub.add_parser("start", help="Start the local MTPLX server")
-    start_p.add_argument("--model", default=default_model)
-    start_p.add_argument("--cache-dir")
-    start_p.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
-    start_p.add_argument("--unsafe-force-unverified", action="store_true")
-    start_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")
-    start_p.add_argument("--host", default="127.0.0.1")
-    start_p.add_argument("--port", type=int, default=8000)
-    start_p.add_argument("--depth", type=int, default=3)
-    start_p.add_argument(
+    quickstart_server_p = sub.add_parser(
+        "quickstart",
+        aliases=["quick-start"],
+        help="Start the local MTPLX server",
+    )
+    quickstart_server_p.add_argument("--model", default=default_model)
+    quickstart_server_p.add_argument("--cache-dir")
+    quickstart_server_p.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
+    quickstart_server_p.add_argument("--unsafe-force-unverified", action="store_true")
+    quickstart_server_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")
+    quickstart_server_p.add_argument("--host", default="127.0.0.1")
+    quickstart_server_p.add_argument("--port", type=int, default=8000)
+    quickstart_server_p.add_argument("--depth", type=int, default=3)
+    quickstart_server_p.add_argument(
         "--api-key",
         default=os.environ.get("MTPLX_AUTH"),
         help="Require Bearer or X-API-Key auth. Required for non-localhost binds.",
     )
-    start_p.add_argument("--rate-limit", type=int, default=0, help="Requests per minute per client/API key. Use 0 to disable.")
-    start_p.add_argument("--stream-interval", type=int, default=1, help="Committed-token batch size per chat SSE chunk.")
-    start_p.add_argument("--max-tokens", dest="max_response_tokens", type=int, help="Default server-side response-token ceiling.")
-    start_p.add_argument("--default-temperature", dest="temperature", type=float, default=0.6)
-    start_p.add_argument("--default-top-p", dest="top_p", type=float, default=0.95)
-    _add_reasoning_arg(start_p)
-    start_p.add_argument("--reasoning-parser", choices=["qwen3", "none"], default="qwen3")
-    start_p.add_argument(
+    quickstart_server_p.add_argument("--rate-limit", type=int, default=0, help="Requests per minute per client/API key. Use 0 to disable.")
+    quickstart_server_p.add_argument("--stream-interval", type=int, default=1, help="Committed-token batch size per chat SSE chunk.")
+    quickstart_server_p.add_argument("--max-tokens", dest="max_response_tokens", type=int, help="Default server-side response-token ceiling.")
+    quickstart_server_p.add_argument("--default-temperature", dest="temperature", type=float, default=0.6)
+    quickstart_server_p.add_argument("--default-top-p", dest="top_p", type=float, default=0.95)
+    _add_reasoning_arg(quickstart_server_p)
+    quickstart_server_p.add_argument("--reasoning-parser", choices=["qwen3", "none"], default="qwen3")
+    quickstart_server_p.add_argument(
         "--stats-footer",
         action="store_true",
         dest="stats_footer",
         default=False,
         help="Append visible MTPLX speed stats to returned text.",
     )
-    start_p.add_argument(
+    quickstart_server_p.add_argument(
         "--no-stats-footer",
         action="store_false",
         dest="stats_footer",
-        help="Keep returned text clean for UI clients. This is the default for start.",
+        help="Keep returned text clean for UI clients. This is the default for quickstart.",
     )
-    start_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for the server lifetime")
-    start_p.add_argument(
+    quickstart_server_p.add_argument("--open-browser", action="store_true", help="Open the built-in browser chat after server startup")
+    quickstart_server_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for the server lifetime")
+    quickstart_server_p.add_argument(
         "--max-idle-min",
         type=int,
         default=15,
         help="Minutes of chat inactivity before --max drops fans back to auto (default: 15; ramps back up on next request)",
     )
-    start_p.add_argument("--warmup-tokens", type=int, default=16, help="Startup warmup generation length. Use 0 to disable.")
-    start_p.add_argument("--strict-warmup", action="store_true", help="Fail server startup if the warmup pass fails.")
-    start_p.add_argument(
+    quickstart_server_p.add_argument("--warmup-tokens", type=int, default=16, help="Startup warmup generation length. Use 0 to disable.")
+    quickstart_server_p.add_argument("--strict-warmup", action="store_true", help="Fail server startup if the warmup pass fails.")
+    quickstart_server_p.add_argument(
         "--strict-fast-path",
         action="store_true",
         help="Fail startup if performance-cold needs the optional fast MLX fork and it is not active.",
     )
-    start_p.set_defaults(func=cmd_serve_public)
+    quickstart_server_p.set_defaults(func=cmd_serve_public)
 
     connect_p = sub.add_parser("connect", help="Show client setup for Open WebUI or Claude Code")
     connect_p.add_argument("integration", nargs="?", choices=["openwebui", "claude-code"])
@@ -1861,6 +1865,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=True,
         help="Do not append the visible MTPLX TPS footer to returned text.",
     )
+    serve_p.add_argument("--open-browser", action="store_true", help="Open the built-in browser chat after server startup")
     serve_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for the server lifetime")
     serve_p.add_argument(
         "--warmup-tokens",

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -1628,6 +1628,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     quickstart_server_p.add_argument("--model", default=default_model)
     quickstart_server_p.add_argument("--cache-dir")
+    quickstart_server_p.add_argument(
+        "--download",
+        action="store_true",
+        help="Download a Hugging Face model before starting if it is not cached",
+    )
     quickstart_server_p.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
     quickstart_server_p.add_argument("--unsafe-force-unverified", action="store_true")
     quickstart_server_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")
@@ -1845,9 +1850,14 @@ def build_parser() -> argparse.ArgumentParser:
     chat_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for this run")
     chat_p.set_defaults(func=cmd_chat_public)
 
-    serve_p = sub.add_parser("serve", help="Start the OpenAI-compatible MTPLX server")
+    serve_p = sub.add_parser("serve", help="Choose model/mode, then start the OpenAI-compatible MTPLX server")
     serve_p.add_argument("--model", default=default_model)
     serve_p.add_argument("--cache-dir")
+    serve_p.add_argument(
+        "--download",
+        action="store_true",
+        help="Download a Hugging Face model before starting if it is not cached",
+    )
     serve_p.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
     serve_p.add_argument("--unsafe-force-unverified", action="store_true")
     serve_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -147,6 +147,17 @@ def _ascii_banner() -> str:
     return "\n".join("  " + _paint(line, "1;36") for line in rows)
 
 
+def _shell_banner_already_shown() -> bool:
+    value = os.environ.get("MTPLX_SHELL_BANNER_SHOWN") or os.environ.get("MTPLX_NO_BANNER")
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _help_banner_prefix() -> str:
+    if _shell_banner_already_shown():
+        return ""
+    return f"{_ascii_banner()}\n\n"
+
+
 def _format_public_help() -> str:
     command_lines = "\n".join(
         f"  {_command_cell(name, 12)} {summary}" for name, summary in PUBLIC_COMMANDS
@@ -155,9 +166,7 @@ def _format_public_help() -> str:
     footer = _muted(
         "more: `mtplx help <command>` · `mtplx help advanced` · `mtplx --help` · `mtplx --version`"
     )
-    return f"""{_ascii_banner()}
-
-  {version_line}
+    return f"""{_help_banner_prefix()}  {version_line}
 
 {_heading("Commands")}
 {command_lines}
@@ -247,9 +256,7 @@ def _format_verbose_help() -> str:
     public_lines = "\n".join(
         f"  {_command_cell(name, 12)} {summary}" for name, summary in PUBLIC_COMMANDS
     )
-    return f"""{_ascii_banner()}
-
-  {_muted(f"v{DISPLAY_VERSION}  ·  Native MTP speculative decoding on Apple Silicon")}
+    return f"""{_help_banner_prefix()}  {_muted(f"v{DISPLAY_VERSION}  ·  Native MTP speculative decoding on Apple Silicon")}
 
 {_heading("Overview")}
 

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -697,7 +697,16 @@ def _cmd_init(args: argparse.Namespace) -> int:
         report["wrote_config"] = True
     if args.download and not args.dry_run:
         try:
-            report["download_result"] = pull_model(args.model, cache_dir=model_dir)
+            progress_callback = None
+            if not args.json:
+                from .commands.public import _download_progress_callback
+
+                progress_callback = _download_progress_callback()
+            report["download_result"] = pull_model(
+                args.model,
+                cache_dir=model_dir,
+                progress_callback=progress_callback,
+            )
         except Exception as exc:
             report["download_error"] = str(exc)
             if args.json:

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -70,7 +70,6 @@ PUBLIC_COMMANDS = (
     ("status", "Check install, model, and integration health"),
     ("inspect", "Check whether a model is MTPLX-compatible"),
     ("models", "List models in the local MTPLX cache"),
-    ("report", "Create a redacted support bundle"),
 )
 
 ADVANCED_COMMANDS = {
@@ -207,7 +206,7 @@ On later runs it offers "same as last time?" so the chat is one keypress away.
 
 What gets asked:
   1. Model — your configured model, the verified default, custom HF, or local
-  2. Mode  — Medium or Max (Stable remains available via --profile stable)
+  2. Mode  — Medium or Max (Stable remains available via --profile safe)
   3. Where — Web UI (default) or terminal CLI
 
 Power-user shortcuts (any of these skip the onboarding wizard):
@@ -221,7 +220,7 @@ Power-user shortcuts (any of these skip the onboarding wizard):
 Useful controls:
   --download       Download the selected/default model if missing
   --model PATH     Use a local model folder or HF repo id
-  --profile stable Use the hidden conservative long-response profile
+  --profile safe   Use the conservative long-response profile
   --prompt TEXT    (cli) Ask once and exit instead of opening chat
   --max-tokens N   (cli) Optional response cap; default uses remaining context
   --no-stats       Hide the TPS footer
@@ -279,7 +278,6 @@ def _format_verbose_help() -> str:
   mtplx start --download            Pull the verified model from Hugging Face
   mtplx quickstart --port 8000      Run the OpenAI/Anthropic server only
   mtplx connect openwebui           Print Open WebUI integration settings
-  mtplx report                      Create a redacted support bundle
   mtplx ask "Write a tiny FastAPI app"
   mtplx inspect Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed
 
@@ -639,7 +637,6 @@ def _cmd_inspect_model(args: argparse.Namespace) -> int:
 def _cmd_init(args: argparse.Namespace) -> int:
     from .hf_loader import model_cache_dir, pull_model
     from .thermal import detect_thermal_control
-    from .diagnostics import host_report, required_download_free_bytes, estimate_runtime_memory_bytes
 
     config_path = Path(args.config).expanduser()
     model_dir = model_cache_dir(args.model_dir)
@@ -653,7 +650,6 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "is_macos": platform.system() == "Darwin",
         "is_apple_silicon": platform.system() == "Darwin" and platform.machine() == "arm64",
     }
-    host = host_report(model_cache=model_dir)
     profile = get_profile(args.profile)
     commands = {
         "doctor": "mtplx doctor --json",
@@ -670,11 +666,6 @@ def _cmd_init(args: argparse.Namespace) -> int:
         "model_dir": str(model_dir),
         "profile": profile.to_dict(),
         "hardware": hardware,
-        "host": host,
-        "resources": {
-            "estimated_runtime_memory_bytes": estimate_runtime_memory_bytes(profile=profile.name),
-            "required_download_free_bytes": required_download_free_bytes(),
-        },
         "thermal_control": {
             "requested": args.thermal_control,
             "detected": thermal_tool,
@@ -739,7 +730,8 @@ def _cmd_profiles(args: argparse.Namespace) -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
-    print(f"default: {DEFAULT_PROFILE_NAME}")
+    print(f"library default: {DEFAULT_PROFILE_NAME}")
+    print("start default: performance-cold (Medium)")
     for profile in payload["profiles"]:
         print(f"{profile['name']}: {profile['summary']}")
     return 0
@@ -773,6 +765,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
 
 def _cmd_connect(args: argparse.Namespace) -> int:
     if not args.integration:
+        server_command = f"mtplx quickstart --host {args.host} --port {args.port}"
         payload = {
             "action": "connect",
             "integrations": [
@@ -787,13 +780,13 @@ def _cmd_connect(args: argparse.Namespace) -> int:
                     "purpose": "Use MTPLX through the Anthropic-compatible Claude Code path.",
                 },
             ],
-            "server": "mtplx quickstart --port 8000",
+            "server": server_command,
         }
         if args.json:
             print(json.dumps(payload, indent=2, sort_keys=True))
         else:
             print("Connect MTPLX")
-            print("1. Start the server: mtplx quickstart --port 8000")
+            print(f"1. Start the server: {server_command}")
             print("2. Pick a client:")
             print("   mtplx connect openwebui")
             print("   mtplx connect claude-code")
@@ -847,6 +840,9 @@ def _cmd_bench_profile(args: argparse.Namespace) -> int:
     from .benchmarks.runners.mtp_depth_sweep import run_mtp_depth_sweep, write_depth_sweep
     from .benchmarks.runners.preflight import run_preflight
     from .benchmarks.schema import now_run_id
+    from .artifacts import inspect_model
+    from .draft_lm_head import draft_lm_head_spec_from_runtime_contract
+    from .draft_sampling import draft_sampler_spec_from_runtime_contract
 
     profile = get_profile(args.profile)
     if profile.name != "performance-cold":
@@ -865,8 +861,29 @@ def _cmd_bench_profile(args: argparse.Namespace) -> int:
             return 2
     prompts = _suite_to_prompts(args.suite, args.prompts)
     out = Path(args.output) if args.output else Path("outputs") / f"{now_run_id(profile.name)}.json"
+    model_arg = NATIVE_MTP_60_MODEL if args.model == str(DEFAULT_RUNTIME_MODEL_DIR) else args.model
+    fallback_draft_lm_head = (
+        None
+        if profile.draft_lm_head is None
+        else {
+            "bits": profile.draft_lm_head.bits,
+            "group_size": profile.draft_lm_head.group_size,
+            "mode": profile.draft_lm_head.mode,
+        }
+    )
+    try:
+        compatibility = inspect_model(model_arg).to_dict().get("compatibility") or {}
+        runtime_contract = compatibility.get("runtime_contract")
+        draft_lm_head = draft_lm_head_spec_from_runtime_contract(
+            runtime_contract,
+            fallback=fallback_draft_lm_head,
+        )
+        draft_sampler = draft_sampler_spec_from_runtime_contract(runtime_contract)
+    except Exception:
+        draft_lm_head = fallback_draft_lm_head
+        draft_sampler = None
     result = run_mtp_depth_sweep(
-        NATIVE_MTP_60_MODEL if args.model == str(DEFAULT_RUNTIME_MODEL_DIR) else args.model,
+        model_arg,
         prompts,
         depths="3",
         temperature=0.6,
@@ -875,7 +892,7 @@ def _cmd_bench_profile(args: argparse.Namespace) -> int:
         max_tokens=192 if args.max_tokens == 128 else args.max_tokens,
         seed=0,
         limit=args.limit,
-        enable_thinking=False if args.disable_thinking else None,
+        enable_thinking=False,
         compare_ar=False,
         mtp_hidden_variant="post_norm",
         mtp_cache_policy="persistent",
@@ -883,18 +900,26 @@ def _cmd_bench_profile(args: argparse.Namespace) -> int:
         min_speculative_depth=1,
         verify_strategy="capture_commit",
         verify_core="linear-gdn-from-conv-tape",
-        draft_lm_head_bits=4,
-        draft_lm_head_group_size=64,
-        draft_lm_head_mode="affine",
+        draft_lm_head_bits=(None if draft_lm_head is None else int(draft_lm_head["bits"])),
+        draft_lm_head_group_size=(64 if draft_lm_head is None else int(draft_lm_head["group_size"])),
+        draft_lm_head_mode=("affine" if draft_lm_head is None else str(draft_lm_head["mode"])),
+        draft_temperature=(
+            None if draft_sampler is None else float(draft_sampler["temperature"])
+        ),
+        draft_top_p=None if draft_sampler is None else float(draft_sampler["top_p"]),
+        draft_top_k=None if draft_sampler is None else int(draft_sampler["top_k"]),
     )
     result["profile"] = {
         **profile.to_dict(),
         "fast_path_env": profile.env_dict(),
-        "model": NATIVE_MTP_60_MODEL,
+        "model": model_arg,
+        "model_id": model_arg,
         "depth": 3,
         "verify_strategy": "capture_commit",
         "verify_core": "linear-gdn-from-conv-tape",
-        "draft_lm_head": {"bits": 4, "group_size": 64, "mode": "affine"},
+        "draft_lm_head": draft_lm_head,
+        "draft_sampler": draft_sampler,
+        "enable_thinking": False,
         "expected_mlx_qmv_fork_commit": profile.required_mlx_fork_commit,
         "strict_preflight": bool(args.strict),
         "preflight": preflight,
@@ -1471,7 +1496,7 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"mtplx {DISPLAY_VERSION} ({__version__})",
     )
     sub = parser.add_subparsers(dest="command", required=True)
-    default_model = DEFAULT_HF_MODEL_ID
+    default_model = str(DEFAULT_RUNTIME_MODEL_DIR)
 
     help_p = sub.add_parser("help", help=argparse.SUPPRESS)
     help_p.add_argument("topic", nargs="?")
@@ -1483,7 +1508,7 @@ def build_parser() -> argparse.ArgumentParser:
     start_flow_p = sub.add_parser(
         "start",
         help="Interactive setup → chat (model · mode · web/CLI)",
-        usage="mtplx start [cli|web] [--fresh] [--max] [--profile stable] [--model PATH_OR_REPO] [--prompt TEXT]",
+        usage="mtplx start [cli|web] [--fresh] [--max] [--profile safe] [--model PATH_OR_REPO] [--prompt TEXT]",
         description="Walk through model / mode / surface in three quick steps, then chat. Returning users get a 'same as last time?' prompt. Use --fresh to redo the onboarding, or pass any of --model / --profile / --max / cli|web to skip it entirely.",
     )
     start_flow_p.add_argument(
@@ -1504,7 +1529,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--profile",
         choices=PROFILE_CHOICES,
         default="performance-cold",
-        help="Runtime profile; start defaults to Medium. Use stable for the hidden conservative path.",
+        help="Runtime profile; start defaults to Medium. Use safe for the hidden Stable path.",
     )
     start_flow_p.add_argument("--download", action="store_true", help="Download the selected/default model if it is missing")
     start_flow_p.add_argument("--yes", action="store_true", help="Use defaults without interactive model prompts")
@@ -1564,12 +1589,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     status_p = sub.add_parser("status", help="Check whether MTPLX is ready to run")
     status_p.add_argument("--project-root", default=".")
-    status_p.add_argument("--smc-path", default=os.environ.get("MTPLX_SMC_PATH") or shutil.which("smc") or "")
-    status_p.add_argument("--sovereign-path", default=os.environ.get("MTPLX_SOVEREIGN_PATH") or shutil.which("sovereign") or "")
     status_p.add_argument("--model-cache")
     status_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     status_p.add_argument("--deep", action="store_true", help="Include launchers, config, staging, release, and integration checks")
-    status_p.add_argument("--summary", action="store_true", help="Print a compact check summary")
     status_p.set_defaults(func=cmd_doctor)
 
     ask_p = sub.add_parser("ask", help="Ask the verified local MTPLX model one question")
@@ -1637,8 +1659,8 @@ def build_parser() -> argparse.ArgumentParser:
         dest="stats_footer",
         help="Keep returned text clean for UI clients. This is the default for quickstart.",
     )
-    quickstart_server_p.add_argument("--open-browser", action="store_true", help="Open the built-in browser chat after server startup")
     quickstart_server_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for the server lifetime")
+    quickstart_server_p.add_argument("--open-browser", action="store_true", help="Open the local browser chat after the server starts")
     quickstart_server_p.add_argument(
         "--max-idle-min",
         type=int,
@@ -1710,7 +1732,7 @@ def build_parser() -> argparse.ArgumentParser:
     report_p.add_argument("--include-paths", action="store_true", help="Keep local paths in the report")
     report_p.add_argument("--deep", action="store_true", default=True, help="Include deep integration checks")
     report_p.add_argument("--summary", action="store_true", help="Print compact check summary instead of JSON")
-    report_p.add_argument("--json", action="store_true", default=True, help="Emit machine-readable JSON")
+    report_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     report_p.set_defaults(func=cmd_doctor, bundle=True)
 
     inspect_public_p = sub.add_parser("inspect", help="Inspect a model and auto-check MTP support")
@@ -1818,6 +1840,7 @@ def build_parser() -> argparse.ArgumentParser:
     chat_p.add_argument("--depth", type=int, default=3)
     chat_p.add_argument("--seed", type=int, default=0)
     _add_reasoning_arg(chat_p)
+    chat_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     chat_p.add_argument("--expect-python", action="store_true")
     chat_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for this run")
     chat_p.set_defaults(func=cmd_chat_public)
@@ -1865,8 +1888,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=True,
         help="Do not append the visible MTPLX TPS footer to returned text.",
     )
-    serve_p.add_argument("--open-browser", action="store_true", help="Open the built-in browser chat after server startup")
     serve_p.add_argument("--max", action="store_true", help="Opt into ThermalForge/TG Pro performance fan profile for the server lifetime")
+    serve_p.add_argument("--open-browser", action="store_true", help="Open the local browser chat after the server starts")
     serve_p.add_argument(
         "--warmup-tokens",
         type=int,
@@ -1919,7 +1942,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--profile",
         choices=(*PROFILE_CHOICES, "native-mtp-60"),
         help=(
-            "Runtime profile for product benchmark actions. Defaults to performance-cold; "
+            "Runtime profile for product benchmark actions. Defaults to safe; "
             "native-mtp-60 is a legacy alias for performance-cold."
         ),
     )
@@ -1967,7 +1990,7 @@ def build_parser() -> argparse.ArgumentParser:
     bench_p.add_argument("--exactness-partition-size", type=int, default=512)
     bench_p.add_argument("--models", nargs="+")
     bench_p.add_argument("--record-champion", action="store_true")
-    bench_p.add_argument("--champion", default=DEFAULT_HF_MODEL_ID)
+    bench_p.add_argument("--champion", default="models/Qwen3.6-27B-MTPLX-Flat4-CyanKiwiMTP")
     bench_p.add_argument("--references", nargs="+", default=["stock_mlx_lm", "llama_cpp"])
     bench_p.add_argument("--url", default="http://127.0.0.1:8000")
     bench_p.add_argument("--port", type=int, default=8041)
@@ -2145,8 +2168,6 @@ def build_parser() -> argparse.ArgumentParser:
     debug_bundle_p.add_argument("--project-root", default=".")
     debug_bundle_p.add_argument("--model-cache")
     debug_bundle_p.add_argument("--url", default="http://127.0.0.1:8000")
-    debug_bundle_p.add_argument("--smc-path", default=os.environ.get("MTPLX_SMC_PATH") or shutil.which("smc") or "")
-    debug_bundle_p.add_argument("--sovereign-path", default=os.environ.get("MTPLX_SOVEREIGN_PATH") or shutil.which("sovereign") or "")
     debug_bundle_p.set_defaults(func=cmd_debug_public)
     debug_hotpath_p = debug_sub.add_parser("hotpath", help="Audit verifier hot-path kernel and sync boundaries")
     debug_hotpath_p.add_argument("--output")
@@ -2777,41 +2798,8 @@ def main(argv: list[str] | None = None) -> int:
     args._cli_flags = _explicit_cli_flags(raw_args)
     from .config import apply_user_config
 
-    try:
-        apply_user_config(args)
-        return int(args.func(args))
-    except ModuleNotFoundError as exc:
-        if str(getattr(exc, "name", "")).startswith("mlx"):
-            from .errors import MissingMLXError
-
-            return _print_cli_error(MissingMLXError(detail=str(exc)), json_mode="--json" in raw_args)
-        raise
-    except Exception as exc:
-        from .errors import MTPLXError
-
-        if isinstance(exc, MTPLXError):
-            return _print_cli_error(exc, json_mode="--json" in raw_args)
-        raise
-
-
-def _print_cli_error(exc: Exception, *, json_mode: bool) -> int:
-    from .errors import MTPLXError
-
-    if isinstance(exc, MTPLXError):
-        payload = exc.to_dict()
-        code = exc.code
-    else:
-        payload = {"error": exc.__class__.__name__, "message": str(exc), "exit_code": 1}
-        code = 1
-    if json_mode:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(f"error: {payload['message']}", file=sys.stderr)
-        if payload.get("fix"):
-            print(f"fix: {payload['fix']}", file=sys.stderr)
-        if payload.get("command"):
-            print(f"try: {payload['command']}", file=sys.stderr)
-    return int(code)
+    apply_user_config(args)
+    return int(args.func(args))
 
 
 def _explicit_cli_flags(raw_args: list[str]) -> set[str]:

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2892,6 +2892,21 @@ def _server_command_name(args: Any) -> str:
     return "quickstart"
 
 
+def _serve_should_onboard(args: Any) -> bool:
+    """Return whether bare interactive ``mtplx serve`` should run setup."""
+
+    if getattr(args, "command", None) != "serve":
+        return False
+    if bool(getattr(args, "yes", False)):
+        return False
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return False
+    cli_flags = getattr(args, "_cli_flags", set()) or set()
+    if {"model", "profile", "max"} & set(cli_flags):
+        return False
+    return True
+
+
 def cmd_serve_public(args: Any) -> int:
     api_key = getattr(args, "api_key", None)
     if not _is_localhost_bind(getattr(args, "host", None)) and not api_key:
@@ -2904,9 +2919,38 @@ def cmd_serve_public(args: Any) -> int:
         else:
             print("error: --api-key is required when --host is not localhost")
             print(f"host: {getattr(args, 'host', None)}")
-            print("try: mtplx quickstart --host 127.0.0.1")
-            print("try: mtplx quickstart --host 0.0.0.0 --api-key $MTPLX_AUTH")
+            server_command = _server_command_name(args)
+            print(f"try: mtplx {server_command} --host 127.0.0.1")
+            print(f"try: mtplx {server_command} --host 0.0.0.0 --api-key $MTPLX_AUTH")
         return 2
+    if _serve_should_onboard(args):
+        from mtplx.ui.onboarding import run_serve_flow
+
+        choice = run_serve_flow(
+            configured_model=getattr(args, "model", None),
+            host=str(getattr(args, "host", "127.0.0.1")),
+            port=int(getattr(args, "port", 8000)),
+            default_open_browser=bool(getattr(args, "open_browser", False)),
+        )
+        if choice is None:
+            _print_serve_start_line("aborted")
+            return 130
+        chosen_model = choice.get("model")
+        if chosen_model:
+            args.model = chosen_model
+            try:
+                from mtplx.hf_loader import repo_id_from_model_ref
+
+                if repo_id_from_model_ref(chosen_model):
+                    args.download = True
+            except Exception:
+                pass
+        chosen_profile = choice.get("profile")
+        if chosen_profile:
+            args.profile = chosen_profile
+        args.max = bool(choice.get("max"))
+        args.open_browser = bool(choice.get("open_browser"))
+        args._onboarded = True
     depth_error = _validate_public_depth(args, printer=_print_serve_start_line)
     if depth_error is not None:
         return depth_error
@@ -2934,17 +2978,57 @@ def cmd_serve_public(args: Any) -> int:
         _print_serve_start_line(f"try: mtplx {server_command} --port {int(args.port) + 1}")
         return 2
     profile = get_profile(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
-    runtime_model, resolve_error = _resolve_runtime_model_path(
-        args.model,
-        cache_dir=getattr(args, "cache_dir", None),
-    )
-    if resolve_error is not None:
-        _print_command_error(
-            resolve_error,
-            command="quickstart",
-            json_output=bool(getattr(args, "json", False)),
+    cache_dir = getattr(args, "cache_dir", None)
+    if bool(getattr(args, "download", False)):
+        try:
+            runtime_model, resolution = _quickstart_resolve_model(
+                args.model,
+                cache_dir=cache_dir,
+                download=True,
+            )
+        except KeyboardInterrupt:
+            _print_serve_start_line("download cancelled")
+            return 130
+        except Exception as exc:
+            _print_serve_start_line(f"error: {exc}")
+            return 1
+        if runtime_model is None:
+            if resolution.get("cancelled"):
+                _print_serve_start_line("download cancelled")
+                return 130
+            gate_inspection = resolution.get("gate_inspection")
+            if isinstance(gate_inspection, dict):
+                _print_model_gate_error(
+                    gate_inspection,
+                    printer=_print_serve_start_line,
+                    json_output=bool(getattr(args, "json", False)),
+                )
+                compatibility = gate_inspection.get("compatibility") or {}
+                return int(compatibility.get("exit_code") or 1)
+            resolution_error = resolution.get("error")
+            if isinstance(resolution_error, dict):
+                _print_command_error(
+                    resolution_error,
+                    command=_server_command_name(args),
+                    json_output=bool(getattr(args, "json", False)),
+                )
+            else:
+                _print_serve_start_line("error: model is not available locally")
+            return 1
+        if resolution.get("downloaded"):
+            _print_serve_start_line(f"downloaded: {resolution.get('download_ref')}")
+    else:
+        runtime_model, resolve_error = _resolve_runtime_model_path(
+            args.model,
+            cache_dir=cache_dir,
         )
-        return 1
+        if resolve_error is not None:
+            _print_command_error(
+                resolve_error,
+                command=_server_command_name(args),
+                json_output=bool(getattr(args, "json", False)),
+            )
+            return 1
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -211,6 +211,62 @@ def _compact_model_summary(inspection: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _profile_draft_lm_head_spec(profile: Any) -> dict[str, Any] | None:
+    draft = getattr(profile, "draft_lm_head", None)
+    if draft is None:
+        return None
+    return {
+        "bits": int(draft.bits),
+        "group_size": int(draft.group_size),
+        "mode": str(draft.mode),
+    }
+
+
+def _profile_draft_sampler_spec(profile: Any) -> dict[str, Any] | None:
+    draft = getattr(profile, "draft_sampler", None)
+    if draft is None:
+        return None
+    return {
+        "temperature": float(draft.temperature),
+        "top_p": float(draft.top_p),
+        "top_k": int(draft.top_k),
+    }
+
+
+def _model_draft_lm_head_spec(
+    inspection: dict[str, Any],
+    profile: Any,
+) -> dict[str, Any] | None:
+    """Use model contract draft-head metadata when present, else profile default."""
+
+    fallback = _profile_draft_lm_head_spec(profile)
+    try:
+        from mtplx.draft_lm_head import draft_lm_head_spec_from_runtime_contract
+
+        compatibility = inspection.get("compatibility") or {}
+        contract = compatibility.get("runtime_contract")
+        return draft_lm_head_spec_from_runtime_contract(contract, fallback=fallback)
+    except ImportError:
+        return fallback
+
+
+def _model_draft_sampler_spec(
+    inspection: dict[str, Any],
+    profile: Any,
+) -> dict[str, Any] | None:
+    """Use model contract draft-sampler metadata when present, else profile default."""
+
+    fallback = _profile_draft_sampler_spec(profile)
+    try:
+        from mtplx.draft_sampling import draft_sampler_spec_from_runtime_contract
+
+        compatibility = inspection.get("compatibility") or {}
+        contract = compatibility.get("runtime_contract")
+        return draft_sampler_spec_from_runtime_contract(contract, fallback=fallback)
+    except ImportError:
+        return fallback
+
+
 def _resolve_model_context_window(tokenizer: Any, model_path: str | Path) -> int:
     candidates: list[int] = []
     tokenizer_max = getattr(tokenizer, "model_max_length", None)
@@ -2572,10 +2628,10 @@ def _print_serve_start_line(text: str = "") -> None:
 
 
 _PROFILE_SHORT_SUMMARIES = {
-    "stable": "conservative no-fan path",
-    "performance-cold": "default cold-speed path",
+    "stable": "Stable: exact/staged long-reply path, no fan control",
+    "performance-cold": "Medium: native-MTP speed path, ~2.2x burst (not sustained)",
     "exact": "QA-only exact paged verifier",
-    "max-diagnostic": "fan-controlled diagnostic",
+    "max-diagnostic": "Max: Medium path with fan control",
 }
 
 
@@ -2587,7 +2643,7 @@ def _print_serve_start_banner(args: Any) -> None:
     port = int(getattr(args, "port", 8000))
     profile_name = getattr(args, "profile", None) or DEFAULT_PROFILE_NAME
     warmup_tokens = int(getattr(args, "warmup_tokens", 16) or 0)
-    mode_label = "Fast MTP" if profile_name == "performance-cold" else profile_name
+    mode_label = "Medium MTP" if profile_name == "performance-cold" else profile_name
     model_label = getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID
     runtime_model = getattr(args, "model", DEFAULT_RUNTIME_MODEL_DIR)
     api_url = f"{_server_url(host, port)}/v1"
@@ -2622,6 +2678,15 @@ def _print_serve_handoff(args: Any, runtime_model: str, profile_name: str) -> No
     _print_serve_start_line()
 
 
+def _server_command_name(args: Any) -> str:
+    command = str(getattr(args, "command", None) or "quickstart")
+    if command == "quick-start":
+        return "quickstart"
+    if command in {"quickstart", "serve"}:
+        return command
+    return "quickstart"
+
+
 def cmd_serve_public(args: Any) -> int:
     api_key = getattr(args, "api_key", None)
     if not _is_localhost_bind(getattr(args, "host", None)) and not api_key:
@@ -2651,8 +2716,9 @@ def cmd_serve_public(args: Any) -> int:
                 return 0
         _print_serve_start_line(f"error: port {int(args.port)} is already in use")
         _print_serve_start_line(f"try: mtplx status")
-        _print_serve_start_line("try: stop the old mtplx start terminal with Ctrl-C")
-        _print_serve_start_line(f"try: mtplx start --port {int(args.port) + 1}")
+        server_command = _server_command_name(args)
+        _print_serve_start_line(f"try: stop the old mtplx {server_command} terminal with Ctrl-C")
+        _print_serve_start_line(f"try: mtplx {server_command} --port {int(args.port) + 1}")
         return 2
     profile = get_profile(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
     runtime_model, resolve_error = _resolve_runtime_model_path(
@@ -2670,6 +2736,12 @@ def cmd_serve_public(args: Any) -> int:
     if gate_exit is not None:
         _print({"error": "model failed MTPLX compatibility gate", "model": inspection})
         return gate_exit
+    draft_lm_head = _model_draft_lm_head_spec(inspection, profile) or {
+        "bits": 4,
+        "group_size": 64,
+        "mode": "affine",
+    }
+    draft_sampler = _model_draft_sampler_spec(inspection, profile)
     strict_fast_path = bool(getattr(args, "strict_fast_path", False))
     relax_mlx_fork_assert = False
     if profile.required_mlx_fork_fragment:
@@ -2686,8 +2758,9 @@ def cmd_serve_public(args: Any) -> int:
                 )
                 observed = fork_status.get("path") or fork_status.get("error") or "unknown"
                 _print_serve_start_line(f"      Found: {observed}")
-                _print_serve_start_line("try: mtplx start --profile stable")
-                _print_serve_start_line("try: mtplx start --profile performance-cold")
+                server_command = _server_command_name(args)
+                _print_serve_start_line(f"try: mtplx {server_command} --profile stable")
+                _print_serve_start_line(f"try: mtplx {server_command} --profile performance-cold")
                 _print_serve_start_line("     (without --strict-fast-path, MTPLX starts in stock-MLX compatibility)")
                 return 2
             relax_mlx_fork_assert = True
@@ -2711,11 +2784,11 @@ def cmd_serve_public(args: Any) -> int:
         "--verify-core",
         "linear-gdn-from-conv-tape",
         "--draft-lm-head-bits",
-        "4",
+        str(draft_lm_head["bits"]),
         "--draft-lm-head-group-size",
-        "64",
+        str(draft_lm_head["group_size"]),
         "--draft-lm-head-mode",
-        "affine",
+        str(draft_lm_head["mode"]),
         "--rate-limit",
         str(getattr(args, "rate_limit", 0)),
         "--stream-interval",
@@ -2725,6 +2798,17 @@ def cmd_serve_public(args: Any) -> int:
         "--model-id",
         str(getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID),
     ]
+    if draft_sampler is not None:
+        cmd.extend(
+            [
+                "--draft-temperature",
+                str(float(draft_sampler["temperature"])),
+                "--draft-top-p",
+                str(float(draft_sampler["top_p"])),
+                "--draft-top-k",
+                str(int(draft_sampler["top_k"])),
+            ]
+        )
     if bool(getattr(args, "open_browser", False)):
         cmd.append("--open-browser")
     if relax_mlx_fork_assert:
@@ -3022,6 +3106,16 @@ def _quickstart_line(text: str = "") -> None:
     print(text, flush=True)
 
 
+def _start_command_name(args: Any) -> str:
+    command = str(getattr(args, "command", None) or "start")
+    return "start" if command in {"start", "quickstart", "quick-start"} else command
+
+
+def _start_invocation(args: Any, suffix: str = "") -> str:
+    command = _start_command_name(args)
+    return f"mtplx {command}{suffix}"
+
+
 def _handle_quickstart_reasoning_command(args: Any, prompt: str) -> bool:
     parts = prompt.strip().split()
     if not parts or parts[0].lower() not in {"/reasoning", "--reasoning"}:
@@ -3169,7 +3263,7 @@ def _quickstart_choose_model(args: Any, *, target: str = "terminal") -> tuple[st
     ):
         return model, download
 
-    _quickstart_line("MTPLX quickstart")
+    _quickstart_line(f"MTPLX {_start_command_name(args)}")
     _quickstart_line("Choose a model:")
     _quickstart_line(f"  1. Use default verified model ({model})")
     _quickstart_line("  2. Choose a local model folder")
@@ -3428,6 +3522,7 @@ def _quickstart_generate(
     max_tokens: int | None = None,
     include_history: bool = True,
     stream_label: str | None = None,
+    draft_sampler: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     from mtplx.benchmarks.schema import PromptCase, encode_prompt_case
     from mtplx.generation import generate_mtpk
@@ -3487,6 +3582,15 @@ def _quickstart_generate(
                 top_p=float(getattr(args, "top_p", 0.95)),
                 top_k=int(getattr(args, "top_k", 20)),
             ),
+            draft_sampler=(
+                None
+                if draft_sampler is None
+                else SamplerConfig(
+                    temperature=float(draft_sampler["temperature"]),
+                    top_p=float(draft_sampler["top_p"]),
+                    top_k=int(draft_sampler["top_k"]),
+                )
+            ),
             speculative_depth=int(getattr(args, "depth", 3)),
             seed=int(getattr(args, "seed", 0)) + turn_index,
             mtp_hidden_variant="post_norm",
@@ -3535,6 +3639,7 @@ def _quickstart_generate(
         "text": out.text,
         "model": _compact_model_summary(inspection),
         "profile": profile.to_dict(),
+        "draft_sampler": draft_sampler,
         "stats": stats,
         "streamed": bool(terminal_streamer and terminal_streamer.started),
         "validations": [
@@ -3559,7 +3664,7 @@ def _quickstart_openwebui_payload(args: Any) -> dict[str, Any]:
         "model_id": model_id,
         "api_key": "not required for localhost",
         "server_command": (
-            f"mtplx start --host {host} --port {port} "
+            f"mtplx quickstart --host {host} --port {port} "
             f"--model {shlex.quote(str(getattr(args, 'model', DEFAULT_RUNTIME_MODEL_DIR)))} "
             "--no-stats-footer --open-browser"
         ),
@@ -3642,6 +3747,8 @@ def _quickstart_run_terminal_chat(args: Any, *, runtime_model: str, inspection: 
 def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspection: dict[str, Any]) -> int:
     profile = get_profile(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
     apply_profile_env(profile.name)
+    draft_lm_head = _model_draft_lm_head_spec(inspection, profile)
+    draft_sampler = _model_draft_sampler_spec(inspection, profile)
 
     from mtplx.runtime import load
     from mtplx.ui import ModelLoadProgress, render_banner, render_startup_panel
@@ -3658,7 +3765,7 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
             mode_label=(
                 "Max MTP"
                 if getattr(args, "max", False)
-                else "Fast MTP"
+                else "Medium MTP"
                 if profile.name == "performance-cold"
                 else profile.name
             ),
@@ -3681,19 +3788,19 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
         progress.set_subtitle("ready")
     _quickstart_line(f"Model ready in {time.perf_counter() - started:.1f}s")
     draft_report = None
-    if profile.draft_lm_head is not None:
+    if draft_lm_head is not None:
         _quickstart_line(
             "[3/4] Installing fast draft head: "
-            f"{profile.draft_lm_head.bits}-bit gs{profile.draft_lm_head.group_size}"
+            f"{int(draft_lm_head['bits'])}-bit gs{int(draft_lm_head['group_size'])}"
         )
         draft_started = time.perf_counter()
         from mtplx.draft_lm_head import _install_draft_lm_head
 
         draft_report = _install_draft_lm_head(
             rt,
-            bits=profile.draft_lm_head.bits,
-            group_size=profile.draft_lm_head.group_size,
-            mode=profile.draft_lm_head.mode,
+            bits=int(draft_lm_head["bits"]),
+            group_size=int(draft_lm_head["group_size"]),
+            mode=str(draft_lm_head["mode"]),
         )
         _quickstart_line(f"      draft head ready in {time.perf_counter() - draft_started:.1f}s")
     _quickstart_line(
@@ -3703,7 +3810,14 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
     )
     _quickstart_line(f"Reasoning: {_reasoning_mode(args)}")
     if draft_report is not None:
-        _quickstart_line("Fast path: draft-only LM head is active.")
+        _quickstart_line("Medium/Max speed path: draft-only LM head is active.")
+    if draft_sampler is not None:
+        _quickstart_line(
+            "Draft sampler: "
+            f"temp={float(draft_sampler['temperature']):.2f} "
+            f"top_p={float(draft_sampler['top_p']):.2f} "
+            f"top_k={int(draft_sampler['top_k'])}"
+        )
     _quickstart_line()
 
     history: list[dict[str, str]] = []
@@ -3730,6 +3844,7 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
             max_tokens=max_tokens,
             include_history=include_history,
             stream_label=response_label,
+            draft_sampler=draft_sampler,
         )
         text = str(payload["text"])
         if not payload.get("streamed"):
@@ -3755,7 +3870,8 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
 
     if not sys.stdin.isatty():
         _quickstart_line("error: no interactive terminal detected")
-        _quickstart_line('try: mtplx quickstart --prompt "Say hi"')
+        prompt_hint = _start_invocation(args, ' --prompt "Say hi"')
+        _quickstart_line(f"try: {prompt_hint}")
         return 2
 
     _quickstart_line("Chat is ready. Type /speed for a real TPS sample, /reasoning on|off|auto, or /exit to quit.")
@@ -3799,7 +3915,7 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
 def cmd_quickstart_public(args: Any) -> int:
     raw_target = getattr(args, "target", None)
 
-    # Quickstart is the most common reason fans get blasted, so this is the
+    # Start is the most common reason fans get blasted, so this is the
     # right place to scrub a stale --max marker left behind by a previously
     # killed session. No-op when the previous run exited cleanly.
     try:
@@ -3812,7 +3928,7 @@ def cmd_quickstart_public(args: Any) -> int:
                 f"did not exit cleanly (stale pid {recovery.get('stale_pid')})\n"
             )
     except Exception:
-        pass  # best-effort — never block quickstart on cleanup
+        pass  # best-effort — never block start on cleanup
 
     # Onboarding flow: only when interactive, no explicit CLI overrides, and not
     # in dry-run / one-shot prompt / non-interactive automation. We detect
@@ -3852,6 +3968,15 @@ def cmd_quickstart_public(args: Any) -> int:
         chosen_model = choice.get("model")
         if chosen_model:
             args.model = chosen_model
+            # The user deliberately picked this model in onboarding. If it is
+            # an HF repo and missing locally, fetch without another prompt.
+            try:
+                from mtplx.hf_loader import repo_id_from_model_ref
+
+                if repo_id_from_model_ref(chosen_model):
+                    args.download = True
+            except Exception:
+                pass
         chosen_profile = choice.get("profile")
         if chosen_profile:
             args.profile = chosen_profile
@@ -3892,16 +4017,16 @@ def cmd_quickstart_public(args: Any) -> int:
     else:
         target = raw_target
     if target not in QUICKSTART_TARGETS:
-        _quickstart_line(f"error: unknown quickstart target: {raw_target}")
-        _quickstart_line("try: mtplx quickstart")
-        _quickstart_line("try: mtplx quickstart cli")
+        _quickstart_line(f"error: unknown start target: {raw_target}")
+        _quickstart_line(f"try: {_start_invocation(args)}")
+        _quickstart_line(f"try: {_start_invocation(args, ' cli')}")
         return 2
     model, download = _quickstart_choose_model(args, target=target)
     cache_dir = getattr(args, "cache_dir", None)
     if getattr(args, "dry_run", False):
         openwebui = _quickstart_openwebui_payload(args) if target == "openwebui" else None
         payload = {
-            "action": "quickstart",
+            "action": _start_command_name(args),
             "target": target,
             "model": model,
             "cache_dir": cache_dir,
@@ -3910,12 +4035,12 @@ def cmd_quickstart_public(args: Any) -> int:
             "terminal_chat": target == "terminal",
             "openwebui": openwebui,
             "stats_visible": bool(getattr(args, "show_stats", True)),
-            "next": "mtplx quickstart" if target == "openwebui" else "mtplx quickstart cli",
+            "next": _start_invocation(args) if target == "openwebui" else _start_invocation(args, " cli"),
         }
         if getattr(args, "json", False):
             _print(payload)
         else:
-            _quickstart_line("MTPLX quickstart")
+            _quickstart_line(f"MTPLX {_start_command_name(args)}")
             _quickstart_line(f"model: {model}")
             _quickstart_line(f"profile: {payload['profile']}")
             _quickstart_line(f"download if missing: {str(download).lower()}")
@@ -3925,7 +4050,7 @@ def cmd_quickstart_public(args: Any) -> int:
                 _quickstart_line("then: load once -> chat in this terminal -> stream output -> show speed stats")
         return 0
 
-    _quickstart_line("MTPLX quickstart")
+    _quickstart_line(f"MTPLX {_start_command_name(args)}")
     _quickstart_line(f"[1/4] Checking model: {model}")
     try:
         runtime_model, resolution = _quickstart_resolve_model(model, cache_dir=cache_dir, download=download)
@@ -3967,8 +4092,8 @@ def cmd_quickstart_public(args: Any) -> int:
         _quickstart_line("model is not available locally")
         if detail:
             _quickstart_line(f"detail: {detail}")
-        _quickstart_line("try: mtplx quickstart --download")
-        _quickstart_line("try: mtplx quickstart --model /path/to/model")
+        _quickstart_line(f"try: {_start_invocation(args, ' --download')}")
+        _quickstart_line(f"try: {_start_invocation(args, ' --model /path/to/model')}")
         return 1
 
     inspection, gate_exit = _model_gate(

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -52,10 +52,17 @@ from mtplx.backends.registry import (
     TIER_ARCH_COMPATIBLE_UNVERIFIED,
     architecture_catalog,
 )
-from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_MODEL_ID, DEFAULT_PROFILE_NAME, apply_profile_env, get_profile
+from mtplx.profiles import (
+    DEFAULT_HF_MODEL_ID,
+    DEFAULT_MODEL_ID,
+    DEFAULT_PROFILE_NAME,
+    DEFAULT_PUBLIC_MODEL_ID,
+    apply_profile_env,
+    get_profile,
+)
 
 
-DEFAULT_CHAMPION = "models/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP"
+DEFAULT_CHAMPION = DEFAULT_HF_MODEL_ID
 QUICKSTART_SPEED_MIN_TOKENS = 64
 QUICKSTART_SPEED_MAX_TOKENS = 192
 QUICKSTART_SPEED_PROMPT = (
@@ -303,7 +310,7 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
     from mtplx.config import load_user_config
 
     config = load_user_config()
-    default_model = config.model or DEFAULT_CHAMPION
+    default_model = config.model or DEFAULT_HF_MODEL_ID
     model_report: dict[str, Any]
     try:
         model_report = _compact_model_summary(inspect_model(default_model).to_dict())
@@ -314,7 +321,7 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
             "error": str(exc),
         }
     release_repo = repo_root()
-    staging_dir = Path("hf-staging/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP")
+    staging_dir = Path("hf-staging/Qwen3.6-27B-MTPLX-Optimized-Speed")
     manifest = staging_dir / "MTPLX_PUBLISH_MANIFEST.json"
     server_deps = {
         name: importlib.util.find_spec(name) is not None
@@ -359,6 +366,8 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
         },
         "product_policy": {
             "fanmax_counts_for_product_gate": False,
+            "default_hf_model_id": DEFAULT_HF_MODEL_ID,
+            "default_profile": DEFAULT_PROFILE_NAME,
             "safe_mode_drops_per_cycle_events": os.environ.get("MTPLX_DROP_EVENTS") == "1",
         },
     }
@@ -392,10 +401,17 @@ def _resolve_runtime_model_path(model: str, *, cache_dir: str | None = None) -> 
     try:
         return str(resolve_model_path(model, cache_dir=cache_dir)), None
     except Exception as exc:
+        from mtplx.hf_loader import repo_id_from_model_ref
+
+        repo_id = repo_id_from_model_ref(model)
+        command = f"mtplx pull {repo_id}" if repo_id else None
         return model, {
             "error": "model is not available locally",
             "model": model,
             "detail": str(exc),
+            "exit_code": 6,
+            "fix": "Download the model or choose an existing local model folder.",
+            "command": command,
         }
 
 
@@ -470,15 +486,21 @@ def cmd_doctor(args: Any) -> int:
     env = collect_environment(args.project_root).to_dict()
     from mtplx.hf_loader import hf_cache_report
     from mtplx.thermal import detect_thermal_control
+    from mtplx.diagnostics import build_diagnostics_payload, write_doctor_bundle
 
     smc_path_raw = getattr(args, "smc_path", None) or shutil.which("smc") or ""
     sovereign_path_raw = getattr(args, "sovereign_path", None) or shutil.which("sovereign") or ""
     smc_path = Path(smc_path_raw) if smc_path_raw else None
     sovereign_path = Path(sovereign_path_raw) if sovereign_path_raw else None
+    thermal_control = detect_thermal_control()
+    server_deps = {
+        name: importlib.util.find_spec(name) is not None
+        for name in ("fastapi", "uvicorn")
+    }
     report = {
         "environment": env,
         "huggingface": hf_cache_report(cache_dir=getattr(args, "model_cache", None)),
-        "thermal_control": detect_thermal_control(),
+        "thermal_control": thermal_control,
         "tools": {
             "python": sys.executable,
             "powermetrics": shutil.which("powermetrics"),
@@ -493,9 +515,36 @@ def cmd_doctor(args: Any) -> int:
             "benchmark_exactness_smoke_context": 2048,
         },
     }
+    report["diagnostics"] = build_diagnostics_payload(
+        model_cache=getattr(args, "model_cache", None),
+        deep=bool(getattr(args, "deep", False)),
+        mlx_info=env.get("mlx") if isinstance(env.get("mlx"), dict) else None,
+        thermal_control=thermal_control,
+        server_dependencies=server_deps if getattr(args, "deep", False) else None,
+    )
     if getattr(args, "deep", False):
         report = _deep_doctor_report(args, report)
-    _print(report)
+    if getattr(args, "bundle", False):
+        report["bundle"] = write_doctor_bundle(
+            report=report,
+            output_dir=getattr(args, "output_dir", None),
+            include_paths=bool(getattr(args, "include_paths", False)),
+        )
+    if getattr(args, "json", False):
+        _print(report)
+    elif getattr(args, "summary", False):
+        diagnostics = report["diagnostics"]
+        print(f"MTPLX doctor: {diagnostics['overall']}")
+        for check in diagnostics["checks"]:
+            marker = check["status"].upper()
+            print(f"{marker:4} {check['id']}: {check['observed']}")
+            if check.get("fix") and check["status"] != "pass":
+                print(f"     fix: {check['fix']}")
+        if report.get("bundle"):
+            print(f"bundle: {report['bundle']['bundle_dir']}")
+            print(f"zip: {report['bundle']['bundle_zip']}")
+    else:
+        _print(report)
     return 0
 
 
@@ -666,7 +715,7 @@ def _cmd_bench_run(args: Any) -> int:
     )
     if resolve_error is not None:
         _print(resolve_error)
-        return 1
+        return int(resolve_error.get("exit_code", 1))
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -2395,8 +2444,57 @@ def _server_url(host: str, port: int) -> str:
     return f"http://{display_host}:{int(port)}"
 
 
+def _api_base_url(host: str, port: int) -> str:
+    return _server_url(host, port).rstrip("/") + "/v1"
+
+
 def _chat_url(host: str, port: int) -> str:
     return _server_url(host, port) + "/"
+
+
+def _openwebui_docker_api_base_url(port: int) -> str:
+    return f"http://host.docker.internal:{int(port)}/v1"
+
+
+def _openwebui_docker_command(
+    *,
+    mtplx_port: int,
+    webui_port: int = 3000,
+    single_user: bool = False,
+    api_key: str = "mtplx-local",
+) -> list[str]:
+    command = [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        "open-webui",
+        "--restart",
+        "unless-stopped",
+        "-p",
+        f"{int(webui_port)}:8080",
+        "--add-host=host.docker.internal:host-gateway",
+        "-e",
+        "ENABLE_OPENAI_API=True",
+        "-e",
+        f"OPENAI_API_BASE_URL={_openwebui_docker_api_base_url(mtplx_port)}",
+        "-e",
+        f"OPENAI_API_KEY={api_key}",
+    ]
+    if single_user:
+        command.extend(["-e", "WEBUI_AUTH=False"])
+    command.extend(
+        [
+            "-v",
+            "open-webui:/app/backend/data",
+            "ghcr.io/open-webui/open-webui:main",
+        ]
+    )
+    return command
+
+
+def _shell_join(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
 
 
 def _open_browser_url(url: str) -> None:
@@ -2474,8 +2572,8 @@ def _print_serve_start_line(text: str = "") -> None:
 
 
 _PROFILE_SHORT_SUMMARIES = {
-    "stable": "default no-fan path",
-    "performance-cold": "cold-speed path",
+    "stable": "conservative no-fan path",
+    "performance-cold": "default cold-speed path",
     "exact": "QA-only exact paged verifier",
     "max-diagnostic": "fan-controlled diagnostic",
 }
@@ -2490,7 +2588,7 @@ def _print_serve_start_banner(args: Any) -> None:
     profile_name = getattr(args, "profile", None) or DEFAULT_PROFILE_NAME
     warmup_tokens = int(getattr(args, "warmup_tokens", 16) or 0)
     mode_label = "Fast MTP" if profile_name == "performance-cold" else profile_name
-    model_label = getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp"
+    model_label = getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID
     runtime_model = getattr(args, "model", DEFAULT_RUNTIME_MODEL_DIR)
     api_url = f"{_server_url(host, port)}/v1"
     chat_url = _chat_url(host, port)
@@ -2540,11 +2638,11 @@ def cmd_serve_public(args: Any) -> int:
             base = _server_url(str(getattr(args, "host", "127.0.0.1")), int(getattr(args, "port", 8000)))
             health = _http_json(base + "/health", timeout=1.5)
             if health.get("ok"):
-                model_id = health.get("model") or getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp"
+                model_id = health.get("model") or getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID
                 chat_url = _chat_url(str(getattr(args, "host", "127.0.0.1")), int(getattr(args, "port", 8000)))
                 _print_serve_start_line("MTPLX is already running.")
                 _print_serve_start_line(f"Chat URL: {chat_url}")
-                _print_serve_start_line(f"OpenAI API Base URL: {base}/v1")
+                _print_serve_start_line(f"OpenAI API Base URL: {_api_base_url(str(getattr(args, 'host', '127.0.0.1')), int(getattr(args, 'port', 8000)))}")
                 _print_serve_start_line(f"Model: {model_id}")
                 _print_serve_start_line("API key: leave blank for localhost")
                 _print_serve_start_line("Opening chat UI in your browser...")
@@ -2563,7 +2661,7 @@ def cmd_serve_public(args: Any) -> int:
     )
     if resolve_error is not None:
         _print(resolve_error)
-        return 1
+        return int(resolve_error.get("exit_code", 1))
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -2625,7 +2723,7 @@ def cmd_serve_public(args: Any) -> int:
         "--warmup-tokens",
         str(getattr(args, "warmup_tokens", 16)),
         "--model-id",
-        str(getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp"),
+        str(getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID),
     ]
     if bool(getattr(args, "open_browser", False)):
         cmd.append("--open-browser")
@@ -2774,7 +2872,7 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
         cache_dir=getattr(args, "cache_dir", None),
     )
     if resolve_error is not None:
-        return 1, resolve_error, []
+        return int(resolve_error.get("exit_code", 1)), resolve_error, []
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -3280,18 +3378,15 @@ def _quickstart_stats_line(payload: dict[str, Any]) -> str:
         decode_tok_s, decode_elapsed_s = _quickstart_decode_timing(stats)
     verify_ms = stats.get("verify_ms_per_call")
     verify_text = f"{verify_ms:.1f} ms/verify" if isinstance(verify_ms, (int, float)) else "verify n/a"
-    prefer_stream_tps = stream_tok_s is not None and generated_tokens >= 8
-    if prefer_stream_tps:
-        speed_text = f"{stream_tok_s:.2f} tok/s"
-        if decode_tok_s is not None and abs(stream_tok_s - decode_tok_s) >= 0.1:
-            speed_text = f"{speed_text} | decode={decode_tok_s:.2f}"
-        if total_tok_s is not None and abs(stream_tok_s - total_tok_s) >= 0.1:
-            speed_text = f"{speed_text} | total={total_tok_s:.2f}"
-    elif decode_tok_s is not None:
+    if decode_tok_s is not None:
         speed_text = f"{decode_tok_s:.2f} tok/s"
         if stream_tok_s is not None and abs(decode_tok_s - stream_tok_s) >= 0.1:
-            speed_text = f"{speed_text} | stream={stream_tok_s:.2f}"
+            speed_text = f"{speed_text} | live_window={stream_tok_s:.2f}"
         if total_tok_s is not None and abs(decode_tok_s - total_tok_s) >= 0.1:
+            speed_text = f"{speed_text} | total={total_tok_s:.2f}"
+    elif stream_tok_s is not None and generated_tokens >= 8:
+        speed_text = f"{stream_tok_s:.2f} live-window tok/s"
+        if total_tok_s is not None and abs(stream_tok_s - total_tok_s) >= 0.1:
             speed_text = f"{speed_text} | total={total_tok_s:.2f}"
     elif total_tok_s is not None:
         speed_text = f"{total_tok_s:.2f} total tok/s"
@@ -3452,12 +3547,15 @@ def _quickstart_generate(
 def _quickstart_openwebui_payload(args: Any) -> dict[str, Any]:
     host = str(getattr(args, "host", "127.0.0.1"))
     port = int(getattr(args, "port", 8000))
-    model_id = str(getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp")
-    base = f"http://{_connect_host_for_bind(host)}:{port}"
+    model_id = str(getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID)
+    server_url = f"http://{_connect_host_for_bind(host)}:{port}"
+    api_base_url = server_url + "/v1"
     return {
         "integration": "openwebui",
-        "base_url": base,
-        "chat_url": base + "/",
+        "server_url": server_url,
+        "base_url": api_base_url,
+        "api_base_url": api_base_url,
+        "chat_url": server_url + "/",
         "model_id": model_id,
         "api_key": "not required for localhost",
         "server_command": (
@@ -3466,8 +3564,8 @@ def _quickstart_openwebui_payload(args: Any) -> dict[str, Any]:
             "--no-stats-footer --open-browser"
         ),
         "openwebui_steps": [
-            f"Open chat UI: {base}/",
-            f"OpenAI-compatible API base URL: {base}/v1",
+            f"Open chat UI: {server_url}/",
+            f"OpenAI-compatible API base URL: {api_base_url}",
             f"Model: {model_id}",
         ],
     }
@@ -3489,7 +3587,7 @@ def _quickstart_run_openwebui(args: Any, *, runtime_model: str, inspection: dict
         model=runtime_model,
         cache_dir=getattr(args, "cache_dir", None),
         profile=getattr(args, "profile", None) or "performance-cold",
-        model_id=getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp",
+        model_id=getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
         yes=True,
         host=str(getattr(args, "host", "127.0.0.1")),
@@ -3932,33 +4030,52 @@ def cmd_metrics_public(args: Any) -> int:
 
 def cmd_integrate_public(args: Any) -> int:
     action = args.integration
-    base = f"http://{args.host}:{args.port}"
-    model_id = getattr(args, "model_id", None) or "mtplx-qwen36-27b-native-mtp"
+    server_url = f"http://{args.host}:{args.port}"
+    api_base_url = server_url.rstrip("/") + "/v1"
+    model_id = getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID
     if action == "openwebui":
+        docker_command = _openwebui_docker_command(
+            mtplx_port=int(args.port),
+            webui_port=int(getattr(args, "webui_port", 3000) or 3000),
+            single_user=bool(getattr(args, "single_user", False)),
+            api_key=str(getattr(args, "api_key", None) or "mtplx-local"),
+        )
         payload = {
             "integration": "openwebui",
-            "base_url": base,
+            "server_url": server_url,
+            "base_url": api_base_url,
+            "api_base_url": api_base_url,
+            "docker_api_base_url": _openwebui_docker_api_base_url(int(args.port)),
             "model_id": model_id,
             "server_command": (
                 f"mtplx serve --host {args.host} --port {args.port} "
                 "--no-stats-footer"
+            ),
+            "docker_command": _shell_join(docker_command),
+            "docker_command_argv": docker_command,
+            "single_user_warning": (
+                "WEBUI_AUTH=False creates a single-user Open WebUI instance and "
+                "cannot be safely toggled on an existing shared data volume."
+                if getattr(args, "single_user", False)
+                else None
             ),
             "api_key": {
                 "required_for_localhost": False,
                 "env": args.api_key_env,
             },
             "notes": [
-                "Use the base URL as the OpenAI-compatible endpoint.",
+                "Use the /v1 base URL as the OpenAI-compatible endpoint.",
+                "Dockerized Open WebUI must use host.docker.internal, not 127.0.0.1, to reach MTPLX on the Mac host.",
                 "Keep --no-stats-footer enabled for UI clients.",
             ],
         }
     elif action == "claude-code":
         payload = {
             "integration": "claude-code",
-            "base_url": base,
+            "base_url": server_url,
             "model_id": model_id,
             "environment": {
-                "ANTHROPIC_BASE_URL": base,
+                "ANTHROPIC_BASE_URL": server_url,
                 "ANTHROPIC_API_KEY": f"${args.api_key_env}",
             },
             "server_command": (
@@ -3966,22 +4083,56 @@ def cmd_integrate_public(args: Any) -> int:
                 "--no-stats-footer"
             ),
             "smoke": {
-                "root_probe": f"curl {base}/",
-                "messages": f"curl {base}/v1/messages",
+                "root_probe": f"curl {server_url}/",
+                "messages": f"curl {server_url}/v1/messages",
             },
         }
     else:
         raise SystemExit(f"unknown integration: {action}")
     if getattr(args, "smoke", False):
         payload["smoke_result"] = {
-            "health": _http_json(base + "/health", timeout=float(args.timeout)),
-            "models": _http_json(base + "/v1/models", timeout=float(args.timeout)),
+            "health": _http_json(server_url + "/health", timeout=float(args.timeout)),
+            "models": _http_json(api_base_url + "/models", timeout=float(args.timeout)),
         }
     if getattr(args, "json", False):
         _print(payload)
     else:
         for key, value in payload.items():
             print(f"{key}: {value}")
+    return 0
+
+
+def cmd_openwebui_public(args: Any) -> int:
+    if args.openwebui_action != "docker-command":
+        raise SystemExit(f"unknown openwebui action: {args.openwebui_action}")
+    command = _openwebui_docker_command(
+        mtplx_port=int(getattr(args, "mtplx_port", 8000)),
+        webui_port=int(getattr(args, "webui_port", 3000)),
+        single_user=bool(getattr(args, "single_user", False)),
+        api_key=str(getattr(args, "api_key", None) or "mtplx-local"),
+    )
+    payload = {
+        "action": "openwebui docker-command",
+        "docker_command": _shell_join(command),
+        "docker_command_argv": command,
+        "openwebui_url": f"http://127.0.0.1:{int(getattr(args, 'webui_port', 3000))}",
+        "mtplx_api_base_url_for_container": _openwebui_docker_api_base_url(
+            int(getattr(args, "mtplx_port", 8000))
+        ),
+        "single_user_warning": (
+            "WEBUI_AUTH=False creates a single-user Open WebUI instance and cannot be safely toggled on an existing shared data volume."
+            if getattr(args, "single_user", False)
+            else None
+        ),
+    }
+    if getattr(args, "json", False):
+        _print(payload)
+    else:
+        print(payload["docker_command"])
+        print(f"Open WebUI: {payload['openwebui_url']}")
+        print(f"MTPLX API from container: {payload['mtplx_api_base_url_for_container']}")
+        if payload["single_user_warning"]:
+            print(f"warning: {payload['single_user_warning']}")
     return 0
 
 

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -211,6 +211,57 @@ def _compact_model_summary(inspection: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _model_gate_error_lines(inspection: dict[str, Any]) -> list[str]:
+    compatibility = inspection.get("compatibility") or {}
+    mtp = inspection.get("mtp") or {}
+    lines = [
+        "error: model cannot run with MTPLX",
+        f"model: {inspection.get('model_dir') or inspection.get('model') or 'unknown'}",
+        f"tier: {compatibility.get('tier') or 'unknown'}",
+    ]
+    runtime_compatibility = compatibility.get("runtime_compatibility") or inspection.get("runtime_compatibility")
+    if runtime_compatibility:
+        lines.append(f"runtime: {runtime_compatibility}")
+    message = compatibility.get("message") or inspection.get("detail")
+    if message:
+        lines.append(f"reason: {message}")
+    if mtp:
+        lines.append(
+            "mtp: "
+            f"exists={str(bool(mtp.get('exists'))).lower()}, "
+            f"tensors={mtp.get('tensor_count', 0)}, "
+            f"gate={str(bool(mtp.get('passes_tensor_gate'))).lower()}"
+        )
+    if runtime_compatibility == "missing-mtp-weights":
+        lines.append(
+            "fix: choose a model with real MTP weights, or graft an MTP sidecar "
+            "into this base model."
+        )
+    elif compatibility.get("unsafe_force_required"):
+        lines.append("try: add --unsafe-force-unverified --yes to run without support guarantees")
+    else:
+        lines.append("try: mtplx inspect MODEL")
+    return lines
+
+
+def _print_model_gate_error(
+    inspection: dict[str, Any],
+    *,
+    printer=print,
+    json_output: bool = False,
+) -> None:
+    if json_output:
+        _print(
+            {
+                "error": "model failed MTPLX compatibility gate",
+                "model": _compact_model_summary(inspection),
+            }
+        )
+        return
+    for line in _model_gate_error_lines(inspection):
+        printer(line)
+
+
 def _profile_draft_lm_head_spec(profile: Any) -> dict[str, Any] | None:
     draft = getattr(profile, "draft_lm_head", None)
     if draft is None:
@@ -2734,7 +2785,7 @@ def cmd_serve_public(args: Any) -> int:
         yes=bool(getattr(args, "yes", False)),
     )
     if gate_exit is not None:
-        _print({"error": "model failed MTPLX compatibility gate", "model": inspection})
+        _print_model_gate_error(inspection, printer=_print_serve_start_line)
         return gate_exit
     draft_lm_head = _model_draft_lm_head_spec(inspection, profile) or {
         "bits": 4,
@@ -4082,7 +4133,11 @@ def cmd_quickstart_public(args: Any) -> int:
                 yes=bool(getattr(args, "yes", False)),
             )
             if gate_exit is not None:
-                _print({"error": "model failed MTPLX compatibility gate", "model": inspection})
+                _print_model_gate_error(
+                    inspection,
+                    printer=_quickstart_line,
+                    json_output=bool(getattr(args, "json", False)),
+                )
                 return gate_exit
             if target == "openwebui":
                 args.model = runtime_model
@@ -4102,7 +4157,11 @@ def cmd_quickstart_public(args: Any) -> int:
         yes=bool(getattr(args, "yes", False)),
     )
     if gate_exit is not None:
-        _print({"error": "model failed MTPLX compatibility gate", "model": inspection})
+        _print_model_gate_error(
+            inspection,
+            printer=_quickstart_line,
+            json_output=bool(getattr(args, "json", False)),
+        )
         return gate_exit
     _quickstart_line(f"model ready: {runtime_model}")
     if resolution.get("downloaded"):

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -35,6 +35,7 @@ from mtplx.kpi import (
     EXIT_EXACTNESS,
     EXIT_QUALITY,
     EXIT_STRICT_GATE,
+    EXIT_TELEMETRY,
     EXIT_UNSUPPORTED_MODEL,
     build_benchmark_envelope,
     default_output_path,
@@ -62,7 +63,7 @@ from mtplx.profiles import (
 )
 
 
-DEFAULT_CHAMPION = DEFAULT_HF_MODEL_ID
+DEFAULT_CHAMPION = "models/Qwen3.6-27B-MTPLX-Flat4-CyanKiwiMTP"
 QUICKSTART_SPEED_MIN_TOKENS = 64
 QUICKSTART_SPEED_MAX_TOKENS = 192
 QUICKSTART_SPEED_PROMPT = (
@@ -92,6 +93,7 @@ EXTERNAL_RUNTIME_ENV_KEYS = (
     "MTPLX_EXPORT_VERIFY_DOT_INCLUDE_CAPTURES",
 )
 LOCALHOST_BINDS = {"", "127.0.0.1", "::1", "localhost"}
+MAX_PUBLIC_SPECULATIVE_DEPTH = 3
 
 
 def _print(value: Any) -> None:
@@ -159,6 +161,13 @@ def _model_gate(
     tier = compatibility.get("tier")
     exit_code = int(compatibility.get("exit_code", EXIT_UNSUPPORTED_MODEL))
     if exit_code == 0 and compatibility.get("can_run"):
+        if compatibility.get("unverified_model"):
+            print(
+                "WARNING: running a family-compatible MTPLX model without a "
+                "recorded mtplx_runtime.json exactness baseline; stats will be "
+                "marked unverified until this artifact is smoke-verified.",
+                file=sys.stderr,
+            )
         return inspection, None
     if (
         unsafe_force_unverified
@@ -278,6 +287,59 @@ def _print_model_gate_error(
         printer(line)
 
 
+def _print_command_error(
+    payload: dict[str, Any],
+    *,
+    command: str,
+    json_output: bool = False,
+) -> None:
+    if json_output:
+        _print(payload)
+        return
+    model = payload.get("model")
+    if isinstance(model, dict):
+        _print_model_gate_error(model, json_output=False)
+        return
+    error = str(payload.get("error") or "model is not available locally")
+    print(f"error: {error}")
+    if model:
+        print(f"model: {model}")
+    detail = payload.get("detail")
+    if detail:
+        print(f"detail: {detail}")
+    if error == "model is not available locally":
+        print(f"try: mtplx {command} --download --model {model}")
+        print("try: mtplx models")
+
+
+def _validate_public_depth(args: Any, *, printer=print) -> int | None:
+    try:
+        depth = int(getattr(args, "depth", 3))
+    except (TypeError, ValueError):
+        printer("error: --depth must be an integer")
+        return 2
+    if depth < 1 or depth > MAX_PUBLIC_SPECULATIVE_DEPTH:
+        printer(
+            "error: --depth must be between "
+            f"1 and {MAX_PUBLIC_SPECULATIVE_DEPTH} for the current MTPLX runtime"
+        )
+        printer("hint: the shipped speed path is tuned for depth 3")
+        return 2
+    args.depth = depth
+    return None
+
+
+def _format_bytes(size_bytes: int | float | None) -> str:
+    if not isinstance(size_bytes, (int, float)):
+        return "unknown size"
+    size = float(size_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(size) < 1000.0 or unit == "TB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1000.0
+    return f"{size:.1f} TB"
+
+
 def _profile_draft_lm_head_spec(profile: Any) -> dict[str, Any] | None:
     draft = getattr(profile, "draft_lm_head", None)
     if draft is None:
@@ -305,7 +367,6 @@ def _model_draft_lm_head_spec(
     profile: Any,
 ) -> dict[str, Any] | None:
     """Use model contract draft-head metadata when present, else profile default."""
-
     fallback = _profile_draft_lm_head_spec(profile)
     try:
         from mtplx.draft_lm_head import draft_lm_head_spec_from_runtime_contract
@@ -322,7 +383,6 @@ def _model_draft_sampler_spec(
     profile: Any,
 ) -> dict[str, Any] | None:
     """Use model contract draft-sampler metadata when present, else profile default."""
-
     fallback = _profile_draft_sampler_spec(profile)
     try:
         from mtplx.draft_sampling import draft_sampler_spec_from_runtime_contract
@@ -332,6 +392,18 @@ def _model_draft_sampler_spec(
         return draft_sampler_spec_from_runtime_contract(contract, fallback=fallback)
     except ImportError:
         return fallback
+
+
+def _draft_sampler_from_spec(spec: dict[str, Any] | None) -> Any | None:
+    if spec is None:
+        return None
+    from mtplx.sampling import SamplerConfig
+
+    return SamplerConfig(
+        temperature=float(spec["temperature"]),
+        top_p=float(spec["top_p"]),
+        top_k=int(spec["top_k"]),
+    )
 
 
 def _resolve_model_context_window(tokenizer: Any, model_path: str | Path) -> int:
@@ -433,7 +505,7 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
     from mtplx.config import load_user_config
 
     config = load_user_config()
-    default_model = config.model or DEFAULT_HF_MODEL_ID
+    default_model = config.model or DEFAULT_CHAMPION
     model_report: dict[str, Any]
     try:
         model_report = _compact_model_summary(inspect_model(default_model).to_dict())
@@ -443,9 +515,6 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
             "ok": False,
             "error": str(exc),
         }
-    release_repo = repo_root()
-    staging_dir = Path("hf-staging/Qwen3.6-27B-MTPLX-Optimized-Speed")
-    manifest = staging_dir / "MTPLX_PUBLISH_MANIFEST.json"
     server_deps = {
         name: importlib.util.find_spec(name) is not None
         for name in ("fastapi", "uvicorn")
@@ -466,38 +535,15 @@ def _deep_doctor_report(args: Any, base: dict[str, Any]) -> dict[str, Any]:
         "default_model": model_report,
         "server_dependencies": server_deps,
         "launchers": launchers,
-        "release_repo": {
-            "path": str(release_repo),
-            "exists": release_repo.exists(),
-            "git_head": _git_value(["rev-parse", "--short", "HEAD"], cwd=release_repo)
-            if release_repo.exists()
-            else None,
-            "git_status": _git_value(["status", "--short"], cwd=release_repo)
-            if release_repo.exists()
-            else None,
-        },
-        "hf_staging": {
-            "path": str(staging_dir),
-            "exists": staging_dir.exists(),
-            "manifest": str(manifest),
-            "manifest_exists": manifest.exists(),
-            "symlink_count": len(list(staging_dir.iterdir())) if staging_dir.exists() else None,
-        },
         "integrations": {
             "openwebui": "mtplx integrate openwebui --port 8000",
             "claude_code": "mtplx integrate claude-code --port 8000",
         },
         "product_policy": {
             "fanmax_counts_for_product_gate": False,
-            "default_hf_model_id": DEFAULT_HF_MODEL_ID,
-            "default_profile": DEFAULT_PROFILE_NAME,
             "safe_mode_drops_per_cycle_events": os.environ.get("MTPLX_DROP_EVENTS") == "1",
         },
     }
-    if staging_dir.exists():
-        base["deep"]["hf_staging"]["symlink_count"] = sum(
-            1 for item in staging_dir.iterdir() if item.is_symlink()
-        )
     return base
 
 
@@ -524,17 +570,10 @@ def _resolve_runtime_model_path(model: str, *, cache_dir: str | None = None) -> 
     try:
         return str(resolve_model_path(model, cache_dir=cache_dir)), None
     except Exception as exc:
-        from mtplx.hf_loader import repo_id_from_model_ref
-
-        repo_id = repo_id_from_model_ref(model)
-        command = f"mtplx pull {repo_id}" if repo_id else None
         return model, {
             "error": "model is not available locally",
             "model": model,
             "detail": str(exc),
-            "exit_code": 6,
-            "fix": "Download the model or choose an existing local model folder.",
-            "command": command,
         }
 
 
@@ -560,10 +599,17 @@ def _depth_sweep_native60(
     max_tokens: int,
     limit: int | None,
     seed: int,
+    draft_lm_head: dict[str, Any] | None = None,
+    draft_sampler: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     from mtplx.benchmarks.runners.mtp_depth_sweep import run_mtp_depth_sweep
 
     apply_profile_env("performance-cold")
+    draft_lm_head = draft_lm_head or {
+        "bits": 4,
+        "group_size": 64,
+        "mode": "affine",
+    }
     return run_mtp_depth_sweep(
         model,
         prompt_suite,
@@ -582,9 +628,14 @@ def _depth_sweep_native60(
         min_speculative_depth=1,
         verify_strategy="capture_commit",
         verify_core="linear-gdn-from-conv-tape",
-        draft_lm_head_bits=4,
-        draft_lm_head_group_size=64,
-        draft_lm_head_mode="affine",
+        draft_lm_head_bits=int(draft_lm_head["bits"]),
+        draft_lm_head_group_size=int(draft_lm_head["group_size"]),
+        draft_lm_head_mode=str(draft_lm_head["mode"]),
+        draft_temperature=(
+            None if draft_sampler is None else float(draft_sampler["temperature"])
+        ),
+        draft_top_p=None if draft_sampler is None else float(draft_sampler["top_p"]),
+        draft_top_k=None if draft_sampler is None else int(draft_sampler["top_k"]),
     )
 
 
@@ -620,6 +671,7 @@ def cmd_doctor(args: Any) -> int:
         name: importlib.util.find_spec(name) is not None
         for name in ("fastapi", "uvicorn")
     }
+
     report = {
         "environment": env,
         "huggingface": hf_cache_report(cache_dir=getattr(args, "model_cache", None)),
@@ -667,7 +719,27 @@ def cmd_doctor(args: Any) -> int:
             print(f"bundle: {report['bundle']['bundle_dir']}")
             print(f"zip: {report['bundle']['bundle_zip']}")
     else:
-        _print(report)
+        env_info = report.get("environment") or {}
+        hf = report.get("huggingface") or {}
+        thermal = report.get("thermal_control") or {}
+        selected = thermal.get("selected") or {}
+        tools = report.get("tools") or {}
+        print("MTPLX status")
+        print(f"python: {tools.get('python') or sys.executable}")
+        print(f"platform: {env_info.get('platform') or env_info.get('system') or 'unknown'}")
+        print(f"project: {env_info.get('project_root') or os.getcwd()}")
+        print(f"model cache: {hf.get('cache_dir') or 'default'}")
+        print(f"cached models: {hf.get('cached_models', 'unknown')}")
+        print(
+            "thermal: "
+            f"{'available' if thermal.get('available') else 'not configured'}"
+            f" ({selected.get('kind') or 'none'})"
+        )
+        if getattr(args, "deep", False):
+            launchers = report.get("launchers") or {}
+            config = report.get("config") or {}
+            print(f"launcher: {launchers.get('global_launcher') or launchers.get('global') or 'unknown'}")
+            print(f"config: {config.get('path') or 'default'}")
     return 0
 
 
@@ -754,10 +826,25 @@ def cmd_pull_public(args: Any) -> int:
 
     try:
         result = pull_model(args.model, cache_dir=args.cache_dir, revision=args.revision)
+    except KeyboardInterrupt:
+        print("download cancelled")
+        return 130
     except Exception as exc:
-        _print({"error": "pull failed", "model": args.model, "detail": str(exc)})
+        if getattr(args, "json", False):
+            _print({"error": "pull failed", "model": args.model, "detail": str(exc)})
+        else:
+            print("error: pull failed")
+            print(f"model: {args.model}")
+            print(f"detail: {exc}")
         return 1
-    _print(result)
+    if getattr(args, "json", False):
+        _print(result)
+    else:
+        print("MTPLX pull")
+        print(f"model: {result.get('repo_id')}")
+        print(f"path: {result.get('path')}")
+        print(f"size: {_format_bytes(result.get('size_bytes'))}")
+        print(f"runtime contract: {str(bool(result.get('has_runtime_contract'))).lower()}")
     return 0
 
 
@@ -765,7 +852,21 @@ def cmd_list_public(args: Any) -> int:
     from mtplx.hf_loader import list_cached_models, model_cache_dir
 
     models = [row.to_dict() for row in list_cached_models(cache_dir=args.cache_dir)]
-    _print({"cache_dir": str(model_cache_dir(args.cache_dir)), "models": models})
+    payload = {"cache_dir": str(model_cache_dir(args.cache_dir)), "models": models}
+    if getattr(args, "json", False):
+        _print(payload)
+    else:
+        print("MTPLX models")
+        print(f"cache: {payload['cache_dir']}")
+        if not models:
+            print("no cached models")
+        for row in models:
+            print(
+                f"- {row.get('repo_id')}  "
+                f"{_format_bytes(row.get('size_bytes'))}  "
+                f"contract={str(bool(row.get('has_runtime_contract'))).lower()}"
+            )
+            print(f"  {row.get('path')}")
     return 0
 
 
@@ -773,7 +874,16 @@ def cmd_remove_public(args: Any) -> int:
     from mtplx.hf_loader import remove_cached_model
 
     result = remove_cached_model(args.model, cache_dir=args.cache_dir)
-    _print(result)
+    if getattr(args, "json", False):
+        _print(result)
+    else:
+        print("MTPLX remove")
+        print(f"model: {result.get('repo_id')}")
+        print(f"path: {result.get('path')}")
+        if result.get("removed"):
+            print(f"removed: {_format_bytes(result.get('size_bytes_removed'))}")
+        else:
+            print("removed: false")
     return 0 if result["removed"] or args.missing_ok else 1
 
 
@@ -790,7 +900,7 @@ def _cmd_bench_run(args: Any) -> int:
     exact_paged_env = _exact_paged_env_from_args(args)
     runtime_profile = selected_profile.runtime_profile
     runtime_env = selected_profile.env_dict()
-    if selected_profile.name in {"stable", "exact", "max-diagnostic"}:
+    if selected_profile.name in {"safe", "exact", "max-diagnostic"}:
         runtime_env.update(exact_paged_env)
     runtime_env = _runtime_env_with_external_overrides(runtime_env)
     harness = getattr(args, "harness", "auto")
@@ -838,7 +948,7 @@ def _cmd_bench_run(args: Any) -> int:
     )
     if resolve_error is not None:
         _print(resolve_error)
-        return int(resolve_error.get("exit_code", 1))
+        return 1
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -847,6 +957,8 @@ def _cmd_bench_run(args: Any) -> int:
     if gate_exit is not None:
         _print({"error": "model failed MTP primary gate", "model": inspection})
         return gate_exit
+    draft_lm_head = _model_draft_lm_head_spec(inspection, selected_profile)
+    draft_sampler = _model_draft_sampler_spec(inspection, selected_profile)
 
     from mtplx.benchmarks.runners.preflight import run_preflight
 
@@ -896,6 +1008,8 @@ def _cmd_bench_run(args: Any) -> int:
             max_tokens=args.max_tokens,
             limit=args.limit,
             seed=benchmark_seed,
+            draft_lm_head=draft_lm_head,
+            draft_sampler=draft_sampler,
         )
     output.parent.mkdir(parents=True, exist_ok=True)
     write_depth_sweep(output, result)
@@ -2191,8 +2305,33 @@ def _cmd_qa_exactness(args: Any) -> int:
     if args.prompt_suite:
         cmd.extend(["--prompt-suite", args.prompt_suite])
     proc = _run_exactness_command(cmd)
-    print(proc.stdout, end="")
-    return 0 if proc.returncode == 0 else EXIT_EXACTNESS
+    if proc.returncode == 0:
+        print(proc.stdout, end="")
+        return 0
+    output_text = proc.stdout or ""
+    print("error: exactness check failed")
+    if "float_to_fp8_e4m3" in output_text:
+        print(
+            "detail: the selected paged-attention exactness path failed to "
+            "compile in the Metal backend on this machine."
+        )
+    else:
+        candidate_lines = [
+            line.strip()
+            for line in output_text.splitlines()
+            if any(
+                marker in line.lower()
+                for marker in ("runtimeerror:", "error:", "failed", "undeclared identifier")
+            )
+        ]
+        for line in reversed(candidate_lines or output_text.splitlines()):
+            stripped = line.strip()
+            if stripped:
+                print(f"detail: {stripped[:240]}")
+                break
+    print(f"output: {output}")
+    print("try: mtplx qa exactness --exactness-attention-impl mlx_vector_paged")
+    return EXIT_EXACTNESS
 
 
 def _cmd_qa_distribution(args: Any) -> int:
@@ -2557,7 +2696,10 @@ def cmd_max_public(args: Any) -> int:
                 print(f"ok: {str(bool(payload.get('ok'))).lower()}")
             if payload.get("message"):
                 print(payload["message"])
-            elif (payload.get("detection") or {}).get("instructions"):
+            elif (
+                not bool((payload.get("detection") or {}).get("available"))
+                and (payload.get("detection") or {}).get("instructions")
+            ):
                 print((payload.get("detection") or {})["instructions"])
     return code
 
@@ -2565,10 +2707,6 @@ def cmd_max_public(args: Any) -> int:
 def _server_url(host: str, port: int) -> str:
     display_host = "127.0.0.1" if str(host).strip() in {"", "0.0.0.0", "::"} else str(host)
     return f"http://{display_host}:{int(port)}"
-
-
-def _api_base_url(host: str, port: int) -> str:
-    return _server_url(host, port).rstrip("/") + "/v1"
 
 
 def _chat_url(host: str, port: int) -> str:
@@ -2695,7 +2833,7 @@ def _print_serve_start_line(text: str = "") -> None:
 
 
 _PROFILE_SHORT_SUMMARIES = {
-    "stable": "Stable: exact/staged long-reply path, no fan control",
+    "safe": "Stable: exact/staged long-reply path, no fan control",
     "performance-cold": "Medium: native-MTP speed path, ~2.2x burst (not sustained)",
     "exact": "QA-only exact paged verifier",
     "max-diagnostic": "Max: Medium path with fan control",
@@ -2757,13 +2895,21 @@ def _server_command_name(args: Any) -> str:
 def cmd_serve_public(args: Any) -> int:
     api_key = getattr(args, "api_key", None)
     if not _is_localhost_bind(getattr(args, "host", None)) and not api_key:
-        _print(
-            {
-                "error": "--api-key is required when --host is not localhost",
-                "host": getattr(args, "host", None),
-            }
-        )
+        payload = {
+            "error": "--api-key is required when --host is not localhost",
+            "host": getattr(args, "host", None),
+        }
+        if getattr(args, "json", False):
+            _print(payload)
+        else:
+            print("error: --api-key is required when --host is not localhost")
+            print(f"host: {getattr(args, 'host', None)}")
+            print("try: mtplx quickstart --host 127.0.0.1")
+            print("try: mtplx quickstart --host 0.0.0.0 --api-key $MTPLX_AUTH")
         return 2
+    depth_error = _validate_public_depth(args, printer=_print_serve_start_line)
+    if depth_error is not None:
+        return depth_error
     _print_serve_start_banner(args)
     if _port_is_busy(str(getattr(args, "host", "127.0.0.1")), int(getattr(args, "port", 8000))):
         if bool(getattr(args, "quickstart_openwebui", False)):
@@ -2774,7 +2920,7 @@ def cmd_serve_public(args: Any) -> int:
                 chat_url = _chat_url(str(getattr(args, "host", "127.0.0.1")), int(getattr(args, "port", 8000)))
                 _print_serve_start_line("MTPLX is already running.")
                 _print_serve_start_line(f"Chat URL: {chat_url}")
-                _print_serve_start_line(f"OpenAI API Base URL: {_api_base_url(str(getattr(args, 'host', '127.0.0.1')), int(getattr(args, 'port', 8000)))}")
+                _print_serve_start_line(f"OpenAI API Base URL: {base}/v1")
                 _print_serve_start_line(f"Model: {model_id}")
                 _print_serve_start_line("API key: leave blank for localhost")
                 _print_serve_start_line("Opening chat UI in your browser...")
@@ -2793,8 +2939,12 @@ def cmd_serve_public(args: Any) -> int:
         cache_dir=getattr(args, "cache_dir", None),
     )
     if resolve_error is not None:
-        _print(resolve_error)
-        return int(resolve_error.get("exit_code", 1))
+        _print_command_error(
+            resolve_error,
+            command="quickstart",
+            json_output=bool(getattr(args, "json", False)),
+        )
+        return 1
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -2826,7 +2976,7 @@ def cmd_serve_public(args: Any) -> int:
                 observed = fork_status.get("path") or fork_status.get("error") or "unknown"
                 _print_serve_start_line(f"      Found: {observed}")
                 server_command = _server_command_name(args)
-                _print_serve_start_line(f"try: mtplx {server_command} --profile stable")
+                _print_serve_start_line(f"try: mtplx {server_command} --profile safe")
                 _print_serve_start_line(f"try: mtplx {server_command} --profile performance-cold")
                 _print_serve_start_line("     (without --strict-fast-path, MTPLX starts in stock-MLX compatibility)")
                 return 2
@@ -2915,7 +3065,7 @@ def cmd_serve_public(args: Any) -> int:
             actionable = verified.get("actionable")
             if actionable:
                 _emit(f"[max]   action: {actionable}")
-            _emit("[max] continuing the server WITHOUT fan boost (Max behaves like Fast).")
+            _emit("[max] continuing the server WITHOUT fan boost (Max behaves like Medium).")
             _emit("")
             args.max = False  # don't lie to the watchdog about fan state
         # Only spin up the idle watchdog when verification confirmed fans
@@ -3018,12 +3168,21 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
     prompt = getattr(args, "prompt", None) or getattr(args, "prompt_arg", None)
     if not prompt:
         raise SystemExit(f"mtplx {command} requires a prompt")
+    depth_error = _validate_public_depth(args, printer=lambda _line: None)
+    if depth_error is not None:
+        return depth_error, {
+            "error": "invalid depth",
+            "detail": (
+                "--depth must be between "
+                f"1 and {MAX_PUBLIC_SPECULATIVE_DEPTH} for the current MTPLX runtime"
+            ),
+        }, []
     runtime_model, resolve_error = _resolve_runtime_model_path(
         args.model,
         cache_dir=getattr(args, "cache_dir", None),
     )
     if resolve_error is not None:
-        return int(resolve_error.get("exit_code", 1)), resolve_error, []
+        return EXIT_TELEMETRY, resolve_error, []
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
@@ -3033,6 +3192,8 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
         return gate_exit, {"error": "model failed MTP primary gate", "model": inspection}, []
     profile = get_profile(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
     apply_profile_env(profile.name)
+    draft_lm_head = _model_draft_lm_head_spec(inspection, profile)
+    draft_sampler = _model_draft_sampler_spec(inspection, profile)
 
     max_session: Any | None = None
     thermal: dict[str, Any] | None = None
@@ -3062,6 +3223,20 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
 
     try:
         rt = load(runtime_model, mtp=True)
+        draft_report = None
+        if (
+            draft_lm_head is not None
+            and hasattr(rt, "model")
+            and bool(getattr(rt, "mtp_enabled", True))
+        ):
+            from mtplx.draft_lm_head import _install_draft_lm_head
+
+            draft_report = _install_draft_lm_head(
+                rt,
+                bits=int(draft_lm_head["bits"]),
+                group_size=int(draft_lm_head["group_size"]),
+                mode=str(draft_lm_head["mode"]),
+            )
         messages = None
         system = getattr(args, "system", None)
         if system:
@@ -3097,6 +3272,7 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
             prompt_ids,
             max_tokens=max_tokens_value,
             sampler=SamplerConfig(temperature=args.temperature, top_p=args.top_p, top_k=args.top_k),
+            draft_sampler=_draft_sampler_from_spec(draft_sampler),
             speculative_depth=args.depth,
             seed=args.seed,
             mtp_hidden_variant="post_norm",
@@ -3119,6 +3295,8 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
         "text": out.text,
         "model": _compact_model_summary(inspection),
         "profile": profile.to_dict(),
+        "draft_lm_head": draft_report,
+        "draft_sampler": draft_sampler,
         "stats": {
             "generated_tokens": out.stats.generated_tokens,
             "max_tokens": max_tokens_value,
@@ -3144,7 +3322,11 @@ def _generate_one_shot_public(args: Any, *, command: str) -> tuple[int, dict[str
 def cmd_run_public(args: Any) -> int:
     code, payload, _validations = _generate_one_shot_public(args, command="run")
     if "error" in payload:
-        _print(payload)
+        _print_command_error(
+            payload,
+            command="run",
+            json_output=bool(getattr(args, "json", False)),
+        )
         return code
     if getattr(args, "json", False):
         _print(payload)
@@ -3165,7 +3347,18 @@ def cmd_run_public(args: Any) -> int:
 def cmd_chat_public(args: Any) -> int:
     # Still a one-shot smoke path until the interactive REPL lands in Phase 5.
     code, payload, _validations = _generate_one_shot_public(args, command="chat")
-    _print(payload)
+    if "error" in payload:
+        _print_command_error(
+            payload,
+            command="chat",
+            json_output=bool(getattr(args, "json", False)),
+        )
+        return code
+    if getattr(args, "json", False):
+        _print(payload)
+    else:
+        text = payload["text"]
+        print(text, end="" if text.endswith("\n") else "\n")
     return code
 
 
@@ -3362,11 +3555,52 @@ def _quickstart_resolve_model(model: str, *, cache_dir: str | None, download: bo
             "error": resolve_error,
         }
 
+    download_ref = _quickstart_download_ref(model)
+    try:
+        inspection = inspect_model(download_ref).to_dict()
+    except Exception as exc:
+        return None, {
+            "model": model,
+            "runtime_model": None,
+            "downloaded": False,
+            "download_ref": download_ref,
+            "error": {
+                "error": "model failed Hugging Face preflight",
+                "model": download_ref,
+                "detail": str(exc),
+            },
+        }
+    compatibility = inspection.get("compatibility") or {}
+    if not bool(compatibility.get("can_run")):
+        return None, {
+            "model": model,
+            "runtime_model": None,
+            "downloaded": False,
+            "download_ref": download_ref,
+            "gate_inspection": inspection,
+            "error": {
+                "error": "model failed MTPLX compatibility gate",
+                "model": inspection,
+            },
+        }
+
     from mtplx.hf_loader import pull_model
 
-    download_ref = _quickstart_download_ref(model)
     _quickstart_line(f"[1/4] Downloading model: {download_ref}")
-    result = pull_model(download_ref, cache_dir=cache_dir)
+    try:
+        result = pull_model(download_ref, cache_dir=cache_dir)
+    except KeyboardInterrupt:
+        return None, {
+            "model": model,
+            "runtime_model": None,
+            "downloaded": False,
+            "download_ref": download_ref,
+            "cancelled": True,
+            "error": {
+                "error": "download cancelled",
+                "model": download_ref,
+            },
+        }
     runtime_model, resolve_error = _resolve_runtime_model_path(download_ref, cache_dir=cache_dir)
     if resolve_error is not None:
         return None, {
@@ -3545,8 +3779,8 @@ def _quickstart_stats_line(payload: dict[str, Any]) -> str:
             speed_text = f"{speed_text} | live_window={stream_tok_s:.2f}"
         if total_tok_s is not None and abs(decode_tok_s - total_tok_s) >= 0.1:
             speed_text = f"{speed_text} | total={total_tok_s:.2f}"
-    elif stream_tok_s is not None and generated_tokens >= 8:
-        speed_text = f"{stream_tok_s:.2f} live-window tok/s"
+    elif stream_tok_s is not None:
+        speed_text = f"{stream_tok_s:.2f} tok/s"
         if total_tok_s is not None and abs(stream_tok_s - total_tok_s) >= 0.1:
             speed_text = f"{speed_text} | total={total_tok_s:.2f}"
     elif total_tok_s is not None:
@@ -3649,15 +3883,7 @@ def _quickstart_generate(
                 top_p=float(getattr(args, "top_p", 0.95)),
                 top_k=int(getattr(args, "top_k", 20)),
             ),
-            draft_sampler=(
-                None
-                if draft_sampler is None
-                else SamplerConfig(
-                    temperature=float(draft_sampler["temperature"]),
-                    top_p=float(draft_sampler["top_p"]),
-                    top_k=int(draft_sampler["top_k"]),
-                )
-            ),
+            draft_sampler=_draft_sampler_from_spec(draft_sampler),
             speculative_depth=int(getattr(args, "depth", 3)),
             seed=int(getattr(args, "seed", 0)) + turn_index,
             mtp_hidden_variant="post_norm",
@@ -3720,14 +3946,13 @@ def _quickstart_openwebui_payload(args: Any) -> dict[str, Any]:
     host = str(getattr(args, "host", "127.0.0.1"))
     port = int(getattr(args, "port", 8000))
     model_id = str(getattr(args, "model_id", None) or DEFAULT_PUBLIC_MODEL_ID)
-    server_url = f"http://{_connect_host_for_bind(host)}:{port}"
-    api_base_url = server_url + "/v1"
+    base = f"http://{_connect_host_for_bind(host)}:{port}"
     return {
         "integration": "openwebui",
-        "server_url": server_url,
-        "base_url": api_base_url,
-        "api_base_url": api_base_url,
-        "chat_url": server_url + "/",
+        "server_url": base,
+        "base_url": base + "/v1",
+        "api_base_url": base + "/v1",
+        "chat_url": base + "/",
         "model_id": model_id,
         "api_key": "not required for localhost",
         "server_command": (
@@ -3736,8 +3961,8 @@ def _quickstart_openwebui_payload(args: Any) -> dict[str, Any]:
             "--no-stats-footer --open-browser"
         ),
         "openwebui_steps": [
-            f"Open chat UI: {server_url}/",
-            f"OpenAI-compatible API base URL: {api_base_url}",
+            f"Open chat UI: {base}/",
+            f"OpenAI-compatible API base URL: {base}/v1",
             f"Model: {model_id}",
         ],
     }
@@ -4035,14 +4260,17 @@ def cmd_quickstart_public(args: Any) -> int:
         chosen_model = choice.get("model")
         if chosen_model:
             args.model = chosen_model
-            # The user deliberately picked this model in onboarding. If it is
-            # an HF repo and missing locally, fetch without another prompt.
+            # Auto-pull policy: the user has explicitly picked this model in
+            # the onboarding wizard; if it isn't on disk we fetch it without
+            # re-prompting. The legacy "Model is missing. Download? [Y/n]"
+            # fallback below is reserved for non-onboarded shortcuts.
             try:
                 from mtplx.hf_loader import repo_id_from_model_ref
 
                 if repo_id_from_model_ref(chosen_model):
                     args.download = True
             except Exception:
+                # Best-effort: never let an import problem break the wizard.
                 pass
         chosen_profile = choice.get("profile")
         if chosen_profile:
@@ -4075,7 +4303,7 @@ def cmd_quickstart_public(args: Any) -> int:
                     args.max = False
 
     if raw_target is None:
-        raw_target = "web"
+        raw_target = "cli" if has_prompt else "web"
     raw_target = str(raw_target).lower()
     if raw_target in {"open-webui", "openwebui", "web"}:
         target = "openwebui"
@@ -4088,6 +4316,9 @@ def cmd_quickstart_public(args: Any) -> int:
         _quickstart_line(f"try: {_start_invocation(args)}")
         _quickstart_line(f"try: {_start_invocation(args, ' cli')}")
         return 2
+    depth_error = _validate_public_depth(args, printer=_quickstart_line)
+    if depth_error is not None:
+        return depth_error
     model, download = _quickstart_choose_model(args, target=target)
     cache_dir = getattr(args, "cache_dir", None)
     if getattr(args, "dry_run", False):
@@ -4098,6 +4329,7 @@ def cmd_quickstart_public(args: Any) -> int:
             "model": model,
             "cache_dir": cache_dir,
             "profile": getattr(args, "profile", DEFAULT_PROFILE_NAME),
+            "max": bool(getattr(args, "max", False)),
             "download_if_missing": download,
             "terminal_chat": target == "terminal",
             "openwebui": openwebui,
@@ -4110,6 +4342,10 @@ def cmd_quickstart_public(args: Any) -> int:
             _quickstart_line(f"MTPLX {_start_command_name(args)}")
             _quickstart_line(f"model: {model}")
             _quickstart_line(f"profile: {payload['profile']}")
+            _quickstart_line(
+                "mode: "
+                + ("Max (Medium path + fan boost)" if payload["max"] else "Medium")
+            )
             _quickstart_line(f"download if missing: {str(download).lower()}")
             if target == "openwebui":
                 _quickstart_line(f"then: start local server -> open browser chat at {openwebui['chat_url']}")
@@ -4121,10 +4357,36 @@ def cmd_quickstart_public(args: Any) -> int:
     _quickstart_line(f"[1/4] Checking model: {model}")
     try:
         runtime_model, resolution = _quickstart_resolve_model(model, cache_dir=cache_dir, download=download)
+    except KeyboardInterrupt:
+        _quickstart_line("download cancelled")
+        return 130
     except Exception as exc:
         _quickstart_line(f"error: {exc}")
         return 1
     if runtime_model is None:
+        if resolution.get("cancelled"):
+            _quickstart_line("download cancelled")
+            return 130
+        gate_inspection = resolution.get("gate_inspection")
+        if isinstance(gate_inspection, dict):
+            _print_model_gate_error(
+                gate_inspection,
+                printer=_quickstart_line,
+                json_output=bool(getattr(args, "json", False)),
+            )
+            compatibility = gate_inspection.get("compatibility") or {}
+            return int(compatibility.get("exit_code") or 1)
+        resolution_error = resolution.get("error")
+        if (
+            isinstance(resolution_error, dict)
+            and resolution_error.get("error") not in {None, "model is not available locally"}
+        ):
+            _print_command_error(
+                resolution_error,
+                command="start",
+                json_output=bool(getattr(args, "json", False)),
+            )
+            return 1
         if sys.stdin.isatty() and not getattr(args, "prompt", None):
             try:
                 download_model = _quickstart_download_ref(model)
@@ -4136,9 +4398,36 @@ def cmd_quickstart_public(args: Any) -> int:
             if answer in {"", "y", "yes"}:
                 try:
                     runtime_model, resolution = _quickstart_resolve_model(download_model, cache_dir=cache_dir, download=True)
+                except KeyboardInterrupt:
+                    _quickstart_line("download cancelled")
+                    return 130
                 except Exception as exc:
                     _quickstart_line(f"error: {exc}")
                     return 1
+        if runtime_model is None and resolution.get("cancelled"):
+            _quickstart_line("download cancelled")
+            return 130
+        gate_inspection = resolution.get("gate_inspection")
+        if runtime_model is None and isinstance(gate_inspection, dict):
+            _print_model_gate_error(
+                gate_inspection,
+                printer=_quickstart_line,
+                json_output=bool(getattr(args, "json", False)),
+            )
+            compatibility = gate_inspection.get("compatibility") or {}
+            return int(compatibility.get("exit_code") or 1)
+        resolution_error = resolution.get("error")
+        if (
+            runtime_model is None
+            and isinstance(resolution_error, dict)
+            and resolution_error.get("error") not in {None, "model is not available locally"}
+        ):
+            _print_command_error(
+                resolution_error,
+                command="start",
+                json_output=bool(getattr(args, "json", False)),
+            )
+            return 1
         if runtime_model is not None:
             _quickstart_line(f"model ready: {runtime_model}")
             if resolution.get("downloaded"):
@@ -4164,6 +4453,11 @@ def cmd_quickstart_public(args: Any) -> int:
         if detail:
             _quickstart_line(f"detail: {detail}")
         _quickstart_line(f"try: {_start_invocation(args, ' --download')}")
+        _quickstart_line(
+            "try: "
+            f"{_start_invocation(args, ' cli' if target == 'terminal' else '')} "
+            f"--model {shlex.quote(str(model))} --download"
+        )
         _quickstart_line(f"try: {_start_invocation(args, ' --model /path/to/model')}")
         return 1
 
@@ -4206,7 +4500,11 @@ def cmd_metrics_public(args: Any) -> int:
         if getattr(args, "json", False):
             print(json.dumps(row, sort_keys=True))
         else:
-            if latest:
+            if not row["ok"]:
+                print(f"metrics: cannot reach {base}/metrics")
+                if isinstance(payload, dict) and payload.get("detail"):
+                    print(f"detail: {payload.get('detail')}")
+            elif latest:
                 tok_s = latest.get("tok_s") or latest.get("decode_tok_s") or latest.get("server_tok_s")
                 generated = latest.get("completion_tokens") or latest.get("generated_tokens")
                 verify_ms = latest.get("verify_ms_per_call") or latest.get("late_verify_ms")
@@ -4225,7 +4523,7 @@ def cmd_metrics_public(args: Any) -> int:
         if count and seen >= count:
             break
         time.sleep(interval)
-    return 0
+    return 0 if row.get("ok") else 1
 
 
 def cmd_integrate_public(args: Any) -> int:
@@ -4248,7 +4546,7 @@ def cmd_integrate_public(args: Any) -> int:
             "docker_api_base_url": _openwebui_docker_api_base_url(int(args.port)),
             "model_id": model_id,
             "server_command": (
-                f"mtplx serve --host {args.host} --port {args.port} "
+                f"mtplx quickstart --host {args.host} --port {args.port} "
                 "--no-stats-footer"
             ),
             "docker_command": _shell_join(docker_command),
@@ -4279,7 +4577,7 @@ def cmd_integrate_public(args: Any) -> int:
                 "ANTHROPIC_API_KEY": f"${args.api_key_env}",
             },
             "server_command": (
-                f"mtplx serve --host {args.host} --port {args.port} "
+                f"mtplx quickstart --host {args.host} --port {args.port} "
                 "--no-stats-footer"
             ),
             "smoke": {
@@ -4297,8 +4595,36 @@ def cmd_integrate_public(args: Any) -> int:
     if getattr(args, "json", False):
         _print(payload)
     else:
-        for key, value in payload.items():
-            print(f"{key}: {value}")
+        print(f"MTPLX connect: {action}")
+        print(f"base URL: {api_base_url if action == 'openwebui' else server_url}")
+        print(f"model: {model_id}")
+        print(f"start server: {payload.get('server_command')}")
+        if action == "openwebui":
+            print("Open WebUI:")
+            print("  Settings -> Connections -> OpenAI API")
+            print(f"  API base URL: {api_base_url}")
+            print("  API key: leave blank for localhost")
+            if getattr(args, "docker", False):
+                print("Docker:")
+                print(f"  {_shell_join(payload['docker_command_argv'])}")
+        else:
+            env = payload.get("environment") or {}
+            print("Claude Code environment:")
+            for key, value in env.items():
+                print(f"  {key}={value}")
+        smoke = payload.get("smoke_result")
+        if isinstance(smoke, dict):
+            health = smoke.get("health") if isinstance(smoke.get("health"), dict) else {}
+            models = smoke.get("models") if isinstance(smoke.get("models"), dict) else {}
+            print("smoke:")
+            print(f"  health: {'ok' if health.get('ok') else 'failed'}")
+            data = models.get("data") if isinstance(models, dict) else None
+            if isinstance(data, list):
+                print(f"  models endpoint: ok ({len(data)} model(s))")
+            elif models.get("error"):
+                print(f"  models endpoint: failed ({models.get('error')})")
+            else:
+                print("  models endpoint: unknown")
     return 0
 
 
@@ -4395,7 +4721,12 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
                 "num_hidden_layers": 61,
             },
             "contract": "deepseek-v3-mtp",
-            "safetensors": {"model.safetensors": ["model.layers.61.enorm.weight"]},
+            "safetensors": {
+                "model.safetensors": [
+                    "model.layers.61.enorm.weight",
+                    "model.layers.62.enorm.weight",
+                ]
+            },
             "expect": {
                 "tier": "verified",
                 "arch_id": "deepseek-v3-mtp",
@@ -4413,7 +4744,12 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
                 "num_hidden_layers": 61,
             },
             "contract": "deepseek-v3-mtp",
-            "safetensors": {"model.safetensors": ["model.layers.61.enorm.weight"]},
+            "safetensors": {
+                "model.safetensors": [
+                    "model.layers.61.enorm.weight",
+                    "model.layers.62.enorm.weight",
+                ]
+            },
             "expect": {
                 "tier": "verified",
                 "arch_id": "deepseek-v3-mtp",
@@ -4431,7 +4767,12 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
                 "num_hidden_layers": 61,
             },
             "contract": "glm-moe-dsa-mtp",
-            "safetensors": {"model.safetensors": ["model.layers.61.enorm.weight"]},
+            "safetensors": {
+                "model.safetensors": [
+                    "model.layers.61.enorm.weight",
+                    "model.layers.62.enorm.weight",
+                ]
+            },
             "expect": {
                 "tier": "verified",
                 "arch_id": "glm-moe-dsa-mtp",
@@ -4459,6 +4800,23 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
             },
         },
         {
+            "label": "glm4-moe-family-gated",
+            "config": {
+                "architectures": ["Glm4MoeForCausalLM"],
+                "model_type": "glm4_moe",
+                "num_nextn_predict_layers": 1,
+                "num_hidden_layers": 47,
+            },
+            "safetensors": {"model.safetensors": ["model.layers.47.hnorm.weight"]},
+            "expect": {
+                "tier": "family-compatible-unverified",
+                "arch_id": "glm4-moe-mtp",
+                "can_run": True,
+                "recommended_backend": "glm_mtp",
+                "runtime_compatibility": "native-family-gated",
+            },
+        },
+        {
             "label": "glm4-moe-lite-contract-gated",
             "config": {
                 "architectures": ["Glm4MoeLiteForCausalLM"],
@@ -4474,6 +4832,23 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
                 "can_run": True,
                 "recommended_backend": "glm_mtp",
                 "runtime_compatibility": "native-contract-gated",
+            },
+        },
+        {
+            "label": "glm4-moe-lite-family-gated",
+            "config": {
+                "architectures": ["Glm4MoeLiteForCausalLM"],
+                "model_type": "glm4_moe_lite",
+                "num_nextn_predict_layers": 1,
+                "num_hidden_layers": 47,
+            },
+            "safetensors": {"model.safetensors": ["model.layers.47.eh_proj.weight"]},
+            "expect": {
+                "tier": "family-compatible-unverified",
+                "arch_id": "glm4-moe-lite-mtp",
+                "can_run": True,
+                "recommended_backend": "glm_mtp",
+                "runtime_compatibility": "native-family-gated",
             },
         },
         {
@@ -4497,6 +4872,25 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
             },
         },
         {
+            "label": "mimo-family-gated",
+            "config": {
+                "architectures": ["MiMoForCausalLM"],
+                "model_type": "mimo",
+                "num_nextn_predict_layers": 2,
+                "num_hidden_layers": 46,
+            },
+            "safetensors": {
+                "model.safetensors": ["model.mtp_layers.0.hidden_layernorm.weight"]
+            },
+            "expect": {
+                "tier": "family-compatible-unverified",
+                "arch_id": "mimo-mtp",
+                "can_run": True,
+                "recommended_backend": "mimo_mtp",
+                "runtime_compatibility": "native-family-gated",
+            },
+        },
+        {
             "label": "minimax-m2-num-mtp-modules-recognized-pending",
             "config": {
                 "architectures": ["MiniMaxM2ForCausalLM"],
@@ -4508,6 +4902,65 @@ def _architecture_qa_fixtures() -> list[dict[str, Any]]:
                 "arch_id": "minimax-m2-mtp",
                 "can_run": False,
                 "runtime_compatibility": "recognized-backend-pending",
+            },
+        },
+        {
+            "label": "nemotron-h-contract-gated",
+            "config": {
+                "architectures": ["NemotronHForCausalLM"],
+                "model_type": "nemotron_h",
+                "num_nextn_predict_layers": 1,
+                "num_hidden_layers": 52,
+                "mtp_hybrid_override_pattern": "*E",
+            },
+            "contract": "nemotron-h-mtp",
+            "safetensors": {
+                "mtp.safetensors": [
+                    "mtp.layers.0.enorm.weight",
+                    "mtp.layers.0.hnorm.weight",
+                    "mtp.layers.0.eh_proj.weight",
+                    "mtp.layers.0.norm.weight",
+                    "mtp.layers.0.mixer.q_proj.weight",
+                    "mtp.layers.1.norm.weight",
+                    "mtp.layers.1.mixer.gate.weight",
+                    "mtp.layers.1.final_layernorm.weight",
+                ]
+            },
+            "expect": {
+                "tier": "verified",
+                "arch_id": "nemotron-h-mtp",
+                "can_run": True,
+                "recommended_backend": "nemotron_h_mtp",
+                "runtime_compatibility": "native-contract-gated",
+            },
+        },
+        {
+            "label": "nemotron-h-family-gated",
+            "config": {
+                "architectures": ["NemotronHForCausalLM"],
+                "model_type": "nemotron_h",
+                "num_nextn_predict_layers": 1,
+                "num_hidden_layers": 52,
+                "mtp_hybrid_override_pattern": "*E",
+            },
+            "safetensors": {
+                "mtp.safetensors": [
+                    "mtp.layers.0.enorm.weight",
+                    "mtp.layers.0.hnorm.weight",
+                    "mtp.layers.0.eh_proj.weight",
+                    "mtp.layers.0.norm.weight",
+                    "mtp.layers.0.mixer.q_proj.weight",
+                    "mtp.layers.1.norm.weight",
+                    "mtp.layers.1.mixer.gate.weight",
+                    "mtp.layers.1.final_layernorm.weight",
+                ]
+            },
+            "expect": {
+                "tier": "family-compatible-unverified",
+                "arch_id": "nemotron-h-mtp",
+                "can_run": True,
+                "recommended_backend": "nemotron_h_mtp",
+                "runtime_compatibility": "native-family-gated",
             },
         },
         {
@@ -4602,6 +5055,7 @@ def _run_runtime_import_smoke() -> list[dict[str, Any]]:
         ("mtplx.backends.deepseek_mtp", "DeepSeekMTPBackend"),
         ("mtplx.backends.glm_mtp", "GLMMTPBackend"),
         ("mtplx.backends.mimo_mtp", "MiMoMTPBackend"),
+        ("mtplx.backends.nemotron_h_mtp", "NemotronHMTPBackend"),
     ):
         try:
             module = importlib.import_module(module_name)
@@ -4637,6 +5091,7 @@ def _cmd_model_qa_architectures(args: Any) -> int:
         "glm4-moe-mtp",
         "glm4-moe-lite-mtp",
         "mimo-mtp",
+        "nemotron-h-mtp",
         "minimax-m2-mtp",
         "gemma-mtp",
     }
@@ -4647,6 +5102,7 @@ def _cmd_model_qa_architectures(args: Any) -> int:
         "glm4-moe-mtp",
         "glm4-moe-lite-mtp",
         "mimo-mtp",
+        "nemotron-h-mtp",
     }
     verified_ids = {row["arch_id"] for row in catalog if row.get("can_run_verified")}
     fixture_rows = _run_architecture_fixture_qa()
@@ -4965,8 +5421,6 @@ def cmd_debug_public(args: Any) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
     doctor_args = type("DoctorArgs", (), vars(args).copy())()
     doctor_args.project_root = getattr(args, "project_root", ".")
-    doctor_args.smc_path = getattr(args, "smc_path", None) or shutil.which("smc") or ""
-    doctor_args.sovereign_path = getattr(args, "sovereign_path", None) or shutil.which("sovereign") or ""
     doctor_args.model_cache = getattr(args, "model_cache", None)
     doctor_args.deep = True
     env = collect_environment(doctor_args.project_root).to_dict()

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -220,9 +220,25 @@ def _model_gate_error_lines(inspection: dict[str, Any]) -> list[str]:
         f"tier: {compatibility.get('tier') or 'unknown'}",
     ]
     runtime_compatibility = compatibility.get("runtime_compatibility") or inspection.get("runtime_compatibility")
+    mtp_layers = int(inspection.get("mtp_num_hidden_layers") or 0)
+    missing_mtp_weights = (
+        mtp_layers > 0
+        and bool(mtp)
+        and not bool(mtp.get("exists"))
+        and compatibility.get("tier") != "no-MTP"
+    )
+    if missing_mtp_weights:
+        runtime_compatibility = "missing-mtp-weights"
     if runtime_compatibility:
         lines.append(f"runtime: {runtime_compatibility}")
-    message = compatibility.get("message") or inspection.get("detail")
+    if missing_mtp_weights:
+        message = (
+            "This model's config advertises MTP, but MTPLX did not find "
+            "runnable MTP weights in the folder. mtplx_runtime.json is "
+            "optional metadata; the blocker is missing MTP weights."
+        )
+    else:
+        message = compatibility.get("message") or inspection.get("detail")
     if message:
         lines.append(f"reason: {message}")
     if mtp:

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -340,6 +340,36 @@ def _format_bytes(size_bytes: int | float | None) -> str:
     return f"{size:.1f} TB"
 
 
+def _download_progress_callback(*, printer=print):
+    def emit(event: dict[str, Any]) -> None:
+        kind = event.get("event")
+        size = _format_bytes(event.get("size_bytes"))
+        if kind == "start":
+            printer(f"[1/4] Download started: {event.get('repo_id')} -> {event.get('path')}")
+        elif kind == "resume":
+            printer(
+                "[1/4] Resuming partial download: "
+                f"{event.get('repo_id')} ({size} already on disk)"
+            )
+        elif kind == "progress":
+            interval = max(1, int(round(float(event.get("interval_s") or 0))))
+            delta = float(event.get("delta_bytes") or 0)
+            if delta > 0:
+                printer(
+                    "[1/4] Still downloading: "
+                    f"{size} on disk (+{_format_bytes(delta)} in {interval}s)"
+                )
+            else:
+                printer(
+                    "[1/4] Still downloading: "
+                    f"{size} on disk (no byte change in {interval}s; waiting on Hugging Face)"
+                )
+        elif kind == "complete":
+            printer(f"[1/4] Download complete: {size} on disk")
+
+    return emit
+
+
 def _profile_draft_lm_head_spec(profile: Any) -> dict[str, Any] | None:
     draft = getattr(profile, "draft_lm_head", None)
     if draft is None:
@@ -825,7 +855,14 @@ def cmd_pull_public(args: Any) -> int:
     from mtplx.hf_loader import pull_model
 
     try:
-        result = pull_model(args.model, cache_dir=args.cache_dir, revision=args.revision)
+        result = pull_model(
+            args.model,
+            cache_dir=args.cache_dir,
+            revision=args.revision,
+            progress_callback=None
+            if getattr(args, "json", False)
+            else _download_progress_callback(printer=print),
+        )
     except KeyboardInterrupt:
         print("download cancelled")
         return 130
@@ -3672,7 +3709,12 @@ def _quickstart_resolve_model(model: str, *, cache_dir: str | None, download: bo
 
     _quickstart_line(f"[1/4] Downloading model: {download_ref}")
     try:
-        result = pull_model(download_ref, cache_dir=cache_dir)
+        result = pull_model(
+            download_ref,
+            cache_dir=cache_dir,
+            progress_callback=_download_progress_callback(printer=_quickstart_line),
+            progress_interval_s=5.0,
+        )
     except KeyboardInterrupt:
         return None, {
             "model": model,

--- a/mtplx/config.py
+++ b/mtplx/config.py
@@ -9,12 +9,17 @@ from pathlib import Path
 from typing import Any
 
 from mtplx.constants import DEFAULT_RUNTIME_MODEL_DIR
-from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_PROFILE_NAME, resolve_profile_name
+from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_MODEL_ID, DEFAULT_PROFILE_NAME, resolve_profile_name
 
 
 DEFAULT_CONFIG_PATH = Path("~/.mtplx/config.toml").expanduser()
-RUNTIME_MODEL_COMMANDS = {"run", "chat", "serve"}
-CACHE_COMMANDS = {"pull", "list", "remove"}
+RUNTIME_MODEL_COMMANDS = {"ask", "run", "chat", "start", "serve", "quickstart", "quick-start"}
+CACHE_COMMANDS = {"pull", "list", "models", "remove"}
+LEGACY_DEFAULT_MODEL_REFS = {
+    "models/Qwen3.6-27B-MTPLX-GDN8-Speed4",
+    "models/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP",
+    "Youssofal/Qwen3.6-27B-MTPLX-Optimized",
+}
 
 
 @dataclass(frozen=True)
@@ -92,8 +97,21 @@ def apply_user_config(args: Any, *, config_path: str | Path | None = None) -> Us
 
 def _apply_model_default(args: Any, config: UserConfig) -> None:
     current = getattr(args, "model", None)
-    if config.model and current in {str(DEFAULT_RUNTIME_MODEL_DIR), DEFAULT_HF_MODEL_ID}:
+    default_refs = {None, str(DEFAULT_RUNTIME_MODEL_DIR), DEFAULT_HF_MODEL_ID, DEFAULT_MODEL_ID}
+    if (
+        config.model
+        and current in default_refs
+        and not _is_legacy_default_model_ref(config.model)
+    ):
         args.model = config.model
+
+
+def _is_legacy_default_model_ref(model: str) -> bool:
+    normalized = str(Path(model).expanduser()) if model.startswith(("~", "/")) else model
+    return any(
+        normalized == ref or normalized.endswith("/" + ref)
+        for ref in LEGACY_DEFAULT_MODEL_REFS
+    )
 
 
 def _apply_cache_default(args: Any, config: UserConfig) -> None:

--- a/mtplx/config.py
+++ b/mtplx/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from mtplx.constants import DEFAULT_RUNTIME_MODEL_DIR
-from mtplx.profiles import DEFAULT_PROFILE_NAME, resolve_profile_name
+from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_PROFILE_NAME, resolve_profile_name
 
 
 DEFAULT_CONFIG_PATH = Path("~/.mtplx/config.toml").expanduser()
@@ -92,7 +92,7 @@ def apply_user_config(args: Any, *, config_path: str | Path | None = None) -> Us
 
 def _apply_model_default(args: Any, config: UserConfig) -> None:
     current = getattr(args, "model", None)
-    if config.model and current == str(DEFAULT_RUNTIME_MODEL_DIR):
+    if config.model and current in {str(DEFAULT_RUNTIME_MODEL_DIR), DEFAULT_HF_MODEL_ID}:
         args.model = config.model
 
 
@@ -102,6 +102,8 @@ def _apply_cache_default(args: Any, config: UserConfig) -> None:
 
 
 def _apply_profile_default(args: Any, config: UserConfig) -> None:
+    if "profile" in getattr(args, "_cli_flags", set()):
+        return
     current = getattr(args, "profile", None)
     if config.profile and current == DEFAULT_PROFILE_NAME:
         args.profile = config.profile

--- a/mtplx/constants.py
+++ b/mtplx/constants.py
@@ -46,6 +46,11 @@ MTP_QUANTIZED_LINEAR_WEIGHT_KEYS = (
     "mtp.layers.0.self_attn.v_proj.weight",
 )
 
+MTP_ALL_QUANTIZED_LINEAR_WEIGHT_KEYS = (
+    "mtp.fc.weight",
+    *MTP_QUANTIZED_LINEAR_WEIGHT_KEYS,
+)
+
 EXPECTED_PREQUANTIZED_MTP_KEYS = tuple(
     sorted(
         EXPECTED_MTP_KEYS
@@ -54,6 +59,21 @@ EXPECTED_PREQUANTIZED_MTP_KEYS = tuple(
     )
 )
 EXPECTED_PREQUANTIZED_MTP_TENSOR_COUNT = len(EXPECTED_PREQUANTIZED_MTP_KEYS)
+
+EXPECTED_ALL_PREQUANTIZED_MTP_KEYS = tuple(
+    sorted(
+        EXPECTED_MTP_KEYS
+        + tuple(
+            key.rsplit(".", 1)[0] + ".scales"
+            for key in MTP_ALL_QUANTIZED_LINEAR_WEIGHT_KEYS
+        )
+        + tuple(
+            key.rsplit(".", 1)[0] + ".biases"
+            for key in MTP_ALL_QUANTIZED_LINEAR_WEIGHT_KEYS
+        )
+    )
+)
+EXPECTED_ALL_PREQUANTIZED_MTP_TENSOR_COUNT = len(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS)
 
 MULTIMODAL_SIDECARS = (
     "preprocessor_config.json",

--- a/mtplx/diagnostics.py
+++ b/mtplx/diagnostics.py
@@ -1,0 +1,618 @@
+"""Production diagnostics for MTPLX.
+
+This module intentionally avoids MLX imports.  `mtplx doctor` must be useful on
+fresh machines before the runtime stack is installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mtplx.hf_loader import cached_model_path, validate_mtplx_model_files
+from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_PROFILE_NAME
+
+
+GIB = 1024**3
+DEFAULT_SPEED_MODEL_SIZE_BYTES = 16_430_000_000
+MIN_RECOMMENDED_MEMORY_BYTES = 48 * GIB
+SUPPORT_MACOS_MAJOR = 14
+SUPPORT_PYTHON = (3, 10)
+SUPPORT_MATRIX = {
+    "supported": {
+        "platform": "Apple Silicon arm64 Mac",
+        "macos": ">= 14.0",
+        "python": "native arm64 Python >= 3.10",
+        "docker": "Docker Desktop current plus previous two macOS major releases",
+        "default_model": DEFAULT_HF_MODEL_ID,
+        "default_profile": DEFAULT_PROFILE_NAME,
+    },
+    "preview_test_targets": [
+        "M3 Max",
+        "M4 Max",
+        "M3 Ultra / Mac Studio",
+        "M5 Max developer machine",
+    ],
+}
+DOCS = {
+    "mlx": "https://ml-explore.github.io/mlx/build/html/install.html",
+    "docker": "https://docs.docker.com/desktop/setup/install/mac-install/",
+    "openwebui": "https://docs.openwebui.com/getting-started/quick-start/",
+    "openwebui_env": "https://docs.openwebui.com/reference/env-configuration/",
+    "docker_openwebui": "https://docs.docker.com/ai/model-runner/openwebui-integration/",
+}
+
+
+@dataclass(frozen=True)
+class DiagnosticCheck:
+    id: str
+    status: str
+    severity: str
+    observed: Any
+    expected: Any
+    fix: str | None = None
+    docs_url: str | None = None
+    command: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "severity": self.severity,
+            "observed": self.observed,
+            "expected": self.expected,
+            "fix": self.fix,
+            "docs_url": self.docs_url,
+            "command": self.command,
+        }
+
+
+def _run(args: list[str], *, timeout: float = 2.0) -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            args,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception as exc:  # pragma: no cover - host dependent
+        return {"ok": False, "error": repr(exc), "command": args}
+    return {
+        "ok": proc.returncode == 0,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "command": args,
+    }
+
+
+def _parse_version(value: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for raw in value.split("."):
+        digits = "".join(ch for ch in raw if ch.isdigit())
+        if digits == "":
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _sysctl(name: str) -> str | None:
+    result = _run(["sysctl", "-n", name])
+    if result.get("ok"):
+        return str(result.get("stdout") or "").strip() or None
+    return None
+
+
+def _pmset_report() -> dict[str, Any]:
+    if platform.system() != "Darwin":
+        return {"available": False, "reason": "not macOS"}
+    power = _run(["pmset", "-g"], timeout=2.0)
+    therm = _run(["pmset", "-g", "therm"], timeout=2.0)
+    low_power: str | None = None
+    power_mode: str | None = None
+    if power.get("ok"):
+        for line in str(power.get("stdout") or "").splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == "lowpowermode":
+                low_power = parts[1]
+            if len(parts) >= 2 and parts[0] == "powermode":
+                power_mode = parts[1]
+    therm_text = str(therm.get("stdout") or therm.get("stderr") or "").strip()
+    thermal_ok = bool(therm.get("ok")) and (
+        "No thermal warning level has been recorded" in therm_text
+        and "No performance warning level has been recorded" in therm_text
+    )
+    return {
+        "available": bool(power.get("ok") or therm.get("ok")),
+        "lowpowermode": low_power,
+        "powermode": power_mode,
+        "thermal": therm_text or None,
+        "thermal_ok": thermal_ok,
+    }
+
+
+def _http_probe(url: str, *, timeout: float = 1.0) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            body = response.read(4096).decode("utf-8", errors="replace")
+            return {
+                "ok": 200 <= int(response.status) < 300,
+                "status": int(response.status),
+                "body_prefix": body[:240],
+            }
+    except urllib.error.HTTPError as exc:
+        return {"ok": False, "status": exc.code, "error": str(exc)}
+    except Exception as exc:
+        return {"ok": False, "error": repr(exc)}
+
+
+def host_report(*, model_cache: str | Path | None = None) -> dict[str, Any]:
+    cache_root = Path(model_cache or os.environ.get("MTPLX_MODEL_DIR") or "~/.mtplx/models").expanduser()
+    macos = _run(["sw_vers", "-productVersion"]) if platform.system() == "Darwin" else {}
+    mem_raw = _sysctl("hw.memsize") if platform.system() == "Darwin" else None
+    memory_bytes = int(mem_raw) if mem_raw and mem_raw.isdigit() else None
+    machine_model = _sysctl("hw.model") if platform.system() == "Darwin" else None
+    chip = _sysctl("machdep.cpu.brand_string") if platform.system() == "Darwin" else None
+    disk_parent = cache_root if cache_root.exists() else cache_root.parent
+    try:
+        disk = shutil.disk_usage(disk_parent)
+    except OSError:
+        disk = None
+    return {
+        "system": platform.system(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "macos_version": macos.get("stdout") if macos.get("ok") else None,
+        "mac_model": machine_model,
+        "chip": chip,
+        "python_version": ".".join(str(part) for part in sys.version_info[:3]),
+        "python_executable": sys.executable,
+        "memory_bytes": memory_bytes,
+        "memory_gib": round(memory_bytes / GIB, 2) if memory_bytes else None,
+        "cache_dir": str(cache_root),
+        "disk_free_bytes": disk.free if disk else None,
+        "disk_free_gib": round(disk.free / GIB, 2) if disk else None,
+    }
+
+
+def estimate_runtime_memory_bytes(
+    *,
+    model_size_bytes: int = DEFAULT_SPEED_MODEL_SIZE_BYTES,
+    profile: str = DEFAULT_PROFILE_NAME,
+) -> int:
+    overhead = 24 * GIB if profile == "performance-cold" else 20 * GIB
+    return int(model_size_bytes + overhead)
+
+
+def required_download_free_bytes(model_size_bytes: int = DEFAULT_SPEED_MODEL_SIZE_BYTES) -> int:
+    return max(int(model_size_bytes * 2.5), int(model_size_bytes + 20 * GIB))
+
+
+def _port_open(host: str, port: int) -> bool:
+    try:
+        with socket.create_connection((host, int(port)), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def build_diagnostic_checks(
+    *,
+    model_cache: str | Path | None = None,
+    deep: bool = False,
+    server_port: int = 8000,
+    openwebui_port: int = 3000,
+    mlx_info: dict[str, Any] | None = None,
+    thermal_control: dict[str, Any] | None = None,
+    server_dependencies: dict[str, bool] | None = None,
+) -> tuple[dict[str, Any], list[DiagnosticCheck]]:
+    host = host_report(model_cache=model_cache)
+    checks: list[DiagnosticCheck] = []
+    cache_root = Path(model_cache or os.environ.get("MTPLX_MODEL_DIR") or "~/.mtplx/models").expanduser()
+    macos_version = host.get("macos_version")
+    macos_ok = platform.system() == "Darwin" and bool(macos_version) and _parse_version(str(macos_version)) >= (SUPPORT_MACOS_MAJOR, 0)
+    checks.append(
+        DiagnosticCheck(
+            "os.macos_version",
+            "pass" if macos_ok else "fail",
+            "error",
+            macos_version or platform.system(),
+            "macOS >= 14.0 on Apple Silicon",
+            "Upgrade to macOS 14+; MLX does not support older macOS.",
+            DOCS["mlx"],
+        )
+    )
+    native_arm = platform.machine() == "arm64" and platform.processor() != "i386"
+    checks.append(
+        DiagnosticCheck(
+            "python.native_arm64",
+            "pass" if native_arm else "fail",
+            "error",
+            {"machine": platform.machine(), "processor": platform.processor()},
+            "native arm64 Python, not Rosetta",
+            "Install/use a native arm64 Python. If needed, reinstall via Homebrew arm64 or uv.",
+            DOCS["mlx"],
+            "python3 -c \"import platform; print(platform.machine(), platform.processor())\"",
+        )
+    )
+    python_ok = sys.version_info >= SUPPORT_PYTHON
+    checks.append(
+        DiagnosticCheck(
+            "python.version",
+            "pass" if python_ok else "fail",
+            "error",
+            host["python_version"],
+            "Python >= 3.10",
+            "Install Python 3.10 or newer.",
+            DOCS["mlx"],
+        )
+    )
+    mlx = mlx_info or {}
+    mlx_ok = "mlx_error" not in mlx
+    checks.append(
+        DiagnosticCheck(
+            "mlx.import",
+            "pass" if mlx_ok else "fail",
+            "error",
+            mlx if mlx else "not probed",
+            "mlx importable",
+            "Install MLX into this same native Python environment.",
+            DOCS["mlx"],
+            "python3 -m pip install mlx",
+        )
+    )
+    memory_bytes = host.get("memory_bytes")
+    estimated = estimate_runtime_memory_bytes(profile=DEFAULT_PROFILE_NAME)
+    memory_status = "warn"
+    memory_fix = "Close other heavy apps or use a smaller model/profile."
+    if isinstance(memory_bytes, int):
+        if estimated > int(memory_bytes * 0.80):
+            memory_status = "fail"
+        elif memory_bytes < MIN_RECOMMENDED_MEMORY_BYTES:
+            memory_status = "warn"
+        else:
+            memory_status = "pass"
+            memory_fix = None
+    checks.append(
+        DiagnosticCheck(
+            "resource.memory",
+            memory_status,
+            "error" if memory_status == "fail" else "warning",
+            {
+                "unified_memory_gib": host.get("memory_gib"),
+                "estimated_peak_gib": round(estimated / GIB, 2),
+            },
+            "estimated peak <= 80% of unified memory; 48 GiB+ recommended",
+            memory_fix,
+        )
+    )
+    required_free = required_download_free_bytes()
+    disk_free = host.get("disk_free_bytes")
+    disk_status = "warn"
+    if isinstance(disk_free, int):
+        disk_status = "pass" if disk_free >= required_free else "fail"
+    checks.append(
+        DiagnosticCheck(
+            "resource.model_cache_disk",
+            disk_status,
+            "error" if disk_status == "fail" else "warning",
+            {
+                "cache_dir": host.get("cache_dir"),
+                "free_gib": host.get("disk_free_gib"),
+                "required_gib": round(required_free / GIB, 2),
+            },
+            "free space for model + temp download + safety headroom",
+            "Free disk space or set MTPLX_MODEL_DIR to a larger volume.",
+        )
+    )
+    default_cached = cached_model_path(DEFAULT_HF_MODEL_ID, cache_dir=cache_root)
+    default_validation = validate_mtplx_model_files(default_cached) if default_cached.exists() else None
+    checks.append(
+        DiagnosticCheck(
+            "model.cache",
+            "pass" if default_validation and default_validation.get("ok") else "warn",
+            "warning",
+            {
+                "path": str(default_cached),
+                "exists": default_cached.exists(),
+                "validation": default_validation,
+            },
+            "default model cached with config/tokenizer/index/mtp/runtime contract",
+            "Download the default model before first run.",
+            "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
+            f"mtplx pull {DEFAULT_HF_MODEL_ID}",
+        )
+    )
+    stale = DEFAULT_HF_MODEL_ID.startswith("mtplx/") or DEFAULT_HF_MODEL_ID.startswith("models/")
+    checks.append(
+        DiagnosticCheck(
+            "model.default_repo",
+            "fail" if stale else "pass",
+            "error",
+            DEFAULT_HF_MODEL_ID,
+            "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
+            "Update DEFAULT_HF_MODEL_ID to the published optimized-speed repo.",
+            "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
+            f"mtplx pull {DEFAULT_HF_MODEL_ID}",
+        )
+    )
+    if deep:
+        try:
+            from huggingface_hub import model_info
+
+            info = model_info(DEFAULT_HF_MODEL_ID)
+            hf_observed: Any = {
+                "repo_id": DEFAULT_HF_MODEL_ID,
+                "sha": getattr(info, "sha", None),
+                "private": getattr(info, "private", None),
+                "gated": getattr(info, "gated", None),
+            }
+            hf_ok = True
+        except Exception as exc:  # pragma: no cover - network/token dependent
+            hf_observed = {"repo_id": DEFAULT_HF_MODEL_ID, "error": repr(exc)}
+            hf_ok = False
+        checks.append(
+            DiagnosticCheck(
+                "hf.default_repo_access",
+                "pass" if hf_ok else "fail",
+                "error",
+                hf_observed,
+                "default Hugging Face repo is reachable from this machine",
+                "Check network/HF auth or verify the model repo is public.",
+                "https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
+                f"mtplx pull {DEFAULT_HF_MODEL_ID}",
+            )
+        )
+    docker_path = shutil.which("docker")
+    checks.append(
+        DiagnosticCheck(
+            "docker.binary",
+            "pass" if docker_path else "warn",
+            "warning",
+            docker_path,
+            "Docker Desktop installed for Open WebUI Docker path",
+            "Install Docker Desktop if you want the Open WebUI Docker integration.",
+            DOCS["docker"],
+        )
+    )
+    if deep and docker_path:
+        docker_info = _run(["docker", "info", "--format", "{{json .ServerVersion}}"], timeout=3.0)
+        docker_ok = bool(docker_info.get("ok"))
+        checks.append(
+            DiagnosticCheck(
+                "docker.daemon",
+                "pass" if docker_ok else "warn",
+                "warning",
+                docker_info,
+                "Docker daemon running",
+                "Start Docker Desktop.",
+                DOCS["docker"],
+                "docker info",
+            )
+        )
+        if docker_ok:
+            host_gateway = _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--pull=never",
+                    "--add-host=host.docker.internal:host-gateway",
+                    "busybox",
+                    "sh",
+                    "-lc",
+                    "getent hosts host.docker.internal || nslookup host.docker.internal",
+                ],
+                timeout=8.0,
+            )
+            checks.append(
+                DiagnosticCheck(
+                    "docker.host_gateway",
+                    "pass" if host_gateway.get("ok") else "warn",
+                    "warning",
+                    host_gateway,
+                    "container can resolve host.docker.internal",
+                    "Use --add-host=host.docker.internal:host-gateway in the Open WebUI Docker command.",
+                    DOCS["docker_openwebui"],
+                    "mtplx openwebui docker-command",
+                )
+            )
+            openwebui_ps = _run(
+                ["docker", "ps", "--filter", "name=open-webui", "--format", "{{.Names}} {{.Ports}}"],
+                timeout=3.0,
+            )
+            checks.append(
+                DiagnosticCheck(
+                    "docker.openwebui_container",
+                    "pass" if openwebui_ps.get("ok") and openwebui_ps.get("stdout") else "warn",
+                    "warning",
+                    openwebui_ps,
+                    "Open WebUI container running if using Docker integration",
+                    "Start Open WebUI with the MTPLX Docker command.",
+                    DOCS["openwebui"],
+                    "mtplx openwebui docker-command",
+                )
+            )
+    checks.append(
+        DiagnosticCheck(
+            "port.mtplx_server",
+            "warn" if _port_open("127.0.0.1", server_port) else "pass",
+            "warning",
+            {"host": "127.0.0.1", "port": server_port, "open": _port_open("127.0.0.1", server_port)},
+            "port free before starting mtplx serve, or already a healthy MTPLX server",
+            f"Use --port {server_port + 1} or stop the existing process.",
+        )
+    )
+    if deep:
+        models_probe = _http_probe(f"http://127.0.0.1:{server_port}/v1/models", timeout=1.0)
+        checks.append(
+            DiagnosticCheck(
+                "server.openai_models",
+                "pass" if models_probe.get("ok") else "warn",
+                "warning",
+                models_probe,
+                "running MTPLX server exposes /v1/models",
+                "Start the server or choose the correct port.",
+                "docs/server.md",
+                f"curl http://127.0.0.1:{server_port}/v1/models",
+            )
+        )
+    checks.append(
+        DiagnosticCheck(
+            "port.openwebui",
+            "warn" if _port_open("127.0.0.1", openwebui_port) else "pass",
+            "warning",
+            {"host": "127.0.0.1", "port": openwebui_port, "open": _port_open("127.0.0.1", openwebui_port)},
+            "port free before starting Open WebUI, or already an Open WebUI container",
+            f"Use a different Open WebUI host port or stop the process on {openwebui_port}.",
+        )
+    )
+    if server_dependencies is not None:
+        for name, ok in sorted(server_dependencies.items()):
+            checks.append(
+                DiagnosticCheck(
+                    f"python.dep.{name}",
+                    "pass" if ok else "fail",
+                    "error",
+                    ok,
+                    f"{name} installed",
+                    "Install MTPLX with server extras.",
+                    command='python3 -m pip install "mtplx[server]"',
+                )
+            )
+    thermal = thermal_control or {}
+    checks.append(
+        DiagnosticCheck(
+            "thermal.control",
+            "pass" if thermal.get("available") else "warn",
+            "warning",
+            thermal.get("selected") or "none",
+            "ThermalForge or TG Pro available for explicit --max only",
+            "Install ThermalForge only if you want opt-in fan boost.",
+        )
+    )
+    pmset = _pmset_report()
+    low_power_enabled = pmset.get("lowpowermode") == "1"
+    checks.append(
+        DiagnosticCheck(
+            "power.low_power_mode",
+            "warn" if low_power_enabled else "pass",
+            "warning",
+            pmset,
+            "Low Power Mode off for best sustained decode",
+            "Turn off Low Power Mode before benchmarking or serving long responses.",
+        )
+    )
+    thermal_pressure_ok = pmset.get("thermal_ok") is True
+    checks.append(
+        DiagnosticCheck(
+            "power.thermal_pressure",
+            "pass" if thermal_pressure_ok else "warn",
+            "warning",
+            pmset.get("thermal"),
+            "no recorded thermal or performance warning",
+            "Let the Mac cool down or improve airflow before sustained benchmarks.",
+        )
+    )
+    return host, checks
+
+
+def summarize_checks(checks: list[DiagnosticCheck]) -> str:
+    if any(check.status == "fail" and check.severity == "error" for check in checks):
+        return "fail"
+    if any(check.status in {"fail", "warn"} for check in checks):
+        return "warn"
+    return "pass"
+
+
+def build_diagnostics_payload(
+    *,
+    model_cache: str | Path | None = None,
+    deep: bool = False,
+    mlx_info: dict[str, Any] | None = None,
+    thermal_control: dict[str, Any] | None = None,
+    server_dependencies: dict[str, bool] | None = None,
+) -> dict[str, Any]:
+    host, checks = build_diagnostic_checks(
+        model_cache=model_cache,
+        deep=deep,
+        mlx_info=mlx_info,
+        thermal_control=thermal_control,
+        server_dependencies=server_dependencies,
+    )
+    return {
+        "schema_version": 1,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "overall": summarize_checks(checks),
+        "support_matrix": SUPPORT_MATRIX,
+        "host": host,
+        "resources": {
+            "default_model_size_bytes": DEFAULT_SPEED_MODEL_SIZE_BYTES,
+            "estimated_runtime_memory_bytes": estimate_runtime_memory_bytes(),
+            "required_download_free_bytes": required_download_free_bytes(),
+        },
+        "checks": [check.to_dict() for check in checks],
+    }
+
+
+def write_doctor_bundle(
+    *,
+    report: dict[str, Any],
+    output_dir: str | Path | None = None,
+    include_paths: bool = False,
+) -> dict[str, Any]:
+    base = Path(output_dir or "~/.mtplx/reports").expanduser()
+    bundle_id = f"doctor-{time.strftime('%Y%m%d-%H%M%S')}"
+    root = base / bundle_id
+    root.mkdir(parents=True, exist_ok=True)
+    redacted = json.loads(json.dumps(report))
+    if not include_paths:
+        for section in ("environment", "host"):
+            item = redacted.get(section)
+            if isinstance(item, dict):
+                for key in ("project_root", "python_executable", "cache_dir"):
+                    if key in item:
+                        item[key] = "[redacted-path]"
+    (root / "doctor.json").write_text(json.dumps(redacted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (root / "summary.json").write_text(
+        json.dumps(
+            {
+                "bundle_id": bundle_id,
+                "created_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "redacted": not include_paths,
+                "files": ["doctor.json", "summary.json"],
+                "zip": f"{bundle_id}.zip",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    zip_path = base / f"{bundle_id}.zip"
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for file_path in sorted(root.iterdir()):
+            if file_path.is_file():
+                archive.write(file_path, arcname=f"{bundle_id}/{file_path.name}")
+    return {
+        "bundle_id": bundle_id,
+        "bundle_dir": str(root),
+        "bundle_zip": str(zip_path),
+        "redacted": not include_paths,
+        "files": ["doctor.json", "summary.json"],
+    }

--- a/mtplx/draft_lm_head.py
+++ b/mtplx/draft_lm_head.py
@@ -6,6 +6,44 @@ import time
 from typing import Any
 
 
+def normalize_draft_lm_head_spec(
+    value: Any,
+    *,
+    fallback: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return a validated draft LM-head spec from profile/contract metadata."""
+    if value is None:
+        return fallback
+    if not isinstance(value, dict):
+        raise ValueError("draft LM-head spec must be an object")
+    if "bits" not in value:
+        raise ValueError("draft LM-head spec missing bits")
+    bits = int(value["bits"])
+    group_size = int(value.get("group_size", 64))
+    mode = str(value.get("mode", "affine"))
+    if bits <= 0:
+        raise ValueError("draft LM-head bits must be positive")
+    if group_size <= 0:
+        raise ValueError("draft LM-head group_size must be positive")
+    if mode not in {"affine", "symmetric"}:
+        raise ValueError("draft LM-head mode must be 'affine' or 'symmetric'")
+    return {"bits": bits, "group_size": group_size, "mode": mode}
+
+
+def draft_lm_head_spec_from_runtime_contract(
+    contract_data: Any,
+    *,
+    fallback: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Resolve a model-specific draft-head recommendation from contract data."""
+    if not isinstance(contract_data, dict):
+        return fallback
+    return normalize_draft_lm_head_spec(
+        contract_data.get("recommended_draft_lm_head"),
+        fallback=fallback,
+    )
+
+
 def _text_model(model: Any) -> Any:
     return getattr(model, "language_model", model)
 

--- a/mtplx/draft_sampling.py
+++ b/mtplx/draft_sampling.py
@@ -1,0 +1,41 @@
+"""Draft proposal sampler metadata helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_draft_sampler_spec(
+    value: Any,
+    *,
+    fallback: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return a validated draft sampler override from profile/contract data."""
+    if value is None:
+        return fallback
+    if not isinstance(value, dict):
+        raise ValueError("draft sampler spec must be an object")
+    temperature = float(value.get("temperature", 0.6))
+    top_p = float(value.get("top_p", 0.95))
+    top_k = int(value.get("top_k", 20))
+    if temperature < 0:
+        raise ValueError("draft sampler temperature must be non-negative")
+    if top_p <= 0:
+        raise ValueError("draft sampler top_p must be positive")
+    if top_k < 0:
+        raise ValueError("draft sampler top_k must be non-negative")
+    return {"temperature": temperature, "top_p": top_p, "top_k": top_k}
+
+
+def draft_sampler_spec_from_runtime_contract(
+    contract_data: Any,
+    *,
+    fallback: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Resolve a model-specific draft sampler recommendation."""
+    if not isinstance(contract_data, dict):
+        return fallback
+    return normalize_draft_sampler_spec(
+        contract_data.get("recommended_draft_sampler"),
+        fallback=fallback,
+    )

--- a/mtplx/errors.py
+++ b/mtplx/errors.py
@@ -1,0 +1,86 @@
+"""User-facing MTPLX error types.
+
+The CLI should only show tracebacks when the user explicitly asks for debug
+output.  These exceptions carry enough structure for both human and JSON
+responses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+EXIT_GENERAL = 1
+EXIT_INVALID_MTP = 2
+EXIT_EXACTNESS = 3
+EXIT_UNSUPPORTED_ARCHITECTURE = 4
+EXIT_ENVIRONMENT = 5
+EXIT_RESOURCE = 6
+EXIT_INTEGRATION = 7
+EXIT_THERMAL = 8
+
+
+@dataclass
+class MTPLXError(Exception):
+    message: str
+    code: int = EXIT_GENERAL
+    kind: str = "mtplx_error"
+    detail: str | None = None
+    fix: str | None = None
+    command: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "error": self.kind,
+            "message": self.message,
+            "exit_code": self.code,
+        }
+        if self.detail:
+            payload["detail"] = self.detail
+        if self.fix:
+            payload["fix"] = self.fix
+        if self.command:
+            payload["command"] = self.command
+        return payload
+
+
+class MissingMLXError(MTPLXError):
+    def __init__(self, detail: str | None = None) -> None:
+        super().__init__(
+            "MLX is not installed for this native arm64 Python environment.",
+            code=EXIT_ENVIRONMENT,
+            kind="missing_mlx",
+            detail=detail,
+            fix=(
+                "Install MLX from a native arm64 Python on Apple Silicon. "
+                "If platform.processor() reports i386, switch out of Rosetta."
+            ),
+            command="python3 -m pip install mlx",
+        )
+
+
+class MissingModelError(MTPLXError):
+    def __init__(self, model: str, pull_command: str) -> None:
+        super().__init__(
+            f"Model {model} is not cached locally.",
+            code=EXIT_RESOURCE,
+            kind="missing_model",
+            fix="Download the verified MTPLX model before running.",
+            command=pull_command,
+        )
+
+
+class IntegrationError(MTPLXError):
+    def __init__(self, message: str, *, fix: str | None = None, command: str | None = None) -> None:
+        super().__init__(
+            message,
+            code=EXIT_INTEGRATION,
+            kind="integration_error",
+            fix=fix,
+            command=command,
+        )
+

--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from mtplx.artifacts import _hf_repo_id_from_ref
+from mtplx.profiles import DEFAULT_PROFILE_NAME
 
 
 DEFAULT_MODEL_CACHE = Path("~/.mtplx/models").expanduser()
+REQUIRED_MTPLX_MODEL_FILES = (
+    "config.json",
+    "tokenizer.json",
+    "model.safetensors.index.json",
+    "mtp.safetensors",
+    "mtplx_runtime.json",
+)
 
 
 def model_cache_dir(value: str | Path | None = None) -> Path:
@@ -50,6 +60,27 @@ def resolve_model_path(model_ref: str, *, cache_dir: str | Path | None = None) -
     )
 
 
+def validate_mtplx_model_files(path: Path) -> dict[str, Any]:
+    missing = [name for name in REQUIRED_MTPLX_MODEL_FILES if not (path / name).exists()]
+    contract: dict[str, Any] | None = None
+    contract_error: str | None = None
+    contract_path = path / "mtplx_runtime.json"
+    if contract_path.exists():
+        try:
+            loaded = json.loads(contract_path.read_text(encoding="utf-8"))
+            contract = loaded if isinstance(loaded, dict) else None
+        except Exception as exc:
+            contract_error = str(exc)
+    return {
+        "ok": not missing and contract_error is None,
+        "required_files": list(REQUIRED_MTPLX_MODEL_FILES),
+        "missing_files": missing,
+        "contract_present": contract_path.exists(),
+        "contract_arch_id": contract.get("arch_id") if isinstance(contract, dict) else None,
+        "contract_error": contract_error,
+    }
+
+
 def directory_size_bytes(path: Path) -> int:
     total = 0
     if not path.exists():
@@ -70,6 +101,7 @@ class CachedModel:
     size_bytes: int
     has_runtime_contract: bool
     has_config: bool
+    validation: dict[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -79,6 +111,9 @@ class CachedModel:
             "size_gb": round(self.size_bytes / 1_000_000_000, 3),
             "has_runtime_contract": self.has_runtime_contract,
             "has_config": self.has_config,
+            "validation": self.validation,
+            "recommended_profile": DEFAULT_PROFILE_NAME if self.validation.get("ok") else None,
+            "delete_command": f"mtplx remove {self.repo_id}",
         }
 
 
@@ -88,7 +123,7 @@ def list_cached_models(*, cache_dir: str | Path | None = None) -> list[CachedMod
         return []
     rows: list[CachedModel] = []
     for child in sorted(root.iterdir()):
-        if not child.is_dir():
+        if not child.is_dir() or child.name.startswith("."):
             continue
         repo_id = child.name.replace("--", "/")
         rows.append(
@@ -98,6 +133,7 @@ def list_cached_models(*, cache_dir: str | Path | None = None) -> list[CachedMod
                 size_bytes=directory_size_bytes(child),
                 has_runtime_contract=(child / "mtplx_runtime.json").exists(),
                 has_config=(child / "config.json").exists(),
+                validation=validate_mtplx_model_files(child),
             )
         )
     return rows
@@ -115,28 +151,55 @@ def pull_model(
     root = model_cache_dir(cache_dir)
     root.mkdir(parents=True, exist_ok=True)
     destination = cached_model_path(repo_id, cache_dir=root)
-    destination.mkdir(parents=True, exist_ok=True)
 
     try:
         from huggingface_hub import snapshot_download
     except Exception as exc:
         raise RuntimeError(f"huggingface_hub is required for mtplx pull: {exc}") from exc
 
-    path = snapshot_download(
-        repo_id=repo_id,
-        repo_type="model",
-        revision=revision,
-        local_dir=str(destination),
-    )
-    resolved = Path(path)
+    if destination.exists():
+        resolved = destination
+        reused_existing = True
+        validation = validate_mtplx_model_files(resolved)
+        if repo_id.lower().startswith("youssofal/qwen3.6-27b-mtplx") and not validation["ok"]:
+            raise RuntimeError(
+                "cached MTPLX model is incomplete: "
+                + ", ".join(validation["missing_files"] or [str(validation.get("contract_error"))])
+            )
+    else:
+        reused_existing = False
+        tmp_parent = root / ".tmp"
+        tmp_parent.mkdir(parents=True, exist_ok=True)
+        tmp_dir = Path(tempfile.mkdtemp(prefix=safe_model_name(repo_id) + "-", dir=str(tmp_parent)))
+        try:
+            path = snapshot_download(
+                repo_id=repo_id,
+                repo_type="model",
+                revision=revision,
+                local_dir=str(tmp_dir),
+            )
+            resolved_tmp = Path(path)
+            validation = validate_mtplx_model_files(resolved_tmp)
+            if repo_id.lower().startswith("youssofal/qwen3.6-27b-mtplx") and not validation["ok"]:
+                raise RuntimeError(
+                    "downloaded MTPLX model is incomplete: "
+                    + ", ".join(validation["missing_files"] or [str(validation.get("contract_error"))])
+                )
+            resolved_tmp.replace(destination)
+            resolved = destination
+        except Exception:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
     return {
         "repo_id": repo_id,
         "path": str(resolved),
         "cache_dir": str(root),
         "revision": revision,
+        "reused_existing": reused_existing,
         "size_bytes": directory_size_bytes(resolved),
         "has_runtime_contract": (resolved / "mtplx_runtime.json").exists(),
         "has_config": (resolved / "config.json").exists(),
+        "validation": validate_mtplx_model_files(resolved),
     }
 
 
@@ -167,10 +230,17 @@ def hf_cache_report(*, cache_dir: str | Path | None = None) -> dict[str, Any]:
             token_source = "huggingface_hub" if token_present else None
         except Exception:
             token_present = False
+    try:
+        usage = shutil.disk_usage(root if root.exists() else root.parent)
+        free_bytes: int | None = usage.free
+    except OSError:
+        free_bytes = None
     return {
         "cache_dir": str(root),
         "cache_exists": root.exists(),
         "cache_writable": os.access(root if root.exists() else root.parent, os.W_OK),
+        "disk_free_bytes": free_bytes,
+        "disk_free_gb": round(free_bytes / 1_000_000_000, 3) if free_bytes is not None else None,
         "cached_models": len(list_cached_models(cache_dir=root)),
         "token_present": token_present,
         "token_source": token_source,

--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -45,6 +45,62 @@ def cached_model_path(repo_id: str, *, cache_dir: str | Path | None = None) -> P
     return model_cache_dir(cache_dir) / safe_model_name(repo_id)
 
 
+def _complete_indexed_weights(path: Path, index_name: str) -> bool:
+    index = path / index_name
+    if not index.is_file():
+        return False
+    try:
+        data = json.loads(index.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    weight_map = data.get("weight_map") if isinstance(data, dict) else None
+    if not isinstance(weight_map, dict):
+        return False
+    filenames = {
+        name
+        for name in weight_map.values()
+        if isinstance(name, str) and name.strip()
+    }
+    if not filenames:
+        return False
+    for name in filenames:
+        shard = path / name
+        try:
+            if not shard.is_file() or shard.stat().st_size <= 0:
+                return False
+        except OSError:
+            return False
+    return True
+
+
+def _complete_unindexed_weights(path: Path) -> bool:
+    for pattern in ("*.safetensors", "*.bin", "*.gguf"):
+        for candidate in path.glob(pattern):
+            try:
+                if candidate.is_file() and candidate.stat().st_size > 0:
+                    return True
+            except OSError:
+                continue
+    return False
+
+
+def cached_model_is_complete(path: Path) -> bool:
+    """Return whether a Hub cache directory is ready to run.
+
+    ``snapshot_download(local_dir=...)`` creates the destination early. An
+    interrupted pull can therefore leave config/tokenizer files plus an index,
+    which looks cached even though the weight shards are missing.
+    """
+
+    if not path.is_dir() or not (path / "config.json").is_file():
+        return False
+    return (
+        _complete_indexed_weights(path, "model.safetensors.index.json")
+        or _complete_indexed_weights(path, "pytorch_model.bin.index.json")
+        or _complete_unindexed_weights(path)
+    )
+
+
 def resolve_model_path(model_ref: str, *, cache_dir: str | Path | None = None) -> Path:
     local = Path(model_ref).expanduser()
     if local.exists():
@@ -53,7 +109,7 @@ def resolve_model_path(model_ref: str, *, cache_dir: str | Path | None = None) -
     if repo_id is None:
         return local
     cached = cached_model_path(repo_id, cache_dir=cache_dir)
-    if cached.exists():
+    if cached_model_is_complete(cached):
         return cached
     raise FileNotFoundError(
         f"Model {repo_id} is not cached. Run: mtplx pull {repo_id}"

--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import tempfile
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from mtplx.artifacts import _hf_repo_id_from_ref
 from mtplx.profiles import DEFAULT_PROFILE_NAME
 
 
 DEFAULT_MODEL_CACHE = Path("~/.mtplx/models").expanduser()
+DownloadProgressCallback = Callable[[dict[str, Any]], None]
 REQUIRED_MTPLX_MODEL_FILES = (
     "config.json",
     "tokenizer.json",
@@ -150,6 +152,53 @@ def directory_size_bytes(path: Path) -> int:
     return total
 
 
+def _emit_download_progress(callback: DownloadProgressCallback | None, payload: dict[str, Any]) -> None:
+    if callback is None:
+        return
+    try:
+        callback(payload)
+    except Exception:
+        # Progress reporting must never break a model download.
+        return
+
+
+def _start_download_heartbeat(
+    destination: Path,
+    *,
+    callback: DownloadProgressCallback | None,
+    interval_s: float,
+) -> tuple[threading.Event | None, threading.Thread | None]:
+    if callback is None or interval_s <= 0:
+        return None, None
+
+    stop = threading.Event()
+    started_at = time.monotonic()
+    last_at = started_at
+    last_size = directory_size_bytes(destination)
+
+    def run() -> None:
+        nonlocal last_at, last_size
+        while not stop.wait(interval_s):
+            now = time.monotonic()
+            current_size = directory_size_bytes(destination)
+            delta = current_size - last_size
+            payload = {
+                "event": "progress",
+                "path": str(destination),
+                "size_bytes": current_size,
+                "delta_bytes": delta,
+                "elapsed_s": now - started_at,
+                "interval_s": now - last_at,
+            }
+            last_at = now
+            last_size = current_size
+            _emit_download_progress(callback, payload)
+
+    thread = threading.Thread(target=run, name="mtplx-download-heartbeat", daemon=True)
+    thread.start()
+    return stop, thread
+
+
 @dataclass(frozen=True)
 class CachedModel:
     repo_id: str
@@ -200,6 +249,8 @@ def pull_model(
     *,
     cache_dir: str | Path | None = None,
     revision: str | None = None,
+    progress_callback: DownloadProgressCallback | None = None,
+    progress_interval_s: float = 10.0,
 ) -> dict[str, Any]:
     repo_id = repo_id_from_model_ref(model_ref)
     if repo_id is None:
@@ -213,9 +264,11 @@ def pull_model(
     except Exception as exc:
         raise RuntimeError(f"huggingface_hub is required for mtplx pull: {exc}") from exc
 
-    if destination.exists():
+    started_size = directory_size_bytes(destination)
+    if destination.exists() and cached_model_is_complete(destination):
         resolved = destination
         reused_existing = True
+        resumed_existing = False
         validation = validate_mtplx_model_files(resolved)
         if repo_id.lower().startswith("youssofal/qwen3.6-27b-mtplx") and not validation["ok"]:
             raise RuntimeError(
@@ -224,34 +277,64 @@ def pull_model(
             )
     else:
         reused_existing = False
-        tmp_parent = root / ".tmp"
-        tmp_parent.mkdir(parents=True, exist_ok=True)
-        tmp_dir = Path(tempfile.mkdtemp(prefix=safe_model_name(repo_id) + "-", dir=str(tmp_parent)))
+        resumed_existing = destination.exists() and started_size > 0
+        destination.mkdir(parents=True, exist_ok=True)
+        _emit_download_progress(
+            progress_callback,
+            {
+                "event": "resume" if resumed_existing else "start",
+                "repo_id": repo_id,
+                "path": str(destination),
+                "size_bytes": started_size,
+            },
+        )
+        stop, thread = _start_download_heartbeat(
+            destination,
+            callback=progress_callback,
+            interval_s=progress_interval_s,
+        )
         try:
             path = snapshot_download(
                 repo_id=repo_id,
                 repo_type="model",
                 revision=revision,
-                local_dir=str(tmp_dir),
+                local_dir=str(destination),
             )
-            resolved_tmp = Path(path)
-            validation = validate_mtplx_model_files(resolved_tmp)
+            resolved = Path(path)
+            validation = validate_mtplx_model_files(resolved)
+            if not cached_model_is_complete(resolved):
+                raise RuntimeError(
+                    "downloaded model is incomplete: weight shards are missing or still partial"
+                )
             if repo_id.lower().startswith("youssofal/qwen3.6-27b-mtplx") and not validation["ok"]:
                 raise RuntimeError(
                     "downloaded MTPLX model is incomplete: "
                     + ", ".join(validation["missing_files"] or [str(validation.get("contract_error"))])
                 )
-            resolved_tmp.replace(destination)
-            resolved = destination
-        except Exception:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise
+        finally:
+            if stop is not None:
+                stop.set()
+            if thread is not None:
+                thread.join(timeout=1.0)
+        final_size = directory_size_bytes(resolved)
+        _emit_download_progress(
+            progress_callback,
+            {
+                "event": "complete",
+                "repo_id": repo_id,
+                "path": str(resolved),
+                "size_bytes": final_size,
+                "delta_bytes": final_size - started_size,
+            },
+        )
     return {
         "repo_id": repo_id,
         "path": str(resolved),
         "cache_dir": str(root),
         "revision": revision,
         "reused_existing": reused_existing,
+        "resumed_existing": resumed_existing,
+        "started_size_bytes": started_size,
         "size_bytes": directory_size_bytes(resolved),
         "has_runtime_contract": (resolved / "mtplx_runtime.json").exists(),
         "has_config": (resolved / "config.json").exists(),

--- a/mtplx/mtp_patch.py
+++ b/mtplx/mtp_patch.py
@@ -276,8 +276,6 @@ def _load_embedded_mtp_weights(
     *,
     prequantized: bool = False,
 ) -> dict[str, Any]:
-    from safetensors import safe_open
-
     key_to_file = _embedded_mtp_weight_map(model_path)
     if not key_to_file:
         return {}
@@ -287,11 +285,20 @@ def _load_embedded_mtp_weights(
     for key, shard in key_to_file.items():
         files.setdefault(shard, []).append(key)
 
-    framework = _safetensors_runtime_framework()
     for shard, keys in files.items():
-        with safe_open(str(shard), framework=framework) as handle:
+        try:
+            import mlx.core as mx
+
+            shard_tensors = mx.load(str(shard))
             for key in sorted(keys):
-                raw_mtp[_strip_mtp_namespace(key)] = handle.get_tensor(key)
+                raw_mtp[_strip_mtp_namespace(key)] = shard_tensors[key]
+            del shard_tensors
+        except Exception:
+            from safetensors import safe_open
+
+            with safe_open(str(shard), framework=_safetensors_runtime_framework()) as handle:
+                for key in sorted(keys):
+                    raw_mtp[_strip_mtp_namespace(key)] = handle.get_tensor(key)
 
     return _finalize_mtp_weights(raw_mtp, config, prequantized=prequantized)
 

--- a/mtplx/mtp_patch.py
+++ b/mtplx/mtp_patch.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 import os
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from .artifacts import expected_mtp_file, text_config
+from .artifacts import expected_mtp_file, is_mtp_key, normalize_mtp_key, text_config
+from .constants import EXPECTED_ALL_PREQUANTIZED_MTP_KEYS, EXPECTED_PREQUANTIZED_MTP_KEYS
 
 logger = logging.getLogger(__name__)
 
@@ -111,13 +113,16 @@ def _quantize_mtp_module(mtp: Any, contract: MTPContract) -> None:
     nn.quantize(mtp, class_predicate=predicate)
 
 
-def _load_mtp_weights(
-    mtp_file: Path,
+def _finalize_mtp_weights(
+    raw_mtp: dict[str, Any],
     config: dict[str, Any],
     *,
     prequantized: bool = False,
 ) -> dict[str, Any]:
-    import mlx.core as mx
+    try:
+        import mlx.core as mx
+    except Exception:
+        mx = None
 
     tcfg = text_config(config)
     quant_config = tcfg.get("quantization") or tcfg.get("quantization_config") or {}
@@ -125,10 +130,6 @@ def _load_mtp_weights(
         quant_config = config.get("quantization") or config.get("quantization_config") or {}
     bits = int(quant_config.get("bits", 4)) if quant_config else 4
     group_size = int(quant_config.get("group_size", 64)) if quant_config else 64
-
-    raw = mx.load(str(mtp_file))
-    raw_mtp = {k.removeprefix("mtp."): v for k, v in raw.items() if k.startswith("mtp.")}
-    del raw
 
     if prequantized:
         weights = dict(raw_mtp)
@@ -146,6 +147,8 @@ def _load_mtp_weights(
         scales_key = key.replace(".weight", ".scales")
         biases_key = key.replace(".weight", ".biases")
         if scales_key != key and scales_key in raw_mtp and biases_key in raw_mtp:
+            if mx is None:
+                raise RuntimeError("MLX is required to dequantize embedded MTP weights")
             weights[key] = mx.dequantize(
                 raw_mtp[key],
                 raw_mtp[scales_key],
@@ -163,6 +166,134 @@ def _load_mtp_weights(
             if float(value.mean().item()) < 0.5:
                 weights[key] = value + 1.0
     return weights
+
+
+def _strip_mtp_namespace(key: str) -> str:
+    return normalize_mtp_key(key).removeprefix("mtp.")
+
+
+def _mtp_contract_for_weight_keys(
+    contract: MTPContract,
+    keys: tuple[str, ...],
+    config: dict[str, Any],
+) -> MTPContract:
+    normalized = {normalize_mtp_key(key) for key in keys}
+    if contract.mtp_prequantized:
+        return contract
+    if normalized == set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS):
+        policy = "all"
+    elif normalized == set(EXPECTED_PREQUANTIZED_MTP_KEYS):
+        policy = "cyankiwi"
+    else:
+        return contract
+
+    tcfg = text_config(config)
+    quant_config = tcfg.get("quantization") or tcfg.get("quantization_config") or {}
+    if not quant_config:
+        quant_config = config.get("quantization") or config.get("quantization_config") or {}
+    updates: dict[str, Any] = {
+        "mtp_prequantized": True,
+        "mtp_quant_policy": contract.mtp_quant_policy or policy,
+    }
+    if contract.mtp_quant_bits is None:
+        updates["mtp_quant_bits"] = int((quant_config or {}).get("bits", 4))
+    if contract.mtp_quant_group_size == 64:
+        updates["mtp_quant_group_size"] = int((quant_config or {}).get("group_size", 64))
+    if contract.mtp_quant_mode == "affine":
+        updates["mtp_quant_mode"] = str((quant_config or {}).get("mode", "affine"))
+    return replace(contract, **updates)
+
+
+def _load_mtp_weights(
+    mtp_file: Path,
+    config: dict[str, Any],
+    *,
+    prequantized: bool = False,
+) -> dict[str, Any]:
+    import mlx.core as mx
+
+    raw = mx.load(str(mtp_file))
+    raw_mtp = {_strip_mtp_namespace(k): v for k, v in raw.items() if is_mtp_key(k)}
+    del raw
+    return _finalize_mtp_weights(raw_mtp, config, prequantized=prequantized)
+
+
+def _safetensors_runtime_framework() -> str:
+    try:
+        import mlx.core  # noqa: F401 - registers mlx.core for safetensors.
+
+        return "mlx"
+    except Exception:
+        return "np"
+
+
+def _mtp_file_keys(mtp_file: Path) -> tuple[str, ...]:
+    try:
+        from safetensors import safe_open
+
+        with safe_open(str(mtp_file), framework=_safetensors_runtime_framework()) as handle:
+            return tuple(sorted(str(key) for key in handle.keys()))
+    except Exception:
+        try:
+            import mlx.core as mx
+
+            raw = mx.load(str(mtp_file))
+            keys = tuple(sorted(str(key) for key in raw.keys()))
+            del raw
+            return keys
+        except Exception:
+            return ()
+
+
+def _embedded_mtp_weight_map(model_path: Path) -> dict[str, Path]:
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text(encoding="utf-8")).get("weight_map", {})
+        except Exception:
+            weight_map = {}
+        return {
+            str(key): model_path / str(rel)
+            for key, rel in weight_map.items()
+            if is_mtp_key(str(key))
+        }
+
+    from safetensors import safe_open
+
+    result: dict[str, Path] = {}
+    framework = _safetensors_runtime_framework()
+    for shard in sorted(model_path.glob("model*.safetensors")):
+        with safe_open(str(shard), framework=framework) as handle:
+            for key in handle.offset_keys():
+                if is_mtp_key(str(key)):
+                    result[str(key)] = shard
+    return result
+
+
+def _load_embedded_mtp_weights(
+    model_path: Path,
+    config: dict[str, Any],
+    *,
+    prequantized: bool = False,
+) -> dict[str, Any]:
+    from safetensors import safe_open
+
+    key_to_file = _embedded_mtp_weight_map(model_path)
+    if not key_to_file:
+        return {}
+
+    raw_mtp: dict[str, Any] = {}
+    files: dict[Path, list[str]] = {}
+    for key, shard in key_to_file.items():
+        files.setdefault(shard, []).append(key)
+
+    framework = _safetensors_runtime_framework()
+    for shard, keys in files.items():
+        with safe_open(str(shard), framework=framework) as handle:
+            for key in sorted(keys):
+                raw_mtp[_strip_mtp_namespace(key)] = handle.get_tensor(key)
+
+    return _finalize_mtp_weights(raw_mtp, config, prequantized=prequantized)
 
 
 def inject_mtp_support(
@@ -187,9 +318,31 @@ def inject_mtp_support(
 
     model_path = Path(model_path)
     mtp_file = expected_mtp_file(model_path, config)
-    if not mtp_file.exists():
-        logger.warning("[MTP inject] MTP weights not found: %s", mtp_file)
-        return False
+    mtp_weights: dict[str, Any] | None = None
+    mtp_source = mtp_file
+    if mtp_file.exists():
+        contract = _mtp_contract_for_weight_keys(contract, _mtp_file_keys(mtp_file), config)
+        mtp_weights = _load_mtp_weights(
+            mtp_file,
+            config,
+            prequantized=contract.mtp_prequantized,
+        )
+    else:
+        embedded_weight_map = _embedded_mtp_weight_map(model_path)
+        contract = _mtp_contract_for_weight_keys(
+            contract,
+            tuple(embedded_weight_map),
+            config,
+        )
+        mtp_weights = _load_embedded_mtp_weights(
+            model_path,
+            config,
+            prequantized=contract.mtp_prequantized,
+        )
+        mtp_source = model_path / "model*.safetensors::embedded-mtp"
+        if not mtp_weights:
+            logger.warning("[MTP inject] MTP weights not found: %s", mtp_file)
+            return False
 
     tcfg = text_config(config)
     text_model = _text_model(model)
@@ -211,11 +364,6 @@ def inject_mtp_support(
     mtp = _MTPModule(args, n_layers)
     if contract.mtp_prequantized:
         _quantize_mtp_module(mtp, contract)
-    mtp_weights = _load_mtp_weights(
-        mtp_file,
-        config,
-        prequantized=contract.mtp_prequantized,
-    )
     mtp.load_weights(list(mtp_weights.items()), strict=False)
     if not contract.mtp_prequantized:
         _quantize_mtp_module(mtp, contract)
@@ -501,7 +649,7 @@ def inject_mtp_support(
 
         model.__class__ = _MTPLXOuterModel
 
-    logger.info("[MTP inject] Loaded %d tensors from %s", len(mtp_weights), mtp_file)
+    logger.info("[MTP inject] Loaded %d tensors from %s", len(mtp_weights), mtp_source)
     return True
 
 

--- a/mtplx/nemotron_h_mtp_patch.py
+++ b/mtplx/nemotron_h_mtp_patch.py
@@ -1,0 +1,381 @@
+"""Runtime MTP injection for Nemotron-H MLX models."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .artifacts import expected_mtp_file, text_config
+
+logger = logging.getLogger(__name__)
+
+NEMOTRON_H_MODEL_TYPES = {"nemotron_h", "nemotron_h_puzzle"}
+
+
+def _num_mtp_layers(config: dict[str, Any]) -> int:
+    tcfg = text_config(config)
+    return int(
+        tcfg.get("num_nextn_predict_layers")
+        or tcfg.get("mtp_num_hidden_layers")
+        or config.get("num_nextn_predict_layers")
+        or config.get("mtp_num_hidden_layers")
+        or 0
+    )
+
+
+def _model_type(config: dict[str, Any]) -> str:
+    tcfg = text_config(config)
+    return str(tcfg.get("model_type") or config.get("model_type") or "").lower()
+
+
+def _mtp_pattern(config: dict[str, Any]) -> str:
+    tcfg = text_config(config)
+    raw = (
+        tcfg.get("mtp_hybrid_override_pattern")
+        or config.get("mtp_hybrid_override_pattern")
+        or tcfg.get("hybrid_override_pattern")
+        or config.get("hybrid_override_pattern")
+    )
+    mapping = {"mamba": "M", "attention": "*", "moe": "E", "mlp": "-"}
+    if isinstance(raw, str):
+        if "," in raw:
+            parts = [part.strip().lower() for part in raw.split(",") if part.strip()]
+            return "".join(mapping.get(part, part) for part in parts)
+        return raw
+    if isinstance(raw, list):
+        return "".join(mapping.get(str(part).lower(), str(part)) for part in raw)
+    return ""
+
+
+def is_nemotron_h_mtp_config(config: dict[str, Any]) -> bool:
+    pattern = _mtp_pattern(config)
+    return (
+        _model_type(config) in NEMOTRON_H_MODEL_TYPES
+        and _num_mtp_layers(config) == 1
+        and bool(pattern)
+        and set(pattern).issubset({"*", "E"})
+    )
+
+
+def _load_weight_file(path: Path) -> dict[str, Any]:
+    import mlx.core as mx
+
+    if path.suffix == ".json":
+        return {}
+    return dict(mx.load(str(path)))
+
+
+def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Path]:
+    mtp_file = expected_mtp_file(model_path, config)
+    if mtp_file.exists():
+        return [mtp_file]
+
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text(encoding="utf-8")).get("weight_map", {})
+        except Exception:
+            weight_map = {}
+        start = int(text_config(config).get("num_hidden_layers") or config.get("num_hidden_layers") or 0)
+        physical_layers = max(len(_mtp_pattern(config)), 1)
+        wanted_prefixes = tuple(
+            [f"model.layers.{start + i}." for i in range(physical_layers)]
+            + [f"backbone.layers.{start + i}." for i in range(physical_layers)]
+            + [f"mtp.layers.{i}." for i in range(physical_layers)]
+        )
+        selected = {
+            model_path / rel
+            for key, rel in weight_map.items()
+            if str(key).startswith(wanted_prefixes)
+            or str(key).startswith(("mtp.", "lm_head.", "backbone.embeddings."))
+        }
+        if selected:
+            return sorted(selected)
+
+    return sorted(model_path.glob("model*.safetensors"))
+
+
+def _num_routed_experts(config: dict[str, Any], args: Any) -> int:
+    tcfg = text_config(config)
+    return int(
+        tcfg.get("mtp_n_routed_experts")
+        or config.get("mtp_n_routed_experts")
+        or getattr(args, "n_routed_experts", 0)
+        or 0
+    )
+
+
+def _stack_moe_experts(weights: dict[str, Any], prefix: str, n_routed_experts: int) -> None:
+    import mlx.core as mx
+
+    if n_routed_experts <= 0:
+        return
+    mapping = {"up_proj": "fc1", "down_proj": "fc2"}
+    for source, target in mapping.items():
+        for leaf in ("weight", "scales", "biases"):
+            first = f"{prefix}.mixer.experts.0.{source}.{leaf}"
+            if first not in weights:
+                continue
+            values = [
+                weights.pop(f"{prefix}.mixer.experts.{idx}.{source}.{leaf}")
+                for idx in range(n_routed_experts)
+            ]
+            weights[f"{prefix}.mixer.switch_mlp.{target}.{leaf}"] = mx.stack(values)
+
+
+def _rewrite_nemotron_h_mtp_weights(
+    raw: dict[str, Any],
+    *,
+    args: Any,
+    config: dict[str, Any],
+    start_layer: int,
+    physical_layers: int,
+) -> dict[str, Any]:
+    mapped: dict[str, Any] = {}
+    for key, value in raw.items():
+        if "rotary_emb.inv_freq" in key:
+            continue
+        if key.startswith(("lm_head.", "backbone.embeddings.", "model.embed_tokens.", "embed_tokens.")):
+            continue
+        if key.startswith("layers."):
+            mapped[key] = value
+            continue
+        if key.startswith("mtp.layers."):
+            mapped[key.removeprefix("mtp.")] = value
+            continue
+        for local_idx in range(physical_layers):
+            raw_prefixes = (
+                f"model.layers.{start_layer + local_idx}.",
+                f"backbone.layers.{start_layer + local_idx}.",
+                f"model.mtp.layers.{local_idx}.",
+            )
+            matched_prefix = next((prefix for prefix in raw_prefixes if key.startswith(prefix)), None)
+            if matched_prefix is None:
+                continue
+            mapped[f"layers.{local_idx}.{key.removeprefix(matched_prefix)}"] = value
+            break
+
+    n_routed = _num_routed_experts(config, args)
+    for local_idx in range(physical_layers):
+        _stack_moe_experts(mapped, f"layers.{local_idx}", n_routed)
+    return mapped
+
+
+def _quantize_for_loaded_weights(mtp: Any, config: dict[str, Any], weights: dict[str, Any]) -> None:
+    import mlx.nn as nn
+
+    quantization = config.get("quantization") or config.get("quantization_config") or {}
+    if not quantization:
+        return
+    if "group_size" not in quantization or "bits" not in quantization:
+        return
+
+    def class_predicate(path: str, module: Any):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if f"{path}.scales" in weights:
+            return {
+                "group_size": int(quantization["group_size"]),
+                "bits": int(quantization["bits"]),
+                "mode": quantization.get("mode", "affine"),
+            }
+        return False
+
+    nn.quantize(
+        mtp,
+        group_size=int(quantization["group_size"]),
+        bits=int(quantization["bits"]),
+        mode=quantization.get("mode", "affine"),
+        class_predicate=class_predicate,
+    )
+
+
+def _make_nemotron_h_mtp_module(config: dict[str, Any], args: Any):
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models import nemotron_h
+    from mlx_lm.models.base import create_attention_mask
+
+    pattern = _mtp_pattern(config)
+
+    class _NemotronHMTPBlock(nn.Module):
+        def __init__(self, block_type: str, *, has_start_projections: bool, has_end_norm: bool):
+            super().__init__()
+            self.block_type = block_type
+            self.has_start_projections = has_start_projections
+            self.has_end_norm = has_end_norm
+            if has_start_projections:
+                self.enorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+                self.hnorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+                self.eh_proj = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+            self.norm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+            if block_type == "*":
+                self.mixer = nemotron_h.NemotronHAttention(args)
+            elif block_type == "E":
+                self.mixer = nemotron_h.NemotronHMoE(args)
+            else:
+                raise ValueError(f"Unsupported Nemotron-H MTP pattern char: {block_type!r}")
+            if has_end_norm:
+                self.final_layernorm = nn.RMSNorm(args.hidden_size, eps=args.layer_norm_epsilon)
+
+        def __call__(self, inputs_embeds, hidden_states, *, cache=None):
+            if self.has_start_projections:
+                hidden_states = self.eh_proj(
+                    mx.concatenate(
+                        [self.enorm(inputs_embeds), self.hnorm(hidden_states)],
+                        axis=-1,
+                    )
+                )
+            residual = hidden_states
+            normed = self.norm(hidden_states)
+            if self.block_type == "*":
+                mask = create_attention_mask(normed, cache)
+                hidden_states = residual + self.mixer(normed, mask=mask, cache=cache)
+            else:
+                hidden_states = residual + self.mixer(normed)
+            if self.has_end_norm:
+                hidden_states = self.final_layernorm(hidden_states)
+            return hidden_states
+
+    class _NemotronHMTP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = [
+                _NemotronHMTPBlock(
+                    block_type,
+                    has_start_projections=idx == 0,
+                    has_end_norm=idx == len(pattern) - 1,
+                )
+                for idx, block_type in enumerate(pattern)
+            ]
+            self.pattern = pattern
+            self.start_layer = int(getattr(args, "num_hidden_layers"))
+            self.num_mtp_layers = 1
+
+    return _NemotronHMTP()
+
+
+def inject_nemotron_h_mtp_support(
+    model: Any,
+    model_path: Path | str,
+    config: dict[str, Any],
+    contract: Any | None = None,
+) -> bool:
+    """Attach Nemotron-H native MTP support to a loaded mlx-lm model."""
+    import mlx.core as mx
+    from mlx_lm.models import nemotron_h
+    from mlx_lm.models.cache import KVCache
+
+    if not is_nemotron_h_mtp_config(config):
+        return False
+
+    model_path = Path(model_path)
+    tcfg = text_config(config)
+    args = getattr(model, "args", None)
+    if args is None:
+        args = nemotron_h.ModelArgs.from_dict(tcfg)
+
+    mtp = _make_nemotron_h_mtp_module(config, args)
+    raw_weights: dict[str, Any] = {}
+    for file in _candidate_weight_files(model_path, config):
+        raw_weights.update(_load_weight_file(file))
+
+    mapped = _rewrite_nemotron_h_mtp_weights(
+        raw_weights,
+        args=args,
+        config=config,
+        start_layer=int(getattr(args, "num_hidden_layers")),
+        physical_layers=len(mtp.layers),
+    )
+    if not mapped:
+        logger.warning("[Nemotron-H MTP inject] No Nemotron-H MTP weights found in %s", model_path)
+        return False
+
+    _quantize_for_loaded_weights(mtp, config, mapped)
+    mtp.load_weights(list(mapped.items()), strict=False)
+    mx.eval(mtp.parameters())
+
+    original_outer_class = model.__class__
+
+    class _MTPLXNemotronHModel(original_outer_class):
+        def __call__(
+            self,
+            inputs,
+            cache=None,
+            return_hidden: bool = False,
+            input_embeddings=None,
+            hidden_variant: str | None = None,
+            **kwargs,
+        ):
+            if input_embeddings is not None:
+                raise ValueError("Nemotron-H MTP backend does not support input_embeddings")
+            hidden = self.backbone(inputs, cache=cache)
+            logits = self.lm_head(hidden)
+            if not return_hidden:
+                return logits
+            return logits, hidden
+
+        def mtp_forward(
+            self,
+            hidden_states,
+            next_token_ids,
+            cache=None,
+            mtp_cache=None,
+            concat_order=None,
+            return_hidden: bool = False,
+            mtp_hidden_variant: str = "post_norm",
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            if concat_order not in {None, "embedding_hidden"}:
+                raise ValueError("Nemotron-H MTP backend supports embedding_hidden concat order only")
+            if mtp_depth is not None and int(mtp_depth) > 1:
+                raise ValueError("Nemotron-H MTP backend currently supports mtp_depth=1 only")
+            inputs_embeds = self.backbone.embeddings(next_token_ids)
+            hidden = hidden_states
+            attention_cache_idx = 0
+            for layer in self.mtp.layers:
+                layer_cache = None
+                if layer.block_type == "*" and mtp_cache is not None:
+                    layer_cache = mtp_cache[attention_cache_idx]
+                    attention_cache_idx += 1
+                hidden = layer(inputs_embeds, hidden, cache=layer_cache)
+            logits = self.lm_head(hidden)
+            if not return_hidden:
+                return logits
+            return logits, hidden
+
+        def mtp_update_cache(
+            self,
+            hidden_states,
+            next_token_ids,
+            mtp_cache=None,
+            concat_order=None,
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            _logits, hidden = self.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache=mtp_cache,
+                concat_order=concat_order,
+                return_hidden=True,
+                mtp_depth=mtp_depth,
+            )
+            return hidden
+
+        def make_mtp_cache(self):
+            return [KVCache() for layer in self.mtp.layers if layer.block_type == "*"]
+
+        def make_cache(self):
+            make_cache = getattr(super(), "make_cache", None)
+            if callable(make_cache):
+                return make_cache()
+            return [KVCache() for layer in self.layers if getattr(layer, "block_type", None) == "*"]
+
+    model.mtp = mtp
+    model.__class__ = _MTPLXNemotronHModel
+    logger.info("[Nemotron-H MTP inject] Loaded %d tensors from %s", len(mapped), model_path)
+    return True

--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -80,6 +80,7 @@ class RuntimeProfile:
     required_mlx_fork_commit: str | None = None
     required_mlx_fork_fragment: str | None = None
     draft_lm_head: DraftLMHeadRequirement | None = None
+    draft_sampler: SamplerDefaults | None = None
     qa_only: bool = False
     fan_control_allowed: bool = False
     clock_anchor_allowed: bool = False
@@ -113,6 +114,15 @@ class RuntimeProfile:
                     "mode": self.draft_lm_head.mode,
                 }
             ),
+            "draft_sampler": (
+                None
+                if self.draft_sampler is None
+                else {
+                    "temperature": self.draft_sampler.temperature,
+                    "top_p": self.draft_sampler.top_p,
+                    "top_k": self.draft_sampler.top_k,
+                }
+            ),
             "qa_only": self.qa_only,
             "fan_control_allowed": self.fan_control_allowed,
             "clock_anchor_allowed": self.clock_anchor_allowed,
@@ -135,8 +145,8 @@ STABLE_PROFILE = RuntimeProfile(
     name="stable",
     runtime_profile="long_response_exact_staged",
     summary=(
-        "Conservative no-fan profile kept as the compatibility alias; it is "
-        "honest about the current sustained-throughput gap."
+        "Stable Mode: exact/staged long-reply path with no fan control. Hidden "
+        "from first-run onboarding, but available by flag for compatibility."
     ),
     env=_merge_env(EXACT_PAGED_ATTENTION_ENV, LONG_RESPONSE_STAGED_ENV),
     benchmark_ids=(
@@ -144,8 +154,8 @@ STABLE_PROFILE = RuntimeProfile(
         "phase0j-gdn8-speed4-target-layer-sched-state-root-mlx-vector-paged-flappy-uncapped-modelswap-20260501",
     ),
     caveats=(
-        "Sustained no-fan long-context throughput is below the 50+ tok/s target.",
-        "Current evidence includes a 37 tok/s no-fan Flappy 10k run.",
+        "Lower peak throughput than Medium or Max.",
+        "Selected for repeatable long replies while the v0.2 decay work continues.",
     ),
 )
 
@@ -153,15 +163,15 @@ PERFORMANCE_COLD_PROFILE = RuntimeProfile(
     name="performance-cold",
     runtime_profile="native_mtp_60_cold",
     summary=(
-        "Default first-run cold-throughput path; preserves the fast coding "
-        "demo path and may decay on long-context generation."
+        "Medium Mode: native-MTP speed path; about 2.2x burst over the same "
+        "Optimized-Speed model with MTP off, but not sustained without fan control."
     ),
     env=_items(NATIVE_MTP_60_FAST_PATH_ENV),
     benchmark_ids=(
         "mtp-depth-d3-gdn8-speed4-cyankiwi-mtp-draftlmhead4b-gs64-linear-gdn-from-conv-tape-mlx-qmv-unroll4-clean-preflight-batchedtargetarrays-lazymtphistory-dropevents-skipsnapshot-v4-20260429-143701",
     ),
     caveats=(
-        "Best cold throughput; may decay on long-context generation.",
+        "Best no-fan burst throughput; may decay on long-context generation.",
         "Requires the MLX-MTPLX fork for the native QMV/QMM fast path.",
     ),
     required_mlx_fork_commit=NATIVE_MTP_60_MLX_FORK_COMMIT,
@@ -182,8 +192,8 @@ MAX_DIAGNOSTIC_PROFILE = RuntimeProfile(
     name="max-diagnostic",
     runtime_profile="max_diagnostic",
     summary=(
-        "Fan-controlled diagnostic profile for sustained-throughput analysis; "
-        "never valid for headline product claims."
+        "Max Mode: Medium path plus ThermalForge fan control; about 2.24x in "
+        "the measured speed lane and loud by design."
     ),
     env=_merge_env(EXACT_PAGED_ATTENTION_ENV, LONG_RESPONSE_STAGED_ENV),
     caveats=(

--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -14,11 +14,12 @@ from typing import Mapping, MutableMapping
 
 ProfileName = str
 
-DEFAULT_PROFILE_NAME = "stable"
+DEFAULT_PROFILE_NAME = "performance-cold"
 PROFILE_CHOICES = ("stable", "performance-cold", "exact", "max-diagnostic")
 
-DEFAULT_MODEL_ID = "models/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP"
-DEFAULT_HF_MODEL_ID = "mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP"
+DEFAULT_HF_MODEL_ID = "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
+DEFAULT_MODEL_ID = DEFAULT_HF_MODEL_ID
+DEFAULT_PUBLIC_MODEL_ID = "mtplx-qwen36-27b-optimized-speed"
 NATIVE_MTP_60_MLX_FORK_COMMIT = "2377a99f"
 NATIVE_MTP_60_MLX_FORK_FRAGMENT = "mlx-mtplx-0.31.2-qmm"
 
@@ -134,8 +135,8 @@ STABLE_PROFILE = RuntimeProfile(
     name="stable",
     runtime_profile="long_response_exact_staged",
     summary=(
-        "Default no-fan profile selected for predictable preview behavior; "
-        "it is honest about the current sustained-throughput gap."
+        "Conservative no-fan profile kept as the compatibility alias; it is "
+        "honest about the current sustained-throughput gap."
     ),
     env=_merge_env(EXACT_PAGED_ATTENTION_ENV, LONG_RESPONSE_STAGED_ENV),
     benchmark_ids=(
@@ -152,8 +153,8 @@ PERFORMANCE_COLD_PROFILE = RuntimeProfile(
     name="performance-cold",
     runtime_profile="native_mtp_60_cold",
     summary=(
-        "Opt-in cold-throughput path; preserves the 60+ tok/s long-code-192 "
-        "result and may decay on long-context generation."
+        "Default first-run cold-throughput path; preserves the fast coding "
+        "demo path and may decay on long-context generation."
     ),
     env=_items(NATIVE_MTP_60_FAST_PATH_ENV),
     benchmark_ids=(
@@ -202,7 +203,7 @@ PROFILES: dict[ProfileName, RuntimeProfile] = {
 }
 
 PROFILE_ALIASES = {
-    "default": "stable",
+    "default": "performance-cold",
     "safe": "stable",
     "native-mtp-60": "performance-cold",
     "native_mtp_60": "performance-cold",

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -165,8 +165,11 @@ def load(
         from .deepseek_mtp_patch import inject_deepseek_mtp_support, is_deepseek_mtp_config
         from .glm_mtp_patch import inject_glm_mtp_support, is_glm_mtp_config
         from .mimo_mtp_patch import inject_mimo_mtp_support, is_mimo_mtp_config
+        from .nemotron_h_mtp_patch import inject_nemotron_h_mtp_support, is_nemotron_h_mtp_config
 
-        if is_mimo_mtp_config(config):
+        if is_nemotron_h_mtp_config(config):
+            mtp_enabled = inject_nemotron_h_mtp_support(model, path, config, contract)
+        elif is_mimo_mtp_config(config):
             mtp_enabled = inject_mimo_mtp_support(model, path, config, contract)
         elif is_glm_mtp_config(config):
             mtp_enabled = inject_glm_mtp_support(model, path, config, contract)

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -310,6 +310,7 @@ class ChatCompletionRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
+    depth: int | None = None
     seed: int | None = None
     enable_thinking: bool | None = None
     stream: bool = False
@@ -324,6 +325,7 @@ class CompletionRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
+    depth: int | None = None
     seed: int | None = None
     stream: bool = False
 
@@ -345,6 +347,7 @@ class AnthropicMessagesRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
+    depth: int | None = None
     stream: bool = False
 
 
@@ -491,6 +494,15 @@ class ServerState:
             )
             if self.runtime.mtp_enabled
             else {"installed": False, "reason": "mtp_disabled"}
+        )
+        self.draft_sampler = (
+            SamplerConfig(
+                temperature=float(args.draft_temperature),
+                top_p=float(args.draft_top_p),
+                top_k=int(args.draft_top_k),
+            )
+            if args.draft_temperature is not None
+            else None
         )
         self.draft_head_identity = _draft_head_identity(self.runtime)
         self.template_hash = _template_hash(self.runtime.tokenizer)
@@ -699,6 +711,7 @@ def _anthropic_to_chat_request(request: AnthropicMessagesRequest) -> ChatComplet
         temperature=request.temperature,
         top_p=request.top_p,
         top_k=request.top_k,
+        depth=request.depth,
         stream=False,
     )
 
@@ -1016,6 +1029,29 @@ def _request_metadata(model: BaseModel) -> dict[str, Any]:
     return metadata if isinstance(metadata, dict) else {}
 
 
+def _request_depth_value(request: BaseModel) -> Any:
+    for key in ("depth", "mtp_depth", "speculative_depth"):
+        value = getattr(request, key, None)
+        if value is None:
+            value = _request_extra(request, key)
+        if value is not None:
+            return value
+    return None
+
+
+def _request_depth_for_generation(state: ServerState, request: BaseModel) -> int:
+    value = _request_depth_value(request)
+    if value is None:
+        return int(getattr(state.args, "depth", 3))
+    try:
+        depth = int(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="depth must be an integer") from exc
+    if depth < 1 or depth > 7:
+        raise HTTPException(status_code=400, detail="depth must be between 1 and 7")
+    return depth
+
+
 def _token_window_rate(token_times: list[float], window: int) -> float | None:
     if len(token_times) < 2:
         return None
@@ -1224,6 +1260,7 @@ def _request_observability(
     headers: dict[str, str],
     metadata: dict[str, Any],
     session_source: str | None,
+    request_depth: int,
 ) -> dict[str, Any]:
     user_texts = [
         _content_to_text(message.content)
@@ -1251,6 +1288,7 @@ def _request_observability(
         "request_metadata_keys": sorted(metadata.keys()),
         "request_session_source": session_source,
         "request_session_candidate_headers": candidate_headers,
+        "request_depth": int(request_depth),
         "request_last_user_preview": user_texts[-1][:180] if user_texts else None,
         "request_last_user_chars": len(user_texts[-1]) if user_texts else 0,
     }
@@ -1260,8 +1298,10 @@ def _policy_fingerprint(
     state: ServerState,
     *,
     thinking_enabled: bool,
+    depth: int | None = None,
 ) -> str:
-    adaptive = _adaptive_config(state.args)
+    effective_depth = int(depth if depth is not None else getattr(state.args, "depth", 3))
+    adaptive = _adaptive_config(state.args, max_depth=effective_depth)
     proposal_cache = _proposal_cache_config(state.args)
     online_hidden = _online_hidden_config(state.args)
     return ";".join(
@@ -1270,6 +1310,7 @@ def _policy_fingerprint(
             f"thinking={int(bool(thinking_enabled))}",
             f"strip_reasoning={int(bool(state.args.strip_assistant_reasoning_history))}",
             f"generation_mode={getattr(state.args, 'generation_mode', 'mtp')}",
+            f"depth={effective_depth}",
             "hidden_variant=post_norm",
             "mtp_history_policy=committed",
             f"draft_head={state.draft_head_identity}",
@@ -1300,13 +1341,14 @@ def _online_hidden_config(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _adaptive_config(args: argparse.Namespace) -> dict[str, Any]:
+def _adaptive_config(args: argparse.Namespace, *, max_depth: int | None = None) -> dict[str, Any]:
     policy = str(getattr(args, "adaptive_policy", "none") or "none")
     if policy == "none":
         return {"policy": "none"}
+    effective_max_depth = int(max_depth if max_depth is not None else args.depth)
     config: dict[str, Any] = {
         "policy": policy,
-        "max_depth": int(args.depth),
+        "max_depth": effective_max_depth,
         "min_depth": int(args.adaptive_min_depth),
     }
     if policy == "streak":
@@ -1339,13 +1381,16 @@ def _adaptive_config(args: argparse.Namespace) -> dict[str, Any]:
 
 def _make_adaptive_policy(
     args: argparse.Namespace,
+    *,
+    max_depth: int | None = None,
 ) -> AdaptiveDepthPolicy | ExpectedValueDepthPolicy | None:
     policy = str(getattr(args, "adaptive_policy", "none") or "none")
     if policy == "none":
         return None
+    effective_max_depth = int(max_depth if max_depth is not None else args.depth)
     if policy == "streak":
         return AdaptiveDepthPolicy(
-            max_depth=int(args.depth),
+            max_depth=effective_max_depth,
             min_depth=int(args.adaptive_min_depth),
             start_depth=int(args.adaptive_start_depth),
             increase_after=int(args.adaptive_increase_after),
@@ -1353,7 +1398,7 @@ def _make_adaptive_policy(
         )
     if policy == "expected_value":
         return ExpectedValueDepthPolicy(
-            max_depth=int(args.depth),
+            max_depth=effective_max_depth,
             min_depth=int(args.adaptive_min_depth),
             base_depth=int(args.adaptive_ev_base_depth),
             accept_priors=tuple(float(v) for v in args.adaptive_ev_accept_priors),
@@ -1507,6 +1552,7 @@ def _run_generation(
     top_p: float | None,
     top_k: int | None,
     seed: int | None,
+    depth: int | None = None,
     token_callback: Callable[[list[int]], None] | None = None,
     session_id: str | None = None,
     session_cache_hit: bool = False,
@@ -1528,6 +1574,7 @@ def _run_generation(
         top_p=top_p,
         top_k=top_k,
     )
+    effective_depth = int(depth if depth is not None else getattr(state.args, "depth", 3))
     started = time.perf_counter()
     token_times: list[float] = []
     lock_wait_time_s = 0.0
@@ -1589,13 +1636,14 @@ def _run_generation(
                     trace_metadata=trace_metadata,
                 )
             else:
-                adaptive_policy = _make_adaptive_policy(state.args)
+                adaptive_policy = _make_adaptive_policy(state.args, max_depth=effective_depth)
                 out = generate_mtpk(
                     state.runtime,
                     prompt_ids,
                     max_tokens=response_max,
                     sampler=sampler,
-                    speculative_depth=state.args.depth,
+                    draft_sampler=getattr(state, "draft_sampler", None),
+                    speculative_depth=effective_depth,
                     seed=generation_seed,
                     mtp_hidden_variant="post_norm",
                     mtp_cache_policy="persistent",
@@ -1700,7 +1748,7 @@ def _run_generation(
             session_cache_hit=session_cache_hit,
             cache_miss_reason=cache_miss_reason,
             session_restore_mode=session_restore_mode,
-            mtp_depth=state.args.depth if state.args.generation_mode == "mtp" else 0,
+            mtp_depth=effective_depth if state.args.generation_mode == "mtp" else 0,
             generation_limits=generation_limits,
         )
         if request_observability:
@@ -3025,6 +3073,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
         stream: true,
         temperature: settingsNow.temperature,
         top_p: settingsNow.top_p,
+        depth: settingsNow.depth,
         max_tokens: settingsNow.max_tokens
       };
       if (settingsNow.top_k > 0) requestBody.top_k = settingsNow.top_k;
@@ -3569,6 +3618,7 @@ def create_app(state: ServerState) -> FastAPI:
                 },
             )
         thinking_enabled = _thinking_enabled_for_request(state, request)
+        request_depth = _request_depth_for_generation(state, request)
         prompt_ids = _encode_messages(
             state.runtime.tokenizer,
             request.messages,
@@ -3590,6 +3640,7 @@ def create_app(state: ServerState) -> FastAPI:
         policy_fingerprint = _policy_fingerprint(
             state,
             thinking_enabled=thinking_enabled,
+            depth=request_depth,
         )
         if not background and not cache_bypass:
             requested_restore_mode = headers.get("x-mtplx-restore-mode", "reference_lease")
@@ -3615,6 +3666,7 @@ def create_app(state: ServerState) -> FastAPI:
             headers=headers,
             metadata=metadata,
             session_source=session_source,
+            request_depth=request_depth,
         )
         model = request.model or state.model_id
         response_id = f"chatcmpl-{uuid.uuid4().hex}"
@@ -3656,6 +3708,7 @@ def create_app(state: ServerState) -> FastAPI:
                                 top_p=request.top_p,
                                 top_k=request.top_k,
                                 seed=request.seed,
+                                depth=request_depth,
                                 token_callback=on_tokens,
                                 session_id=session_id,
                                 cache_miss_reason=cache_miss_reason,
@@ -3677,6 +3730,7 @@ def create_app(state: ServerState) -> FastAPI:
                                     top_p=request.top_p,
                                     top_k=request.top_k,
                                     seed=request.seed,
+                                    depth=request_depth,
                                     token_callback=on_tokens,
                                     session_id=session_id,
                                     cache_miss_reason=cache_miss_reason,
@@ -3974,6 +4028,7 @@ def create_app(state: ServerState) -> FastAPI:
                     top_p=request.top_p,
                     top_k=request.top_k,
                     seed=request.seed,
+                    depth=request_depth,
                     session_id=session_id,
                     cache_miss_reason=cache_miss_reason,
                     session_restore_mode=session_restore_mode,
@@ -3993,6 +4048,7 @@ def create_app(state: ServerState) -> FastAPI:
                     top_p=request.top_p,
                     top_k=request.top_k,
                     seed=request.seed,
+                    depth=request_depth,
                     session_id=session_id,
                     cache_miss_reason=cache_miss_reason,
                     session_restore_mode=session_restore_mode,
@@ -4109,6 +4165,7 @@ def create_app(state: ServerState) -> FastAPI:
     @app.post("/v1/completions")
     async def completions(request: CompletionRequest) -> Any:
         prompt_ids = _encode_prompt(state.runtime.tokenizer, request.prompt)
+        request_depth = _request_depth_for_generation(state, request)
         generated = _run_generation(
             state,
             prompt_ids,
@@ -4117,6 +4174,7 @@ def create_app(state: ServerState) -> FastAPI:
             top_p=request.top_p,
             top_k=request.top_k,
             seed=request.seed,
+            depth=request_depth,
         )
         model = request.model or state.model_id
         response_id = f"cmpl-{uuid.uuid4().hex}"
@@ -4366,6 +4424,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--draft-lm-head-bits", type=int, default=4)
     parser.add_argument("--draft-lm-head-group-size", type=int, default=64)
     parser.add_argument("--draft-lm-head-mode", default="affine")
+    parser.add_argument("--draft-temperature", type=float)
+    parser.add_argument("--draft-top-p", type=float, default=0.95)
+    parser.add_argument("--draft-top-k", type=int, default=20)
     parser.add_argument(
         "--mlx-cache-limit",
         help=(

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -47,7 +47,9 @@ from mtplx.cache_state import snapshot_cache
 from mtplx.mtp_patch import MTPContract
 from mtplx.sampling import SamplerConfig
 from mtplx.profiles import (
+    DEFAULT_HF_MODEL_ID,
     DEFAULT_PROFILE_NAME,
+    DEFAULT_PUBLIC_MODEL_ID,
     PROFILE_CHOICES,
     apply_profile_env,
     get_profile,
@@ -2948,10 +2950,16 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
       statsEl.hidden = parts.length === 0;
     }
     function renderLiveStats(state) {
-      const tps = state.tokens > 0 && state.elapsed > 0 ? (state.tokens / state.elapsed) : null;
+      const finalStats = state.finalStats || null;
+      const tps = finalStats
+        ? Number(finalStats.decode_tok_s ?? finalStats.request_tok_s)
+        : (state.tokens > 0 && state.elapsed > 0 ? (state.tokens / state.elapsed) : null);
+      const tokenCount = finalStats
+        ? Number(finalStats.completion_tokens ?? finalStats.generated_tokens ?? state.tokens)
+        : state.tokens;
       const parts = [];
-      if (tps !== null) parts.push('<span class="tps">' + tps.toFixed(1) + ' tok/s</span>');
-      if (state.tokens > 0) parts.push(state.tokens + ' tokens');
+      if (Number.isFinite(tps)) parts.push('<span class="tps">' + tps.toFixed(1) + ' tok/s</span>');
+      if (Number.isFinite(tokenCount) && tokenCount > 0) parts.push(tokenCount + ' tokens');
       liveStatsEl.innerHTML = parts.length ? '· ' + parts.join(' · ') : '';
     }
 
@@ -3083,6 +3091,15 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
             if (payload.mtplx_stats) {
               finalStats = payload.mtplx_stats;
               renderStats(turn.stats, finalStats);
+              renderLiveStats({finalStats, tokens: liveState.tokens, elapsed: liveState.elapsed});
+            }
+            if (payload.mtplx_live) {
+              const streamedTokens = Number(payload.mtplx_live.stream_tokens || 0);
+              if (Number.isFinite(streamedTokens) && streamedTokens > 0) {
+                liveState.tokens += streamedTokens;
+                liveState.elapsed = Number(payload.mtplx_live.decode_elapsed_s || 0);
+                renderLiveStats(liveState);
+              }
             }
             const delta = payload.choices?.[0]?.delta || {};
             const reasoningPiece = delta.reasoning_content || "";
@@ -3100,9 +3117,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
               if (firstTokenAt === null) firstTokenAt = performance.now();
               assistantText += answerPiece;
               turn.answerBody.textContent = assistantText;
-              liveState.tokens += 1;
-              liveState.elapsed = (performance.now() - startedAt) / 1000;
-              renderLiveStats(liveState);
+              if (liveState.tokens <= 0) renderLiveStats(liveState);
               setStatus("Streaming", "streaming");
               // Auto-collapse the reasoning block once the answer starts (still expandable).
               if (!turn.reasoningBlock.hidden) {
@@ -3126,7 +3141,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
         if (finalStats) renderStats(turn.stats, finalStats);
         history.push({role: "assistant", content: assistantText});
         setStatus("Ready", "ready");
-        renderLiveStats(liveState);
+        renderLiveStats(finalStats ? {finalStats, tokens: liveState.tokens, elapsed: liveState.elapsed} : liveState);
       } catch (err) {
         const aborted = err && (err.name === "AbortError" || /aborted/i.test(String(err.message || "")));
         const stalled =
@@ -3725,7 +3740,13 @@ def create_app(state: ServerState) -> FastAPI:
 
                 generation_future = state.generation_executor.submit(worker)
 
-                def delta_chunk(field: str, text: str) -> str:
+                stream_started_at = time.perf_counter()
+                stream_token_count = 0
+
+                def delta_chunk(field: str, text: str, *, stream_tokens: int = 0) -> str:
+                    nonlocal stream_token_count
+                    stream_tokens = max(0, int(stream_tokens or 0))
+                    stream_token_count += stream_tokens
                     payload = {
                         "id": response_id,
                         "object": "chat.completion.chunk",
@@ -3739,6 +3760,16 @@ def create_app(state: ServerState) -> FastAPI:
                                 }
                         ],
                     }
+                    if stream_tokens:
+                        elapsed = max(0.0, time.perf_counter() - stream_started_at)
+                        payload["mtplx_live"] = {
+                            "stream_tokens": stream_tokens,
+                            "completion_tokens_so_far": stream_token_count,
+                            "decode_elapsed_s": elapsed,
+                            "live_decode_tok_s": (
+                                stream_token_count / elapsed if elapsed > 0.0 else None
+                            ),
+                        }
                     return f"data: {json.dumps(payload)}\n\n"
 
                 def error_chunk(exc: BaseException) -> str:
@@ -3780,7 +3811,7 @@ def create_app(state: ServerState) -> FastAPI:
                     force: bool = False,
                 ) -> list[tuple[str, str]]:
                     pending_stream_tokens.extend(tokens)
-                    chunks: list[tuple[str, str]] = []
+                    chunks: list[tuple[str, str, int]] = []
                     while pending_stream_tokens and (
                         force or len(pending_stream_tokens) >= stream_interval
                     ):
@@ -3788,11 +3819,9 @@ def create_app(state: ServerState) -> FastAPI:
                         batch = pending_stream_tokens[:batch_size]
                         del pending_stream_tokens[:batch_size]
                         delta = decoder.feed(batch)
-                        chunks.extend(
-                            (field, text)
-                            for field, text in splitter.feed(delta)
-                            if text
-                        )
+                        emitted = [(field, text) for field, text in splitter.feed(delta) if text]
+                        for index, (field, text) in enumerate(emitted):
+                            chunks.append((field, text, len(batch) if index == 0 else 0))
                     return chunks
 
                 def streamed_history_content() -> str:
@@ -3830,14 +3859,14 @@ def create_app(state: ServerState) -> FastAPI:
                                 return
                             continue
                         if kind == "tokens":
-                            for field, text in drain_stream_tokens(item):
+                            for field, text, stream_tokens in drain_stream_tokens(item):
                                 remember_stream_chunk(field, text)
-                                yield delta_chunk(field, text)
+                                yield delta_chunk(field, text, stream_tokens=stream_tokens)
                         elif kind == "done":
                             generated = item
-                            for field, text in drain_stream_tokens([], force=True):
+                            for field, text, stream_tokens in drain_stream_tokens([], force=True):
                                 remember_stream_chunk(field, text)
-                                yield delta_chunk(field, text)
+                                yield delta_chunk(field, text, stream_tokens=stream_tokens)
                             tail = decoder.finish()
                             if tail:
                                 for field, text in splitter.feed(tail):
@@ -4142,8 +4171,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     postcommit_default = os.environ.get("MTPLX_SESSION_POSTCOMMIT_MODE", "inline")
     if postcommit_default not in {"inline", "async"}:
         postcommit_default = "inline"
-    parser.add_argument("--model", default="models/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP")
-    parser.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp")
+    parser.add_argument("--model", default=DEFAULT_HF_MODEL_ID)
+    parser.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID)
     parser.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -47,9 +47,7 @@ from mtplx.cache_state import snapshot_cache
 from mtplx.mtp_patch import MTPContract
 from mtplx.sampling import SamplerConfig
 from mtplx.profiles import (
-    DEFAULT_HF_MODEL_ID,
     DEFAULT_PROFILE_NAME,
-    DEFAULT_PUBLIC_MODEL_ID,
     PROFILE_CHOICES,
     apply_profile_env,
     get_profile,
@@ -433,7 +431,7 @@ class ServerState:
         self.foreground_active = 0
         self.rate_limiter = _RateLimiter(args.rate_limit)
         self.profile = get_profile(args.profile)
-        runtime_label = "Fast MTP" if self.profile.name == "performance-cold" else self.profile.name
+        runtime_label = "Medium MTP" if self.profile.name == "performance-cold" else self.profile.name
         _startup_line(f"[4/6] Preparing {runtime_label} runtime")
         if args.generation_mode == "mtp" and not args.load_mtp:
             raise ValueError("--generation-mode mtp requires --load-mtp")
@@ -1047,8 +1045,8 @@ def _request_depth_for_generation(state: ServerState, request: BaseModel) -> int
         depth = int(value)
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=400, detail="depth must be an integer") from exc
-    if depth < 1 or depth > 7:
-        raise HTTPException(status_code=400, detail="depth must be between 1 and 7")
+    if depth < 1 or depth > 3:
+        raise HTTPException(status_code=400, detail="depth must be between 1 and 3")
     return depth
 
 
@@ -1165,6 +1163,29 @@ def _repair_streamed_generation_stats(
             float(completion_tokens) / elapsed_s if elapsed_s > 0 else 0.0
         )
     return repaired
+
+
+def _stream_progress_payload(
+    *,
+    completion_tokens: int,
+    decode_started_s: float | None,
+    now_s: float,
+) -> dict[str, Any]:
+    decode_elapsed_s = (
+        max(0.0, float(now_s) - float(decode_started_s))
+        if decode_started_s is not None
+        else 0.0
+    )
+    decode_tok_s = (
+        float(completion_tokens) / decode_elapsed_s
+        if completion_tokens > 0 and decode_elapsed_s > 0.0
+        else None
+    )
+    return {
+        "completion_tokens": int(completion_tokens),
+        "decode_elapsed_s": decode_elapsed_s,
+        "decode_tok_s": decode_tok_s,
+    }
 
 
 PUBLIC_MTPLX_STATS_KEYS = (
@@ -1341,11 +1362,15 @@ def _online_hidden_config(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _adaptive_config(args: argparse.Namespace, *, max_depth: int | None = None) -> dict[str, Any]:
+def _adaptive_config(
+    args: argparse.Namespace,
+    *,
+    max_depth: int | None = None,
+) -> dict[str, Any]:
     policy = str(getattr(args, "adaptive_policy", "none") or "none")
     if policy == "none":
         return {"policy": "none"}
-    effective_max_depth = int(max_depth if max_depth is not None else args.depth)
+    effective_max_depth = int(max_depth if max_depth is not None else getattr(args, "depth", 3))
     config: dict[str, Any] = {
         "policy": policy,
         "max_depth": effective_max_depth,
@@ -1387,7 +1412,7 @@ def _make_adaptive_policy(
     policy = str(getattr(args, "adaptive_policy", "none") or "none")
     if policy == "none":
         return None
-    effective_max_depth = int(max_depth if max_depth is not None else args.depth)
+    effective_max_depth = int(max_depth if max_depth is not None else getattr(args, "depth", 3))
     if policy == "streak":
         return AdaptiveDepthPolicy(
             max_depth=effective_max_depth,
@@ -1642,7 +1667,7 @@ def _run_generation(
                     prompt_ids,
                     max_tokens=response_max,
                     sampler=sampler,
-                    draft_sampler=getattr(state, "draft_sampler", None),
+                    draft_sampler=state.draft_sampler,
                     speculative_depth=effective_depth,
                     seed=generation_seed,
                     mtp_hidden_variant="post_norm",
@@ -2614,7 +2639,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
       <p class="sb-title">Speculative</p>
       <div class="sb-row">
         <label for="ctl-depth">Draft depth <span class="v" id="val-depth">3</span></label>
-        <input id="ctl-depth" type="range" min="1" max="7" step="1" value="3">
+        <input id="ctl-depth" type="range" min="1" max="3" step="1" value="3">
         <p class="help">MTP draft tokens per verify cycle.</p>
       </div>
     </div>
@@ -2716,7 +2741,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
       temperature: {min: 0, max: 2},
       top_p: {min: 0, max: 1},
       top_k: {min: 0, max: 100},
-      depth: {min: 1, max: 7},
+      depth: {min: 1, max: 3},
       max_tokens: {min: 256, max: 32768}
     };
     const maxTokensHelpEl = document.getElementById("max-tokens-help");
@@ -2998,17 +3023,36 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
       statsEl.hidden = parts.length === 0;
     }
     function renderLiveStats(state) {
-      const finalStats = state.finalStats || null;
-      const tps = finalStats
-        ? Number(finalStats.decode_tok_s ?? finalStats.request_tok_s)
+      const explicitTps = Number(state.tps);
+      const tps = Number.isFinite(explicitTps)
+        ? explicitTps
         : (state.tokens > 0 && state.elapsed > 0 ? (state.tokens / state.elapsed) : null);
-      const tokenCount = finalStats
-        ? Number(finalStats.completion_tokens ?? finalStats.generated_tokens ?? state.tokens)
-        : state.tokens;
       const parts = [];
-      if (Number.isFinite(tps)) parts.push('<span class="tps">' + tps.toFixed(1) + ' tok/s</span>');
-      if (Number.isFinite(tokenCount) && tokenCount > 0) parts.push(tokenCount + ' tokens');
+      if (tps !== null) parts.push('<span class="tps">' + tps.toFixed(1) + ' tok/s</span>');
+      if (state.tokens > 0) parts.push(state.tokens + ' tokens');
       liveStatsEl.innerHTML = parts.length ? '· ' + parts.join(' · ') : '';
+    }
+    function applyProgressToLiveState(liveState, progress) {
+      if (!progress) return;
+      const tokens = Number(progress.completion_tokens ?? progress.generated_tokens);
+      const elapsed = Number(progress.decode_elapsed_s ?? progress.elapsed_s);
+      const tps = Number(progress.decode_tok_s ?? progress.tok_s);
+      if (Number.isFinite(tokens) && tokens >= 0) liveState.tokens = tokens;
+      if (Number.isFinite(elapsed) && elapsed >= 0) liveState.elapsed = elapsed;
+      if (Number.isFinite(tps) && tps >= 0) liveState.tps = tps;
+      liveState.hasServerProgress = true;
+      renderLiveStats(liveState);
+    }
+    function applyFinalStatsToLiveState(liveState, stats) {
+      if (!stats) return;
+      const tokens = Number(stats.completion_tokens ?? stats.generated_tokens);
+      const elapsed = Number(stats.decode_elapsed_s ?? stats.request_elapsed_s ?? stats.elapsed_s);
+      const tps = Number(stats.decode_tok_s ?? stats.request_tok_s ?? stats.tok_s);
+      if (Number.isFinite(tokens) && tokens >= 0) liveState.tokens = tokens;
+      if (Number.isFinite(elapsed) && elapsed >= 0) liveState.elapsed = elapsed;
+      if (Number.isFinite(tps) && tps >= 0) liveState.tps = tps;
+      liveState.hasServerProgress = true;
+      renderLiveStats(liveState);
     }
 
     // ---------- streaming -----------------------------------------------------
@@ -3086,7 +3130,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
       let finalStats = null;
       let firstTokenAt = null;
       const startedAt = performance.now();
-      const liveState = {tokens: 0, elapsed: 0};
+      const liveState = {tokens: 0, elapsed: 0, tps: null, hasServerProgress: false};
       // Stall watchdog: if no SSE chunk arrives within this window, abort
       // and surface a clear error instead of leaving the UI parked on
       // "Thinking" forever (the failure mode the user reported after a
@@ -3137,18 +3181,13 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
           buffer += decoder.decode(value, {stream: true});
           buffer = drainSse(buffer, (payload) => {
             if (payload.error) throw new Error(payload.error.message || "generation failed");
+            if (payload.mtplx_progress) {
+              applyProgressToLiveState(liveState, payload.mtplx_progress);
+            }
             if (payload.mtplx_stats) {
               finalStats = payload.mtplx_stats;
               renderStats(turn.stats, finalStats);
-              renderLiveStats({finalStats, tokens: liveState.tokens, elapsed: liveState.elapsed});
-            }
-            if (payload.mtplx_live) {
-              const streamedTokens = Number(payload.mtplx_live.stream_tokens || 0);
-              if (Number.isFinite(streamedTokens) && streamedTokens > 0) {
-                liveState.tokens += streamedTokens;
-                liveState.elapsed = Number(payload.mtplx_live.decode_elapsed_s || 0);
-                renderLiveStats(liveState);
-              }
+              applyFinalStatsToLiveState(liveState, finalStats);
             }
             const delta = payload.choices?.[0]?.delta || {};
             const reasoningPiece = delta.reasoning_content || "";
@@ -3166,7 +3205,12 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
               if (firstTokenAt === null) firstTokenAt = performance.now();
               assistantText += answerPiece;
               turn.answerBody.textContent = assistantText;
-              if (liveState.tokens <= 0) renderLiveStats(liveState);
+              if (!liveState.hasServerProgress) {
+                liveState.tokens += 1;
+                liveState.elapsed = (performance.now() - startedAt) / 1000;
+                liveState.tps = null;
+                renderLiveStats(liveState);
+              }
               setStatus("Streaming", "streaming");
               // Auto-collapse the reasoning block once the answer starts (still expandable).
               if (!turn.reasoningBlock.hidden) {
@@ -3190,7 +3234,7 @@ def _chat_ui_html(*, model_id: str, server_url: str, api_key_required: bool) -> 
         if (finalStats) renderStats(turn.stats, finalStats);
         history.push({role: "assistant", content: assistantText});
         setStatus("Ready", "ready");
-        renderLiveStats(finalStats ? {finalStats, tokens: liveState.tokens, elapsed: liveState.elapsed} : liveState);
+        renderLiveStats(liveState);
       } catch (err) {
         const aborted = err && (err.name === "AbortError" || /aborted/i.test(String(err.message || "")));
         const stalled =
@@ -3410,6 +3454,11 @@ def create_app(state: ServerState) -> FastAPI:
             "reasoning_parser": state.args.reasoning_parser,
             "load_time_s": state.load_time_s,
             "draft_lm_head": state.draft_lm_head,
+            "draft_sampler": (
+                asdict(getattr(state, "draft_sampler", None))
+                if is_dataclass(getattr(state, "draft_sampler", None))
+                else None
+            ),
             "draft_head_identity": state.draft_head_identity,
             "tokenizer_template_hash": state.template_hash,
             "fast_path_env": state.fast_path_env_status,
@@ -3693,7 +3742,15 @@ def create_app(state: ServerState) -> FastAPI:
 
                 def on_tokens(new_tokens: list[int]) -> None:
                     _raise_if_stream_cancelled(cancel_event)
-                    queue.put(("tokens", list(new_tokens)))
+                    queue.put(
+                        (
+                            "tokens",
+                            {
+                                "tokens": list(new_tokens),
+                                "timestamp_s": time.perf_counter(),
+                            },
+                        )
+                    )
                     _raise_if_stream_cancelled(cancel_event)
 
                 def worker() -> None:
@@ -3794,13 +3851,7 @@ def create_app(state: ServerState) -> FastAPI:
 
                 generation_future = state.generation_executor.submit(worker)
 
-                stream_started_at = time.perf_counter()
-                stream_token_count = 0
-
-                def delta_chunk(field: str, text: str, *, stream_tokens: int = 0) -> str:
-                    nonlocal stream_token_count
-                    stream_tokens = max(0, int(stream_tokens or 0))
-                    stream_token_count += stream_tokens
+                def delta_chunk(field: str, text: str) -> str:
                     payload = {
                         "id": response_id,
                         "object": "chat.completion.chunk",
@@ -3814,16 +3865,23 @@ def create_app(state: ServerState) -> FastAPI:
                                 }
                         ],
                     }
-                    if stream_tokens:
-                        elapsed = max(0.0, time.perf_counter() - stream_started_at)
-                        payload["mtplx_live"] = {
-                            "stream_tokens": stream_tokens,
-                            "completion_tokens_so_far": stream_token_count,
-                            "decode_elapsed_s": elapsed,
-                            "live_decode_tok_s": (
-                                stream_token_count / elapsed if elapsed > 0.0 else None
-                            ),
-                        }
+                    return f"data: {json.dumps(payload)}\n\n"
+
+                def progress_chunk(progress: dict[str, Any]) -> str:
+                    payload = {
+                        "id": response_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {},
+                                "finish_reason": None,
+                            }
+                        ],
+                        "mtplx_progress": _json_safe(progress),
+                    }
                     return f"data: {json.dumps(payload)}\n\n"
 
                 def error_chunk(exc: BaseException) -> str:
@@ -3852,6 +3910,8 @@ def create_app(state: ServerState) -> FastAPI:
                 generated: dict[str, Any] | None = None
                 history_reasoning_chunks: list[str] = []
                 history_content_chunks: list[str] = []
+                streamed_progress_tokens = 0
+                streamed_decode_started_s: float | None = None
 
                 def remember_stream_chunk(field: str, text: str) -> None:
                     if field == "reasoning_content":
@@ -3865,7 +3925,7 @@ def create_app(state: ServerState) -> FastAPI:
                     force: bool = False,
                 ) -> list[tuple[str, str]]:
                     pending_stream_tokens.extend(tokens)
-                    chunks: list[tuple[str, str, int]] = []
+                    chunks: list[tuple[str, str]] = []
                     while pending_stream_tokens and (
                         force or len(pending_stream_tokens) >= stream_interval
                     ):
@@ -3873,9 +3933,11 @@ def create_app(state: ServerState) -> FastAPI:
                         batch = pending_stream_tokens[:batch_size]
                         del pending_stream_tokens[:batch_size]
                         delta = decoder.feed(batch)
-                        emitted = [(field, text) for field, text in splitter.feed(delta) if text]
-                        for index, (field, text) in enumerate(emitted):
-                            chunks.append((field, text, len(batch) if index == 0 else 0))
+                        chunks.extend(
+                            (field, text)
+                            for field, text in splitter.feed(delta)
+                            if text
+                        )
                     return chunks
 
                 def streamed_history_content() -> str:
@@ -3913,14 +3975,33 @@ def create_app(state: ServerState) -> FastAPI:
                                 return
                             continue
                         if kind == "tokens":
-                            for field, text, stream_tokens in drain_stream_tokens(item):
+                            if isinstance(item, dict):
+                                stream_tokens = list(item.get("tokens") or [])
+                                token_timestamp_s = float(
+                                    item.get("timestamp_s") or time.perf_counter()
+                                )
+                            else:
+                                stream_tokens = list(item or [])
+                                token_timestamp_s = time.perf_counter()
+                            if stream_tokens:
+                                if streamed_decode_started_s is None:
+                                    streamed_decode_started_s = token_timestamp_s
+                                streamed_progress_tokens += len(stream_tokens)
+                                yield progress_chunk(
+                                    _stream_progress_payload(
+                                        completion_tokens=streamed_progress_tokens,
+                                        decode_started_s=streamed_decode_started_s,
+                                        now_s=token_timestamp_s,
+                                    )
+                                )
+                            for field, text in drain_stream_tokens(stream_tokens):
                                 remember_stream_chunk(field, text)
-                                yield delta_chunk(field, text, stream_tokens=stream_tokens)
+                                yield delta_chunk(field, text)
                         elif kind == "done":
                             generated = item
-                            for field, text, stream_tokens in drain_stream_tokens([], force=True):
+                            for field, text in drain_stream_tokens([], force=True):
                                 remember_stream_chunk(field, text)
-                                yield delta_chunk(field, text, stream_tokens=stream_tokens)
+                                yield delta_chunk(field, text)
                             tail = decoder.finish()
                             if tail:
                                 for field, text in splitter.feed(tail):
@@ -4229,8 +4310,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     postcommit_default = os.environ.get("MTPLX_SESSION_POSTCOMMIT_MODE", "inline")
     if postcommit_default not in {"inline", "async"}:
         postcommit_default = "inline"
-    parser.add_argument("--model", default=DEFAULT_HF_MODEL_ID)
-    parser.add_argument("--model-id", default=DEFAULT_PUBLIC_MODEL_ID)
+    parser.add_argument("--model", default="models/Qwen3.6-27B-MTPLX-Flat4-CyanKiwiMTP")
+    parser.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp")
     parser.add_argument("--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
@@ -4471,7 +4552,7 @@ def main(argv: list[str] | None = None) -> None:
         if str(exc).startswith("Patched MLX qmv fork is not active:"):
             _startup_line("error: fast MLX fork is not active")
             _startup_line(str(exc))
-            _startup_line("try: mtplx start --profile stable")
+            _startup_line("try: mtplx start --profile safe")
             _startup_line("try: mtplx start --profile performance-cold")
             _startup_line("     (public start disables the strict fork assert when the fork is missing)")
             raise SystemExit(2) from None

--- a/mtplx/thermal.py
+++ b/mtplx/thermal.py
@@ -990,7 +990,7 @@ def run_command_with_profile(
 
 # ---------- auto-install -----------------------------------------------------
 #
-# Bootstrap path for users who pick Max mode in `mtplx quickstart` and don't
+# Bootstrap path for users who pick Max mode in `mtplx start` and don't
 # already have a fan controller.
 #
 # As of 2026-04 the upstream Homebrew tap (ProducerGuy/tap) ships a formula

--- a/mtplx/thermal.py
+++ b/mtplx/thermal.py
@@ -269,9 +269,30 @@ def fan_summary() -> dict[str, Any]:
     }
 
 
-# Threshold (RPM) above which we consider fans "ramped" after `thermalforge max`.
-# Apple Silicon idle RPMs are usually ~1500-2000; 4000+ is clearly elevated.
-FAN_RAMP_THRESHOLD_RPM = 4000
+# Fraction of a fan's reported capacity that proves a max/performance command
+# has reached the controller. Some Macs report very different RPM envelopes, so
+# use hardware capacity when available and keep the old absolute threshold only
+# as a sensorless fallback.
+FAN_RAMP_TARGET_FRACTION = 0.85
+FAN_RAMP_FALLBACK_THRESHOLD_RPM = 4000
+
+
+def _fan_target_is_ramped(fan: dict[str, Any]) -> bool:
+    target = fan.get("target_rpm")
+    try:
+        target_int = None if target is None else int(target)
+    except (TypeError, ValueError):
+        target_int = None
+    if target_int is None:
+        return False
+    max_capacity = fan.get("max_capacity_rpm") or (fan.get("raw") or {}).get("max_rpm")
+    try:
+        max_int = None if max_capacity is None else int(max_capacity)
+    except (TypeError, ValueError):
+        max_int = None
+    if max_int and max_int > 0:
+        return target_int >= int(max_int * FAN_RAMP_TARGET_FRACTION)
+    return target_int >= FAN_RAMP_FALLBACK_THRESHOLD_RPM
 
 
 def _summary_indicates_max(summary: dict[str, Any]) -> bool:
@@ -291,12 +312,8 @@ def _summary_indicates_max(summary: dict[str, Any]) -> bool:
         mode = (fan.get("mode") or "").lower()
         if mode in {"manual", "max"}:
             return True
-        target = fan.get("target_rpm")
-        try:
-            if target is not None and int(target) >= FAN_RAMP_THRESHOLD_RPM:
-                return True
-        except (TypeError, ValueError):
-            pass
+        if _fan_target_is_ramped(fan):
+            return True
     return False
 
 
@@ -319,7 +336,7 @@ def _summary_indicates_auto(summary: dict[str, Any]) -> bool:
         # setpoint (~min_rpm) while mode is auto. The mode is the authoritative
         # restore signal; target only helps when a tool omits mode.
         if mode in {"auto", "automatic", "default"}:
-            if target_int is not None and target_int >= FAN_RAMP_THRESHOLD_RPM:
+            if _fan_target_is_ramped(fan):
                 return False
             continue
         if target_int is not None and target_int <= 0:
@@ -459,7 +476,12 @@ def set_thermal_profile_verified(
     }
 
 
-def restore_thermal_profile_verified(*, log: Any = None) -> dict[str, Any]:
+def restore_thermal_profile_verified(
+    *,
+    log: Any = None,
+    settle_timeout_s: float = 12.0,
+    poll_interval_s: float = 1.0,
+) -> dict[str, Any]:
     """Restore Apple-default fan control and prove the daemon accepted it.
 
     This is intentionally stricter than the old ``set_thermal_profile("silent")``
@@ -476,7 +498,13 @@ def restore_thermal_profile_verified(*, log: Any = None) -> dict[str, Any]:
 
     _emit("[max] restoring fans to Apple auto curve...")
     set_result = set_thermal_profile("silent")
+    deadline = time.monotonic() + max(0.0, float(settle_timeout_s))
     after = fan_summary()
+    while bool(set_result.get("ok")) and not _summary_indicates_auto(after):
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(max(0.1, float(poll_interval_s)))
+        after = fan_summary()
     ok = bool(set_result.get("ok")) and _summary_indicates_auto(after)
     message = "fan profile restored" if ok else "fan restore was attempted but not verified"
     if ok:

--- a/mtplx/ui/banner.py
+++ b/mtplx/ui/banner.py
@@ -7,6 +7,7 @@ to plain stdlib ``print`` so the CLI works without ``rich`` installed.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 
@@ -22,6 +23,13 @@ _MTPLX_BANNER = [
 ]
 
 _TAGLINE = "Native MTP speculative decoding · Apple Silicon"
+
+
+def shell_banner_already_shown() -> bool:
+    """Return whether the shell hook already printed the session banner."""
+
+    value = os.environ.get("MTPLX_SHELL_BANNER_SHOWN") or os.environ.get("MTPLX_NO_BANNER")
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def banner_text(*, indent: int = 2) -> str:
@@ -43,6 +51,9 @@ def render_banner(*, console: Any | None = None, no_color: bool = False) -> None
     Falls back to plain text when ``rich`` is not importable or when
     ``no_color`` is set, so the CLI banner survives without dependencies.
     """
+
+    if shell_banner_already_shown():
+        return
 
     if no_color:
         print(banner_text())

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -756,7 +756,12 @@ def _print_welcome() -> None:
     console.print()
 
 
-def _print_summary(state: dict) -> None:
+def _print_summary(
+    state: dict,
+    *,
+    title: str = "Ready to go",
+    plain_heading: str = "Your quickstart configuration:",
+) -> None:
     model_display = _pretty_path(state.get("model")) or "?"
     try:
         from rich.panel import Panel
@@ -764,7 +769,7 @@ def _print_summary(state: dict) -> None:
         from rich.text import Text
     except ImportError:
         print()
-        print("  Your quickstart configuration:")
+        print(f"  {plain_heading}")
         print(f"    Model:     {model_display}")
         print(f"    Mode:      {mode_label(state)}")
         print(f"    Interface: {interface_label(state.get('target'))}")
@@ -776,7 +781,7 @@ def _print_summary(state: dict) -> None:
         # ``Console()`` couldn't initialize (no tty, weird stdout, etc.) —
         # fall back to the same plain-stdout layout as the import-fail path.
         print()
-        print("  Your quickstart configuration:")
+        print(f"  {plain_heading}")
         print(f"    Model:     {model_display}")
         print(f"    Mode:      {mode_label(state)}")
         print(f"    Interface: {interface_label(state.get('target'))}")
@@ -790,7 +795,7 @@ def _print_summary(state: dict) -> None:
     table.add_row("Interface", interface_label(state.get("target")))
     panel = Panel(
         table,
-        title=Text("Ready to go", style="bold green"),
+        title=Text(title, style="bold green"),
         title_align="left",
         border_style="green",
         padding=(1, 2),
@@ -1065,6 +1070,39 @@ def screen_interface() -> str:
     return "openwebui" if choice == "1" else "terminal"
 
 
+def screen_server_surface(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    default_open_browser: bool = False,
+) -> bool:
+    """Return whether the server flow should open the browser chat."""
+
+    raw_host = str(host or "").strip()
+    display_host = "127.0.0.1" if raw_host in {"", "0.0.0.0", "::"} else raw_host
+    base = f"http://{display_host}:{int(port)}"
+    _step_panel(
+        step=3,
+        total=3,
+        title="How should the server start?",
+        options=[
+            (
+                "1",
+                f"API server only [{base}/v1]",
+                "Starts the OpenAI-compatible endpoint and leaves this terminal attached to the server logs.",
+            ),
+            (
+                "2",
+                f"Open browser chat too [{base}/]",
+                "Starts the same server and opens the local MTPLX chat UI after startup.",
+            ),
+        ],
+    )
+    default = "2" if default_open_browser else "1"
+    choice = _prompt_choice("Select", ["1", "2"], default=default)
+    return choice == "2"
+
+
 def run_onboarding_screens(*, configured_model: str | None = None) -> dict:
     """Walk all three screens and return the chosen state dict.
 
@@ -1084,6 +1122,33 @@ def run_onboarding_screens(*, configured_model: str | None = None) -> dict:
         "profile": profile,
         "max": max_mode,
         "target": target,
+    }
+
+
+def run_serve_onboarding_screens(
+    *,
+    configured_model: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    default_open_browser: bool = False,
+) -> dict:
+    """Walk the advanced server setup screens and return the chosen state."""
+
+    model = screen_model(configured=configured_model)
+    profile, max_mode = screen_mode()
+    if max_mode:
+        max_mode = ensure_thermal_control_installed()
+    open_browser = screen_server_surface(
+        host=host,
+        port=port,
+        default_open_browser=default_open_browser,
+    )
+    return {
+        "model": model,
+        "profile": profile,
+        "max": max_mode,
+        "target": "openwebui" if open_browser else "server",
+        "open_browser": open_browser,
     }
 
 
@@ -1323,6 +1388,82 @@ def run_quickstart_flow(
         return None
 
 
+def _print_server_welcome() -> None:
+    try:
+        from rich.panel import Panel
+        from rich.text import Text
+    except ImportError:
+        print()
+        print("MTPLX server setup. Three quick questions before the server starts.")
+        print("For each step, type the number of your choice and press Enter.")
+        print()
+        return
+    console = _console()
+    if console is None:
+        print()
+        print("MTPLX server setup. Three quick questions before the server starts.")
+        print("For each step, type the number of your choice and press Enter.")
+        print()
+        return
+    body = Text()
+    body.append("MTPLX server setup.\n\n", style="bold")
+    body.append("Three questions before the OpenAI-compatible server starts:\n", style="")
+    body.append("  1. Which model?\n", style="dim")
+    body.append("  2. Which runtime mode?\n", style="dim")
+    body.append("  3. API only, or also open the browser chat?\n\n", style="dim")
+    body.append("For each step, type the number of your choice and press Enter.", style="italic")
+    panel = Panel(
+        body,
+        title=Text("Server setup", style="bold cyan"),
+        title_align="left",
+        border_style="cyan",
+        padding=(1, 2),
+        expand=False,
+    )
+    console.print()
+    console.print(panel)
+    console.print()
+
+
+def run_serve_flow(
+    *,
+    fresh: bool = False,
+    configured_model: str | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    default_open_browser: bool = False,
+) -> dict | None:
+    """Interactive setup for bare ``mtplx serve``.
+
+    Unlike ``run_quickstart_flow``, this intentionally does not offer "same as
+    last time" reuse: ``serve`` is the advanced server command, so a bare
+    interactive invocation should always let the user pick the server model and
+    runtime mode before binding a port.
+    """
+
+    _ = fresh  # Symmetric with quickstart; serve always starts from choices.
+    try:
+        _print_server_welcome()
+        choice = run_serve_onboarding_screens(
+            configured_model=configured_model,
+            host=host,
+            port=port,
+            default_open_browser=default_open_browser,
+        )
+        _print_summary(
+            choice,
+            title="Server ready",
+            plain_heading="Your server configuration:",
+        )
+        return choice
+    except (KeyboardInterrupt, EOFError):
+        try:
+            print()
+        except Exception:  # pragma: no cover - stdout is closed
+            pass
+        return None
+
+
 # ---------- label helpers ---------------------------------------------------
 def mode_label(state: dict) -> str:
     profile = state.get("profile", "safe")
@@ -1338,6 +1479,8 @@ def mode_label(state: dict) -> str:
 def interface_label(target: str | None) -> str:
     if target in ("openwebui", "open-webui", "web"):
         return "Web UI  ·  browser"
+    if target in ("server", "api", "api-server"):
+        return "API server  ·  no browser"
     if target in ("cli", "terminal"):
         return "CLI  ·  this terminal"
     return target or "?"

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import datetime
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,7 @@ DEFAULT_HF_MODEL = DEFAULT_HF_MODEL_ID
 STATE_PATH = Path("~/.mtplx/quickstart.json").expanduser()
 LOCAL_SCAN_TIMEOUT_S = 3.0
 LOCAL_SCAN_CLASSIFY_TIMEOUT_S = 4.0
+_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _TIER_RANK: dict[str, int] = {
     "verified": 0,
     "arch-compatible": 1,
@@ -472,6 +474,60 @@ def _prompt_text(prompt: str, *, default: str | None = None) -> str:
     return answer
 
 
+def _normalize_hf_repo_id(value: str) -> str:
+    text = str(value or "").strip()
+    prefix = "https://huggingface.co/"
+    if text.startswith(prefix):
+        text = text[len(prefix) :]
+        text = text.split("?", 1)[0].split("#", 1)[0]
+        for marker in ("/tree/", "/blob/", "/resolve/"):
+            if marker in text:
+                text = text.split(marker, 1)[0]
+                break
+    return text.strip("/")
+
+
+def _hf_repo_id_error(value: str) -> str | None:
+    text = _normalize_hf_repo_id(value)
+    if not text:
+        return "Please enter a Hugging Face repo id like namespace/name."
+    if any(ch.isspace() for ch in text):
+        return "That has spaces, so it is not a Hugging Face repo id."
+    if ":" in text or text.startswith(("╭", "│", "╰")):
+        return "That looks like pasted terminal output, not a Hugging Face repo id."
+    if "/" not in text:
+        return "Please include the namespace, for example trevon/Qwen3.5-27B-MLX-MTP."
+    if text.count("/") != 1:
+        return "Please enter only namespace/name, not a nested path."
+    namespace, name = text.split("/", 1)
+    if not namespace or not name:
+        return "Please enter a Hugging Face repo id like namespace/name."
+    if not _HF_REPO_ID_RE.fullmatch(text):
+        return "Repo ids can only use letters, numbers, dot, dash, and underscore."
+    if any(part.startswith(("-", ".")) or part.endswith(("-", ".")) for part in (namespace, name)):
+        return "Repo id parts cannot start or end with dot or dash."
+    if "--" in text or ".." in text:
+        return "Repo ids cannot contain consecutive dashes or dots."
+    return None
+
+
+def _prompt_hf_repo_id(*, default: str = DEFAULT_HF_MODEL) -> str:
+    saw_invalid = False
+    while True:
+        entered = _prompt_text(
+            "Hugging Face repo id (namespace/name)",
+            default=default if not saw_invalid else None,
+        )
+        candidate = _normalize_hf_repo_id(entered)
+        error = _hf_repo_id_error(candidate)
+        if error is None:
+            return candidate
+        saw_invalid = True
+        print(f"  {error}")
+        print("  Example: trevon/Qwen3.5-27B-MLX-MTP")
+        print()
+
+
 def _print_welcome() -> None:
     try:
         from rich.panel import Panel
@@ -618,16 +674,14 @@ def screen_model(*, configured: str | None = None) -> str:
         if choice == "2":
             return DEFAULT_HF_MODEL
         if choice == "3":
-            entered = _prompt_text("Hugging Face repo id (namespace/name)", default=DEFAULT_HF_MODEL)
-            return entered or DEFAULT_HF_MODEL
+            return _prompt_hf_repo_id(default=DEFAULT_HF_MODEL)
         # choice == "4"
         return _pick_local_model(default=str(configured))
 
     if choice == "1":
         return DEFAULT_HF_MODEL
     if choice == "2":
-        entered = _prompt_text("Hugging Face repo id (namespace/name)", default=DEFAULT_HF_MODEL)
-        return entered or DEFAULT_HF_MODEL
+        return _prompt_hf_repo_id(default=DEFAULT_HF_MODEL)
     # choice == "3"
     return _pick_local_model(default=None)
 

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -16,8 +16,9 @@ import os
 from pathlib import Path
 from typing import Any
 
+from mtplx.profiles import DEFAULT_HF_MODEL_ID
 
-DEFAULT_HF_MODEL = "mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP"
+DEFAULT_HF_MODEL = DEFAULT_HF_MODEL_ID
 STATE_PATH = Path("~/.mtplx/quickstart.json").expanduser()
 
 
@@ -355,8 +356,8 @@ def screen_mode() -> tuple[str, bool]:
 
     Three modes laid out on two axes — runtime path × fan control:
 
-      Stable : conservative MTP path,  no fan control     ~37 tok/s, holds steady
       Fast : aggressive cold-speed path, no fan control   ~60 tok/s start, decays
+      Stable : conservative MTP path,  no fan control     ~37 tok/s, holds steady
       Max  : aggressive cold-speed path, fans pinned 100% for better sustained throughput (loud)
 
     The user-visible difference between Stable and Fast is *which decoding path*
@@ -371,13 +372,13 @@ def screen_mode() -> tuple[str, bool]:
         options=[
             (
                 "1",
-                "Stable  ·  ~37 tok/s steady, no fan boost",
-                "Conservative MTP path. Slower but the speed barely changes between a 50-token reply and a 5000-token reply. Best for long answers.",
+                "Fast  ·  ~60 tok/s on short replies, slows down on long ones",
+                "Aggressive cold-speed path. Snappy at first; throughput drops on long-context generation because fans stay on Apple's default curve.",
             ),
             (
                 "2",
-                "Fast  ·  ~60 tok/s on short replies, slows down on long ones",
-                "Aggressive cold-speed path. Snappy at first; throughput drops on long-context generation because fans stay on Apple's default curve.",
+                "Stable  ·  ~37 tok/s steady, no fan boost",
+                "Conservative MTP path. Slower but the speed barely changes between a 50-token reply and a 5000-token reply. Best for long answers.",
             ),
             (
                 "3",
@@ -387,7 +388,7 @@ def screen_mode() -> tuple[str, bool]:
         ],
     )
     choice = _prompt_choice("Select", ["1", "2", "3"], default="1")
-    if choice == "2":
+    if choice == "1":
         return "performance-cold", False
     if choice == "3":
         return "performance-cold", True

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -1,4 +1,4 @@
-"""Interactive onboarding flow for ``mtplx quickstart``.
+"""Interactive onboarding flow for ``mtplx start``.
 
 Three screens for first-time users (model -> mode -> interface), and a
 "same as last time?" prompt for returning users. Choices persist to
@@ -354,15 +354,12 @@ def screen_model(*, configured: str | None = None) -> str:
 def screen_mode() -> tuple[str, bool]:
     """Return (profile_name, max_mode_flag).
 
-    Three modes laid out on two axes — runtime path × fan control:
+    The consumer onboarding is speed-first:
 
-      Fast : aggressive cold-speed path, no fan control   ~60 tok/s start, decays
-      Stable : conservative MTP path,  no fan control     ~37 tok/s, holds steady
-      Max  : aggressive cold-speed path, fans pinned 100% for better sustained throughput (loud)
+      Medium : native-MTP speed path, Apple fan curve, burst not sustained
+      Max    : same path, ThermalForge pins fans at 100% for sustained speed
 
-    The user-visible difference between Stable and Fast is *which decoding path*
-    runs (different profile env, different throughput envelope). Both leave
-    fans on Apple's default curve. Max is Fast + ThermalForge fan boost.
+    Stable remains available through ``--profile stable`` / ``--profile safe``.
     """
 
     _step_panel(
@@ -372,27 +369,20 @@ def screen_mode() -> tuple[str, bool]:
         options=[
             (
                 "1",
-                "Fast  ·  ~60 tok/s on short replies, slows down on long ones",
-                "Aggressive cold-speed path. Snappy at first; throughput drops on long-context generation because fans stay on Apple's default curve.",
+                "Medium  ·  native-MTP speed path, about 2.2x burst (not sustained)",
+                "Fast speculative path with Apple's default fan curve; snappy on short replies, slower on long hot runs.",
             ),
             (
                 "2",
-                "Stable  ·  ~37 tok/s steady, no fan boost",
-                "Conservative MTP path. Slower but the speed barely changes between a 50-token reply and a 5000-token reply. Best for long answers.",
-            ),
-            (
-                "3",
-                "Max  ·  fan-boosted Fast path, fans pinned at 100% (loud)",
-                "Same cold-speed path as Fast, plus ThermalForge ramps the fans to reduce long-reply slowdown. Needs ThermalForge installed.",
+                "Max  ·  Medium path plus fans pinned at 100%, about 2.24x (loud)",
+                "Same runtime path as Medium, plus ThermalForge fan control to reduce long-reply slowdown.",
             ),
         ],
     )
-    choice = _prompt_choice("Select", ["1", "2", "3"], default="1")
+    choice = _prompt_choice("Select", ["1", "2"], default="1")
     if choice == "1":
         return "performance-cold", False
-    if choice == "3":
-        return "performance-cold", True
-    return "stable", False
+    return "performance-cold", True
 
 
 def screen_interface() -> str:
@@ -473,7 +463,7 @@ def ensure_thermal_control_installed() -> bool:
             ),
             (
                 "2",
-                "Skip — Max falls back to Cold-Speed",
+                "Skip — Max falls back to Medium",
                 "No fan boost, but everything else still works.",
             ),
         ],
@@ -509,7 +499,7 @@ def _print_install_skipped() -> None:
         console = Console()
         console.print(
             "[yellow]  Skipped. Continuing without fan boost — "
-            "Max behaves like Cold-Speed.[/yellow]\n"
+            "Max behaves like Medium.[/yellow]\n"
         )
     except Exception:
         print("  Skipped. Continuing without fan boost.\n")
@@ -607,6 +597,14 @@ def confirm_same_as_last(last: dict) -> bool:
     return answer in {"", "y", "yes", "same"}
 
 
+def _quickstart_state_is_reusable(last: dict | None) -> bool:
+    if not isinstance(last, dict):
+        return False
+    # Stable/safe remains available by explicit flag, but old saved states
+    # should not keep showing it in the speed-first onboarding path.
+    return str(last.get("profile") or "") == "performance-cold"
+
+
 def run_quickstart_flow(
     *,
     fresh: bool = False,
@@ -624,6 +622,8 @@ def run_quickstart_flow(
     """
 
     last = None if fresh else load_state()
+    if not _quickstart_state_is_reusable(last):
+        last = None
     try:
         if last and not fresh:
             if confirm_same_as_last(last):
@@ -651,13 +651,13 @@ def run_quickstart_flow(
 
 # ---------- label helpers ---------------------------------------------------
 def mode_label(state: dict) -> str:
-    profile = state.get("profile", "stable")
+    profile = state.get("profile", "performance-cold")
     if state.get("max"):
-        return "Max  ·  fan-boosted Fast path, fans pinned at 100%"
+        return "Max  ·  Medium path plus fans pinned at 100%, ~2.24x"
     if profile == "performance-cold":
-        return "Fast  ·  ~60 tok/s start, decays on long replies"
+        return "Medium  ·  native-MTP speed path, ~2.2x burst (not sustained)"
     if profile == "stable":
-        return "Stable  ·  ~37 tok/s, holds steady"
+        return "Stable  ·  exact/staged long-reply path"
     return str(profile)
 
 

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import datetime
 import json
 import os
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,33 @@ from mtplx.profiles import DEFAULT_HF_MODEL_ID
 
 DEFAULT_HF_MODEL = DEFAULT_HF_MODEL_ID
 STATE_PATH = Path("~/.mtplx/quickstart.json").expanduser()
+LOCAL_SCAN_TIMEOUT_S = 3.0
+LOCAL_SCAN_CLASSIFY_TIMEOUT_S = 4.0
+_TIER_RANK: dict[str, int] = {
+    "verified": 0,
+    "arch-compatible": 1,
+    "unknown": 2,
+    "no-mtp": 3,
+    "incompatible": 4,
+}
+
+
+def _pretty_path(value: str | Path | None) -> str:
+    """Render a filesystem path with the user's home directory collapsed."""
+
+    if value is None:
+        return ""
+    text = str(value)
+    if not text:
+        return ""
+    if "://" in text:
+        return text
+    try:
+        path = Path(text).expanduser()
+        home = Path.home()
+        return "~/" + str(path.relative_to(home)) if path.is_absolute() else text
+    except Exception:
+        return text
 
 
 # ---------- state file ------------------------------------------------------
@@ -54,6 +83,200 @@ def save_state(state: dict) -> None:
     with path.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
         handle.write("\n")
+
+
+# ---------- local-folder scanning ------------------------------------------
+@dataclass(frozen=True)
+class ScannedModel:
+    path: Path
+    tier: str
+    arch_id: str | None
+    architecture: str | None
+    error: str | None = None
+
+
+def _is_model_dir(path: Path) -> bool:
+    return (path / "config.json").is_file()
+
+
+_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".cache",
+        "__pycache__",
+        "node_modules",
+        "blobs",
+        "refs",
+        "DerivedData",
+    }
+)
+
+
+def _scan_for_models(
+    root: Path,
+    *,
+    max_depth: int = 4,
+    cap: int = 200,
+    timeout_s: float = LOCAL_SCAN_TIMEOUT_S,
+) -> list[Path]:
+    if _is_model_dir(root):
+        return [root]
+
+    results: list[Path] = []
+    deadline = time.monotonic() + max(0.1, float(timeout_s)) if timeout_s else None
+
+    def _expired() -> bool:
+        return deadline is not None and time.monotonic() >= deadline
+
+    def _walk(p: Path, depth: int) -> None:
+        if depth > max_depth or len(results) >= cap or _expired():
+            return
+        try:
+            entries = sorted(p.iterdir(), key=lambda x: x.name.lower())
+        except (PermissionError, OSError):
+            return
+        for child in entries:
+            if len(results) >= cap or _expired():
+                return
+            if not child.is_dir():
+                continue
+            name = child.name
+            if name in _SKIP_DIRS:
+                continue
+            if name.startswith(".") and depth >= 0:
+                continue
+            if _is_model_dir(child):
+                results.append(child)
+                continue
+            _walk(child, depth + 1)
+
+    _walk(root, 0)
+    return results
+
+
+def _classify_scanned_model(model_dir: Path) -> ScannedModel:
+    config_path = model_dir / "config.json"
+    if not config_path.is_file():
+        return ScannedModel(model_dir, "incompatible", None, None, "missing config.json")
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return ScannedModel(model_dir, "unknown", None, None, str(exc)[:80])
+
+    tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
+    archs = (
+        (config.get("architectures") if isinstance(config, dict) else None)
+        or tcfg.get("architectures")
+        or []
+    )
+    architecture = archs[0] if archs else None
+    model_type = tcfg.get("model_type") or (
+        config.get("model_type") if isinstance(config, dict) else None
+    )
+
+    def _maybe_int(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    mtp_num_hidden_layers = max(
+        _maybe_int(tcfg.get("mtp_num_hidden_layers")),
+        _maybe_int(tcfg.get("num_nextn_predict_layers")),
+        _maybe_int(tcfg.get("num_mtp_modules")),
+        _maybe_int(config.get("num_nextn_predict_layers")) if isinstance(config, dict) else 0,
+        _maybe_int(config.get("num_mtp_modules")) if isinstance(config, dict) else 0,
+    )
+
+    contract_path = model_dir / "mtplx_runtime.json"
+    runtime_contract_data: dict | None = None
+    runtime_contract_error: str | None = None
+    if contract_path.is_file():
+        try:
+            runtime_contract_data = json.loads(contract_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            runtime_contract_error = str(exc)[:80]
+
+    try:
+        model_files = tuple(sorted(p.name for p in model_dir.glob("model*.safetensors")))
+    except OSError:
+        model_files = ()
+
+    class _StubMTP:
+        exists = mtp_num_hidden_layers > 0
+        passes_tensor_gate = False
+
+    class _StubInspection:
+        pass
+
+    stub = _StubInspection()
+    stub.model_dir = str(model_dir)
+    stub.architecture = architecture
+    stub.model_type = model_type
+    stub.mtp_num_hidden_layers = mtp_num_hidden_layers
+    stub.mtp = _StubMTP()
+    stub.model_files = model_files
+    stub.runtime_contract_data = runtime_contract_data
+    stub.runtime_contract_error = runtime_contract_error
+    stub.runtime_contract_path = str(contract_path) if contract_path.is_file() else None
+
+    try:
+        from mtplx.backends.registry import SUPPORTED_ARCH_IDS, compatibility_for_inspection
+
+        verdict = compatibility_for_inspection(stub)
+    except Exception as exc:
+        return ScannedModel(model_dir, "unknown", None, architecture, str(exc)[:80])
+
+    raw_tier = verdict.tier
+    if raw_tier == "verified":
+        tier = "verified"
+    elif raw_tier == "architecture-compatible-but-unverified":
+        if (
+            verdict.runtime_contract is not None
+            and verdict.arch_id is not None
+            and verdict.arch_id in SUPPORTED_ARCH_IDS
+            and runtime_contract_error is None
+        ):
+            tier = "verified"
+        else:
+            tier = "arch-compatible"
+    elif raw_tier == "no-MTP":
+        tier = "no-mtp"
+    elif raw_tier == "incompatible-architecture":
+        tier = "incompatible"
+    else:
+        tier = "unknown"
+
+    return ScannedModel(model_dir, tier, verdict.arch_id, architecture)
+
+
+def _tier_badge(tier: str) -> tuple[str, str]:
+    if tier == "verified":
+        return ("Verified", "bold green")
+    if tier == "arch-compatible":
+        return ("Compatible (unverified)", "yellow")
+    if tier == "no-mtp":
+        return ("No MTP head", "dim")
+    if tier == "incompatible":
+        return ("Unsupported architecture", "red")
+    return ("Unknown", "dim")
+
+
+def _scanned_model_options(
+    models: list[ScannedModel],
+    root: Path,
+) -> list[tuple[str, str, str]]:
+    options: list[tuple[str, str, str]] = []
+    for index, model in enumerate(models, start=1):
+        try:
+            display_name = str(model.path.relative_to(root))
+        except ValueError:
+            display_name = _pretty_path(model.path)
+        badge, _ = _tier_badge(model.tier)
+        arch = model.architecture or model.arch_id or "unknown architecture"
+        subline = f"{badge}  ·  {model.error[:80]}" if model.error else f"{badge}  ·  {arch}"
+        options.append((str(index), display_name, subline))
+    return options
 
 
 # ---------- rich helpers (with stdlib fallback) -----------------------------
@@ -299,7 +522,7 @@ def screen_model(*, configured: str | None = None) -> str:
             (
                 "4",
                 "Local folder",
-                "e.g. /Users/you/models/your-model",
+                "e.g. ~/models/your-model  ·  or a parent like ~/.lmstudio/models",
             )
         )
     else:
@@ -321,7 +544,7 @@ def screen_model(*, configured: str | None = None) -> str:
             (
                 "3",
                 "Local folder",
-                "e.g. /Users/you/models/your-model",
+                "e.g. ~/models/your-model  ·  or a parent like ~/.lmstudio/models",
             )
         )
 
@@ -338,8 +561,7 @@ def screen_model(*, configured: str | None = None) -> str:
             entered = _prompt_text("Hugging Face repo id (namespace/name)", default=DEFAULT_HF_MODEL)
             return entered or DEFAULT_HF_MODEL
         # choice == "4"
-        entered = _prompt_text("Local folder path", default=str(configured) or DEFAULT_HF_MODEL)
-        return entered or str(configured) or DEFAULT_HF_MODEL
+        return _pick_local_model(default=str(configured))
 
     if choice == "1":
         return DEFAULT_HF_MODEL
@@ -347,8 +569,97 @@ def screen_model(*, configured: str | None = None) -> str:
         entered = _prompt_text("Hugging Face repo id (namespace/name)", default=DEFAULT_HF_MODEL)
         return entered or DEFAULT_HF_MODEL
     # choice == "3"
-    entered = _prompt_text("Local folder path", default=DEFAULT_HF_MODEL)
-    return entered or DEFAULT_HF_MODEL
+    return _pick_local_model(default=None)
+
+
+def _pick_local_model(*, default: str | None) -> str:
+    pretty_default = _pretty_path(default) if default else None
+    while True:
+        entered = _prompt_text("Local folder path", default=pretty_default)
+        if not entered:
+            print("  Path is required. Falling back to verified default.")
+            return DEFAULT_HF_MODEL
+
+        root = Path(entered).expanduser().resolve()
+        if not root.exists():
+            print(f"  Path does not exist: {_pretty_path(root)}")
+            print()
+            continue
+        if not root.is_dir():
+            print(f"  Not a directory: {_pretty_path(root)}")
+            print()
+            continue
+
+        if _is_model_dir(root):
+            return str(root)
+
+        chosen = _scan_and_pick(root)
+        if chosen is None:
+            continue
+        return chosen
+
+
+def _scan_and_pick(root: Path) -> str | None:
+    print(f"  Scanning {_pretty_path(root)} for MTP-compatible models...")
+    found = _scan_for_models(root)
+    if found:
+        print(f"  Found {len(found)} candidate model folder(s). Checking configs...")
+    classified: list[ScannedModel] = []
+    classify_deadline = time.monotonic() + LOCAL_SCAN_CLASSIFY_TIMEOUT_S
+    for path in found:
+        if classified and time.monotonic() >= classify_deadline:
+            print(
+                "  Compatibility scan is taking longer than expected; "
+                f"showing {len(classified)} result(s)."
+            )
+            break
+        classified.append(_classify_scanned_model(path))
+
+    if not classified:
+        print(f"  No models found under {_pretty_path(root)}.")
+        print(
+            "  (a model directory has a config.json at its root — "
+            "for LM Studio that's <publisher>/<repo-name>/)"
+        )
+        print()
+        return None
+
+    classified.sort(key=lambda m: (_TIER_RANK.get(m.tier, 99), str(m.path).lower()))
+
+    cap = 24
+    visible = classified[:cap]
+    hidden = len(classified) - cap
+    options = _scanned_model_options(visible, root)
+    options.append(
+        (
+            str(len(visible) + 1),
+            "Type a different folder path",
+            "Re-enter a model directory or a different parent.",
+        )
+    )
+
+    runnable = sum(1 for m in classified if m.tier == "verified")
+    compat = sum(1 for m in classified if m.tier == "arch-compatible")
+    intro = (
+        f"Found {len(classified)} model(s) under {_pretty_path(root)}  ·  "
+        f"{runnable} verified, {compat} compatible"
+    )
+    if hidden > 0:
+        intro += f"  (showing first {cap}; {hidden} not shown)"
+
+    _choice_panel(
+        heading="Pick a model",
+        intro=intro,
+        options=options,
+        border_style="cyan",
+    )
+
+    valid = [opt[0] for opt in options]
+    choice = _prompt_choice("Select", valid, default="1")
+    idx = int(choice) - 1
+    if idx == len(visible):
+        return None
+    return str(visible[idx].path)
 
 
 def screen_mode() -> tuple[str, bool]:

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -19,13 +19,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from mtplx.profiles import DEFAULT_HF_MODEL_ID
+from mtplx.constants import (
+    EXPECTED_ALL_PREQUANTIZED_MTP_KEYS,
+    EXPECTED_MTP_KEYS,
+    EXPECTED_PREQUANTIZED_MTP_KEYS,
+)
+from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_MODEL_ID
 
 DEFAULT_HF_MODEL = DEFAULT_HF_MODEL_ID
+DEFAULT_LOCAL_MODEL = DEFAULT_MODEL_ID
 STATE_PATH = Path("~/.mtplx/quickstart.json").expanduser()
-LOCAL_SCAN_TIMEOUT_S = 3.0
-LOCAL_SCAN_CLASSIFY_TIMEOUT_S = 4.0
-_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+# Tier ranks for sorting scanned-model lists. Lower = surfaced higher in the
+# picker. The intent is "verified first, runnable next, blocked last" so the
+# user never has to scroll past unsupported entries to find a launchable one.
 _TIER_RANK: dict[str, int] = {
     "verified": 0,
     "arch-compatible": 1,
@@ -37,24 +44,67 @@ _TIER_RANK: dict[str, int] = {
     "incompatible": 7,
     "unknown": 8,
 }
+LOCAL_SCAN_TIMEOUT_S = 3.0
+LOCAL_SCAN_CLASSIFY_TIMEOUT_S = 4.0
+_HF_REPO_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
 def _pretty_path(value: str | Path | None) -> str:
-    """Render a filesystem path with the user's home directory collapsed."""
+    """Render a filesystem path with the user's home directory collapsed to ``~``.
+
+    Returns the input unchanged when it isn't path-shaped (HF refs like
+    ``namespace/name``) or when it doesn't live under ``$HOME``. The point is
+    to stop the UI from screaming ``/Users/<me>/...`` at users who reasonably
+    expect a portable product.
+    """
 
     if value is None:
         return ""
     text = str(value)
     if not text:
         return ""
-    if "://" in text:
+    # Heuristic: an HF repo ref is exactly ``namespace/name`` with no leading
+    # path indicator. Don't try to munge those.
+    if not text.startswith(("/", "~", "./", "../")):
         return text
     try:
         path = Path(text).expanduser()
         home = Path.home()
-        return "~/" + str(path.relative_to(home)) if path.is_absolute() else text
+        try:
+            rel = path.relative_to(home)
+        except ValueError:
+            return text
+        rel_str = str(rel)
+        if rel_str in {"", "."}:
+            return "~"
+        return f"~/{rel_str}"
     except Exception:
         return text
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_local_model_path() -> Path:
+    local = Path(DEFAULT_LOCAL_MODEL).expanduser()
+    if local.is_absolute():
+        return local
+    return (_repo_root() / local).resolve()
+
+
+def _verified_default_model() -> str:
+    local = _default_local_model_path()
+    if _is_model_dir(local):
+        return str(local)
+    return DEFAULT_HF_MODEL
+
+
+def _verified_default_label() -> str:
+    model = _verified_default_model()
+    if model == DEFAULT_HF_MODEL:
+        return f"{DEFAULT_HF_MODEL}  ·  cold-speed champion"
+    return f"{_pretty_path(model)}  ·  local speed champion"
 
 
 # ---------- state file ------------------------------------------------------
@@ -94,6 +144,15 @@ def save_state(state: dict) -> None:
 # ---------- local-folder scanning ------------------------------------------
 @dataclass(frozen=True)
 class ScannedModel:
+    """A model directory found while walking a user-supplied folder.
+
+    ``tier`` is the normalized compatibility verdict, one of
+    ``verified`` / ``arch-compatible`` / ``needs-verification`` /
+    ``mtp-invalid`` / ``mtp-missing`` / ``backend-pending`` / ``no-mtp`` /
+    ``incompatible`` / ``unknown``. The display layer turns it into a coloured
+    badge. ``arch-compatible`` means launchable, not merely recognized.
+    """
+
     path: Path
     tier: str
     arch_id: str | None
@@ -105,6 +164,10 @@ def _is_model_dir(path: Path) -> bool:
     return (path / "config.json").is_file()
 
 
+# Folder names that are known to be internal/auxiliary and not worth recursing
+# into. ``blobs`` and ``refs`` are part of the HuggingFace cache layout where
+# only ``snapshots/<commit>/`` contains model files; the rest are common
+# project clutter.
 _SKIP_DIRS: frozenset[str] = frozenset(
     {
         ".git",
@@ -125,6 +188,24 @@ def _scan_for_models(
     cap: int = 200,
     timeout_s: float = LOCAL_SCAN_TIMEOUT_S,
 ) -> list[Path]:
+    """Walk ``root`` and return all directories containing ``config.json``.
+
+    The user can point us at three kinds of paths:
+
+    * A single model directory (e.g. ``~/models/Qwen-7B/``) — returns
+      ``[root]`` immediately.
+    * A flat parent of model directories (e.g. ``~/models/``) — returns each
+      child that has a ``config.json``.
+    * A nested layout like LM Studio (``<root>/<publisher>/<model>/``) or the
+      HuggingFace cache (``<root>/models--*/snapshots/<hash>/``). We descend
+      up to ``max_depth`` levels and stop at the first ``config.json`` on each
+      branch so we don't double-count.
+
+    ``cap`` bounds the result list so a misdirected scan into ``$HOME`` can't
+    produce a 10k-line picker. ``timeout_s`` keeps parent-folder scans from
+    making first-run setup feel dead on slow external/cloud-backed folders.
+    """
+
     if _is_model_dir(root):
         return [root]
 
@@ -149,6 +230,9 @@ def _scan_for_models(
             name = child.name
             if name in _SKIP_DIRS:
                 continue
+            # Hidden directories below the root are noise (``.DS_Store``,
+            # ``.huggingface``). The root itself is allowed to be hidden — that
+            # is how ``~/.lmstudio/models`` works.
             if name.startswith(".") and depth >= 0:
                 continue
             if _is_model_dir(child):
@@ -158,6 +242,29 @@ def _scan_for_models(
 
     _walk(root, 0)
     return results
+
+
+def _expected_embedded_mtp_keys(config: dict[str, Any]) -> set[str]:
+    mtp_quant = config.get("mtplx_mtp_quantization", {})
+    prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
+    quant_policy = str(mtp_quant.get("policy") or "") if isinstance(mtp_quant, dict) else ""
+    if prequantized and quant_policy == "all":
+        return set(EXPECTED_ALL_PREQUANTIZED_MTP_KEYS)
+    if prequantized:
+        return set(EXPECTED_PREQUANTIZED_MTP_KEYS)
+    return set(EXPECTED_MTP_KEYS)
+
+
+def _is_mtp_weight_key(key: str) -> bool:
+    text = str(key)
+    return text.startswith("mtp.") or text.startswith("language_model.mtp.")
+
+
+def _normalize_mtp_weight_key(key: str) -> str:
+    text = str(key)
+    if text.startswith("language_model.mtp."):
+        return "mtp." + text[len("language_model.mtp.") :]
+    return text
 
 
 def _scan_mtp_sidecar_exists(model_dir: Path, config: dict[str, Any]) -> bool:
@@ -186,17 +293,48 @@ def _scan_embedded_mtp_keys(model_dir: Path) -> tuple[str, ...]:
     weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
     if not isinstance(weight_map, dict):
         return ()
-    return tuple(sorted(str(key) for key in weight_map if str(key).startswith("mtp.")))
+    return tuple(
+        sorted(_normalize_mtp_weight_key(str(key)) for key in weight_map if _is_mtp_weight_key(str(key)))
+    )
 
 
 def _classify_scanned_model(model_dir: Path) -> ScannedModel:
+    """Bucket a model directory into our four-tier compatibility model from
+    config.json alone — never mmap any safetensors file.
+
+    The scanner runs over arbitrary user folders (LM Studio caches, HF caches,
+    half-downloaded directories) and at least one of those models is allowed
+    to be partially evicted, broken, or APFS-dataless without crashing the
+    whole picker. ``inspect_model`` mmaps ``mtp.safetensors`` to count tensors
+    — a SIGBUS on that mmap kills the Python process and there is nothing
+    Python-level can catch. So for the picker we synthesize a minimal stub
+    inspection and run it through the same ``compatibility_for_inspection``
+    verdict logic the rest of the runtime uses. The runtime layer does the
+    full mmap when the user actually picks a model and produces a precise
+    error there if the artifact is broken.
+    """
+
     config_path = model_dir / "config.json"
     if not config_path.is_file():
-        return ScannedModel(model_dir, "incompatible", None, None, "missing config.json")
+        return ScannedModel(
+            path=model_dir,
+            tier="incompatible",
+            arch_id=None,
+            architecture=None,
+            error="missing config.json",
+        )
+
     try:
-        config = json.loads(config_path.read_text(encoding="utf-8"))
+        raw = config_path.read_text(encoding="utf-8")
+        config = json.loads(raw)
     except Exception as exc:
-        return ScannedModel(model_dir, "unknown", None, None, str(exc)[:80])
+        return ScannedModel(
+            path=model_dir,
+            tier="unknown",
+            arch_id=None,
+            architecture=None,
+            error=str(exc)[:80],
+        )
 
     tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
     archs = (
@@ -209,9 +347,9 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         config.get("model_type") if isinstance(config, dict) else None
     )
 
-    def _maybe_int(value: Any) -> int:
+    def _maybe_int(v: Any) -> int:
         try:
-            return int(value or 0)
+            return int(v or 0)
         except (TypeError, ValueError):
             return 0
 
@@ -223,6 +361,7 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         _maybe_int(config.get("num_mtp_modules")) if isinstance(config, dict) else 0,
     )
 
+    # Runtime contract is a small JSON file — safe to read.
     contract_path = model_dir / "mtplx_runtime.json"
     runtime_contract_data: dict | None = None
     runtime_contract_error: str | None = None
@@ -232,19 +371,25 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         except Exception as exc:
             runtime_contract_error = str(exc)[:80]
 
+    # List ``model*.safetensors`` filenames without reading tensor data, so the
+    # non-Qwen verified-runtime gate has the file presence it expects.
     try:
         model_files = tuple(sorted(p.name for p in model_dir.glob("model*.safetensors")))
     except OSError:
         model_files = ()
     sidecar_exists = _scan_mtp_sidecar_exists(model_dir, config if isinstance(config, dict) else {})
     embedded_mtp_keys = _scan_embedded_mtp_keys(model_dir)
+    expected_embedded = _expected_embedded_mtp_keys(config if isinstance(config, dict) else {})
+    embedded_gate = bool(embedded_mtp_keys) and set(embedded_mtp_keys) == expected_embedded
     mtp_artifact_exists = sidecar_exists or bool(embedded_mtp_keys)
+    mtp_tensor_gate = sidecar_exists or embedded_gate
 
     class _StubMTP:
-        # Picker-level evidence only. The runtime still validates the sidecar
-        # header and exact key layout before loading.
+        # Never mmap safetensors here. Sidecar presence or complete embedded
+        # ``mtp.*`` keys are enough for picker-level "can try this" UX; the
+        # runtime still performs the full tensor gate before loading.
         exists = mtp_artifact_exists
-        passes_tensor_gate = mtp_artifact_exists
+        passes_tensor_gate = mtp_tensor_gate
 
     class _StubInspection:
         pass
@@ -261,11 +406,33 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     stub.runtime_contract_path = str(contract_path) if contract_path.is_file() else None
 
     try:
-        from mtplx.backends.registry import SUPPORTED_ARCH_IDS, compatibility_for_inspection
+        from mtplx.backends.registry import compatibility_for_inspection
+    except Exception as exc:
+        return ScannedModel(
+            path=model_dir,
+            tier="unknown",
+            arch_id=None,
+            architecture=architecture,
+            error=str(exc)[:80],
+        )
 
+    try:
         verdict = compatibility_for_inspection(stub)
     except Exception as exc:
-        return ScannedModel(model_dir, "unknown", None, architecture, str(exc)[:80])
+        return ScannedModel(
+            path=model_dir,
+            tier="unknown",
+            arch_id=None,
+            architecture=architecture,
+            error=str(exc)[:80],
+        )
+
+    # Resolve the supported-arch set lazily so missing the import doesn't
+    # crash the picker — the unknown bucket is fine in that pathological case.
+    try:
+        from mtplx.backends.registry import SUPPORTED_ARCH_IDS as _SUPPORTED
+    except Exception:
+        _SUPPORTED = set()
 
     raw_tier = verdict.tier
     runtime_status = verdict.runtime_compatibility
@@ -275,10 +442,17 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     elif verdict.can_run or raw_tier == "family-compatible-unverified":
         tier = "arch-compatible"
     elif raw_tier == "architecture-compatible-but-unverified":
+        # The picker's safety pass deliberately skips the safetensors mmap
+        # that the runtime's verified gate needs for ``qwen3-next-mtp``. To
+        # avoid showing the flagship as "Compatible (unverified)" in the
+        # picker when it has a blessed ``mtplx_runtime.json`` we trust the
+        # contract: contract present + parsed cleanly + arch in our supported
+        # set ⇒ label as verified. The runtime layer still runs the full
+        # tensor check before any model actually loads.
         if (
             verdict.runtime_contract is not None
             and verdict.arch_id is not None
-            and verdict.arch_id in SUPPORTED_ARCH_IDS
+            and verdict.arch_id in _SUPPORTED
             and runtime_contract_error is None
         ):
             tier = "verified"
@@ -301,10 +475,17 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     else:
         tier = "unknown"
 
-    return ScannedModel(model_dir, tier, verdict.arch_id, architecture)
+    return ScannedModel(
+        path=model_dir,
+        tier=tier,
+        arch_id=verdict.arch_id,
+        architecture=architecture,
+    )
 
 
 def _tier_badge(tier: str) -> tuple[str, str]:
+    """Return ``(label, rich_style)`` for a compatibility tier."""
+
     if tier == "verified":
         return ("Verified", "bold green")
     if tier == "arch-compatible":
@@ -328,6 +509,13 @@ def _scanned_model_options(
     models: list[ScannedModel],
     root: Path,
 ) -> list[tuple[str, str, str]]:
+    """Convert scanned-model entries into ``(key, headline, subline)`` tuples
+    suitable for ``_choice_panel``.
+
+    Display path is rendered relative to ``root`` so the panel doesn't show
+    the whole ``/Users/<me>/...`` prefix on every line.
+    """
+
     options: list[tuple[str, str, str]] = []
     for index, model in enumerate(models, start=1):
         try:
@@ -336,7 +524,10 @@ def _scanned_model_options(
             display_name = _pretty_path(model.path)
         badge, _ = _tier_badge(model.tier)
         arch = model.architecture or model.arch_id or "unknown architecture"
-        subline = f"{badge}  ·  {model.error[:80]}" if model.error else f"{badge}  ·  {arch}"
+        if model.error:
+            subline = f"{badge}  ·  {model.error[:80]}"
+        else:
+            subline = f"{badge}  ·  {arch}"
         options.append((str(index), display_name, subline))
     return options
 
@@ -566,6 +757,7 @@ def _print_welcome() -> None:
 
 
 def _print_summary(state: dict) -> None:
+    model_display = _pretty_path(state.get("model")) or "?"
     try:
         from rich.panel import Panel
         from rich.table import Table
@@ -573,18 +765,27 @@ def _print_summary(state: dict) -> None:
     except ImportError:
         print()
         print("  Your quickstart configuration:")
-        print(f"    Model:     {state.get('model', '?')}")
+        print(f"    Model:     {model_display}")
         print(f"    Mode:      {mode_label(state)}")
         print(f"    Interface: {interface_label(state.get('target'))}")
         print()
         return
     console = _console()
     if console is None:
+        # Don't silently swallow the summary when rich is installed but
+        # ``Console()`` couldn't initialize (no tty, weird stdout, etc.) —
+        # fall back to the same plain-stdout layout as the import-fail path.
+        print()
+        print("  Your quickstart configuration:")
+        print(f"    Model:     {model_display}")
+        print(f"    Mode:      {mode_label(state)}")
+        print(f"    Interface: {interface_label(state.get('target'))}")
+        print()
         return
     table = Table.grid(padding=(0, 2))
     table.add_column(style="dim", justify="right", no_wrap=True)
     table.add_column(no_wrap=False)
-    table.add_row("Model", str(state.get("model", "?")))
+    table.add_row("Model", model_display)
     table.add_row("Mode", mode_label(state))
     table.add_row("Interface", interface_label(state.get("target")))
     panel = Panel(
@@ -605,11 +806,17 @@ def screen_model(*, configured: str | None = None) -> str:
     """Render screen 1 and return the user's choice.
 
     If ``configured`` is set and differs from the canonical default, it is
-    surfaced as the first option (so accepting the default reuses the user's
-    already-resolved local path instead of forcing a re-download).
+    surfaced as the first option for deliberate reuse. Pressing Enter still
+    picks the current verified default, so stale saved configs cannot silently
+    keep an old model as the speed lane.
     """
 
-    show_configured = bool(configured) and configured != DEFAULT_HF_MODEL
+    verified_default = _verified_default_model()
+    verified_label = _verified_default_label()
+    show_configured = bool(configured) and str(configured) not in {
+        DEFAULT_HF_MODEL,
+        verified_default,
+    }
 
     options: list[tuple[str, str, str]] = []
     if show_configured:
@@ -617,14 +824,14 @@ def screen_model(*, configured: str | None = None) -> str:
             (
                 "1",
                 "Use your configured model",
-                str(configured),
+                _pretty_path(configured),
             )
         )
         options.append(
             (
                 "2",
                 "Verified default",
-                f"{DEFAULT_HF_MODEL} · cold-speed champion",
+                verified_label,
             )
         )
         options.append(
@@ -646,7 +853,7 @@ def screen_model(*, configured: str | None = None) -> str:
             (
                 "1",
                 "Verified default",
-                f"{DEFAULT_HF_MODEL} · cold-speed champion",
+                verified_label,
             )
         )
         options.append(
@@ -666,20 +873,20 @@ def screen_model(*, configured: str | None = None) -> str:
 
     _step_panel(step=1, total=3, title="Choose your model", options=options)
     valid_choices = [opt[0] for opt in options]
-    choice = _prompt_choice("Select", valid_choices, default="1")
+    choice = _prompt_choice("Select", valid_choices, default="2" if show_configured else "1")
 
     if show_configured:
         if choice == "1":
             return str(configured)
         if choice == "2":
-            return DEFAULT_HF_MODEL
+            return verified_default
         if choice == "3":
             return _prompt_hf_repo_id(default=DEFAULT_HF_MODEL)
         # choice == "4"
         return _pick_local_model(default=str(configured))
 
     if choice == "1":
-        return DEFAULT_HF_MODEL
+        return verified_default
     if choice == "2":
         return _prompt_hf_repo_id(default=DEFAULT_HF_MODEL)
     # choice == "3"
@@ -687,12 +894,20 @@ def screen_model(*, configured: str | None = None) -> str:
 
 
 def _pick_local_model(*, default: str | None) -> str:
+    """Ask for a local folder. If it isn't a model directory itself, scan
+    inside it and present a numbered list of candidate models with their
+    four-tier compatibility verdict.
+
+    Loops until the user either picks a model, types Ctrl-C, or falls back
+    to the canonical HF default. Always returns a usable identifier.
+    """
+
     pretty_default = _pretty_path(default) if default else None
     while True:
         entered = _prompt_text("Local folder path", default=pretty_default)
         if not entered:
             print("  Path is required. Falling back to verified default.")
-            return DEFAULT_HF_MODEL
+            return _verified_default_model()
 
         root = Path(entered).expanduser().resolve()
         if not root.exists():
@@ -704,16 +919,22 @@ def _pick_local_model(*, default: str | None) -> str:
             print()
             continue
 
+        # Single-model case: no scanning needed, just return.
         if _is_model_dir(root):
             return str(root)
 
         chosen = _scan_and_pick(root)
         if chosen is None:
+            # User asked to retype the path — loop again.
             continue
         return chosen
 
 
 def _scan_and_pick(root: Path) -> str | None:
+    """Walk ``root`` for models, render the picker, and return the chosen
+    absolute path. ``None`` means the user wants to type a different folder.
+    """
+
     print(f"  Scanning {_pretty_path(root)} for model folders...")
     found = _scan_for_models(root)
     if found:
@@ -743,6 +964,7 @@ def _scan_and_pick(root: Path) -> str | None:
     cap = 24
     visible = classified[:cap]
     hidden = len(classified) - cap
+
     options = _scanned_model_options(visible, root)
     options.append(
         (
@@ -775,7 +997,9 @@ def _scan_and_pick(root: Path) -> str | None:
     )
 
     valid = [opt[0] for opt in options]
-    choice = _prompt_choice("Select", valid, default="1")
+    default_choice = "1" if visible else None
+    choice = _prompt_choice("Select", valid, default=default_choice)
+
     idx = int(choice) - 1
     if idx == len(visible):
         return None
@@ -785,12 +1009,13 @@ def _scan_and_pick(root: Path) -> str | None:
 def screen_mode() -> tuple[str, bool]:
     """Return (profile_name, max_mode_flag).
 
-    The consumer onboarding is speed-first:
+    Quickstart exposes the two speed-first product choices:
 
-      Medium : native-MTP speed path, Apple fan curve, burst not sustained
-      Max    : same path, ThermalForge pins fans at 100% for sustained speed
+      Medium : native-MTP speed path, no fan control, burst only
+      Max    : same native-MTP speed path, fans pinned 100% while running
 
-    Stable remains available through ``--profile stable`` / ``--profile safe``.
+    The Stable/safe profile remains available through explicit flags, but it
+    is no longer part of the default onboarding path.
     """
 
     _step_panel(
@@ -800,20 +1025,20 @@ def screen_mode() -> tuple[str, bool]:
         options=[
             (
                 "1",
-                "Medium  ·  native-MTP speed path, about 2.2x burst (not sustained)",
-                "Fast speculative path with Apple's default fan curve; snappy on short replies, slower on long hot runs.",
+                "Medium  ·  native-MTP speed path, ~2.2x burst (not sustained)",
+                "Uses the performance-cold profile: depth-3 speculative decode, capture-commit verify, linear-GDN tape verifier, optimized draft head/sampler when the model contract provides them. Fans stay on Apple's default curve.",
             ),
             (
                 "2",
-                "Max  ·  Medium path plus fans pinned at 100%, about 2.24x (loud)",
-                "Same runtime path as Medium, plus ThermalForge fan control to reduce long-reply slowdown.",
+                "Max  ·  Medium + fans pinned at 100%, ~2.24x (loud)",
+                "Same decoding path as Medium, plus ThermalForge pins the fans while MTPLX runs and restores them after shutdown. Needs ThermalForge installed.",
             ),
         ],
     )
     choice = _prompt_choice("Select", ["1", "2"], default="1")
-    if choice == "1":
-        return "performance-cold", False
-    return "performance-cold", True
+    if choice == "2":
+        return "performance-cold", True
+    return "performance-cold", False
 
 
 def screen_interface() -> str:
@@ -979,9 +1204,35 @@ def _print_install_result(result: dict) -> None:
 
 
 # ---------- top-level flow --------------------------------------------------
+def _quickstart_state_is_reusable(last: dict) -> bool:
+    """Return whether a saved state should be offered by Quickstart.
+
+    Stable/safe remains a supported explicit profile, but Quickstart no longer
+    advertises or reuses it as the default consumer path.
+    """
+
+    model = str(last.get("model") or "").strip()
+    target = str(last.get("target") or "")
+    if last.get("profile") != "performance-cold":
+        return False
+    if target not in {"openwebui", "open-webui", "web", "terminal", "cli"}:
+        return False
+    if not model or "\n" in model or "\r" in model:
+        return False
+    if model.startswith(("Last login:", "╭", "│", "╰")) or "Use the same configuration?" in model:
+        return False
+    if _hf_repo_id_error(model) is None:
+        return True
+    expanded = Path(model).expanduser()
+    if expanded.exists():
+        return True
+    return model.startswith(("/", "~", "./", "../", "models/"))
+
+
 def confirm_same_as_last(last: dict) -> bool:
     """Ask the user whether to reuse the last configuration."""
 
+    model_display = _pretty_path(last.get("model")) or "?"
     try:
         from rich.panel import Panel
         from rich.table import Table
@@ -989,7 +1240,7 @@ def confirm_same_as_last(last: dict) -> bool:
     except ImportError:
         print()
         print("  Last time you used:")
-        print(f"    Model:     {last.get('model', '?')}")
+        print(f"    Model:     {model_display}")
         print(f"    Mode:      {mode_label(last)}")
         print(f"    Interface: {interface_label(last.get('target'))}")
         print()
@@ -1000,7 +1251,7 @@ def confirm_same_as_last(last: dict) -> bool:
     if console is None:
         print()
         print("  Last time you used:")
-        print(f"    Model:     {last.get('model', '?')}")
+        print(f"    Model:     {model_display}")
         print(f"    Mode:      {mode_label(last)}")
         print(f"    Interface: {interface_label(last.get('target'))}")
         print()
@@ -1010,7 +1261,7 @@ def confirm_same_as_last(last: dict) -> bool:
     table = Table.grid(padding=(0, 2))
     table.add_column(style="dim", justify="right", no_wrap=True)
     table.add_column(no_wrap=False)
-    table.add_row("Model", str(last.get("model", "?")))
+    table.add_row("Model", model_display)
     table.add_row("Mode", mode_label(last))
     table.add_row("Interface", interface_label(last.get("target")))
     panel = Panel(
@@ -1026,14 +1277,6 @@ def confirm_same_as_last(last: dict) -> bool:
     console.print()
     answer = input("  Use the same configuration? [Y/n] ").strip().lower()
     return answer in {"", "y", "yes", "same"}
-
-
-def _quickstart_state_is_reusable(last: dict | None) -> bool:
-    if not isinstance(last, dict):
-        return False
-    # Stable/safe remains available by explicit flag, but old saved states
-    # should not keep showing it in the speed-first onboarding path.
-    return str(last.get("profile") or "") == "performance-cold"
 
 
 def run_quickstart_flow(
@@ -1053,7 +1296,7 @@ def run_quickstart_flow(
     """
 
     last = None if fresh else load_state()
-    if not _quickstart_state_is_reusable(last):
+    if last is not None and not _quickstart_state_is_reusable(last):
         last = None
     try:
         if last and not fresh:
@@ -1082,13 +1325,13 @@ def run_quickstart_flow(
 
 # ---------- label helpers ---------------------------------------------------
 def mode_label(state: dict) -> str:
-    profile = state.get("profile", "performance-cold")
+    profile = state.get("profile", "safe")
     if state.get("max"):
-        return "Max  ·  Medium path plus fans pinned at 100%, ~2.24x"
+        return "Max  ·  Medium path + fans pinned at 100%  ·  ~2.24x"
     if profile == "performance-cold":
-        return "Medium  ·  native-MTP speed path, ~2.2x burst (not sustained)"
-    if profile == "stable":
-        return "Stable  ·  exact/staged long-reply path"
+        return "Medium  ·  native-MTP speed path  ·  ~2.2x burst (not sustained)"
+    if profile in {"safe", "stable"}:
+        return "Stable  ·  long-reply exact/staged path  ·  no fan control"
     return str(profile)
 
 

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -28,8 +28,9 @@ _TIER_RANK: dict[str, int] = {
     "verified": 0,
     "arch-compatible": 1,
     "unknown": 2,
-    "no-mtp": 3,
-    "incompatible": 4,
+    "mtp-missing": 3,
+    "no-mtp": 4,
+    "incompatible": 5,
 }
 
 
@@ -154,6 +155,21 @@ def _scan_for_models(
     return results
 
 
+def _scan_mtp_sidecar_exists(model_dir: Path, config: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    extra = config.get("mlx_lm_extra_tensors", {})
+    if isinstance(extra, dict) and extra.get("mtp_file"):
+        candidates.append(str(extra["mtp_file"]))
+    candidates.extend(("mtp.safetensors", "mtp/weights.safetensors", "model-mtp.safetensors"))
+    for rel in candidates:
+        try:
+            if (model_dir / rel).is_file():
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     config_path = model_dir / "config.json"
     if not config_path.is_file():
@@ -201,10 +217,13 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         model_files = tuple(sorted(p.name for p in model_dir.glob("model*.safetensors")))
     except OSError:
         model_files = ()
+    mtp_artifact_exists = _scan_mtp_sidecar_exists(model_dir, config if isinstance(config, dict) else {})
 
     class _StubMTP:
-        exists = mtp_num_hidden_layers > 0
-        passes_tensor_gate = False
+        # Picker-level evidence only. The runtime still validates the sidecar
+        # header and exact key layout before loading.
+        exists = mtp_artifact_exists
+        passes_tensor_gate = mtp_artifact_exists
 
     class _StubInspection:
         pass
@@ -230,6 +249,8 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     raw_tier = verdict.tier
     if raw_tier == "verified":
         tier = "verified"
+    elif raw_tier == "family-compatible-unverified":
+        tier = "arch-compatible"
     elif raw_tier == "architecture-compatible-but-unverified":
         if (
             verdict.runtime_contract is not None
@@ -238,6 +259,8 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
             and runtime_contract_error is None
         ):
             tier = "verified"
+        elif verdict.runtime_compatibility == "missing-mtp-weights":
+            tier = "mtp-missing"
         else:
             tier = "arch-compatible"
     elif raw_tier == "no-MTP":
@@ -255,6 +278,8 @@ def _tier_badge(tier: str) -> tuple[str, str]:
         return ("Verified", "bold green")
     if tier == "arch-compatible":
         return ("Compatible (unverified)", "yellow")
+    if tier == "mtp-missing":
+        return ("MTP weights missing", "yellow")
     if tier == "no-mtp":
         return ("No MTP head", "dim")
     if tier == "incompatible":
@@ -640,10 +665,13 @@ def _scan_and_pick(root: Path) -> str | None:
 
     runnable = sum(1 for m in classified if m.tier == "verified")
     compat = sum(1 for m in classified if m.tier == "arch-compatible")
+    missing = sum(1 for m in classified if m.tier == "mtp-missing")
     intro = (
         f"Found {len(classified)} model(s) under {_pretty_path(root)}  ·  "
         f"{runnable} verified, {compat} compatible"
     )
+    if missing:
+        intro += f", {missing} missing MTP weights"
     if hidden > 0:
         intro += f"  (showing first {cap}; {hidden} not shown)"
 

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -27,10 +27,13 @@ LOCAL_SCAN_CLASSIFY_TIMEOUT_S = 4.0
 _TIER_RANK: dict[str, int] = {
     "verified": 0,
     "arch-compatible": 1,
-    "unknown": 2,
-    "mtp-missing": 3,
-    "no-mtp": 4,
-    "incompatible": 5,
+    "needs-verification": 2,
+    "mtp-invalid": 3,
+    "mtp-missing": 4,
+    "backend-pending": 5,
+    "no-mtp": 6,
+    "incompatible": 7,
+    "unknown": 8,
 }
 
 
@@ -170,6 +173,20 @@ def _scan_mtp_sidecar_exists(model_dir: Path, config: dict[str, Any]) -> bool:
     return False
 
 
+def _scan_embedded_mtp_keys(model_dir: Path) -> tuple[str, ...]:
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        return ()
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return ()
+    weight_map = payload.get("weight_map") if isinstance(payload, dict) else None
+    if not isinstance(weight_map, dict):
+        return ()
+    return tuple(sorted(str(key) for key in weight_map if str(key).startswith("mtp.")))
+
+
 def _classify_scanned_model(model_dir: Path) -> ScannedModel:
     config_path = model_dir / "config.json"
     if not config_path.is_file():
@@ -217,7 +234,9 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         model_files = tuple(sorted(p.name for p in model_dir.glob("model*.safetensors")))
     except OSError:
         model_files = ()
-    mtp_artifact_exists = _scan_mtp_sidecar_exists(model_dir, config if isinstance(config, dict) else {})
+    sidecar_exists = _scan_mtp_sidecar_exists(model_dir, config if isinstance(config, dict) else {})
+    embedded_mtp_keys = _scan_embedded_mtp_keys(model_dir)
+    mtp_artifact_exists = sidecar_exists or bool(embedded_mtp_keys)
 
     class _StubMTP:
         # Picker-level evidence only. The runtime still validates the sidecar
@@ -247,9 +266,11 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         return ScannedModel(model_dir, "unknown", None, architecture, str(exc)[:80])
 
     raw_tier = verdict.tier
+    runtime_status = verdict.runtime_compatibility
+    artifact_missing = mtp_num_hidden_layers > 0 and not mtp_artifact_exists
     if raw_tier == "verified":
         tier = "verified"
-    elif raw_tier == "family-compatible-unverified":
+    elif verdict.can_run or raw_tier == "family-compatible-unverified":
         tier = "arch-compatible"
     elif raw_tier == "architecture-compatible-but-unverified":
         if (
@@ -261,12 +282,20 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
             tier = "verified"
         elif verdict.runtime_compatibility == "missing-mtp-weights":
             tier = "mtp-missing"
+        elif artifact_missing:
+            tier = "mtp-missing"
+        elif verdict.runtime_compatibility == "invalid-mtp-tensor-layout":
+            tier = "mtp-invalid"
+        elif verdict.runtime_compatibility in {"needs-contract", "needs-grafting"}:
+            tier = "needs-verification"
+        elif verdict.runtime_compatibility == "recognized-backend-pending":
+            tier = "backend-pending"
         else:
-            tier = "arch-compatible"
+            tier = "needs-verification"
     elif raw_tier == "no-MTP":
         tier = "no-mtp"
     elif raw_tier == "incompatible-architecture":
-        tier = "incompatible"
+        tier = "backend-pending" if runtime_status == "recognized-backend-pending" else "incompatible"
     else:
         tier = "unknown"
 
@@ -277,9 +306,15 @@ def _tier_badge(tier: str) -> tuple[str, str]:
     if tier == "verified":
         return ("Verified", "bold green")
     if tier == "arch-compatible":
-        return ("Compatible (unverified)", "yellow")
+        return ("Runnable (unverified)", "yellow")
+    if tier == "needs-verification":
+        return ("Needs MTPLX verification", "yellow")
+    if tier == "mtp-invalid":
+        return ("MTP weights invalid", "yellow")
     if tier == "mtp-missing":
         return ("MTP weights missing", "yellow")
+    if tier == "backend-pending":
+        return ("Backend not runnable yet", "dim")
     if tier == "no-mtp":
         return ("No MTP head", "dim")
     if tier == "incompatible":
@@ -625,7 +660,7 @@ def _pick_local_model(*, default: str | None) -> str:
 
 
 def _scan_and_pick(root: Path) -> str | None:
-    print(f"  Scanning {_pretty_path(root)} for MTP-compatible models...")
+    print(f"  Scanning {_pretty_path(root)} for model folders...")
     found = _scan_for_models(root)
     if found:
         print(f"  Found {len(found)} candidate model folder(s). Checking configs...")
@@ -663,13 +698,16 @@ def _scan_and_pick(root: Path) -> str | None:
         )
     )
 
-    runnable = sum(1 for m in classified if m.tier == "verified")
-    compat = sum(1 for m in classified if m.tier == "arch-compatible")
+    verified = sum(1 for m in classified if m.tier == "verified")
+    runnable = sum(1 for m in classified if m.tier == "arch-compatible")
+    needs = sum(1 for m in classified if m.tier == "needs-verification")
     missing = sum(1 for m in classified if m.tier == "mtp-missing")
     intro = (
         f"Found {len(classified)} model(s) under {_pretty_path(root)}  ·  "
-        f"{runnable} verified, {compat} compatible"
+        f"{verified} verified, {runnable} runnable unverified"
     )
+    if needs:
+        intro += f", {needs} need verification"
     if missing:
         intro += f", {missing} missing MTP weights"
     if hidden > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ license-files = ["LICENSE"]
 authors = [{name = "Youssof A.", email = "business@youssofal.com"}]
 dependencies = [
   "huggingface-hub>=0.36",
-  "mlx>=0.31,<0.32",
-  "mlx-lm>=0.31,<0.32",
+  "mlx>=0.31,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "mlx-lm>=0.31,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy>=2",
   "safetensors>=0.6",
 ]

--- a/scripts/install_preview_global.sh
+++ b/scripts/install_preview_global.sh
@@ -46,6 +46,8 @@ fi
 venv="${MTPLX_PREVIEW_VENV:-$HOME/.mtplx/preview-venv}"
 user_bin="${MTPLX_USER_BIN:-$HOME/.local/bin}"
 launcher="$user_bin/mtplx"
+shell_dir="$HOME/.mtplx/shell"
+shell_hook="$shell_dir/once-banner.zsh"
 install_target="${wheel}[server]"
 python_bin="${MTPLX_PYTHON:-}"
 
@@ -81,6 +83,54 @@ exec "$venv/bin/mtplx" "\$@"
 EOF
 chmod 755 "$launcher"
 
+mkdir -p "$shell_dir"
+cat > "$shell_hook" <<'EOF'
+# MTPLX once-per-terminal banner for interactive zsh sessions.
+# Sourced from ~/.zshrc by scripts/install_preview_global.sh.
+
+_mtplx_once_banner_print() {
+  printf '%s\n' \
+'  ███╗   ███╗ ████████╗ ██████╗  ██╗      ██╗  ██╗' \
+'  ████╗ ████║ ╚══██╔══╝ ██╔══██╗ ██║      ╚██╗██╔╝' \
+'  ██╔████╔██║    ██║    ██████╔╝ ██║       ╚███╔╝ ' \
+'  ██║╚██╔╝██║    ██║    ██╔═══╝  ██║       ██╔██╗ ' \
+'  ██║ ╚═╝ ██║    ██║    ██║      ███████╗ ██╔╝ ██╗' \
+'  ╚═╝     ╚═╝    ╚═╝    ╚═╝      ╚══════╝ ╚═╝  ╚═╝' \
+'' \
+'  Native MTP speculative decoding · Apple Silicon' \
+''
+}
+
+_mtplx_once_banner_preexec() {
+  emulate -L zsh
+  local cmd="${1:-}"
+  [[ -n "$cmd" ]] || return 0
+  [[ "${MTPLX_DISABLE_SHELL_BANNER:-0}" == "1" ]] && return 0
+  [[ "${MTPLX_SHELL_BANNER_SHOWN:-0}" == "1" ]] && return 0
+  local lower="${cmd:l}"
+  case "$cmd" in
+    *MTPLX_DISABLE_SHELL_BANNER=1*) return 0 ;;
+  esac
+  case "$lower" in
+    *mtplx*)
+      export MTPLX_SHELL_BANNER_SHOWN=1
+      _mtplx_once_banner_print
+      ;;
+  esac
+}
+
+if [[ -n "${ZSH_VERSION:-}" ]]; then
+  autoload -Uz add-zsh-hook 2>/dev/null || true
+  if (( $+functions[add-zsh-hook] )); then
+    add-zsh-hook -d preexec _mtplx_once_banner_preexec 2>/dev/null || true
+    add-zsh-hook preexec _mtplx_once_banner_preexec
+  elif [[ -z "${preexec_functions[(r)_mtplx_once_banner_preexec]:-}" ]]; then
+    preexec_functions+=(_mtplx_once_banner_preexec)
+  fi
+fi
+EOF
+chmod 644 "$shell_hook"
+
 homebrew_launcher_installed=0
 if [ "${MTPLX_SKIP_HOMEBREW_LAUNCHER:-0}" != "1" ] && [ -d /opt/homebrew/bin ] && [ -w /opt/homebrew/bin ]; then
   cp "$launcher" /opt/homebrew/bin/mtplx
@@ -103,11 +153,24 @@ for rcfile in "$HOME/.zprofile" "$HOME/.zshrc"; do
   fi
 done
 
+shell_snippet='
+# MTPLX once-per-terminal banner
+if [ -r "$HOME/.mtplx/shell/once-banner.zsh" ]; then
+  source "$HOME/.mtplx/shell/once-banner.zsh"
+fi
+'
+
+touch "$HOME/.zshrc"
+if ! grep -q 'MTPLX once-per-terminal banner' "$HOME/.zshrc"; then
+  printf '%s\n' "$shell_snippet" >> "$HOME/.zshrc"
+fi
+
 "$launcher" --version
 "$launcher" help >/dev/null
 
 echo "MTPLX preview CLI installed:"
 echo "  $launcher"
+echo "  $shell_hook"
 if [ "$homebrew_launcher_installed" -eq 1 ]; then
   echo "  /opt/homebrew/bin/mtplx"
 fi

--- a/scripts/phase0h_paged_verifier_exactness.py
+++ b/scripts/phase0h_paged_verifier_exactness.py
@@ -177,11 +177,12 @@ def _forward_decode_from_stock_prefix_last_logits(
         prefill = rt.forward_ar(prefill_ids, cache=cache, return_hidden=False)
         _eval_result(prefill)
     if paged:
-        install_vllm_metal_paged_attention_kv_cache(
-            cache,
-            block_size=args.block_size,
-            num_blocks=args.num_blocks,
-        )
+        with patched_env(_profile_env(args, enabled=True)):
+            install_vllm_metal_paged_attention_kv_cache(
+                cache,
+                block_size=args.block_size,
+                num_blocks=args.num_blocks,
+            )
     input_ids = mx.array([verify_ids], dtype=mx.int32)
     with patched_env(_profile_env(args, enabled=paged)):
         configure_split_full_attention(rt.model)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -618,6 +618,29 @@ def test_hf_qwen_mtp_without_runtime_contract_is_family_runnable(monkeypatch):
     assert calls == [("Qwen/Qwen3-Next-80B-A3B-Instruct", "mtp.safetensors")]
 
 
+def test_qwen_runtime_loader_reads_bf16_embedded_mtp_weights(tmp_path):
+    import mlx.core as mx
+    from mtplx.mtp_patch import _load_embedded_mtp_weights
+
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"),
+        {
+            **{key: mx.ones((1,), dtype=mx.bfloat16) for key in EXPECTED_MTP_KEYS},
+            "model.language_model.layers.0.mlp.down_proj.weight": mx.ones(
+                (1,), dtype=mx.bfloat16
+            ),
+        },
+    )
+
+    weights = _load_embedded_mtp_weights(
+        tmp_path,
+        {"model_type": "qwen3_5", "mtp_num_hidden_layers": 1},
+    )
+
+    assert sorted(weights) == sorted(key.removeprefix("mtp.") for key in EXPECTED_MTP_KEYS)
+    assert weights["fc.weight"].dtype == mx.bfloat16
+
+
 def test_hf_verified_contract_passes_metadata_gate(monkeypatch):
     from mtplx import artifacts
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -250,7 +250,13 @@ def test_deepseek_mtp_with_runtime_contract_and_model_file_is_verified(tmp_path)
         ),
         encoding="utf-8",
     )
-    save_file({"model.layers.61.enorm.weight": np.ones((1,), dtype=np.float32)}, tmp_path / "model.safetensors")
+    save_file(
+        {
+            "model.layers.61.enorm.weight": np.ones((1,), dtype=np.float32),
+            "model.layers.62.enorm.weight": np.ones((1,), dtype=np.float32),
+        },
+        tmp_path / "model.safetensors",
+    )
     _write_runtime_contract(tmp_path, arch_id="deepseek-v3-mtp")
 
     result = inspect_model(tmp_path)
@@ -362,7 +368,13 @@ def test_glm_moe_dsa_mtp_with_runtime_contract_and_model_file_is_verified(tmp_pa
         ),
         encoding="utf-8",
     )
-    save_file({"model.layers.61.enorm.weight": np.ones((1,), dtype=np.float32)}, tmp_path / "model.safetensors")
+    save_file(
+        {
+            "model.layers.61.enorm.weight": np.ones((1,), dtype=np.float32),
+            "model.layers.62.enorm.weight": np.ones((1,), dtype=np.float32),
+        },
+        tmp_path / "model.safetensors",
+    )
     _write_runtime_contract(tmp_path, arch_id="glm-moe-dsa-mtp")
 
     result = inspect_model(tmp_path)
@@ -517,10 +529,11 @@ def test_big_mtp_architecture_markers_are_recognized_backend_pending(
         in {
             "deepseek-v3-mtp",
             "glm-moe-dsa-mtp",
-            "glm4-moe-mtp",
-            "glm4-moe-lite-mtp",
-            "mimo-mtp",
-        }
+                "glm4-moe-mtp",
+                "glm4-moe-lite-mtp",
+                "mimo-mtp",
+                "nemotron-h-mtp",
+            }
         else "recognized-backend-pending"
     )
     assert result.compatibility["runtime_compatibility"] == expected_runtime

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -67,6 +67,10 @@ def test_inspect_model_reads_qwen_mtp_config_without_weights(tmp_path):
     assert result.mtp.exists is False
     assert result.compatibility["tier"] == "architecture-compatible-but-unverified"
     assert result.compatibility["exit_code"] == 3
+    assert result.compatibility["runtime_compatibility"] == "missing-mtp-weights"
+    assert result.compatibility["unsafe_force_required"] is False
+    assert "mtplx_runtime.json is optional metadata" in result.compatibility["message"]
+    assert "missing MTP weights" in result.compatibility["message"]
 
 
 def test_qwen3_5_text_subtype_can_pass_primary_gate_when_mtp_is_valid(monkeypatch, tmp_path):
@@ -142,7 +146,7 @@ def test_prequantized_mtp_sidecar_accepts_mlx_affine_scale_bias_tensors(tmp_path
     assert result.compatibility["recommended_profile"] == "performance-cold"
 
 
-def test_qwen_mtp_without_runtime_contract_is_unverified(monkeypatch, tmp_path):
+def test_qwen_mtp_without_runtime_contract_is_family_runnable(monkeypatch, tmp_path):
     from mtplx import artifacts
     from mtplx.artifacts import MTPInspection
 
@@ -172,9 +176,12 @@ def test_qwen_mtp_without_runtime_contract_is_unverified(monkeypatch, tmp_path):
 
     result = inspect_model(tmp_path)
 
-    assert result.passes_primary_gate is False
-    assert result.compatibility["tier"] == "architecture-compatible-but-unverified"
-    assert result.compatibility["unsafe_force_required"] is True
+    assert result.passes_primary_gate is True
+    assert result.compatibility["tier"] == "family-compatible-unverified"
+    assert result.compatibility["can_run"] is True
+    assert result.compatibility["exit_code"] == 0
+    assert result.compatibility["unsafe_force_required"] is False
+    assert result.compatibility["runtime_compatibility"] == "native-family-gated"
 
 
 def test_qwen3_next_architecture_without_mtp_sidecar_is_unverified(tmp_path):
@@ -192,7 +199,7 @@ def test_qwen3_next_architecture_without_mtp_sidecar_is_unverified(tmp_path):
 
     assert result.compatibility["tier"] == "architecture-compatible-but-unverified"
     assert result.compatibility["exit_code"] == 3
-    assert result.compatibility["runtime_compatibility"] == "needs-grafting"
+    assert result.compatibility["runtime_compatibility"] == "missing-mtp-weights"
 
 
 def test_architecture_catalog_tracks_main_mtp_families():
@@ -555,7 +562,7 @@ def test_llama_without_mtp_is_no_mtp(tmp_path):
     assert result.compatibility["exit_code"] == 2
 
 
-def test_hf_qwen_mtp_without_runtime_contract_is_unverified(monkeypatch):
+def test_hf_qwen_mtp_without_runtime_contract_is_family_runnable(monkeypatch):
     from mtplx import artifacts
 
     calls = []
@@ -592,8 +599,9 @@ def test_hf_qwen_mtp_without_runtime_contract_is_unverified(monkeypatch):
     assert result.source == "hf"
     assert result.mtp is not None
     assert result.mtp.metadata_only is True
-    assert result.compatibility["tier"] == "architecture-compatible-but-unverified"
-    assert result.compatibility["exit_code"] == 3
+    assert result.compatibility["tier"] == "family-compatible-unverified"
+    assert result.compatibility["can_run"] is True
+    assert result.compatibility["exit_code"] == 0
     assert calls == [("Qwen/Qwen3-Next-80B-A3B-Instruct", "mtp.safetensors")]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import argparse
 
 from mtplx.config import apply_user_config, load_user_config
 from mtplx.constants import DEFAULT_RUNTIME_MODEL_DIR
+from mtplx.profiles import DEFAULT_PROFILE_NAME
 
 
 def test_load_user_config_reads_runtime_defaults(tmp_path):
@@ -38,7 +39,8 @@ def test_apply_user_config_fills_runtime_defaults(tmp_path):
         command="run",
         model=str(DEFAULT_RUNTIME_MODEL_DIR),
         cache_dir=None,
-        profile="stable",
+        profile=DEFAULT_PROFILE_NAME,
+        _cli_flags=set(),
     )
 
     loaded = apply_user_config(args, config_path=config)
@@ -63,6 +65,7 @@ def test_apply_user_config_preserves_explicit_runtime_values(tmp_path):
         model="models/local",
         cache_dir="/tmp/explicit-cache",
         profile="performance-cold",
+        _cli_flags={"model", "cache-dir", "profile"},
     )
 
     apply_user_config(args, config_path=config)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from mtplx.diagnostics import (
+    DEFAULT_SPEED_MODEL_SIZE_BYTES,
+    build_diagnostics_payload,
+    required_download_free_bytes,
+    write_doctor_bundle,
+)
+
+
+def test_required_download_free_bytes_has_temp_and_headroom() -> None:
+    required = required_download_free_bytes(DEFAULT_SPEED_MODEL_SIZE_BYTES)
+
+    assert required > DEFAULT_SPEED_MODEL_SIZE_BYTES
+    assert required >= int(DEFAULT_SPEED_MODEL_SIZE_BYTES * 2.5)
+
+
+def test_diagnostics_payload_has_production_checks(tmp_path) -> None:
+    payload = build_diagnostics_payload(
+        model_cache=tmp_path,
+        mlx_info={"mlx_error": "missing"},
+        thermal_control={"available": False},
+    )
+
+    assert payload["support_matrix"]["supported"]["default_model"] == (
+        "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
+    )
+    assert payload["support_matrix"]["supported"]["default_profile"] == "performance-cold"
+    ids = {check["id"] for check in payload["checks"]}
+    assert {
+        "os.macos_version",
+        "python.native_arm64",
+        "python.version",
+        "mlx.import",
+        "resource.memory",
+        "resource.model_cache_disk",
+        "model.cache",
+        "model.default_repo",
+        "docker.binary",
+        "thermal.control",
+        "power.low_power_mode",
+        "power.thermal_pressure",
+    }.issubset(ids)
+
+
+def test_default_repo_check_rejects_stale_public_namespace(tmp_path) -> None:
+    payload = build_diagnostics_payload(model_cache=tmp_path)
+    check = next(item for item in payload["checks"] if item["id"] == "model.default_repo")
+
+    assert check["status"] == "pass"
+    assert check["observed"] == "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
+    assert not check["observed"].startswith("mtplx/")
+
+
+def test_write_doctor_bundle_creates_redacted_zip(tmp_path) -> None:
+    report = {
+        "environment": {"project_root": "/Users/example/private"},
+        "host": {"python_executable": "/Users/example/.venv/bin/python"},
+    }
+
+    bundle = write_doctor_bundle(report=report, output_dir=tmp_path)
+
+    assert bundle["redacted"] is True
+    assert bundle["bundle_zip"].endswith(".zip")
+    assert (tmp_path / bundle["bundle_id"] / "doctor.json").exists()
+    assert (tmp_path / f"{bundle['bundle_id']}.zip").exists()

--- a/tests/test_hf_loader.py
+++ b/tests/test_hf_loader.py
@@ -10,6 +10,7 @@ from mtplx.hf_loader import (
     repo_id_from_model_ref,
     resolve_model_path,
     safe_model_name,
+    validate_mtplx_model_files,
 )
 
 
@@ -44,6 +45,7 @@ def test_resolve_model_path_reports_missing_cache(tmp_path: Path):
 
 
 def test_list_and_remove_cached_models(tmp_path: Path):
+    (tmp_path / ".tmp").mkdir()
     model = tmp_path / "mtplx--example"
     model.mkdir()
     (model / "config.json").write_text("{}\n", encoding="utf-8")
@@ -56,6 +58,8 @@ def test_list_and_remove_cached_models(tmp_path: Path):
     assert rows[0].repo_id == "mtplx/example"
     assert rows[0].has_config is True
     assert rows[0].has_runtime_contract is True
+    assert rows[0].validation["missing_files"]
+    assert rows[0].to_dict()["recommended_profile"] is None
     assert rows[0].size_bytes >= 4
 
     removed = remove_cached_model("mtplx/example", cache_dir=tmp_path)
@@ -74,3 +78,23 @@ def test_hf_cache_report_is_no_network(tmp_path: Path, monkeypatch):
     assert report["cache_exists"] is False
     assert report["cached_models"] == 0
     assert "token_present" in report
+    assert "disk_free_bytes" in report
+
+
+def test_validate_mtplx_model_files_reports_required_payload(tmp_path: Path):
+    model = tmp_path / "model"
+    model.mkdir()
+    for name in (
+        "config.json",
+        "tokenizer.json",
+        "model.safetensors.index.json",
+        "mtp.safetensors",
+    ):
+        (model / name).write_text("{}\n", encoding="utf-8")
+    (model / "mtplx_runtime.json").write_text('{"arch_id": "qwen3-next-mtp"}\n', encoding="utf-8")
+
+    validation = validate_mtplx_model_files(model)
+
+    assert validation["ok"] is True
+    assert validation["missing_files"] == []
+    assert validation["contract_arch_id"] == "qwen3-next-mtp"

--- a/tests/test_hf_loader.py
+++ b/tests/test_hf_loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from mtplx.hf_loader import (
+    cached_model_is_complete,
     cached_model_path,
     hf_cache_report,
     list_cached_models,
@@ -31,8 +32,22 @@ def test_safe_model_name_and_cache_path(tmp_path: Path):
 def test_resolve_model_path_uses_cache_for_hf_refs(tmp_path: Path):
     cached = tmp_path / "mtplx--example"
     cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors").write_bytes(b"1234")
 
     assert resolve_model_path("mtplx/example", cache_dir=tmp_path) == cached
+
+
+def test_cached_model_is_complete_rejects_interrupted_indexed_download(tmp_path: Path):
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"lm_head.weight": "model-00001-of-00002.safetensors"}}\n',
+        encoding="utf-8",
+    )
+
+    assert cached_model_is_complete(cached) is False
 
 
 def test_resolve_model_path_reports_missing_cache(tmp_path: Path):

--- a/tests/test_hf_loader.py
+++ b/tests/test_hf_loader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 from mtplx.hf_loader import (
@@ -7,6 +9,7 @@ from mtplx.hf_loader import (
     cached_model_path,
     hf_cache_report,
     list_cached_models,
+    pull_model,
     remove_cached_model,
     repo_id_from_model_ref,
     resolve_model_path,
@@ -48,6 +51,76 @@ def test_cached_model_is_complete_rejects_interrupted_indexed_download(tmp_path:
     )
 
     assert cached_model_is_complete(cached) is False
+
+
+def test_pull_model_reuses_complete_destination_without_redownload(
+    tmp_path: Path, monkeypatch
+):
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"lm_head.weight": "model-00001-of-00001.safetensors"}}\n',
+        encoding="utf-8",
+    )
+    (cached / "model-00001-of-00001.safetensors").write_bytes(b"weights")
+
+    def fail_snapshot_download(**_kwargs):
+        raise AssertionError("complete cached model should not download again")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fail_snapshot_download),
+    )
+
+    result = pull_model("mtplx/example", cache_dir=tmp_path)
+
+    assert result["path"] == str(cached)
+    assert result["reused_existing"] is True
+    assert result["resumed_existing"] is False
+
+
+def test_pull_model_resumes_incomplete_destination(
+    tmp_path: Path, monkeypatch
+):
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"lm_head.weight": "model-00001-of-00001.safetensors"}}\n',
+        encoding="utf-8",
+    )
+    download_cache = cached / ".cache" / "huggingface" / "download"
+    download_cache.mkdir(parents=True)
+    (download_cache / "model-00001-of-00001.safetensors.incomplete").write_bytes(
+        b"partial"
+    )
+
+    def fake_snapshot_download(**kwargs):
+        destination = Path(kwargs["local_dir"])
+        (destination / "model-00001-of-00001.safetensors").write_bytes(b"weights")
+        return str(destination)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+    events: list[dict] = []
+
+    result = pull_model(
+        "mtplx/example",
+        cache_dir=tmp_path,
+        progress_callback=events.append,
+        progress_interval_s=0,
+    )
+
+    assert result["path"] == str(cached)
+    assert result["reused_existing"] is False
+    assert result["resumed_existing"] is True
+    assert result["started_size_bytes"] > 0
+    assert [event["event"] for event in events] == ["resume", "complete"]
 
 
 def test_resolve_model_path_reports_missing_cache(tmp_path: Path):

--- a/tests/test_no_mlx_imports.py
+++ b/tests/test_no_mlx_imports.py
@@ -94,6 +94,13 @@ def test_doctor_json_reports_missing_mlx_without_traceback(tmp_path: Path) -> No
     assert "blocked mlx_lm" in mlx_info["mlx_lm_error"]
     assert "huggingface" in payload
     assert "cache_dir" in payload["huggingface"]
+    assert payload["diagnostics"]["support_matrix"]["supported"]["default_model"] == (
+        "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
+    )
+    check_ids = {check["id"] for check in payload["diagnostics"]["checks"]}
+    assert "resource.memory" in check_ids
+    assert "resource.model_cache_disk" in check_ids
+    assert "model.default_repo" in check_ids
 
 
 def test_inspect_local_non_mtp_model_without_mlx(tmp_path: Path) -> None:
@@ -164,7 +171,7 @@ def test_run_reports_uncached_hf_model_without_importing_mlx(tmp_path: Path) -> 
         ],
     )
 
-    assert proc.returncode == 1, proc.stderr
+    assert proc.returncode == 6, proc.stderr
     assert "Traceback" not in proc.stderr
     payload = json.loads(proc.stdout)
     assert payload["error"] == "model is not available locally"
@@ -187,7 +194,7 @@ def test_run_uses_config_model_without_importing_mlx(tmp_path: Path) -> None:
         env_extra={"MTPLX_CONFIG": str(config)},
     )
 
-    assert proc.returncode == 1, proc.stderr
+    assert proc.returncode == 6, proc.stderr
     assert "Traceback" not in proc.stderr
     payload = json.loads(proc.stdout)
     assert payload["model"] == "mtplx/example"
@@ -218,9 +225,9 @@ def test_init_dry_run_without_mlx_does_not_write_config(tmp_path: Path) -> None:
     assert payload["status"] == "ready_for_init"
     assert payload["dry_run"] is True
     assert payload["wrote_config"] is False
-    assert payload["model"].startswith("mtplx/")
+    assert payload["model"] == "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
     assert payload["model_dir"] == str(model_dir)
-    assert payload["profile"]["name"] == "stable"
+    assert payload["profile"]["name"] == "performance-cold"
     assert payload["hardware"]["system"]
     assert payload["commands"]["pull"].startswith("mtplx pull ")
     assert not config.exists()
@@ -267,7 +274,7 @@ def test_profiles_without_mlx(tmp_path: Path) -> None:
 
     assert proc.returncode == 0, proc.stderr
     payload = json.loads(proc.stdout)
-    assert payload["default"] == "stable"
+    assert payload["default"] == "performance-cold"
     assert [profile["name"] for profile in payload["profiles"]] == [
         "stable",
         "performance-cold",

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -58,6 +58,7 @@ def test_mode_label_covers_all_modes():
 def test_interface_label_covers_all_targets():
     assert "Web UI" in onboarding.interface_label("openwebui")
     assert "Web UI" in onboarding.interface_label("web")
+    assert "API server" in onboarding.interface_label("server")
     assert "CLI" in onboarding.interface_label("cli")
     assert "CLI" in onboarding.interface_label("terminal")
 
@@ -94,6 +95,43 @@ def test_run_onboarding_max_mode_drops_flag_when_thermal_unavailable(monkeypatch
     assert state["profile"] == "performance-cold"
     assert state["max"] is False
     assert state["target"] == "terminal"
+
+
+def test_run_serve_onboarding_screens_defaults_to_api_server(monkeypatch):
+    answers = iter(["1", "1", "1"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    state = onboarding.run_serve_onboarding_screens(host="127.0.0.1", port=8765)
+    assert state["model"] == onboarding._verified_default_model()
+    assert state["profile"] == "performance-cold"
+    assert state["max"] is False
+    assert state["target"] == "server"
+    assert state["open_browser"] is False
+
+
+def test_run_serve_onboarding_screens_can_open_browser(monkeypatch):
+    answers = iter(["1", "1", "2"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    state = onboarding.run_serve_onboarding_screens(host="127.0.0.1", port=8765)
+    assert state["target"] == "openwebui"
+    assert state["open_browser"] is True
+
+
+def test_run_serve_flow_does_not_reuse_quickstart_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("MTPLX_QUICKSTART_STATE", str(tmp_path / "serve.json"))
+    onboarding.save_state(
+        {
+            "model": "mtplx/old",
+            "profile": "performance-cold",
+            "max": False,
+            "target": "openwebui",
+        }
+    )
+    answers = iter(["1", "1", "1"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    state = onboarding.run_serve_flow()
+    assert state is not None
+    assert state["model"] == onboarding._verified_default_model()
+    assert state["target"] == "server"
 
 
 def test_ensure_thermal_control_installed_returns_true_when_already_present(monkeypatch):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -329,6 +329,55 @@ def test_screen_model_no_configured_uses_three_options(monkeypatch):
     assert chosen == onboarding.DEFAULT_HF_MODEL
 
 
+def test_custom_hf_repo_rejects_pasted_terminal_output(monkeypatch, capsys):
+    answers = iter(
+        [
+            "2",
+            "Last login: Mon May  4 00:55:41 on ttys000",
+            "trevon/Qwen3.5-27B-MLX-MTP",
+        ]
+    )
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    chosen = onboarding.screen_model(configured=None)
+
+    captured = capsys.readouterr().out
+    assert chosen == "trevon/Qwen3.5-27B-MLX-MTP"
+    assert "not a Hugging Face repo id" in captured
+
+
+def test_custom_hf_repo_blank_after_invalid_does_not_accept_default(monkeypatch, capsys):
+    answers = iter(
+        [
+            "2",
+            "Last login: Mon May  4 00:55:41 on ttys000",
+            "",
+            "trevon/Qwen3.5-27B-MLX-MTP",
+        ]
+    )
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    chosen = onboarding.screen_model(configured=None)
+
+    captured = capsys.readouterr().out
+    assert chosen == "trevon/Qwen3.5-27B-MLX-MTP"
+    assert captured.count("Example: trevon/Qwen3.5-27B-MLX-MTP") == 2
+
+
+def test_custom_hf_repo_accepts_huggingface_url(monkeypatch):
+    answers = iter(
+        [
+            "2",
+            "https://huggingface.co/trevon/Qwen3.5-27B-MLX-MTP/tree/main",
+        ]
+    )
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+
+    chosen = onboarding.screen_model(configured=None)
+
+    assert chosen == "trevon/Qwen3.5-27B-MLX-MTP"
+
+
 def test_run_quickstart_flow_fresh_skips_returning_prompt(tmp_path, monkeypatch):
     monkeypatch.setenv("MTPLX_QUICKSTART_STATE", str(tmp_path / "fresh.json"))
     onboarding.save_state(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -45,16 +45,13 @@ def test_state_round_trip(tmp_path, monkeypatch):
 
 
 def test_mode_label_covers_all_modes():
-    """Mode labels must include the actual tok/s envelope so users can tell
-    the difference between Stable and Fast at a glance — the old labels just
-    said 'no fan control' twice without explaining what the runtime path
-    difference was."""
-    safe = onboarding.mode_label({"profile": "stable", "max": False})
-    fast = onboarding.mode_label({"profile": "performance-cold", "max": False})
+    """Mode labels explain runtime mechanics and hardware-neutral speed gain."""
+    stable = onboarding.mode_label({"profile": "stable", "max": False})
+    medium = onboarding.mode_label({"profile": "performance-cold", "max": False})
     maxed = onboarding.mode_label({"profile": "performance-cold", "max": True})
-    assert "Stable" in safe and "tok/s" in safe
-    assert "Fast" in fast and "tok/s" in fast
-    assert "Max" in maxed and "100%" in maxed
+    assert "Stable" in stable and "exact/staged" in stable and "tok/s" not in stable
+    assert "Medium" in medium and "~2.2x" in medium and "not sustained" in medium
+    assert "Max" in maxed and "100%" in maxed and "~2.24x" in maxed
 
 
 def test_interface_label_covers_all_targets():
@@ -77,7 +74,7 @@ def test_run_onboarding_screens_with_stubbed_input(monkeypatch, capsys):
 
 def test_run_onboarding_max_mode_sets_max_flag_when_thermal_available(monkeypatch):
     """Picking Max + a working fan controller → ``max=True``."""
-    answers = iter(["1", "3", "2"])
+    answers = iter(["1", "2", "2"])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     monkeypatch.setattr(onboarding, "ensure_thermal_control_installed", lambda: True)
     state = onboarding.run_onboarding_screens()
@@ -89,7 +86,7 @@ def test_run_onboarding_max_mode_sets_max_flag_when_thermal_available(monkeypatc
 def test_run_onboarding_max_mode_drops_flag_when_thermal_unavailable(monkeypatch):
     """Picking Max + declined/failed install → ``max=False`` (don't lie about
     fan boost we can't deliver)."""
-    answers = iter(["1", "3", "2"])
+    answers = iter(["1", "2", "2"])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     monkeypatch.setattr(onboarding, "ensure_thermal_control_installed", lambda: False)
     state = onboarding.run_onboarding_screens()
@@ -217,7 +214,7 @@ def test_run_quickstart_flow_returning_user_says_same(tmp_path, monkeypatch):
     onboarding.save_state(
         {
             "model": "mtplx/foo",
-            "profile": "stable",
+            "profile": "performance-cold",
             "max": False,
             "target": "openwebui",
         }
@@ -228,6 +225,28 @@ def test_run_quickstart_flow_returning_user_says_same(tmp_path, monkeypatch):
     state = onboarding.run_quickstart_flow(fresh=False)
     assert state is not None
     assert state["model"] == "mtplx/foo"
+    assert state["target"] == "openwebui"
+
+
+def test_run_quickstart_flow_legacy_stable_state_is_not_reused(tmp_path, monkeypatch):
+    """Stable is still an explicit flag, but no longer a reusable Start mode."""
+
+    monkeypatch.setenv("MTPLX_QUICKSTART_STATE", str(tmp_path / "legacy-stable.json"))
+    onboarding.save_state(
+        {
+            "model": "mtplx/old-stable",
+            "profile": "stable",
+            "max": False,
+            "target": "terminal",
+        }
+    )
+    answers = iter(["1", "1", "1"])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    state = onboarding.run_quickstart_flow(fresh=False)
+    assert state is not None
+    assert state["model"] == onboarding.DEFAULT_HF_MODEL
+    assert state["profile"] == "performance-cold"
+    assert state["max"] is False
     assert state["target"] == "openwebui"
 
 
@@ -266,7 +285,7 @@ def test_run_quickstart_flow_returning_user_says_no(tmp_path, monkeypatch):
     onboarding.save_state(
         {
             "model": "mtplx/old",
-            "profile": "stable",
+            "profile": "performance-cold",
             "max": False,
             "target": "terminal",
         }
@@ -340,17 +359,17 @@ def test_run_quickstart_flow_returns_none_on_ctrlc(tmp_path, monkeypatch, capsys
 
 # ---------- regression: ~/.mtplx/config.toml must not silently skip the flow --
 #
-# The original bug report: ``mtplx quickstart`` skipped the onboarding because
+# The original bug report: ``mtplx start`` skipped the onboarding because
 # ``apply_user_config`` had pre-filled ``args.model`` from ``~/.mtplx/config.toml``
 # and the heuristic mistook that for an explicit ``--model`` on the command line.
 # These tests pin the new flag-scan based detection so the regression can't
 # come back.
 def test_explicit_cli_flag_detection_ignores_config_file_defaults(tmp_path, monkeypatch):
-    """Simulating a user with config.toml model + bare ``mtplx quickstart`` must
+    """Simulating a user with config.toml model + bare ``mtplx start`` must
     still allow onboarding (i.e. ``has_explicit_model`` must be False)."""
     from mtplx.cli import _explicit_cli_flags
 
-    flags = _explicit_cli_flags(["quickstart"])
+    flags = _explicit_cli_flags(["start"])
     assert "model" not in flags
     assert "profile" not in flags
     assert "max" not in flags
@@ -359,19 +378,19 @@ def test_explicit_cli_flag_detection_ignores_config_file_defaults(tmp_path, monk
 def test_explicit_cli_flag_detection_picks_up_typed_flags():
     from mtplx.cli import _explicit_cli_flags
 
-    flags = _explicit_cli_flags(["quickstart", "cli", "--model", "foo", "--profile", "stable"])
+    flags = _explicit_cli_flags(["start", "cli", "--model", "foo", "--profile", "stable"])
     assert "model" in flags
     assert "profile" in flags
 
-    flags_eq = _explicit_cli_flags(["quickstart", "--model=foo"])
+    flags_eq = _explicit_cli_flags(["start", "--model=foo"])
     assert "model" in flags_eq
 
-    flags_max = _explicit_cli_flags(["quickstart", "--max"])
+    flags_max = _explicit_cli_flags(["start", "--max"])
     assert "max" in flags_max
 
 
-def test_quickstart_invokes_onboarding_when_no_explicit_flags(tmp_path, monkeypatch):
-    """Bare ``mtplx quickstart`` (with config.toml pre-filling model) must drop
+def test_start_invokes_onboarding_when_no_explicit_flags(tmp_path, monkeypatch):
+    """Bare ``mtplx start`` (with config.toml pre-filling model) must drop
     into ``run_quickstart_flow`` — this is the user-reported bug."""
     monkeypatch.setenv("MTPLX_QUICKSTART_STATE", str(tmp_path / "regression.json"))
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -390,7 +409,7 @@ def test_quickstart_invokes_onboarding_when_no_explicit_flags(tmp_path, monkeypa
 
     monkeypatch.setattr("mtplx.ui.onboarding.run_quickstart_flow", fake_flow)
 
-    # Simulate the post-config args object that quickstart sees.
+    # Simulate the post-config args object that start sees.
     import argparse
 
     args = argparse.Namespace(
@@ -468,7 +487,7 @@ def test_quickstart_invokes_onboarding_when_no_explicit_flags(tmp_path, monkeypa
     assert args.model == "mtplx/onboarded"
 
 
-def test_quickstart_skips_onboarding_with_explicit_flags(tmp_path, monkeypatch):
+def test_start_skips_onboarding_with_explicit_flags(tmp_path, monkeypatch):
     """Explicit ``--model`` (or any of the gating flags) must short-circuit
     the onboarding entirely."""
     monkeypatch.setenv("MTPLX_QUICKSTART_STATE", str(tmp_path / "skipped.json"))

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -26,7 +26,7 @@ def test_state_round_trip(tmp_path, monkeypatch):
 
     onboarding.save_state(
         {
-            "model": "mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP",
+            "model": "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed",
             "profile": "performance-cold",
             "max": True,
             "target": "openwebui",
@@ -34,7 +34,7 @@ def test_state_round_trip(tmp_path, monkeypatch):
     )
     loaded = onboarding.load_state()
     assert loaded is not None
-    assert loaded["model"] == "mtplx/Qwen3.6-27B-MTPLX-GDN8-Speed4-CyanKiwiMTP"
+    assert loaded["model"] == "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
     assert loaded["profile"] == "performance-cold"
     assert loaded["max"] is True
     assert loaded["target"] == "openwebui"
@@ -66,7 +66,7 @@ def test_interface_label_covers_all_targets():
 
 def test_run_onboarding_screens_with_stubbed_input(monkeypatch, capsys):
     """Walk all three screens with stubbed ``input`` answers."""
-    answers = iter(["1", "2", "1"])
+    answers = iter(["1", "1", "1"])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     state = onboarding.run_onboarding_screens()
     assert state["model"] == onboarding.DEFAULT_HF_MODEL
@@ -271,7 +271,7 @@ def test_run_quickstart_flow_returning_user_says_no(tmp_path, monkeypatch):
             "target": "terminal",
         }
     )
-    answers = iter(["n", "1", "2", "1"])  # 'n' → walk onboarding again
+    answers = iter(["n", "1", "1", "1"])  # 'n' → walk onboarding again
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     state = onboarding.run_quickstart_flow(fresh=False)
     assert state is not None

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import builtins
 import json
+from pathlib import Path
 
 import pytest
 
@@ -545,3 +546,85 @@ def test_start_skips_onboarding_with_explicit_flags(tmp_path, monkeypatch):
     assert rc == 0
     assert invocations == []  # onboarding was NOT invoked
     assert getattr(args, "_onboarded", False) is False
+
+
+# ---------- local-folder scanning: typing a parent dir lists models -------
+def _make_model_dir(parent, name, *, config: dict | None = None) -> Path:
+    target = parent / name
+    target.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "architectures": ["Qwen3NextForCausalLM"],
+        "model_type": "qwen3_next",
+        "hidden_size": 5120,
+        "num_hidden_layers": 64,
+        "vocab_size": 248320,
+        "mtp_num_hidden_layers": 1,
+    }
+    if config is not None:
+        payload.update(config)
+    (target / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def test_scan_walks_lmstudio_publisher_layout(tmp_path):
+    _make_model_dir(tmp_path, "lmstudio-community/Qwen2.5-7B-Instruct-MLX-4bit")
+    _make_model_dir(tmp_path, "mlx-community/Qwen3.5-27B-4bit")
+    _make_model_dir(tmp_path, "Youssofal/Qwen3.6-27B-MTPLX")
+
+    found = onboarding._scan_for_models(tmp_path)
+
+    assert sorted(p.name for p in found) == sorted(
+        [
+            "Qwen2.5-7B-Instruct-MLX-4bit",
+            "Qwen3.5-27B-4bit",
+            "Qwen3.6-27B-MTPLX",
+        ]
+    )
+
+
+def test_scan_for_models_honors_timeout(tmp_path, monkeypatch):
+    _make_model_dir(tmp_path, "pub/model")
+    ticks = iter([0.0, 10.0])
+    monkeypatch.setattr(onboarding.time, "monotonic", lambda: next(ticks, 10.0))
+
+    found = onboarding._scan_for_models(tmp_path, timeout_s=1.0)
+
+    assert found == []
+
+
+def test_scan_and_pick_prints_candidate_progress_before_picker(tmp_path, monkeypatch, capsys):
+    target = _make_model_dir(tmp_path, "lmstudio-community/Qwen-A")
+    monkeypatch.setattr(
+        onboarding,
+        "_classify_scanned_model",
+        lambda path: onboarding.ScannedModel(
+            path=path,
+            tier="arch-compatible",
+            arch_id="qwen3-next-mtp",
+            architecture="Qwen3NextForCausalLM",
+        ),
+    )
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "1")
+
+    chosen = onboarding._scan_and_pick(tmp_path)
+
+    captured = capsys.readouterr().out
+    assert chosen == str(target)
+    assert "Found 1 candidate model folder(s). Checking configs..." in captured
+
+
+def test_screen_model_local_folder_routes_through_picker(tmp_path, monkeypatch):
+    target = _make_model_dir(tmp_path, "Real")
+    invocations: list[str | None] = []
+
+    def fake_picker(*, default):
+        invocations.append(default)
+        return str(target)
+
+    monkeypatch.setattr(onboarding, "_pick_local_model", fake_picker)
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "3")
+
+    chosen = onboarding.screen_model(configured=None)
+
+    assert chosen == str(target)
+    assert invocations == [None]

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -613,6 +613,60 @@ def test_classify_scanned_model_qwen_sidecar_without_contract_is_arch_compatible
     assert result.arch_id == "qwen3-next-mtp"
 
 
+def test_classify_scanned_model_glm_config_only_marks_mtp_missing(tmp_path):
+    target = tmp_path / "GLM-config-only"
+    target.mkdir()
+    (target / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Glm4MoeLiteForCausalLM"],
+                "model_type": "glm4_moe_lite",
+                "num_hidden_layers": 47,
+                "num_nextn_predict_layers": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = onboarding._classify_scanned_model(target)
+
+    assert result.tier == "mtp-missing"
+    assert result.arch_id == "glm4-moe-lite-mtp"
+
+
+def test_classify_scanned_model_glm_sidecar_needs_verification(tmp_path):
+    target = tmp_path / "GLM-sidecar-unverified"
+    target.mkdir()
+    (target / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Glm4MoeLiteForCausalLM"],
+                "model_type": "glm4_moe_lite",
+                "num_hidden_layers": 47,
+                "num_nextn_predict_layers": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (target / "mtp.safetensors").write_bytes(b"placeholder")
+
+    result = onboarding._classify_scanned_model(target)
+
+    assert result.tier == "needs-verification"
+    assert result.arch_id == "glm4-moe-lite-mtp"
+
+
+def test_tier_badges_distinguish_runnable_from_blocked():
+    label, _ = onboarding._tier_badge("arch-compatible")
+    assert "Runnable" in label
+    label, _ = onboarding._tier_badge("needs-verification")
+    assert "Needs MTPLX verification" in label
+    label, _ = onboarding._tier_badge("mtp-invalid")
+    assert "MTP weights invalid" in label
+    label, _ = onboarding._tier_badge("backend-pending")
+    assert "Backend not runnable yet" in label
+
+
 def test_scan_and_pick_prints_candidate_progress_before_picker(tmp_path, monkeypatch, capsys):
     target = _make_model_dir(tmp_path, "lmstudio-community/Qwen-A")
     monkeypatch.setattr(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -592,6 +592,27 @@ def test_scan_for_models_honors_timeout(tmp_path, monkeypatch):
     assert found == []
 
 
+def test_classify_scanned_model_qwen_config_only_marks_mtp_missing(tmp_path):
+    target = _make_model_dir(tmp_path, "mlx-community/Qwen-config-only")
+
+    result = onboarding._classify_scanned_model(target)
+
+    assert result.tier == "mtp-missing"
+    assert result.arch_id == "qwen3-next-mtp"
+    label, _ = onboarding._tier_badge(result.tier)
+    assert "MTP weights missing" in label
+
+
+def test_classify_scanned_model_qwen_sidecar_without_contract_is_arch_compatible(tmp_path):
+    target = _make_model_dir(tmp_path, "Youssofal/Qwen-sidecar")
+    (target / "mtp.safetensors").write_bytes(b"placeholder")
+
+    result = onboarding._classify_scanned_model(target)
+
+    assert result.tier == "arch-compatible"
+    assert result.arch_id == "qwen3-next-mtp"
+
+
 def test_scan_and_pick_prints_candidate_progress_before_picker(tmp_path, monkeypatch, capsys):
     target = _make_model_dir(tmp_path, "lmstudio-community/Qwen-A")
     monkeypatch.setattr(

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -14,9 +14,9 @@ from mtplx.profiles import (
 def test_profile_registry_default_is_stable() -> None:
     profile = get_profile()
 
-    assert DEFAULT_PROFILE_NAME == "stable"
-    assert profile.name == "stable"
-    assert profile.runtime_profile == "long_response_exact_staged"
+    assert DEFAULT_PROFILE_NAME == "performance-cold"
+    assert profile.name == "performance-cold"
+    assert profile.runtime_profile == "native_mtp_60_cold"
     assert profile.product_claim_eligible is True
 
 

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -117,29 +117,29 @@ def test_main_menu_advertises_help_command(capsys):
     # `help` appears in the Commands section, not just as part of the footer.
     assert "  help " in captured or "help         " in captured
     # Listed near the top: must come before the lab-only commands.
-    quickstart_pos = captured.find("quickstart")
+    quickstart_pos = captured.find("start")
     help_pos = captured.find("\n  help")
     inspect_pos = captured.find("inspect")
     assert quickstart_pos != -1 and help_pos != -1 and inspect_pos != -1
     assert quickstart_pos < help_pos < inspect_pos
 
 
-def test_quickstart_help_is_a_user_journey(capsys):
-    code = main(["help", "quickstart"])
+def test_start_help_is_a_user_journey(capsys):
+    code = main(["help", "start"])
 
     captured = capsys.readouterr().out
     assert code == 0
-    assert "MTPLX quickstart" in captured
+    assert "MTPLX start" in captured
     # Help leads with the interactive onboarding (model/mode/where) instead
     # of the old browser/CLI bifurcation.
     assert "Interactive end-to-end setup" in captured
     assert "What gets asked" in captured
     assert "ThermalForge" in captured  # Max mode advertises auto-install
     # Power-user shortcuts still showcased.
-    assert "mtplx quickstart --fresh" in captured
-    assert "mtplx quickstart --max" in captured
-    assert "mtplx quickstart cli" in captured
-    assert "mtplx quickstart --download" in captured
+    assert "mtplx start --fresh" in captured
+    assert "mtplx start --max" in captured
+    assert "mtplx start cli" in captured
+    assert "mtplx start --download" in captured
     assert "/speed" in captured
     assert "Aliases:" in captured
     assert "openwebui" in captured
@@ -156,13 +156,13 @@ def test_unknown_command_is_targeted_not_argparse_dump(capsys):
     assert "usage: mtplx" not in captured
 
 
-def test_quickstart_dry_run_is_consumer_friendly(monkeypatch, tmp_path, capsys):
-    """The default quickstart now opens the browser chat; the terminal flow lives behind `cli`."""
+def test_start_dry_run_is_consumer_friendly(monkeypatch, tmp_path, capsys):
+    """The default start opens the browser chat; the terminal flow lives behind `cli`."""
     monkeypatch.setenv("MTPLX_CONFIG", str(tmp_path / "missing-config.toml"))
 
     code = main(
         [
-            "quickstart",
+            "start",
             "cli",
             "--dry-run",
             "--model",
@@ -173,14 +173,14 @@ def test_quickstart_dry_run_is_consumer_friendly(monkeypatch, tmp_path, capsys):
 
     captured = capsys.readouterr().out
     assert code == 0
-    assert "MTPLX quickstart" in captured
+    assert "MTPLX start" in captured
     assert "model: models/example" in captured
     assert "profile: performance-cold" in captured
     assert "then: load once -> chat in this terminal -> stream output -> show speed stats" in captured
 
 
-def test_quickstart_default_target_is_browser(monkeypatch, tmp_path):
-    """`mtplx quickstart` (no target) must dry-run as the openwebui browser path."""
+def test_start_default_target_is_browser(monkeypatch, tmp_path):
+    """`mtplx start` (no target) must dry-run as the openwebui browser path."""
     monkeypatch.setenv("MTPLX_CONFIG", str(tmp_path / "missing-config.toml"))
     args = SimpleNamespace(
         target=None,
@@ -202,12 +202,12 @@ def test_quickstart_default_target_is_browser(monkeypatch, tmp_path):
     assert code == 0
 
 
-def test_quickstart_target_aliases_route_correctly(monkeypatch, tmp_path, capsys):
+def test_start_target_aliases_route_correctly(monkeypatch, tmp_path, capsys):
     """`web`, `openwebui`, `open-webui` -> openwebui; `cli`, `terminal` -> terminal."""
     monkeypatch.setenv("MTPLX_CONFIG", str(tmp_path / "missing-config.toml"))
 
     def run(target: str | None) -> dict:
-        argv = ["quickstart"]
+        argv = ["start"]
         if target:
             argv.append(target)
         argv += ["--dry-run", "--json", "--model", "models/example", "--yes"]
@@ -341,26 +341,26 @@ def test_one_shot_max_uses_verified_max_session(monkeypatch):
     assert calls == ["start", "stop"]
 
 
-def test_quickstart_parser_accepts_new_target_choices():
+def test_start_parser_accepts_target_choices():
     """Parser must accept the new `web` and `cli` target literals."""
     parser = build_parser()
     for target in ("web", "cli", "openwebui", "open-webui", "terminal"):
-        args = parser.parse_args(["quickstart", target, "--dry-run"])
+        args = parser.parse_args(["start", target, "--dry-run"])
         assert args.target == target
     # Default target (no positional) is now None — the absence of an explicit
     # target is what tells the handler to run the interactive onboarding flow
     # (or fall back to "web" when non-interactive). The `--fresh` flag is also
     # accepted for forcing the full onboarding.
-    args_default = parser.parse_args(["quickstart", "--dry-run"])
+    args_default = parser.parse_args(["start", "--dry-run"])
     assert args_default.target is None
-    args_fresh = parser.parse_args(["quickstart", "--fresh", "--dry-run"])
+    args_fresh = parser.parse_args(["start", "--fresh", "--dry-run"])
     assert args_fresh.fresh is True
 
 
 def test_cli_response_cap_defaults_to_remaining_context():
     parser = build_parser()
 
-    quickstart = parser.parse_args(["quickstart", "cli", "--dry-run"])
+    quickstart = parser.parse_args(["start", "cli", "--dry-run"])
     ask = parser.parse_args(["ask", "hello"])
     run = parser.parse_args(["run", "hello"])
     chat = parser.parse_args(["chat", "--prompt", "hello"])
@@ -374,7 +374,7 @@ def test_cli_response_cap_defaults_to_remaining_context():
 def test_cli_reasoning_flags_parse_without_being_chat_text():
     parser = build_parser()
 
-    quickstart = parser.parse_args(["quickstart", "cli", "--reasoning", "on"])
+    quickstart = parser.parse_args(["start", "cli", "--reasoning", "on"])
     run = parser.parse_args(["run", "hello", "--reasoning", "off"])
     serve = parser.parse_args(["serve", "--reasoning", "auto"])
 
@@ -383,13 +383,14 @@ def test_cli_reasoning_flags_parse_without_being_chat_text():
     assert serve.reasoning == "auto"
 
 
-def test_quickstart_missing_model_suggests_download(monkeypatch, capsys):
+def test_start_missing_model_suggests_download(monkeypatch, capsys):
     monkeypatch.setattr(
         public,
         "_resolve_runtime_model_path",
         lambda model, cache_dir=None: (None, {"detail": "not cached"}),
     )
     args = SimpleNamespace(
+        command="start",
         model="mtplx/example",
         cache_dir="/tmp/mtplx-models",
         download=False,
@@ -406,11 +407,11 @@ def test_quickstart_missing_model_suggests_download(monkeypatch, capsys):
 
     captured = capsys.readouterr().out
     assert code == 1
-    assert "MTPLX quickstart" in captured
+    assert "MTPLX start" in captured
     assert "model is not available locally" in captured
     assert "detail: not cached" in captured
-    assert "try: mtplx quickstart --download" in captured
-    assert "try: mtplx quickstart --model /path/to/model" in captured
+    assert "try: mtplx start --download" in captured
+    assert "try: mtplx start --model /path/to/model" in captured
 
 
 def test_quickstart_short_reply_reports_decode_tps():
@@ -650,7 +651,7 @@ def test_quickstart_openwebui_dry_run_json(monkeypatch, tmp_path, capsys):
 
     code = main(
         [
-            "quickstart",
+            "start",
             "openwebui",
             "--dry-run",
             "--json",
@@ -1072,17 +1073,18 @@ def test_chat_and_serve_default_to_performance_cold_mode():
 def test_product_helper_commands_parse():
     parser = build_parser()
 
-    quickstart = parser.parse_args(
-        ["quickstart", "--prompt", "hello", "--max-tokens", "16", "--no-stats"]
+    start = parser.parse_args(
+        ["start", "--prompt", "hello", "--max-tokens", "16", "--no-stats"]
     )
-    quickstart_openwebui = parser.parse_args(["quickstart", "openwebui", "--port", "18012"])
-    quickstart_openwebui_strict = parser.parse_args(["quickstart", "openwebui", "--strict-fast-path"])
-    quickstart_alias = parser.parse_args(["quick-start", "--dry-run"])
+    start_openwebui = parser.parse_args(["start", "openwebui", "--port", "18012"])
+    start_openwebui_strict = parser.parse_args(["start", "openwebui", "--strict-fast-path"])
+    quickstart = parser.parse_args(["quickstart", "--port", "18012"])
+    quickstart_alias = parser.parse_args(["quick-start", "--port", "18013"])
     setup = parser.parse_args(["setup", "--dry-run"])
     pull_default = parser.parse_args(["pull"])
     ask = parser.parse_args(["ask", "hello"])
     ask_stats = parser.parse_args(["ask", "hello", "--stats"])
-    start = parser.parse_args(["start", "--port", "18012"])
+    serve_start = parser.parse_args(["serve", "--port", "18012"])
     status = parser.parse_args(["status", "--deep"])
     connect = parser.parse_args(["connect", "openwebui", "--port", "18012"])
     models = parser.parse_args(["models", "--json"])
@@ -1101,16 +1103,18 @@ def test_product_helper_commands_parse():
     config = parser.parse_args(["config", "set", "profile", "exact", "--dry-run"])
     attribution = parser.parse_args(["profile", "eval-attribution", "--dry-run"])
 
+    assert start.command == "start"
+    assert start.prompt == "hello"
+    assert start.max_tokens == 16
+    assert start.show_stats is False
+    assert start_openwebui.target == "openwebui"
+    assert start_openwebui.port == 18012
+    assert start_openwebui.strict_fast_path is False
+    assert start_openwebui_strict.strict_fast_path is True
     assert quickstart.command == "quickstart"
-    assert quickstart.prompt == "hello"
-    assert quickstart.max_tokens == 16
-    assert quickstart.show_stats is False
-    assert quickstart_openwebui.target == "openwebui"
-    assert quickstart_openwebui.port == 18012
-    assert quickstart_openwebui.strict_fast_path is False
-    assert quickstart_openwebui_strict.strict_fast_path is True
+    assert quickstart.port == 18012
     assert quickstart_alias.command == "quick-start"
-    assert quickstart_alias.dry_run is True
+    assert quickstart_alias.port == 18013
     assert setup.command == "setup"
     assert setup.dry_run is True
     assert pull_default.command == "pull"
@@ -1119,9 +1123,9 @@ def test_product_helper_commands_parse():
     assert ask.prompt_arg == "hello"
     assert ask.quiet is True
     assert ask_stats.quiet is False
-    assert start.command == "start"
-    assert start.port == 18012
-    assert start.stats_footer is False
+    assert serve_start.command == "serve"
+    assert serve_start.port == 18012
+    assert serve_start.stats_footer is True
     assert status.command == "status"
     assert status.deep is True
     assert connect.command == "connect"
@@ -1440,8 +1444,8 @@ def test_serve_reports_busy_port_before_model_resolution(monkeypatch, capsys):
     assert "MTPLX" in captured
     assert "0.1.0-preview" in captured
     assert "error: port 8000 is already in use" in captured
-    assert "stop the old mtplx start terminal with Ctrl-C" in captured
-    assert "try: mtplx start --port 8001" in captured
+    assert "stop the old mtplx quickstart terminal with Ctrl-C" in captured
+    assert "try: mtplx quickstart --port 8001" in captured
 
 
 def test_quickstart_openwebui_reuses_existing_server(monkeypatch, capsys):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -432,7 +432,7 @@ def test_quickstart_short_reply_reports_decode_tps():
     assert "54.8 ms/verify" in line
 
 
-def test_quickstart_short_reply_prefers_stream_tps_when_available():
+def test_quickstart_short_reply_prefers_decode_tps_and_labels_live_window():
     line = public._quickstart_stats_line(
         {
             "profile": {"name": "performance-cold"},
@@ -450,8 +450,8 @@ def test_quickstart_short_reply_prefers_stream_tps_when_available():
         }
     )
 
-    assert "42.00 tok/s" in line
-    assert "decode=28.48" in line
+    assert "28.48 tok/s" in line
+    assert "live_window=42.00" in line
     assert "total=25.00" in line
     assert "5 verify calls" in line
     assert "accept=[4, 3, 2]" in line
@@ -476,7 +476,7 @@ def test_quickstart_tiny_reply_prefers_decode_over_noisy_stream_window():
     )
 
     assert "34.68 tok/s" in line
-    assert "stream=12.24" in line
+    assert "live_window=12.24" in line
     assert "total=8.73" in line
 
 
@@ -666,7 +666,9 @@ def test_quickstart_openwebui_dry_run_json(monkeypatch, tmp_path, capsys):
     assert code == 0
     assert payload["target"] == "openwebui"
     assert payload["terminal_chat"] is False
-    assert payload["openwebui"]["base_url"] == "http://127.0.0.1:18012"
+    assert payload["openwebui"]["server_url"] == "http://127.0.0.1:18012"
+    assert payload["openwebui"]["base_url"] == "http://127.0.0.1:18012/v1"
+    assert payload["openwebui"]["api_base_url"] == "http://127.0.0.1:18012/v1"
     assert payload["openwebui"]["chat_url"] == "http://127.0.0.1:18012/"
     assert "Open chat UI: http://127.0.0.1:18012/" in payload["openwebui"]["openwebui_steps"]
     assert "OpenAI-compatible API base URL: http://127.0.0.1:18012/v1" in payload["openwebui"]["openwebui_steps"]
@@ -754,13 +756,11 @@ def test_public_bench_run_dry_run(capsys):
     assert code == 0
     assert '"action": "bench run"' in captured
     assert '"automatic": true' in captured
-    assert '"harness": "direct-http"' in captured
-    assert '"seed": 42' in captured
-    assert "run_context_degradation_diagnostics.py" in captured
-    assert '"runtime_profile": "long_response_exact_staged"' in captured
-    assert '"MTPLX_DROP_EVENTS": "1"' in captured
-    assert '"MTPLX_EVAL_STATE_ROOTS_ON_COMMIT": "1"' in captured
-    assert '"MTPLX_TARGET_LAYER_EVAL_SCHEDULE": "2048:16,8192:8"' in captured
+    assert '"harness": "depth-sweep"' in captured
+    assert '"seed": 0' in captured
+    assert '"direct_http_command": null' in captured
+    assert '"runtime_profile": "native_mtp_60_cold"' in captured
+    assert '"MTPLX_LAZY_VERIFY_LOGITS": "1"' in captured
 
 
 def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsys):
@@ -798,7 +798,7 @@ def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsy
     assert payload["runtime_env"]["MTPLX_EVAL_STATE_ROOTS_INCLUDE_LIVE"] == "0"
 
 
-def test_public_bench_cold_run_defaults_to_stable_mode(capsys):
+def test_public_bench_cold_run_defaults_to_performance_cold_mode(capsys):
     code = main(
         [
             "bench",
@@ -817,12 +817,12 @@ def test_public_bench_cold_run_defaults_to_stable_mode(capsys):
     captured = capsys.readouterr().out
     payload = json.loads(captured)
     assert code == 0
-    assert payload["profile"]["name"] == "stable"
-    assert payload["harness"] == "direct-http"
-    assert payload["seed"] == 42
-    assert payload["runtime_profile"] == "long_response_exact_staged"
-    assert payload["runtime_env"]["MTPLX_DROP_EVENTS"] == "1"
-    assert payload["runtime_env"]["MTPLX_TARGET_LAYER_EVAL_SCHEDULE"] == "2048:16,8192:8"
+    assert payload["profile"]["name"] == "performance-cold"
+    assert payload["harness"] == "depth-sweep"
+    assert payload["seed"] == 0
+    assert payload["runtime_profile"] == "native_mtp_60_cold"
+    assert payload["runtime_env"]["MTPLX_LAZY_VERIFY_LOGITS"] == "1"
+    assert "MTPLX_TARGET_LAYER_EVAL_SCHEDULE" not in payload["runtime_env"]
 
 
 def test_public_bench_performance_cold_is_explicit(capsys):
@@ -986,9 +986,9 @@ def test_bench_nightly_dry_run_lists_kernel_gate_tasks(capsys):
     assert payload["full_exactness_command"][0:2] == ["qa", "exactness"]
     assert [task["profile"] for task in payload["tasks"]] == [
         "performance-cold",
-        "stable",
-        "stable",
-        "stable",
+        "performance-cold",
+        "performance-cold",
+        "performance-cold",
     ]
     flappy_6k_command = payload["tasks"][1]["direct_http_command"]
     assert "--python-bin" in flappy_6k_command
@@ -1042,7 +1042,7 @@ def test_bench_compare_envelopes_detects_cold_regression(tmp_path, capsys):
     assert payload["comparisons"][0]["gates"]["cold_floor_ge_59"] is False
 
 
-def test_chat_and_serve_default_to_stable_mode():
+def test_chat_and_serve_default_to_performance_cold_mode():
     parser = build_parser()
 
     run_args = parser.parse_args(["run", "hello", "--cache-dir", "/tmp/mtplx-models"])
@@ -1051,15 +1051,15 @@ def test_chat_and_serve_default_to_stable_mode():
     serve_max_args = parser.parse_args(["serve", "--max"])
     serve_no_footer_args = parser.parse_args(["serve", "--no-stats-footer"])
 
-    assert run_args.profile == "stable"
+    assert run_args.profile == "performance-cold"
     assert run_args.prompt_arg == "hello"
     assert run_args.cache_dir == "/tmp/mtplx-models"
     assert run_args.max_tokens is None
     assert run_args.reasoning is None
-    assert chat_args.profile == "stable"
+    assert chat_args.profile == "performance-cold"
     assert chat_args.max_tokens is None
     assert chat_args.reasoning is None
-    assert serve_args.profile == "stable"
+    assert serve_args.profile == "performance-cold"
     assert serve_args.reasoning is None
     assert serve_max_args.max is True
     assert serve_args.stream_interval == 1
@@ -1079,18 +1079,21 @@ def test_product_helper_commands_parse():
     quickstart_openwebui_strict = parser.parse_args(["quickstart", "openwebui", "--strict-fast-path"])
     quickstart_alias = parser.parse_args(["quick-start", "--dry-run"])
     setup = parser.parse_args(["setup", "--dry-run"])
+    pull_default = parser.parse_args(["pull"])
     ask = parser.parse_args(["ask", "hello"])
     ask_stats = parser.parse_args(["ask", "hello", "--stats"])
     start = parser.parse_args(["start", "--port", "18012"])
     status = parser.parse_args(["status", "--deep"])
     connect = parser.parse_args(["connect", "openwebui", "--port", "18012"])
     models = parser.parse_args(["models", "--json"])
+    report = parser.parse_args(["report", "--output-dir", "reports"])
     nightly = parser.parse_args(["bench", "nightly", "--out", "out.json"])
     nightly_json = parser.parse_args(["bench", "nightly", "--json", "--dry-run"])
     debug = parser.parse_args(["debug", "bundle", "--run-id", "debug-test"])
     hotpath = parser.parse_args(["debug", "hotpath"])
     metrics = parser.parse_args(["metrics", "watch", "--count", "1", "--json"])
     openwebui = parser.parse_args(["integrate", "openwebui", "--port", "18012", "--json"])
+    openwebui_docker = parser.parse_args(["openwebui", "docker-command", "--mtplx-port", "18012"])
     claude = parser.parse_args(["integrate", "claude-code", "--port", "18012"])
     architectures = parser.parse_args(["model", "architectures", "--json"])
     qa_architectures = parser.parse_args(["model", "qa-architectures", "--json"])
@@ -1110,6 +1113,8 @@ def test_product_helper_commands_parse():
     assert quickstart_alias.dry_run is True
     assert setup.command == "setup"
     assert setup.dry_run is True
+    assert pull_default.command == "pull"
+    assert pull_default.model == "Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed"
     assert ask.command == "ask"
     assert ask.prompt_arg == "hello"
     assert ask.quiet is True
@@ -1122,6 +1127,9 @@ def test_product_helper_commands_parse():
     assert connect.command == "connect"
     assert connect.integration == "openwebui"
     assert models.command == "models"
+    assert report.command == "report"
+    assert report.bundle is True
+    assert report.deep is True
     assert nightly.bench_action == "nightly"
     assert nightly.output == "out.json"
     assert nightly_json.json is True
@@ -1129,6 +1137,8 @@ def test_product_helper_commands_parse():
     assert hotpath.debug_action == "hotpath"
     assert metrics.metrics_action == "watch"
     assert openwebui.integration == "openwebui"
+    assert openwebui_docker.openwebui_action == "docker-command"
+    assert openwebui_docker.mtplx_port == 18012
     assert claude.integration == "claude-code"
     assert architectures.model_action == "architectures"
     assert qa_architectures.model_action == "qa-architectures"
@@ -1176,7 +1186,10 @@ def test_integrate_openwebui_json(capsys):
     payload = json.loads(capsys.readouterr().out)
     assert code == 0
     assert payload["integration"] == "openwebui"
-    assert payload["base_url"] == "http://127.0.0.1:18012"
+    assert payload["server_url"] == "http://127.0.0.1:18012"
+    assert payload["base_url"] == "http://127.0.0.1:18012/v1"
+    assert payload["docker_api_base_url"] == "http://host.docker.internal:18012/v1"
+    assert "host.docker.internal:18012/v1" in payload["docker_command"]
     assert "--no-stats-footer" in payload["server_command"]
 
 
@@ -1279,7 +1292,7 @@ def test_serve_dispatches_packaged_openai_server(monkeypatch, capsys):
     assert calls["cmd"][calls["cmd"].index("--rate-limit") + 1] == "120"
     assert calls["cmd"][calls["cmd"].index("--stream-interval") + 1] == "4"
     assert calls["cmd"][calls["cmd"].index("--max-response-tokens") + 1] == "512"
-    assert calls["cmd"][calls["cmd"].index("--model-id") + 1] == "mtplx-qwen36-27b-native-mtp"
+    assert calls["cmd"][calls["cmd"].index("--model-id") + 1] == "mtplx-qwen36-27b-optimized-speed"
     assert "--no-enable-thinking" in calls["cmd"]
     assert "--no-stats-footer" in calls["cmd"]
     assert "--strict-warmup" in calls["cmd"]
@@ -1436,7 +1449,7 @@ def test_quickstart_openwebui_reuses_existing_server(monkeypatch, capsys):
     monkeypatch.setattr(
         public,
         "_http_json",
-        lambda url, timeout=15.0: {"ok": True, "model": "mtplx-qwen36-27b-native-mtp"},
+        lambda url, timeout=15.0: {"ok": True, "model": "mtplx-qwen36-27b-optimized-speed"},
     )
     monkeypatch.setattr(
         public,
@@ -1447,7 +1460,7 @@ def test_quickstart_openwebui_reuses_existing_server(monkeypatch, capsys):
     monkeypatch.setattr(public, "_open_browser_url", lambda url: opened.setdefault("url", url))
     args = SimpleNamespace(
         model="models/example",
-        model_id="mtplx-qwen36-27b-native-mtp",
+        model_id="mtplx-qwen36-27b-optimized-speed",
         cache_dir=None,
         profile="performance-cold",
         unsafe_force_unverified=False,
@@ -1561,7 +1574,7 @@ def test_profiles_command_lists_default_without_mlx(capsys):
 
     payload = json.loads(capsys.readouterr().out)
     assert code == 0
-    assert payload["default"] == "stable"
+    assert payload["default"] == "performance-cold"
     assert [profile["name"] for profile in payload["profiles"]] == [
         "stable",
         "performance-cold",

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1302,6 +1302,219 @@ def test_serve_dispatches_packaged_openai_server(monkeypatch, capsys):
     assert "--strict-warmup" in calls["cmd"]
 
 
+def test_bare_serve_invokes_server_onboarding_in_tty(monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(public, "_port_is_busy", lambda host, port: False)
+    monkeypatch.setattr(public, "_resolve_runtime_model_path", lambda model, cache_dir=None: (model, None))
+    monkeypatch.setattr(
+        public,
+        "_model_gate",
+        lambda model, unsafe_force_unverified=False, yes=False: (
+            {"compatibility": {"tier": "verified", "can_run": True, "exit_code": 0}},
+            None,
+        ),
+    )
+    invocations: list[dict] = []
+
+    def fake_flow(**kwargs):
+        invocations.append(kwargs)
+        return {
+            "model": "models/onboarded",
+            "profile": "performance-cold",
+            "max": False,
+            "target": "server",
+            "open_browser": False,
+        }
+
+    monkeypatch.setattr("mtplx.ui.onboarding.run_serve_flow", fake_flow)
+    calls = {}
+
+    def fake_execvpe(executable, cmd, env):
+        calls["cmd"] = cmd
+        raise SystemExit(0)
+
+    monkeypatch.setattr(public.os, "execvpe", fake_execvpe)
+    args = SimpleNamespace(
+        command="serve",
+        model="models/configured",
+        cache_dir=None,
+        download=False,
+        profile="stable",
+        unsafe_force_unverified=False,
+        yes=False,
+        host="127.0.0.1",
+        port=8765,
+        depth=3,
+        api_key=None,
+        rate_limit=0,
+        stream_interval=1,
+        max_response_tokens=None,
+        temperature=0.6,
+        top_p=0.95,
+        reasoning_parser="qwen3",
+        stats_footer=True,
+        warmup_tokens=0,
+        strict_warmup=False,
+        strict_fast_path=False,
+        max=False,
+        open_browser=False,
+        _cli_flags=set(),
+    )
+
+    try:
+        public.cmd_serve_public(args)
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert len(invocations) == 1
+    assert invocations[0]["configured_model"] == "models/configured"
+    assert invocations[0]["port"] == 8765
+    assert args._onboarded is True
+    assert args.model == "models/onboarded"
+    assert calls["cmd"][calls["cmd"].index("--model") + 1] == "models/onboarded"
+    assert "--open-browser" not in calls["cmd"]
+
+
+def test_bare_serve_hf_choice_enables_download_and_browser(monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(public, "_port_is_busy", lambda host, port: False)
+    monkeypatch.setattr(
+        public,
+        "_model_gate",
+        lambda model, unsafe_force_unverified=False, yes=False: (
+            {"compatibility": {"tier": "verified", "can_run": True, "exit_code": 0}},
+            None,
+        ),
+    )
+
+    def fake_flow(**_kwargs):
+        return {
+            "model": "owner/repo",
+            "profile": "performance-cold",
+            "max": False,
+            "target": "openwebui",
+            "open_browser": True,
+        }
+
+    resolution_calls: list[dict] = []
+
+    def fake_quickstart_resolve(model, *, cache_dir, download):
+        resolution_calls.append({"model": model, "download": download})
+        return "/tmp/runtime-model", {
+            "model": model,
+            "runtime_model": "/tmp/runtime-model",
+            "downloaded": True,
+            "download_ref": model,
+        }
+
+    monkeypatch.setattr("mtplx.ui.onboarding.run_serve_flow", fake_flow)
+    monkeypatch.setattr(public, "_quickstart_resolve_model", fake_quickstart_resolve)
+    calls = {}
+
+    def fake_execvpe(executable, cmd, env):
+        calls["cmd"] = cmd
+        raise SystemExit(0)
+
+    monkeypatch.setattr(public.os, "execvpe", fake_execvpe)
+    args = SimpleNamespace(
+        command="serve",
+        model="models/configured",
+        cache_dir=None,
+        download=False,
+        profile="stable",
+        unsafe_force_unverified=False,
+        yes=False,
+        host="127.0.0.1",
+        port=8765,
+        depth=3,
+        api_key=None,
+        rate_limit=0,
+        stream_interval=1,
+        max_response_tokens=None,
+        temperature=0.6,
+        top_p=0.95,
+        reasoning_parser="qwen3",
+        stats_footer=True,
+        warmup_tokens=0,
+        strict_warmup=False,
+        strict_fast_path=False,
+        max=False,
+        open_browser=False,
+        _cli_flags=set(),
+    )
+
+    try:
+        public.cmd_serve_public(args)
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert resolution_calls == [{"model": "owner/repo", "download": True}]
+    assert calls["cmd"][calls["cmd"].index("--model") + 1] == "/tmp/runtime-model"
+    assert "--open-browser" in calls["cmd"]
+
+
+def test_serve_skips_onboarding_with_explicit_model(monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr(public, "_port_is_busy", lambda host, port: False)
+    monkeypatch.setattr(public, "_resolve_runtime_model_path", lambda model, cache_dir=None: (model, None))
+    monkeypatch.setattr(
+        public,
+        "_model_gate",
+        lambda model, unsafe_force_unverified=False, yes=False: (
+            {"compatibility": {"tier": "verified", "can_run": True, "exit_code": 0}},
+            None,
+        ),
+    )
+
+    def fail_flow(**_kwargs):
+        raise AssertionError("explicit --model should skip server onboarding")
+
+    monkeypatch.setattr("mtplx.ui.onboarding.run_serve_flow", fail_flow)
+    calls = {}
+
+    def fake_execvpe(executable, cmd, env):
+        calls["cmd"] = cmd
+        raise SystemExit(0)
+
+    monkeypatch.setattr(public.os, "execvpe", fake_execvpe)
+    args = SimpleNamespace(
+        command="serve",
+        model="models/explicit",
+        cache_dir=None,
+        download=False,
+        profile="performance-cold",
+        unsafe_force_unverified=False,
+        yes=False,
+        host="127.0.0.1",
+        port=8000,
+        depth=3,
+        api_key=None,
+        rate_limit=0,
+        stream_interval=1,
+        max_response_tokens=None,
+        temperature=0.6,
+        top_p=0.95,
+        reasoning_parser="qwen3",
+        stats_footer=True,
+        warmup_tokens=0,
+        strict_warmup=False,
+        strict_fast_path=False,
+        max=False,
+        open_browser=False,
+        _cli_flags={"model"},
+    )
+
+    try:
+        public.cmd_serve_public(args)
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert calls["cmd"][calls["cmd"].index("--model") + 1] == "models/explicit"
+
+
 def test_serve_relaxes_missing_fast_mlx_fork_for_product_start(monkeypatch, capsys):
     calls = {}
 

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -34,6 +34,27 @@ def test_empty_cli_shows_friendly_consumer_help(capsys):
     assert "capture-commit-equivalence" not in captured
 
 
+def test_shell_banner_env_suppresses_compact_help_ascii(monkeypatch, capsys):
+    monkeypatch.setenv("MTPLX_SHELL_BANNER_SHOWN", "1")
+
+    code = main([])
+
+    captured = capsys.readouterr().out
+    assert code == 0
+    assert "███╗" not in captured
+    assert "Commands" in captured
+    assert "mtplx start" in captured
+
+
+def test_render_banner_respects_shell_banner_env(monkeypatch, capsys):
+    from mtplx.ui.banner import render_banner
+
+    monkeypatch.setenv("MTPLX_SHELL_BANNER_SHOWN", "1")
+    render_banner(no_color=True)
+
+    assert capsys.readouterr().out == ""
+
+
 def test_top_level_help_is_friendly(capsys):
     code = main(["--help"])
 

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1573,6 +1573,33 @@ def test_inspect_human_output_is_default(tmp_path, capsys):
     assert "message: Model has no MTP head." in captured
 
 
+def test_start_gate_failure_is_human_readable_for_config_only_qwen(tmp_path, capsys):
+    model = tmp_path / "qwen-config-only"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "model_type": "qwen3_5",
+                "mtp_num_hidden_layers": 1,
+                "num_hidden_layers": 64,
+                "hidden_size": 5120,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = main(["start", "cli", "--model", str(model), "--yes"])
+
+    captured = capsys.readouterr().out
+    assert code == 3
+    assert "error: model cannot run with MTPLX" in captured
+    assert "runtime: missing-mtp-weights" in captured
+    assert "mtplx_runtime.json is optional metadata" in captured
+    assert "fix: choose a model with real MTP weights" in captured
+    assert "\"model_files\"" not in captured
+
+
 def test_profiles_command_lists_default_without_mlx(capsys):
     code = main(["profiles", "--json"])
 

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1600,6 +1600,33 @@ def test_start_gate_failure_is_human_readable_for_config_only_qwen(tmp_path, cap
     assert "\"model_files\"" not in captured
 
 
+def test_start_gate_failure_is_human_readable_for_config_only_glm(tmp_path, capsys):
+    model = tmp_path / "glm-config-only"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["Glm4MoeLiteForCausalLM"],
+                "model_type": "glm4_moe_lite",
+                "num_hidden_layers": 47,
+                "num_nextn_predict_layers": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    code = main(["start", "cli", "--model", str(model), "--yes"])
+
+    captured = capsys.readouterr().out
+    assert code == 3
+    assert "error: model cannot run with MTPLX" in captured
+    assert "runtime: missing-mtp-weights" in captured
+    assert "mtplx_runtime.json is optional metadata" in captured
+    assert "fix: choose a model with real MTP weights" in captured
+    assert "MTP MTP markers" not in captured
+    assert "\"model_files\"" not in captured
+
+
 def test_profiles_command_lists_default_without_mlx(capsys):
     code = main(["profiles", "--json"])
 

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -178,7 +178,7 @@ def test_server_state_emits_startup_progress(monkeypatch, capsys):
     state = openai.ServerState(args)
 
     captured = capsys.readouterr().out
-    assert "[4/6] Preparing stable runtime" in captured
+    assert "[4/6] Preparing Fast MTP runtime" in captured
     assert "[5/6] Loading model weights: models/example" in captured
     assert "This is the long step" in captured
     assert "Model load in progress (this may take a minute)" in captured

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -178,7 +178,7 @@ def test_server_state_emits_startup_progress(monkeypatch, capsys):
     state = openai.ServerState(args)
 
     captured = capsys.readouterr().out
-    assert "[4/6] Preparing Fast MTP runtime" in captured
+    assert "[4/6] Preparing Medium MTP runtime" in captured
     assert "[5/6] Loading model weights: models/example" in captured
     assert "This is the long step" in captured
     assert "Model load in progress (this may take a minute)" in captured

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -447,9 +447,45 @@ def test_restore_thermal_profile_verified_rejects_auto_with_max_target(monkeypat
 
     monkeypatch.setattr(thermal, "_run_probe", fake_run)
 
-    result = thermal.restore_thermal_profile_verified()
+    result = thermal.restore_thermal_profile_verified(settle_timeout_s=0)
 
     assert result["ok"] is False
+    thermal.detect_thermal_control.cache_clear()
+
+
+def test_restore_thermal_profile_verified_waits_for_auto_target_to_settle(monkeypatch):
+    thermal.detect_thermal_control.cache_clear()
+    monkeypatch.setattr(thermal, "_find_thermalforge", lambda: "/usr/local/bin/thermalforge")
+    snapshots = [
+        (
+            '{"fans": ['
+            '{"actual_rpm": 7400, "target_rpm": 7826, "max_rpm": 7826, "mode": "auto", "index": 0}'
+            ']}'
+        ),
+        (
+            '{"fans": ['
+            '{"actual_rpm": 2400, "target_rpm": 2318, "max_rpm": 7826, "mode": "auto", "index": 0}'
+            ']}'
+        ),
+    ]
+
+    def fake_run(command, *, timeout_s=None, cwd=None):
+        if command and command[-1] == "status":
+            stdout = snapshots.pop(0) if snapshots else (
+                '{"fans": ['
+                '{"actual_rpm": 2400, "target_rpm": 2318, "max_rpm": 7826, "mode": "auto", "index": 0}'
+                ']}'
+            )
+            return {"command": command, "returncode": 0, "ok": True, "stdout": stdout, "stderr": ""}
+        return {"command": command, "returncode": 0, "ok": True, "stdout": "", "stderr": ""}
+
+    monkeypatch.setattr(thermal, "_run_probe", fake_run)
+    monkeypatch.setattr(thermal.time, "sleep", lambda _seconds: None)
+
+    result = thermal.restore_thermal_profile_verified(settle_timeout_s=2, poll_interval_s=0.1)
+
+    assert result["ok"] is True
+    assert result["message"] == "fan profile restored"
     thermal.detect_thermal_control.cache_clear()
 
 


### PR DESCRIPTION
## What changed

- Inverted the consumer command contract: `mtplx start` now owns onboarding/chat, while `mtplx quickstart` owns server startup.
- Updated onboarding to advertise Medium/Max only, keep Stable as an explicit hidden profile, and describe mode mechanics with hardware-neutral multipliers.
- Added a bounded local-folder picker for parent directories like `~/.lmstudio/models`: it lists candidate model folders, prints scan progress before compatibility classification, and offers a retype option.
- Added runtime-contract draft head/sampler metadata plumbing, incomplete HF-cache rejection, and per-request speculative depth for the web/server APIs.
- Kept the release checkout curated: no research logs, model artifacts, benchmark output folders, or experimental flat4 build scripts.

## Validation

- `python -m py_compile` on changed runtime modules.
- Focused CLI/onboarding/config/server/cache/artifact/profile pytest gates.
- Live scan smoke against `/Users/youssof/.lmstudio/models`: 31 candidates, picker rendered in ~0.04s on this machine.
- Full `python -m pytest -q` suite green: 354 collected, 2 skipped.