### PR TITLE
Handle mixed text + <tool_call> responses in streaming translator (closes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable user-facing changes are recorded here.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `_ToolAwareContentStreamTranslator` so it correctly handles assistant
+  responses that emit preamble text *before* a `<tool_call>` block. Previously
+  the splitter locked into `mode="content"` on the first non-marker byte and
+  never re-checked, so a response shaped like `"Let me investigate. <tool_call>...`
+  would emit the entire payload (including the tool_call markup) as
+  `delta.content` text. OpenAI-compatible clients then saw zero
+  `delta.tool_calls`, no tools were dispatched, and the agent loop exited
+  with no work done. The translator now also scans incoming text in `content`
+  mode for `<tool_call>` markers (with proper handling of partial markers
+  spanning multiple stream chunks). Tool-only responses and pure-text
+  responses are unchanged. Closes #20.
+
 ## v0.2.0
 
 ### Added

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1323,8 +1323,6 @@ class _ToolAwareContentStreamTranslator:
             return []
         if field != "content" or self._mode == "passthrough":
             return [{field: text}]
-        if self._mode == "content":
-            return [{"content": text}]
         if self._mode == "done":
             self._trailing += text
             return []
@@ -1333,20 +1331,79 @@ class _ToolAwareContentStreamTranslator:
         if self._mode == "tool":
             return self._tool_deltas_if_complete(final=False)
 
-        stripped = self._pending.lstrip()
-        if not stripped:
-            return []
-        lowered = stripped.lower()
-        if lowered.startswith(self._START_MARKER):
-            self._mode = "tool"
-            return self._tool_deltas_if_complete(final=False)
-        if self._START_MARKER.startswith(lowered):
-            return []
+        # Modes "undecided" and "content" both need to scan the pending buffer
+        # for `<tool_call>` markers. Previously "content" mode locked in on the
+        # first non-marker byte and never re-checked, so any preamble text
+        # followed by a tool_call block (a common Qwen3.6 27B output shape when
+        # given long system prompts) caused the entire response - including the
+        # tool_call markup - to leak through as `delta.content`. Clients then
+        # saw zero `delta.tool_calls` and the agent loop exited with no work
+        # done. Now both modes look for the marker; "content" mode also holds
+        # any trailing partial-marker bytes so the marker can complete on a
+        # later chunk.
 
-        self._mode = "content"
-        content = self._pending
-        self._pending = ""
-        return [{"content": content}]
+        idx = self._pending.lower().find(self._START_MARKER)
+        if idx >= 0:
+            deltas: list[dict[str, Any]] = []
+            if idx > 0:
+                pre = self._pending[:idx]
+                # In undecided mode, leading whitespace before the marker is
+                # decoration, not content - drop it to match the original
+                # behaviour for tool-only responses with a leading newline.
+                if self._mode == "undecided" and not pre.strip():
+                    pass
+                else:
+                    deltas.append({"content": pre})
+            self._pending = self._pending[idx:]
+            self._mode = "tool"
+            deltas.extend(self._tool_deltas_if_complete(final=False))
+            return deltas
+
+        # No complete marker found in the pending buffer. We may still have a
+        # partial marker on the tail (e.g. pending ends with `<tool_ca`) that
+        # could complete on the next chunk; hold those bytes back.
+        held = self._partial_marker_tail_len(self._pending)
+
+        if self._mode == "undecided":
+            stripped = self._pending.lstrip()
+            if not stripped:
+                return []
+            lowered = stripped.lower()
+            # Whole stripped pending could still grow into a marker; keep waiting
+            # (preserves the original behaviour for the tool-only case).
+            if self._START_MARKER.startswith(lowered):
+                return []
+            # Commit to content mode but keep any partial-marker tail for the
+            # next chunk to potentially complete the marker.
+            self._mode = "content"
+
+        if held == 0 or held >= len(self._pending):
+            # Either no partial marker (emit all) or pending is entirely a
+            # partial marker (hold all, wait for more).
+            if held >= len(self._pending):
+                return []
+            content = self._pending
+            self._pending = ""
+            return [{"content": content}]
+
+        # Emit everything up to the partial-marker tail; hold the tail.
+        pre = self._pending[:-held]
+        self._pending = self._pending[-held:]
+        return [{"content": pre}]
+
+    def _partial_marker_tail_len(self, text: str) -> int:
+        """Return the length of the trailing suffix of `text` that is a
+        prefix of `<tool_call`. 0 if no suffix matches.
+
+        Used to hold back bytes that *could* be the start of a tool_call
+        marker spanning multiple stream chunks, so the marker can complete
+        on a later chunk instead of being emitted as content prematurely."""
+        marker = self._START_MARKER
+        text_lower = text.lower()
+        for n in range(min(len(marker), len(text)), 0, -1):
+            if marker.startswith(text_lower[-n:]):
+                return n
+        return 0
 
     def finish(self) -> list[dict[str, Any]]:
         if self._mode == "tool":

--- a/tests/test_tool_aware_stream_translator.py
+++ b/tests/test_tool_aware_stream_translator.py
@@ -1,0 +1,158 @@
+"""Unit tests for _ToolAwareContentStreamTranslator covering both
+tool-only responses (the original v0.2.0 fix) and mixed text+tool responses
+(this fix - issue #20)."""
+
+import pytest
+
+from mtplx.server.openai import _ToolAwareContentStreamTranslator
+
+
+TOOL_SPECS = [{"function": {"name": "lookup", "parameters": {"type": "object"}}}]
+
+
+def _make(*, tools=TOOL_SPECS):
+    return _ToolAwareContentStreamTranslator(
+        tools=tools,
+        argument_chunk_chars=64,
+    )
+
+
+# ---------- existing behaviour (regression coverage) ----------
+
+def test_no_tools_passthrough():
+    """Without tools, every chunk passes through as-is."""
+    t = _make(tools=[])
+    assert t.feed("content", "hello ") == [{"content": "hello "}]
+    assert t.feed("content", "world") == [{"content": "world"}]
+    assert t.finish() == []
+
+
+def test_pure_text_response():
+    """Text-only response with tools available: emit as content."""
+    t = _make()
+    out = t.feed("content", "Plain answer.")
+    assert {"content": "Plain answer."} in out
+    assert t.finish() == []
+    assert t.has_tool_calls is False
+
+
+def test_pure_tool_call_response_streamed_in_pieces():
+    """Tool-only response (the v0.2.0 happy path) still works after the patch."""
+    t = _make()
+    # Stream the marker in pieces so we exercise the prefix-hold path
+    assert t.feed("content", "<tool_") == []
+    assert t.feed("content", "call>\n<function=lookup>\n") == []
+    assert t.feed("content", "<parameter=q>\nhello\n</parameter>\n") == []
+    assert t.feed("content", "</function>\n</tool_call>") == []
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    # finish() should have emitted tool_calls deltas
+    assert any("tool_calls" in d for d in finish_deltas)
+
+
+# ---------- the NEW bug-fix coverage ----------
+
+def test_mixed_text_then_tool_call_in_one_chunk():
+    """Issue #20: model emits preamble text + tool_call in one chunk.
+    Old code emitted the entire chunk as content (markup leaked).
+    New code: emit preamble as content, switch to tool mode, parse correctly."""
+    t = _make()
+    out = t.feed(
+        "content",
+        "Let me search.\n<tool_call>\n<function=lookup>\n"
+        "<parameter=q>\nhello\n</parameter>\n</function>\n</tool_call>",
+    )
+    # Should have emitted the preamble as content
+    contents = [d["content"] for d in out if "content" in d]
+    assert "Let me search.\n" in "".join(contents)
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in d for d in finish_deltas), \
+        "tool_calls should be in deltas after finish()"
+
+
+def test_mixed_text_then_tool_call_streamed_in_pieces():
+    """Same as above but with the marker arriving in a separate chunk
+    (verifies the partial-marker hold logic in content mode)."""
+    t = _make()
+    deltas_a = t.feed("content", "I will investigate. ")
+    # Preamble emits as content
+    assert any(d.get("content") == "I will investigate. " for d in deltas_a)
+    # Now the marker arrives
+    deltas_b = t.feed("content", "<tool_call>\n<function=lookup>\n"
+                                 "<parameter=q>\ny\n</parameter>\n"
+                                 "</function>\n</tool_call>")
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in d for d in finish_deltas)
+
+
+def test_partial_marker_held_across_chunks_in_content_mode():
+    """If text + partial marker arrive together, the partial bytes must be
+    held so the marker can complete on the next chunk."""
+    t = _make()
+    out_a = t.feed("content", "preamble<tool_ca")
+    contents_a = [d["content"] for d in out_a if "content" in d]
+    # 'preamble' should be emitted, '<tool_ca' should be held
+    assert "preamble" in "".join(contents_a)
+    assert not any("<tool_ca" in c for c in contents_a)
+
+    # Complete the marker
+    out_b = t.feed("content", "ll>\n<function=lookup>\n"
+                              "<parameter=q>\ny\n</parameter>\n"
+                              "</function>\n</tool_call>")
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in d for d in finish_deltas)
+
+
+def test_lookalike_marker_prefix_in_content_does_not_block_emission():
+    """Text containing chars that look like marker bytes but cannot complete
+    must eventually be emitted, not held forever."""
+    t = _make()
+    out = t.feed("content", "this is text with <html tag>")
+    # The trailing "<" might briefly be held but a follow-up that disambiguates
+    # should release it. In a single-chunk feed, the held tail is "<" because
+    # "<" is a prefix of "<tool_call". Subsequent text resolves it.
+    out_next = t.feed("content", " and more text")
+    # By the end of these two feeds, all the content text should have been emitted
+    contents = [d["content"] for d in out + out_next if "content" in d]
+    full = "".join(contents)
+    assert "this is text with <html tag>" in full
+    # No tool_calls
+    assert t.finish() == []
+    assert t.has_tool_calls is False
+
+
+def test_marker_split_across_three_chunks_after_text():
+    """`text` then `<tool_` then `call>...` - exercises the held-suffix path
+    multiple times across content-mode feeds."""
+    t = _make()
+    a = t.feed("content", "hello ")
+    b = t.feed("content", "<tool_")
+    c = t.feed("content", "call>\n<function=lookup>\n"
+                          "<parameter=q>\ny\n</parameter>\n"
+                          "</function>\n</tool_call>")
+    finish_deltas = t.finish()
+    contents = [d["content"] for d in (a + b + c) if "content" in d]
+    assert "hello " in "".join(contents)
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in d for d in finish_deltas)
+
+
+def test_leading_whitespace_before_marker_still_dropped():
+    """Existing behaviour: a tool-only response with leading whitespace
+    drops the whitespace (it isn't content). Make sure the patch preserves
+    this for the tool-only happy path."""
+    t = _make()
+    out = t.feed(
+        "content",
+        "\n\n<tool_call>\n<function=lookup>\n"
+        "<parameter=q>\nhello\n</parameter>\n</function>\n</tool_call>",
+    )
+    contents = [d["content"] for d in out if "content" in d]
+    # No whitespace-only content should leak (was dropped in original undecided path)
+    assert all(c.strip() for c in contents) or contents == []
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in d for d in finish_deltas)


