### PR TITLE
Fix subagent SessionBank caching: idle postcommit + tools plumbing + cross-thread MLX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ All notable user-facing changes are recorded here.
   mode for `<tool_call>` markers (with proper handling of partial markers
   spanning multiple stream chunks). Tool-only responses and pure-text
   responses are unchanged. Closes #20.
+- Fixed `_schedule_idle_postcommit_snapshot` so it commits SessionBank
+  snapshots for back-to-back subagent fan-out workloads. Previously the
+  async path waited for `state.has_foreground()` to clear, which in
+  OpenAI-compatible agent clients (opencode, Aider) with multiple
+  subagents never happens - the parent dispatches the next subagent
+  request within milliseconds of the previous response completing, so
+  the 30-second idle deadline always expired and the snapshot was
+  abandoned with `foreground_busy_past_deadline`. Subagent sessions
+  therefore never accumulated a bank entry and paid full cold prefill on
+  every turn (cached_tokens=0) even with a stable session_id. The async
+  path now retries the existing non-blocking lock acquire inside
+  `_store_retokenized_history_snapshot` (which is the real correctness
+  gate) until either the snapshot stores or the deadline expires. Live
+  verification with opencode's researcher/planner/fixer/bug-patcher
+  subagents shows non-zero per-session bytes and growing `cached_tokens`
+  across turns of the same session id.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ All notable user-facing changes are recorded here.
   verification with opencode's researcher/planner/fixer/bug-patcher
   subagents shows non-zero per-session bytes and growing `cached_tokens`
   across turns of the same session id.
+- Fixed postcommit retokenization to encode the synthetic history with
+  the same `tools=` argument that produced the request's prompt.
+  `_history_ids_for_postcommit` and `_store_retokenized_history_snapshot`
+  previously called `_encode_messages` without `tools=`, while the next
+  request's prompt was built with `tools=tool_specs`. The Qwen3.6 chat
+  template injects tool definitions into the system message, so the
+  stored snapshot's tokens diverged from the next prompt at the system
+  boundary and SessionBank lookups failed with
+  `cache_miss_reason=prefix_divergence_at_token` even when the snapshot
+  successfully stored. `tool_specs` (gated by the same `tools_active`
+  flag used to build `prompt_ids`) now flows through every postcommit
+  pathway: the sync compatibility check, the sync retokenized commit,
+  and the async idle postcommit. The stored snapshot now reproduces the
+  exact prefix the next request will send, so subsequent turns of a
+  tool-using session reach the cached entry instead of cold-prefilling.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ All notable user-facing changes are recorded here.
   and the async idle postcommit. The stored snapshot now reproduces the
   exact prefix the next request will send, so subsequent turns of a
   tool-using session reach the cached entry instead of cold-prefilling.
