### PR TITLE
Fix install_macos.sh crash on global launcher permission denied

### DIFF
--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -133,10 +133,13 @@ if [ "${MTPLX_SKIP_GLOBAL_LAUNCHER:-0}" != "1" ]; then
     global_bin=""
   fi
 
-  if [ -n "$global_bin" ] && [ -w "$global_bin" ]; then
-    cp "$launcher" "$global_bin/mtplx"
-    chmod 755 "$global_bin/mtplx"
-    global_launcher="$global_bin/mtplx"
+  if [ -n "$global_bin" ]; then
+    if cp "$launcher" "$global_bin/mtplx" 2>/dev/null && chmod 755 "$global_bin/mtplx" 2>/dev/null; then
+      global_launcher="$global_bin/mtplx"
+    else
+      echo "Note: could not write to $global_bin (permission denied). Skipping global launcher."
+      echo "      You can rerun with sudo or set MTPLX_SKIP_GLOBAL_LAUNCHER=1 to silence this."
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- The `[ -w "$global_bin" ]` check can pass even when `cp` into that directory fails (e.g. `/opt/homebrew/bin` owned by root), causing the install to abort due to `set -e`
- Replaced the pre-check with a try-the-copy-and-handle-failure approach so the install completes successfully via `~/.local/bin/mtplx`
- Prints a helpful note when the global launcher copy is skipped

## Test plan
- [x] Run `install_macos.sh` on a machine where `/opt/homebrew/bin` is not writable — install should succeed with a note
- [x] Run `install_macos.sh` on a machine where `/opt/homebrew/bin` is writable — global launcher should still be created
- [x] Run with `MTPLX_SKIP_GLOBAL_LAUNCHER=1` — no copy attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)