### PR DESCRIPTION
# Fix: handle mixed text + `<tool_call>` responses in streaming translator

Closes #20.

## Summary

`_ToolAwareContentStreamTranslator.feed()` locked into `mode="content"` the moment it saw a non-`<tool_call>` byte and never re-examined the stream for tool-call markers afterward. As a result, any response shaped like:

```
Let me investigate this systematically.

<tool_call>
<function=grep>
<parameter=pattern>foo</parameter>
</function>
</tool_call>
```

was emitted entirely as `delta.content` text - the `<tool_call>` markup leaked through verbatim. OpenAI-compatible clients (opencode, Aider, Claude Code) saw zero `delta.tool_calls` chunks, so no tools were dispatched and the agent loop exited without doing any work.

This is the same regression captured in #20 with reproduction evidence.

## What this PR changes

- `mtplx/server/openai.py`: in the streaming translator, both `undecided` and `content` modes now scan the pending buffer for `<tool_call>` markers. When a marker is found, any preceding text is emitted as content first, then the translator transitions to `tool` mode and the tool block is parsed normally. Partial markers spanning multiple stream chunks are held back at the tail of the buffer so they can complete on the next chunk instead of being prematurely emitted as text.
- `tests/test_tool_aware_stream_translator.py`: 9 new unit tests covering:
  - tool-only responses (existing happy path - regression coverage)
  - pure text responses
  - mixed text + tool_call in one chunk
  - mixed text + tool_call streamed in pieces
  - partial-marker bytes held across chunks in content mode
  - lookalike `<` chars that don't actually start a marker
  - marker split across three chunks after preamble text
  - leading whitespace before marker still dropped (preserves original behaviour)