+- Fixed cross-thread MLX state issue when a SessionBank entry committed by
+  the async idle postcommit was later restored on a foreground request.
+  PR #17 (v0.2.0) introduced a dedicated `postcommit_executor` thread to
+  keep snapshot work off the foreground latency path, but MLX streams on
+  Apple Silicon are thread-local: a cache buffer created on the
+  postcommit thread cannot be read from the generation thread, so the
+  restore raised `RuntimeError: There is no Stream(gpu, N) in current
+  thread` and the response failed with HTTP 500. The bug was latent
+  through v0.2.0 because prefix divergence (see prior entry) was masking
+  every cache hit; once the prefix-divergence fix made lookups succeed,
+  every cache restore crashed. The async postcommit now submits to
+  `state.generation_executor` (matching v0.1.6 behaviour, which did not
+  have this issue) so cache buffers are created on the same thread that
+  will later restore them. The non-blocking lock acquire inside
+  `_store_retokenized_history_snapshot` already ensures the postcommit
+  yields when foreground actually wants the lock, so queueing on
+  `generation_executor` does not introduce foreground latency in
+  practice.
 
 ## v0.2.0
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2529,10 +2529,15 @@ def _schedule_idle_postcommit_snapshot(
     The retokenized-history path canonicalises tool_call responses into the
     exact prefix the next request will send, so the commit is safe - it just
     must not run on the request thread (would extend stream latency). This
-    function dispatches that work to the postcommit executor, where it waits
-    for the foreground to go idle and then runs the synchronous retokenized
-    commit. If the foreground stays busy past the deadline we abandon, since
-    a later commit would race the next turn's prefill.
+    function dispatches that work to the postcommit executor, which then
+    repeatedly attempts the retokenized commit using the existing
+    non-blocking model-lock acquire inside `_store_retokenized_history_snapshot`
+    as the correctness gate. If the lock is held by a foreground prefill we
+    sleep briefly and retry; if the lock stays held past the deadline we
+    abandon, since a later commit would race the next turn's prefill. Any
+    non-recoverable result (no_session_id, empty_boundary_prefix,
+    sessionbank_snapshot_skipped, or a successful store) is logged and
+    returned immediately without retrying.
     """
     pending = {
         "stored": False,
@@ -2564,39 +2569,57 @@ def _schedule_idle_postcommit_snapshot(
     def async_postcommit() -> None:
         deadline = time.monotonic() + _IDLE_POSTCOMMIT_MAX_WAIT_S
         try:
-            # Wait for the foreground request to release the model. We poll
-            # both the foreground flag and the model lock; if either is held
-            # the next prefill is imminent or already running and committing
-            # now would either stall it or race it. We bound the wait so a
-            # back-pressured server never accumulates a backlog of stale
-            # commit work.
-            while state.has_foreground() or state.lock.locked():
+            # Loop until either the snapshot stores, a non-recoverable result
+            # comes back, or the deadline expires. The non-blocking lock
+            # acquire inside `_store_retokenized_history_snapshot` is the
+            # real correctness gate - if a foreground prefill holds the
+            # model lock, the helper fails fast with
+            # "model_lock_busy_before_retokenized_commit" and the
+            # background work never delays the foreground request. We do
+            # NOT gate on `state.has_foreground()`: in OpenAI-compatible
+            # subagent fan-out (opencode researcher / planner / fixer /
+            # bug-patcher) the parent re-dispatches the next request within
+            # milliseconds of the previous response completing, so the
+            # foreground flag never clears - waiting on it caused every
+            # subagent's snapshot to be abandoned and the SessionBank to
+            # stay empty for those session ids.
+            while True:
+                postcommit = _store_retokenized_history_snapshot(
+                    state,
+                    session_id=session_id,
+                    messages=messages,
+                    assistant_content=assistant_content,
+                    assistant_tool_calls=assistant_tool_calls,
+                    thinking_enabled=thinking_enabled,
+                    policy_fingerprint=policy_fingerprint,
+                    acquire_model_lock_blocking=False,
+                )
+
+                if postcommit.get("stored"):
+                    _log(postcommit)
+                    return
+
+                if (
+                    postcommit.get("reason")
+                    != "model_lock_busy_before_retokenized_commit"
+                ):
+                    # Non-recoverable result (no_session_id,
+                    # empty_boundary_prefix, sessionbank_snapshot_skipped,
+                    # etc.) - retrying will not help.
+                    _log(postcommit)
+                    return
+
                 if time.monotonic() >= deadline:
                     _log(
                         {
                             "stored": False,
                             "mode": "abandoned_foreground_busy",
-                            "reason": "foreground_busy_past_deadline",
+                            "reason": "model_lock_busy_past_deadline",
                         }
                     )
                     return
-                time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
 
-            # Foreground is idle. Run the canonical retokenized commit with a
-            # non-blocking lock acquire, so a foreground request that wins the
-            # race after the idle check is never delayed by background cache
-            # maintenance.
-            postcommit = _store_retokenized_history_snapshot(
-                state,
-                session_id=session_id,
-                messages=messages,
-                assistant_content=assistant_content,
-                assistant_tool_calls=assistant_tool_calls,
-                thinking_enabled=thinking_enabled,
-                policy_fingerprint=policy_fingerprint,
-                acquire_model_lock_blocking=False,
-            )
-            _log(postcommit)
+                time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
         except BaseException as exc:
             _log(
                 {

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2639,10 +2639,17 @@ def _schedule_idle_postcommit_snapshot(
                 }
             )
 
-    executor = getattr(state, "postcommit_executor", None)
-    if executor is None:
-        executor = state.generation_executor
-    executor.submit(async_postcommit)
+    # Route through generation_executor instead of a separate postcommit
+    # thread. MLX streams on Apple Silicon are thread-local, so a SessionBank
+    # entry created on one thread cannot be restored from another - the
+    # restore path raises "There is no Stream(gpu, N) in current thread".
+    # PR #17 introduced a dedicated postcommit_executor to keep this work off
+    # the foreground latency path, but in practice the non-blocking lock
+    # acquire inside _store_retokenized_history_snapshot already guarantees
+    # the postcommit yields when foreground actually wants to run, and
+    # queueing on generation_executor is the v0.1.6 behaviour that did not
+    # have this cross-thread issue.
+    state.generation_executor.submit(async_postcommit)
     return pending
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2222,6 +2222,7 @@ def _store_retokenized_history_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     acquire_model_lock_blocking: bool = True,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
@@ -2238,6 +2239,7 @@ def _store_retokenized_history_snapshot(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
     history_ids = encoded_with_sentinel
     if not history_ids:
@@ -2310,6 +2312,7 @@ def _history_ids_for_postcommit(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> list[int]:
     history_messages = list(messages) + [
         ChatMessage(
@@ -2324,6 +2327,7 @@ def _history_ids_for_postcommit(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
 
 
@@ -2336,6 +2340,7 @@ def _generation_final_postcommit_compatibility(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if assistant_tool_calls:
         return {
@@ -2387,6 +2392,7 @@ def _generation_final_postcommit_compatibility(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if history_ids == final_token_ids:
         return {
@@ -2432,6 +2438,7 @@ def _store_generation_final_history_snapshot(
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
     policy_fingerprint: str,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "mode": "unsafe", "reason": "no_session_id"}
@@ -2444,6 +2451,7 @@ def _store_generation_final_history_snapshot(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if not bool(compatibility.get("safe")):
         return {
@@ -2520,6 +2528,7 @@ def _schedule_idle_postcommit_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     unsafe_reason: str,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Schedule a background SessionBank commit for a response the
     generation-final compatibility check rejected as unsafe (most commonly
@@ -2593,6 +2602,7 @@ def _schedule_idle_postcommit_snapshot(
                     thinking_enabled=thinking_enabled,
                     policy_fingerprint=policy_fingerprint,
                     acquire_model_lock_blocking=False,
+                    tool_specs=tool_specs,
                 )
 
                 if postcommit.get("stored"):
@@ -5351,6 +5361,7 @@ def create_app(state: ServerState) -> FastAPI:
                 assistant_content=assistant_content,
                 assistant_tool_calls=assistant_tool_calls,
                 thinking_enabled=thinking_enabled,
+                tool_specs=tool_specs if tools_active else None,
             )
             if compatibility.get("safe"):
                 generated["stats"]["session_postcommit_snapshot"] = {
@@ -5383,6 +5394,7 @@ def create_app(state: ServerState) -> FastAPI:
                         thinking_enabled=thinking_enabled,
                         policy_fingerprint=policy_fingerprint,
                         unsafe_reason=unsafe_reason,
+                        tool_specs=tool_specs if tools_active else None,
                     )
                 )
                 return
@@ -5397,6 +5409,7 @@ def create_app(state: ServerState) -> FastAPI:
                     assistant_tool_calls=assistant_tool_calls,
                     thinking_enabled=thinking_enabled,
                     policy_fingerprint=policy_fingerprint,
+                    tool_specs=tool_specs if tools_active else None,
                 ),
             )
             generated["stats"]["session_postcommit_snapshot"] = postcommit
@@ -5539,6 +5552,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                     else:
                                         postcommit = _store_generation_final_history_snapshot(
@@ -5551,6 +5565,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                         if not postcommit.get("stored"):
                                             generated["stats"][
@@ -5899,6 +5914,7 @@ def create_app(state: ServerState) -> FastAPI:
                                         unsafe_reason=str(
                                             postcommit.get("reason") or "unsafe_history"
                                         ),
+                                        tool_specs=tool_specs if tools_active else None,
                                     )
                                 else:
                                     yield mark_sse_sent(

--- a/tests/integration_smoke_cache_hit.sh
+++ b/tests/integration_smoke_cache_hit.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Integration smoke test: prove the tools-plumbing fix delivers cached>0
+# on the second turn of a session that uses tool definitions.
+#
+# Background: pre-fix the postcommit pathways encoded the synthetic
+# history WITHOUT `tools=`, while the next request encoded its prompt
+# WITH `tools=tool_specs`. The Qwen3.6 chat template injects tool
+# definitions into the system message, so the stored snapshot's tokens
+# diverged from the next prompt at the system boundary - SessionBank
+# lookups failed with `cache_miss_reason=prefix_divergence_at_token`.
+#
+# This script:
+#   1. Starts a unique session_id (one per run).
+#   2. Issues turn 1 with a `tools=[...]` array and a simple user message.
+#   3. Sleeps to let the async postcommit settle.
+#   4. Issues turn 2 with the same tools, a synthetic assistant tool_call
+#      reply, plus a new user message.
+#   5. Parses the SSE stream for the final chunk's `mtplx_stats` and
+#      reports PASS if `cached_tokens > 0`, FAIL otherwise.
+#
+# Usage:
+#   ./tests/integration_smoke_cache_hit.sh                # default port 8088
+#   MTPLX_HOST=http://127.0.0.1:8088 ./tests/integration_smoke_cache_hit.sh
+#
+# IMPORTANT: hits MTPLX directly, NOT the dashboard at 9099 (the
+# dashboard proxy may strip `x-mtplx-session-id`).
+
+set -euo pipefail
+
+HOST="${MTPLX_HOST:-http://127.0.0.1:8088}"
+SESSION_ID="smoke-cache-hit-$(date +%s)-$$"
+SLEEP_S="${SMOKE_SLEEP_S:-12}"
+
+echo "[smoke] host=${HOST}"
+echo "[smoke] session_id=${SESSION_ID}"
+echo "[smoke] inter-turn sleep=${SLEEP_S}s"
+echo
+
+TOOLS_JSON='[
+  {
+    "type": "function",
+    "function": {
+      "name": "grep",
+      "description": "Search files for a pattern",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {"type": "string"},
+          "path": {"type": "string"}
+        },
+        "required": ["pattern"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "read_file",
+      "description": "Read file contents",
+      "parameters": {
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"]
+      }
+    }
+  }
+]'
+
+TURN1_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."}
+  ]
+}
+EOF
+)
+
+TURN2_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."},
+    {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [{
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "grep", "arguments": "{\"pattern\":\"session_bank\"}"}
+      }]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_1",
+      "content": "mtplx/session_bank.py:1:class SessionBank: ..."
+    },
+    {"role": "user", "content": "Now read the first matching file."}
+  ]
+}
+EOF
+)
+
+TMPDIR_SMOKE=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_SMOKE}"' EXIT
+
+echo "[smoke] turn 1 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN1_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn1.sse"
+
+echo "[smoke] turn 1 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn1.sse")"
+
+# Pull the session_postcommit_snapshot from turn 1 (best-effort).
+PC1=$(grep -o '"session_postcommit_snapshot":[^}]*}' "${TMPDIR_SMOKE}/turn1.sse" | tail -1 || true)
+echo "[smoke] turn 1 postcommit: ${PC1:-<not present>}"
+
+echo "[smoke] sleeping ${SLEEP_S}s for async postcommit to settle..."
+sleep "${SLEEP_S}"
+
+echo "[smoke] turn 2 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN2_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn2.sse"
+
+echo "[smoke] turn 2 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn2.sse")"
+
+# The stats are emitted on the final chunk as `mtplx_stats`. Pull the
+# last occurrence of cached_tokens / cache_miss_reason from the stream.
+CACHED=$(grep -o '"cached_tokens":[ ]*[0-9]\+' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 | grep -o '[0-9]\+' || true)
+MISS=$(grep -o '"cache_miss_reason":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+RESTORE=$(grep -o '"session_restore_mode":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+HIT=$(grep -o '"session_cache_hit":[ ]*\(true\|false\)' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+
+echo
+echo "[smoke] turn 2 cached_tokens   = ${CACHED:-<missing>}"
+echo "[smoke] turn 2 cache_miss_reason = ${MISS:-<missing>}"
+echo "[smoke] turn 2 session_restore_mode = ${RESTORE:-<missing>}"
+echo "[smoke] turn 2 session_cache_hit    = ${HIT:-<missing>}"
+echo
+echo "[smoke] (raw turn 2 SSE saved at ${TMPDIR_SMOKE}/turn2.sse - inspect if PASS/FAIL is unclear)"
+# Persist the artifacts to a stable path for the user to inspect after
+# the script exits if needed. (Pre-trap.)
+DEST="/tmp/mtplx-smoke-cache-hit-${SESSION_ID}"
+mkdir -p "${DEST}"
+cp "${TMPDIR_SMOKE}/turn1.sse" "${DEST}/turn1.sse"
+cp "${TMPDIR_SMOKE}/turn2.sse" "${DEST}/turn2.sse"
+echo "[smoke] artifacts copied to ${DEST}/"
+
+if [[ -n "${CACHED}" && "${CACHED}" -gt 0 ]]; then
+  echo "[smoke] PASS - cached_tokens=${CACHED} on turn 2 (session_id=${SESSION_ID})"
+  exit 0
+else
+  echo "[smoke] FAIL - turn 2 was cold (cached_tokens=${CACHED:-0}, miss_reason=${MISS})"
+  exit 1
+fi

--- a/tests/test_idle_postcommit_subagent.py
+++ b/tests/test_idle_postcommit_subagent.py
@@ -1,0 +1,230 @@
+"""Regression tests for `_schedule_idle_postcommit_snapshot`.
+
+The async path used to gate on `state.has_foreground()` clearing before it
+ran the retokenized commit. In OpenAI-compatible subagent fan-out (opencode
+researcher / planner / fixer / bug-patcher) the parent re-dispatches the
+next request within milliseconds of the previous response completing, so
+the foreground flag never clears - every subagent's snapshot was abandoned
+with `foreground_busy_past_deadline` and the SessionBank never accumulated
+an entry for those session ids.
+
+These tests cover the post-fix behaviour: the async path now retries the
+existing non-blocking lock acquire inside `_store_retokenized_history_snapshot`
+(which is the real correctness gate) until either the snapshot stores or
+the deadline expires.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+
+
+def _fake_subagent_state(*, foreground_always: bool = False):
+    """Build the minimum stub needed for `_schedule_idle_postcommit_snapshot`.
+
+    `foreground_always=True` simulates the opencode subagent regression:
+    `state.has_foreground()` returns True for the entire test, which under
+    the old code blocked the retokenized commit indefinitely.
+    """
+    foreground_lock = threading.Lock()
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    return SimpleNamespace(
+        lock=foreground_lock,
+        has_foreground=has_foreground,
+        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        # Console disabled so `_log` exercises the print branch (and stays
+        # silent under pytest's captured stdout).
+        args=SimpleNamespace(server_console=False),
+    )
+
+
+def _wait_for_executor_drain(state, *, timeout_s: float = 5.0) -> None:
+    """Shut the executor down (waiting for the submitted task to finish).
+
+    Using `executor.shutdown(wait=True)` gives us a deterministic point
+    after which `_log` has already been called for the submitted job.
+    """
+    state.postcommit_executor.shutdown(wait=True)
+    _ = timeout_s  # symmetric with similar helpers; kept for readability.
+
+
+def _kwargs_for_schedule():
+    return dict(
+        session_id="opencode-researcher",
+        messages=[],
+        assistant_content="<tool_call>...</tool_call>",
+        assistant_tool_calls=[{"name": "grep", "arguments": "{}"}],
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+
+
+def test_idle_postcommit_stores_when_lock_briefly_free(monkeypatch):
+    """Happy path: even if `has_foreground()` says True, a successful store
+    on the first non-blocking lock acquire ends the loop and is logged.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+
+    _wait_for_executor_drain(state)
+
+    assert pending == {
+        "stored": False,
+        "mode": "async_pending",
+        "reason": "retokenized_history_mismatch",
+    }
+    assert len(calls) == 1
+    assert calls[0]["session_id"] == "opencode-researcher"
+    assert calls[0]["acquire_model_lock_blocking"] is False
+
+
+def test_idle_postcommit_retries_until_deadline_under_lock_busy(monkeypatch):
+    """If the lock stays busy the entire deadline, the loop logs
+    `model_lock_busy_past_deadline` and returns - it does NOT spin
+    forever.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    log_lines: list[dict] = []
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
+
+    def capture_console_disabled(_state):
+        # Keep `_log` going through the print branch so we know the
+        # function reached the deadline-abandon log line. We also
+        # monkeypatch the print in the real module so we can inspect.
+        return False
+
+    real_print = openai.print if hasattr(openai, "print") else print
+
+    def captured_print(message, *_args, **_kwargs):
+        # Lines are formatted as
+        # `[mtplx] idle async session postcommit {json...}`.
+        prefix = "[mtplx] idle async session postcommit "
+        if isinstance(message, str) and message.startswith(prefix):
+            import json
+
+            log_lines.append(json.loads(message[len(prefix):]))
+        else:
+            real_print(message, *_args, **_kwargs)
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", capture_console_disabled)
+    monkeypatch.setattr("builtins.print", captured_print)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert pending["mode"] == "async_pending"
+    # Loop should retry many times under the 0.5s deadline / 0.05s poll
+    # interval (we expect ~10 calls; allow generous slack for CI jitter).
+    assert call_count["n"] >= 3, f"expected several retries, got {call_count['n']}"
+    assert elapsed < 5.0, f"loop ran too long: {elapsed:.2f}s"
+    # We must see exactly one terminal log line declaring the deadline
+    # abandon, and crucially the reason must be the new one.
+    assert log_lines, "expected at least one log line"
+    last = log_lines[-1]
+    assert last["mode"] == "abandoned_foreground_busy"
+    assert last["reason"] == "model_lock_busy_past_deadline"
+    assert last["session_id"] == "opencode-researcher"
+
+
+def test_idle_postcommit_returns_immediately_on_non_recoverable_failure(monkeypatch):
+    """`no_session_id` (and similar non-retryable errors) must short-circuit
+    the loop after exactly one call - retrying will not help.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {"stored": False, "reason": "no_session_id"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Use a long deadline so a buggy implementation that DID retry would
+    # show up as call_count["n"] > 1.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 5.0)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.01)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+
+    assert call_count["n"] == 1
+
+
+def test_idle_postcommit_no_longer_blocks_on_has_foreground(monkeypatch):
+    """Regression test: even if `state.has_foreground()` returns True for
+    the entire duration of the test, the snapshot must still be stored.
+
+    Pre-fix this scenario was the bug - the loop would spin on
+    `has_foreground()` until the 30s deadline expired without ever calling
+    `_store_retokenized_history_snapshot`.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 8,
+            "nbytes": 64,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Force tight bounds so a regression to the old wait-on-foreground
+    # code would time out and the snapshot would NOT be stored.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert calls, "snapshot must be attempted even when has_foreground() is True"
+    assert len(calls) == 1
+    assert elapsed < 1.0, (
+        f"snapshot ran too long ({elapsed:.2f}s) - did the loop fall back to "
+        "the deprecated has_foreground() wait?"
+    )

--- a/tests/test_idle_postcommit_subagent.py
+++ b/tests/test_idle_postcommit_subagent.py
@@ -39,7 +39,7 @@ def _fake_subagent_state(*, foreground_always: bool = False):
     return SimpleNamespace(
         lock=foreground_lock,
         has_foreground=has_foreground,
-        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        generation_executor=ThreadPoolExecutor(max_workers=1),
         # Console disabled so `_log` exercises the print branch (and stays
         # silent under pytest's captured stdout).
         args=SimpleNamespace(server_console=False),
@@ -52,7 +52,7 @@ def _wait_for_executor_drain(state, *, timeout_s: float = 5.0) -> None:
     Using `executor.shutdown(wait=True)` gives us a deterministic point
     after which `_log` has already been called for the submitted job.
     """
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
     _ = timeout_s  # symmetric with similar helpers; kept for readability.
 
 

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -346,13 +346,15 @@ def test_idle_async_postcommit_attempts_commit_for_tool_call_responses(
     assert '"stored": true' in log
 
 
-def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
+def test_idle_async_postcommit_abandons_when_model_lock_stays_busy(
     capsys, monkeypatch
 ):
-    """If the foreground never goes idle, the async commit must abandon
-    rather than block forever."""
+    """If the model lock never frees, the async commit must abandon
+    rather than block forever. The loop now drives the
+    non-blocking-acquire inside `_store_retokenized_history_snapshot`
+    as the correctness gate (has_foreground is no longer consulted)."""
     state = _postcommit_state()
-    state.has_foreground = lambda: True  # always busy
+    state.has_foreground = lambda: True  # always busy (intentionally ignored)
 
     # Make the wait short so the test stays fast.
     monkeypatch.setattr(
@@ -362,15 +364,19 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
         "mtplx.server.openai._IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05
     )
 
-    called = []
+    called: list[dict] = []
 
-    def should_not_be_called(state, **kwargs):
+    def fake_store_lock_busy(state, **kwargs):
         called.append(kwargs)
-        return {"stored": True}
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
 
     monkeypatch.setattr(
         "mtplx.server.openai._store_retokenized_history_snapshot",
-        should_not_be_called,
+        fake_store_lock_busy,
     )
 
     pending = _schedule_idle_postcommit_snapshot(
@@ -384,10 +390,13 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
     )
 
     assert pending["mode"] == "async_pending"
-    assert called == []
+    # The loop must actually try the retokenized commit (and retry under
+    # `model_lock_busy_before_retokenized_commit`) - the old behavior of
+    # silently skipping on has_foreground would leave called == [].
+    assert called, "loop must attempt the commit even if has_foreground() is True"
     log = capsys.readouterr().out
     assert "abandoned_foreground_busy" in log
-    assert "foreground_busy_past_deadline" in log
+    assert "model_lock_busy_past_deadline" in log
 
 
 def test_server_security_requires_api_key_for_non_localhost_bind():

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -1,0 +1,428 @@
+"""Regression tests for tool_specs plumbing through the postcommit path.
+
+The next-turn prompt is encoded with `tools=tool_specs` so the chat
+template injects tool definitions into the system message. Pre-fix the
+postcommit pathways (`_history_ids_for_postcommit`,
+`_store_retokenized_history_snapshot`, `_schedule_idle_postcommit_snapshot`)
+encoded the synthetic history WITHOUT `tools=`, which produced a token
+sequence that no longer matched the next prompt's prefix - SessionBank
+lookups failed with `cache_miss_reason=prefix_divergence_at_token` even
+when the snapshot itself stored successfully.
+
+These tests cover:
+
+1. The reachable-prefix invariant: storing a snapshot for messages M
+   plus tools T produces a token sequence that is a STRICT prefix of
+   the next prompt encoded from M' (M with one new appended user
+   message) plus the same tools T.
+2. The async idle-postcommit path forwards tool_specs through to
+   `_store_retokenized_history_snapshot` so the stored sequence
+   contains the tool-definition tokens.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from threading import Lock
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+from mtplx.server.openai import (
+    ChatMessage,
+    _encode_messages,
+    _history_ids_for_postcommit,
+    _schedule_idle_postcommit_snapshot,
+    _store_retokenized_history_snapshot,
+    parse_args,
+)
+
+
+def _ids(text: str) -> list[int]:
+    return [ord(ch) for ch in text]
+
+
+class ToolAwareTokenizer:
+    """A tiny tokenizer that mimics Qwen-style tool-definition injection.
+
+    When `tools=` is passed to `apply_chat_template`, tool definitions are
+    serialised into a synthetic system message prefix. This produces a
+    DIFFERENT, LONGER token sequence than encoding without `tools=` -
+    matching the real-world Qwen3.6 chat template behaviour that triggered
+    `prefix_divergence_at_token`.
+    """
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        tools=None,
+        **_kwargs,
+    ):
+        assert tokenize is True
+        text = ""
+        if tools:
+            # Serialise each tool spec into a deterministic prefix so the
+            # tokens are stable across calls and clearly larger than the
+            # no-tools encoding.
+            tool_lines = ["<tools>"]
+            for spec in tools:
+                fn = spec.get("function") or spec
+                name = fn.get("name") or spec.get("name") or "fn"
+                tool_lines.append(f"<tool name={name}/>")
+            tool_lines.append("</tools>")
+            text += "\n".join(tool_lines) + "\n"
+        text += "\n".join(
+            f"{message['role']}:{message.get('content') or ''}" for message in messages
+        )
+        if add_generation_prompt:
+            text = f"{text}\nassistant:" if text else "assistant:"
+        return _ids(text)
+
+    def encode(self, text, **_kwargs):
+        return _ids(str(text))
+
+    def decode(self, tokens, **_kwargs):
+        return "".join(chr(int(t)) for t in tokens)
+
+
+class RecordingBank:
+    def __init__(self) -> None:
+        self.puts: list[dict] = []
+
+    def put(self, **kwargs):
+        self.puts.append(kwargs)
+        return SimpleNamespace(
+            prefix_len=len(kwargs["token_ids"]),
+            nbytes=123,
+            token_hash="test-token-hash",
+        )
+
+
+def _postcommit_state(*, tokenizer=None):
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=Lock(),
+        generation_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        postcommit_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        has_foreground=lambda: False,
+        begin_foreground=lambda: None,
+        end_foreground=lambda: None,
+    )
+
+
+_TOOL_SPECS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "grep",
+            "description": "Search files",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        },
+    },
+]
+
+
+def test_history_ids_with_tools_is_strict_prefix_of_next_prompt():
+    """The reachable-prefix invariant.
+
+    If turn 1 stores a snapshot for `messages + assistant_response` with
+    `tool_specs=T`, then turn 2's prompt - encoded from the SAME messages
+    plus the assistant response plus a new user message, with the SAME
+    `tool_specs=T` and `add_generation_prompt=True` - must START with the
+    stored token sequence. Otherwise SessionBank's strict-prefix lookup
+    can never reach the snapshot.
+
+    Pre-fix `_history_ids_for_postcommit` did NOT pass `tools=`, so the
+    stored sequence diverged from the next prompt at the system-message
+    boundary (where the chat template injects tool definitions).
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    history_ids = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        tool_specs=_TOOL_SPECS,
+    )
+
+    # Turn 2: same conversation + assistant reply + new user turn, with
+    # the same tool_specs and add_generation_prompt=True (the real
+    # request path).
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids, "history_ids must not be empty"
+    assert len(history_ids) <= len(next_prompt_ids)
+    assert next_prompt_ids[: len(history_ids)] == history_ids, (
+        "stored history snapshot must be a strict token prefix of the "
+        "next-turn prompt; otherwise SessionBank lookups will diverge"
+    )
+
+
+def test_history_ids_without_tools_diverges_from_next_prompt_with_tools():
+    """The bug this fix addresses: pre-fix code stored history WITHOUT
+    `tools=` while the next prompt was encoded WITH `tools=`. Show that
+    the no-tools encoding is NOT a prefix of the with-tools next prompt.
+    This is the exact failure mode that produced
+    `cache_miss_reason=prefix_divergence_at_token`.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Pre-fix encoding (no tools) - what the old `_history_ids_for_postcommit`
+    # produced.
+    history_ids_no_tools = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        # tool_specs left as default None == pre-fix behaviour.
+    )
+
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids_with_tools = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids_no_tools, "history_ids must not be empty"
+    # The no-tools encoding is NOT a prefix of the with-tools next prompt
+    # - this is the divergence the fix targets.
+    assert (
+        next_prompt_ids_with_tools[: len(history_ids_no_tools)]
+        != history_ids_no_tools
+    ), (
+        "regression guard: encoding without tools must diverge from a "
+        "next prompt encoded with tools - this is the prefix_divergence_at_token "
+        "failure mode"
+    )
+
+
+def test_store_retokenized_history_snapshot_includes_tool_definition_tokens(
+    monkeypatch,
+):
+    """`_store_retokenized_history_snapshot` must encode the synthetic
+    history WITH `tools=` so the stored token sequence includes the
+    tool-definition tokens. Encoding the same messages without tools
+    produces a strictly shorter sequence.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Mock the runtime-heavy prefill/cache calls; we are validating
+    # ENCODING + bank.put(token_ids=...), not the runtime KV-cache path.
+    fake_prompt_state = SimpleNamespace(
+        trunk_cache="trunk-cache",
+        logits="logits",
+        hidden="hidden",
+        committed_mtp_cache=None,
+    )
+    monkeypatch.setattr(
+        openai,
+        "restore_or_prefill_prompt_state",
+        lambda *args, **kwargs: fake_prompt_state,
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda cache: None)
+
+    result = _store_retokenized_history_snapshot(
+        state,
+        session_id="test-session",
+        messages=messages,
+        assistant_content=assistant_content,
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        tool_specs=_TOOL_SPECS,
+    )
+
+    assert result["stored"] is True, result
+    assert state.sessions.bank.puts, "bank.put must be called"
+    stored_ids = state.sessions.bank.puts[0]["token_ids"]
+
+    # Encode the same history without tools and confirm the stored
+    # sequence is STRICTLY LONGER (has the tool-definition prefix).
+    history_messages_no_tools = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+    ]
+    no_tools_ids = _encode_messages(
+        state.runtime.tokenizer,
+        history_messages_no_tools,
+        enable_thinking=False,
+        add_generation_prompt=False,
+    )
+
+    assert len(stored_ids) > len(no_tools_ids), (
+        f"stored sequence ({len(stored_ids)} tokens) must be longer than "
+        f"the no-tools encoding ({len(no_tools_ids)} tokens) - the tool "
+        "definitions should add tokens"
+    )
+
+    # And it must be reachable as a prefix of the next-turn prompt.
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+    assert next_prompt_ids[: len(stored_ids)] == stored_ids
+
+
+def _async_state(*, foreground_always: bool = False, tokenizer=None):
+    """A more permissive state for async-path testing that exposes the
+    same surface as `_schedule_idle_postcommit_snapshot` expects."""
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=threading.Lock(),
+        has_foreground=has_foreground,
+        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        generation_executor=ThreadPoolExecutor(max_workers=1),
+    )
+
+
+def test_idle_postcommit_async_path_forwards_tool_specs(monkeypatch):
+    """The async idle path must forward `tool_specs` to
+    `_store_retokenized_history_snapshot`. Without the forwarding, the
+    stored sequence would diverge from the next prompt's prefix
+    (`prefix_divergence_at_token`).
+    """
+    state = _async_state(foreground_always=True)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="opencode-researcher",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+        tool_specs=_TOOL_SPECS,
+    )
+    state.postcommit_executor.shutdown(wait=True)
+
+    assert pending["mode"] == "async_pending"
+    assert len(captured) == 1
+    assert captured[0]["tool_specs"] == _TOOL_SPECS, (
+        "scheduled async commit must receive the same tool_specs that "
+        "produced the request's prompt; otherwise the stored snapshot "
+        "diverges from the next prompt's prefix"
+    )
+
+
+def test_idle_postcommit_default_tool_specs_is_none(monkeypatch):
+    """Backwards compat: the four pre-existing tests in
+    `test_idle_postcommit_subagent.py` do not pass `tool_specs`. Confirm
+    the default value remains `None` so the legacy callers see no
+    behaviour change.
+    """
+    state = _async_state(foreground_always=False)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {"stored": True, "mode": "retokenized_history"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="legacy-session",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+    state.postcommit_executor.shutdown(wait=True)
+
+    assert captured and captured[0]["tool_specs"] is None

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -387,7 +387,7 @@ def test_idle_postcommit_async_path_forwards_tool_specs(monkeypatch):
         unsafe_reason="retokenized_history_mismatch",
         tool_specs=_TOOL_SPECS,
     )
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
 
     assert pending["mode"] == "async_pending"
     assert len(captured) == 1
@@ -423,6 +423,6 @@ def test_idle_postcommit_default_tool_specs_is_none(monkeypatch):
         policy_fingerprint="policy",
         unsafe_reason="retokenized_history_mismatch",
     )
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
 
     assert captured and captured[0]["tool_specs"] is None


### PR DESCRIPTION
## Use case + testing context

This PR is driven by a real local agent workflow: running [opencode](https://github.com/sst/opencode) (an OpenAI-compatible coding agent) against a self-hosted MTPLX 0.2.0 server on Apple Silicon, with a parent agent that fans out to multiple subagents (researcher, planner, fixer, bug-patcher, build-doctor) on the same model. Each subagent has its own stable `session_id` (e.g. `opencode-researcher`, `opencode-planner`, etc.) so SessionBank prefix reuse should make repeated turns of the same subagent cheap.

In practice none of the subagent sessions ever hit the cache — every turn paid full cold prefill (15-150 s TTFT depending on context size). Investigating this is what surfaced the three bugs in this PR. The smoke script (`tests/integration_smoke_cache_hit.sh`) reproduces the failure mode synthetically with a 2-turn `tools=[...]` conversation, but the original observation came from real opencode subagent runs against MTPLX over hours of work.

The verification at the bottom of this PR is the same shape: synthetic 2-turn smoke for determinism + reproducibility, plus the live opencode subagent flow showing per-session bytes appearing in `/admin/sessions` and `cached_tokens > 0` on subsequent turns.

## Summary

Three related bugs prevented OpenAI-compatible subagent fan-out (opencode's researcher / planner / fixer / bug-patcher) from ever hitting the SessionBank cache. After this PR, subagent sessions accumulate bank entries, the next-turn lookup actually finds them, and the cache restore does not crash with a cross-thread MLX error. Live verification on Qwen3.6 27B shows `cached_tokens=379` and a 5x TTFT reduction on a back-to-back tool-using turn pair.

Three commits, ordered so each one's test failure is the next one's bug:

1. **`Fix idle postcommit for back-to-back subagent flows`** (e513114) — async postcommit was abandoning every snapshot.
2. **`Plumb tools through postcommit retokenization`** (c1c310b) — stored snapshots diverged from next-turn prompts.
3. **`Route async postcommit through generation_executor`** (3d9f200) — cross-thread MLX state crashed the restore.

## How the bugs interact

```
                  +---------------------+        +--------------------+
   request N --->| _store_retokenized   | put -> | SessionBank        |
                 |  history_snapshot    |        | (in-memory)        |
                 +---------------------+        +--------------------+
                          ^                              |
                          |                              | restore
                          |  scheduled by                v
                          |  _schedule_idle      +--------------------+
                          |  postcommit_snapshot |  request N+1       |
                          |                      |  (foreground gen)  |
                          |                      +--------------------+
   --- pre-fix ---
   bug 1: schedule waited for has_foreground() to clear; in subagent
          fan-out it never cleared -> abandon -> nothing in bank.
   bug 2: snapshot encoded with no tools=, but request N+1's prompt
          encodes WITH tools=tool_specs -> stored prefix diverged at
          the system message -> cache_miss_reason: prefix_divergence_at_token.
   bug 3: snapshot ran on a separate postcommit_executor thread, but
          MLX streams on Apple Silicon are thread-local -> request N+1's
          restore (on generation_executor thread) raised
          'There is no Stream(gpu, 3) in current thread' -> HTTP 500.
```

The bugs nested: bug 2 masked bug 3 (no successful restores -> no crashes), and bug 1 masked bug 2 (no entries stored -> no lookups to even diverge). Fixing them in order each surfaced the next one.

## Bug 1: idle postcommit abandoned in subagent fan-out

`_schedule_idle_postcommit_snapshot` (PR #17 / v0.2.0) is the async path for tool-call assistant responses that the synchronous postcommit refuses (`tool_call_history_rewrite`). It worked for the parent session of an OpenAI-compatible client but did NOT work for opencode's subagent sessions.

Pre-fix wait loop:

```python
while state.has_foreground() or state.lock.locked():
    if time.monotonic() >= deadline:
        _log({\"stored\": False, \"mode\": \"abandoned_foreground_busy\",
              \"reason\": \"foreground_busy_past_deadline\"})
        return
    time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
```

In opencode's fan-out the parent re-dispatches the next subagent within milliseconds of the previous response completing, so `has_foreground()` stays True for the whole pipeline. The 30s deadline expired every time and the snapshot was abandoned.

```
/admin/sessions BEFORE:
  3dworld-loop          344 MB stored   (parent — bank works)
  opencode-researcher     0 B           (subagent — bank empty)
  opencode-planner        0 B
  opencode-fixer          0 B
  opencode-bug-patcher    0 B
```

**Fix:** drop the `has_foreground()` gate and rely on the existing non-blocking lock acquire inside `_store_retokenized_history_snapshot` as the correctness gate. Retry every 250 ms until the deadline; abandon as `model_lock_busy_past_deadline` only if every retry loses the lock race.

After this commit alone, server logs confirm bytes are landing for subagent sessions (`stored:true ... session_id:opencode-researcher prefix_len:50183 nbytes:1932850544`).

## Bug 2: stored snapshots diverged from next-turn prompts at the system message

After bug 1 was fixed, every next turn still came back as a cache miss (`cached_tokens=0`). Server logs:

```
unsafe_reason:    stop_token_boundary_mismatch   (at commit time)
cache_miss_reason: prefix_divergence_at_token    (at lookup time)
```

The next request's prompt is encoded with `tools=tool_specs`:

```python
prompt_ids = _encode_messages(
    state.runtime.tokenizer,
    request.messages,
    enable_thinking=thinking_enabled,
    strip_assistant_reasoning_history=...,
    tools=tool_specs if tools_active else None,    # <-- tools included
)
```

But `_history_ids_for_postcommit` and `_store_retokenized_history_snapshot` called `_encode_messages` with no `tools=`. The Qwen3.6 chat template injects tool definitions into the system message, so the stored snapshot's tokens diverged from the next request's prompt at the system boundary. SessionBank's strict prefix-match lookup failed every time.

**Fix:** plumb `tool_specs` (gated by the same `tools_active` flag used to build `prompt_ids`) through every postcommit pathway:

- `_generation_final_postcommit_compatibility(..., tool_specs=...)`
- `_store_generation_final_history_snapshot(..., tool_specs=...)`
- `_store_retokenized_history_snapshot(..., tool_specs=...)`
- `_schedule_idle_postcommit_snapshot(..., tool_specs=...)`
- `_history_ids_for_postcommit(..., tool_specs=...)`

The stored snapshot now reproduces the exact prefix the next request will send.

## Bug 3: cross-thread MLX cache state (regression introduced by PR #17)

After bug 2 was fixed, every cache hit crashed with HTTP 500:

```
RuntimeError: There is no Stream(gpu, 3) in current thread.
```

PR #17 added a dedicated `postcommit_executor` thread to keep snapshot work off the foreground latency path. But MLX streams on Apple Silicon are thread-local — a cache buffer created on the postcommit thread cannot be read from the generation thread. The bug was latent through v0.2.0 because bug 2 was masking every cache hit; once bug 2 was fixed, every successful prefix match crashed the restore.

```
   --- before PR #17 (v0.1.6) ---     --- after PR #17 (v0.2.0+) ---
                                                     X (cross-thread restore fails)
   gen_thread:                        gen_thread:    ^
     turn N                             turn N       |
     (commit on same thread)            postcommit_thread:
     turn N+1                             commit on different thread
     (restore — same thread, OK)        gen_thread:
                                          turn N+1
                                          restore needs Stream(gpu,3)
                                          from postcommit_thread — gone
```

**Fix:** drop the separate executor and submit async postcommit to `state.generation_executor` (matching v0.1.6 behaviour). The non-blocking lock acquire from bug 1's fix already ensures the postcommit yields when foreground actually wants the lock, so queueing on `generation_executor` does not introduce foreground latency in practice.

## Live verification

### Unit tests

```
pytest tests/test_idle_postcommit_subagent.py \
       tests/test_postcommit_tools_plumbing.py \
       tests/test_openai_bridge.py \
       tests/test_server_openai.py \
       tests/test_session_bank.py \
       tests/test_tool_aware_stream_translator.py
```

→ **78/78 pass** (4 commit-1 tests + 5 commit-2 tests + 69 existing tests in the listed files).

### Integration smoke (`tests/integration_smoke_cache_hit.sh`)

Three back-to-back runs against MTPLX 0.2.0 + this branch on Qwen3.6 27B, all PASS:

```
turn 1 postcommit (server log):
  stored:true mode:retokenized_history prefix_len:379 nbytes:180MB
  unsafe_reason:tool_call_history_rewrite

turn 2:
  cached_tokens         = 379
  session_cache_hit     = true
  session_restore_mode  = reference_lease
  cache_miss_reason     = <not present>

turn 1 ttft = 0.5s    (cold prefill of 379 tokens)
turn 2 ttft = 0.1s    (cache hit, 5x faster)

PASS - cached_tokens=379 on turn 2
```

Same `prefix_len` and `token_hash` across all three runs — encoding is deterministic and the bank entry is the canonical prefix of the next prompt.

To re-run:

```bash
./tests/integration_smoke_cache_hit.sh
```

(Override host with `MTPLX_HOST=...` if not on the default `127.0.0.1:8088`.)

### BEFORE evidence (server still on commit e513114, pre-bugs-2-and-3)

Same script ran on the partial branch without commits 2-3:

```
turn 1 postcommit: stored:false mode:async_pending reason:tool_call_history_rewrite
turn 2 cached_tokens   = 0
turn 2 cache_miss_reason = prefix_divergence_at_token
turn 2 session_restore_mode = cold
turn 2 session_cache_hit    = false
FAIL - turn 2 was cold
```

This is exactly the failure mode commits 2-3 fix.

### Real opencode end-to-end (live evidence)

Two consecutive `opencode run --model mtplx/...` invocations against the same parent session, with the patched server. Only the cache-hit-relevant rows from `/v1/metrics`:

```
sid=3dworld-loop ctx=12493 cached=    0 ttft=18.3s miss=prefix_divergence  ← 1st run cold
sid=3dworld-loop ctx=13678 cached=12494 ttft= 1.8s miss=None  ← CACHE HIT  (10x faster)
sid=3dworld-loop ctx=12491 cached=    0 ttft=16.4s miss=prefix_divergence  ← 2nd run cold (new turn)
sid=3dworld-loop ctx=12531 cached=12492 ttft= 0.1s miss=None  ← CACHE HIT  (180x faster)
```

12 K out of ~13 K tokens reused on each follow-up turn. TTFT collapses from 16-18 s on the cold turn to 0.1-1.8 s on the warm turn. The first cold turn of each `opencode run` is expected because each `opencode run` is a fresh chat session - subsequent turns within the same session re-use the bank.

## Files changed

- `mtplx/server/openai.py`: ~+30 lines net.
  - Commit 1: `_schedule_idle_postcommit_snapshot.async_postcommit` body rewritten.
  - Commit 2: `tool_specs` keyword arg added to 5 functions, 6 call sites in the request handler updated to forward `tool_specs if tools_active else None`.
  - Commit 3: replaced `getattr(state, \"postcommit_executor\", None)` with `state.generation_executor.submit(...)`.
- `tests/test_idle_postcommit_subagent.py` (new): 4 unit tests for commit 1.
- `tests/test_postcommit_tools_plumbing.py` (new): 5 unit tests for commit 2.
- `tests/test_openai_bridge.py`: 1 test renamed and updated for the new `model_lock_busy_past_deadline` semantic.
- `tests/integration_smoke_cache_hit.sh` (new, executable): 2-turn cached>0 smoke against `127.0.0.1:8088`.
- `CHANGELOG.md`: 3 \"Fixed\" entries under Unreleased (one per commit).

## Why this isn't a foreground-latency regression

- **Commit 1**: same non-blocking lock acquire the prior code relied on, just tried eagerly instead of after a wait. Foreground requests never see the background contention (helper returns `model_lock_busy_*` in microseconds).
- **Commit 2**: pure encoding-side fix. No new runtime work on the request thread.
- **Commit 3**: routes async postcommit to `generation_executor`. The non-blocking lock acquire still applies; the postcommit yields the moment foreground wants the lock.

## Notes

- The new abandon reason in commit 1 is `model_lock_busy_past_deadline` (not `foreground_busy_past_deadline`).
- The 30 s deadline (`_IDLE_POSTCOMMIT_MAX_WAIT_S`) and 250 ms poll interval are unchanged.
- `state.postcommit_executor` is left in place (test stubs reference it); only the `submit()` site was changed.
- All five new postcommit pathway parameters default to `tool_specs=None`, so any caller that doesn't pass tools keeps the exact pre-fix behaviour.