## Why I'm confident this isn't a regression for the existing happy path

The two pre-existing behaviours are preserved verbatim:

1. **Tool-only responses** (e.g. `<tool_call>...</tool_call>`): the translator still finds the marker at index 0 in the very first feed and switches to `tool` mode immediately. The marker-prefix-hold path for streamed-in-pieces markers (`<tool_` → `call>...`) still works because `undecided` mode keeps holding bytes when the lstripped pending is a prefix of `<tool_call`.
2. **Pure text responses** (no marker ever): the translator transitions into `content` mode after deciding the lstripped pending is not a marker prefix, then emits each chunk - same as before. The new partial-marker-tail logic in `content` mode only holds bytes that *could* be the start of a marker, which is conservative: when the next chunk arrives and disambiguates, the held bytes are emitted normally.

All 4 existing test files that touch the tool-call / streaming code (`test_server_openai.py`, `test_openai_bridge.py`, `test_session_bank.py`, plus the new test file) still pass: 69/69 tests green.

## Diff size

- `mtplx/server/openai.py`: +71 / -14 lines (one method body rewritten, one helper added)
- `tests/test_tool_aware_stream_translator.py`: ~120 lines, 9 tests
- `CHANGELOG.md`: 1 Unreleased entry

## Local verification

- Reproduces the issue on the unpatched v0.2.0 with a Qwen3.6 27B model and the captured assistant payload.
- After the patch: same payload yields one `delta.content` chunk for the preamble + correct `delta.tool_calls` chunks for the tool blocks. opencode dispatches the tools and the agent loop continues.

## Notes

- This patch only addresses the **streaming** path. The non-streaming `_parse_generated_tool_calls` already finds tool_call blocks anywhere in the buffer (it uses regex search, not anchored match), so it isn't affected.
- The patch does NOT change behaviour for trailing text *after* a tool_call block (still raises `_tool_protocol_error("text after tool_call block")` per the existing contract). That's a separate question.
