### PR TITLE
Batch-ready SessionBank model scheduler

### DIFF
--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -168,6 +168,7 @@ class EngineSession:
         self.last_cache_miss_reason: str | None = CacheMissReason.NEW_SESSION.value
         self.last_restore_mode: str = "cold"
         self.bytes_estimate = 0
+        self.revision = 0
         self._lock = Lock()
 
     @property
@@ -212,6 +213,7 @@ class EngineSession:
         self.last_commit_s = time.time()
         self.last_finish_reason = finish_reason
         self.bytes_estimate = int(nbytes)
+        self.revision += 1
         self._record_interval_boundaries(tokens)
         self.add_boundary(boundary_kind, tokens, nbytes=nbytes)
         return EngineSessionCommit(True, "committed", self.prefix_len)
@@ -260,6 +262,7 @@ class EngineSession:
             "last_access_s": self.last_access_s,
             "last_commit_s": self.last_commit_s,
             "last_finish_reason": self.last_finish_reason,
+            "revision": self.revision,
             "in_flight": self.in_flight,
             "in_flight_started_s": self.in_flight_started_s,
             "last_cache_miss_reason": self.last_cache_miss_reason,

--- a/mtplx/model_scheduler.py
+++ b/mtplx/model_scheduler.py
@@ -1,0 +1,214 @@
+"""Single-owner model work scheduler for MTPLX serving.
+
+The scheduler deliberately runs model work on one thread because MLX stream
+state and live cache references are thread-affine on Apple Silicon. It still
+keeps request admission explicit: foreground generation has priority over idle
+maintenance work such as SessionBank postcommit snapshots.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from threading import Condition, Thread, get_ident
+import time
+from typing import Any, Callable
+
+
+@dataclass
+class _WorkItem:
+    kind: str
+    fn: Callable[..., Any]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+    future: Future
+    sequence: int
+    batch_key: str | None = None
+    queued_at_s: float = field(default_factory=time.monotonic)
+    earliest_start_s: float = field(default_factory=time.monotonic)
+
+
+class ModelWorkScheduler:
+    """Priority admission scheduler for the single MLX/model owner thread."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "mtplx-model",
+        idle_grace_s: float = 0.025,
+    ) -> None:
+        self.name = str(name)
+        self.idle_grace_s = max(0.0, float(idle_grace_s))
+        self._condition = Condition()
+        self._foreground: deque[_WorkItem] = deque()
+        self._idle: deque[_WorkItem] = deque()
+        self._sequence = 0
+        self._shutdown = False
+        self._active_kind: str | None = None
+        self._owner_thread_id: int | None = None
+        self._started = 0
+        self._completed = 0
+        self._thread = Thread(
+            target=self._run,
+            name=f"{self.name}-owner",
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def owner_thread_id(self) -> int | None:
+        return self._owner_thread_id
+
+    def is_owner_thread(self) -> bool:
+        return self._owner_thread_id == get_ident()
+
+    def foreground_pending(self) -> int:
+        with self._condition:
+            return len(self._foreground)
+
+    def has_foreground_pending(self) -> bool:
+        return self.foreground_pending() > 0
+
+    def foreground_pending_or_active(self) -> bool:
+        with self._condition:
+            return bool(self._foreground) or self._active_kind == "foreground"
+
+    def stats(self) -> dict[str, Any]:
+        with self._condition:
+            return {
+                "foreground_pending": len(self._foreground),
+                "idle_pending": len(self._idle),
+                "active_kind": self._active_kind,
+                "started": self._started,
+                "completed": self._completed,
+                "owner_thread_id": self._owner_thread_id,
+                "shutdown": self._shutdown,
+            }
+
+    def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Future:
+        """ThreadPoolExecutor-compatible foreground submit."""
+        return self._submit(
+            "foreground",
+            fn,
+            args=args,
+            kwargs=kwargs,
+            batch_key=None,
+            earliest_start_s=time.monotonic(),
+        )
+
+    def submit_foreground(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        batch_key: str | None = None,
+        **kwargs: Any,
+    ) -> Future:
+        return self._submit(
+            "foreground",
+            fn,
+            args=args,
+            kwargs=kwargs,
+            batch_key=batch_key,
+            earliest_start_s=time.monotonic(),
+        )
+
+    def submit_idle_postcommit(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        batch_key: str | None = None,
+        **kwargs: Any,
+    ) -> Future:
+        return self._submit(
+            "idle_postcommit",
+            fn,
+            args=args,
+            kwargs=kwargs,
+            batch_key=batch_key,
+            earliest_start_s=time.monotonic() + self.idle_grace_s,
+        )
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._condition:
+            self._shutdown = True
+            if cancel_futures:
+                for queue in (self._foreground, self._idle):
+                    while queue:
+                        item = queue.popleft()
+                        item.future.cancel()
+            self._condition.notify_all()
+        if wait and self._thread.is_alive():
+            self._thread.join()
+
+    def _submit(
+        self,
+        kind: str,
+        fn: Callable[..., Any],
+        *,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        batch_key: str | None,
+        earliest_start_s: float,
+    ) -> Future:
+        future: Future = Future()
+        with self._condition:
+            if self._shutdown:
+                future.set_exception(RuntimeError("model scheduler is shut down"))
+                return future
+            self._sequence += 1
+            item = _WorkItem(
+                kind=kind,
+                fn=fn,
+                args=args,
+                kwargs=kwargs,
+                future=future,
+                sequence=self._sequence,
+                batch_key=batch_key,
+                earliest_start_s=earliest_start_s,
+            )
+            if kind == "foreground":
+                self._foreground.append(item)
+            else:
+                self._idle.append(item)
+            self._condition.notify_all()
+        return future
+
+    def _run(self) -> None:
+        self._owner_thread_id = get_ident()
+        while True:
+            item = self._take_next()
+            if item is None:
+                return
+            if not item.future.set_running_or_notify_cancel():
+                continue
+            with self._condition:
+                self._active_kind = (
+                    "foreground" if item.kind == "foreground" else "idle_postcommit"
+                )
+                self._started += 1
+            try:
+                item.future.set_result(item.fn(*item.args, **item.kwargs))
+            except BaseException as exc:
+                item.future.set_exception(exc)
+            finally:
+                with self._condition:
+                    self._completed += 1
+                    self._active_kind = None
+                    self._condition.notify_all()
+
+    def _take_next(self) -> _WorkItem | None:
+        with self._condition:
+            while True:
+                if self._shutdown and not self._foreground and not self._idle:
+                    return None
+                if self._foreground:
+                    return self._foreground.popleft()
+                if self._idle:
+                    now = time.monotonic()
+                    delay = self._idle[0].earliest_start_s - now
+                    if delay <= 0:
+                        return self._idle.popleft()
+                    self._condition.wait(timeout=delay)
+                    continue
+                self._condition.wait()

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -24,7 +24,6 @@ import sys
 import time
 import uuid
 import webbrowser
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, is_dataclass
 from enum import Enum
@@ -48,6 +47,7 @@ from mtplx.adaptive import AdaptiveDepthPolicy, ExpectedValueDepthPolicy
 from mtplx.attention_context import attention_phase
 from mtplx.cache_state import snapshot_cache
 from mtplx.mtp_patch import MTPContract
+from mtplx.model_scheduler import ModelWorkScheduler
 from mtplx.sampling import SamplerConfig
 from mtplx.profiles import (
     DEFAULT_PROFILE_NAME,
@@ -511,6 +511,12 @@ class ServerState:
         self.lock = Lock()
         self.foreground_lock = Lock()
         self.foreground_active = 0
+        self.model_scheduler = ModelWorkScheduler(name="mtplx-model")
+        # Compatibility shim for older tests/helpers that expect an executor
+        # with submit()/shutdown(). New serving code uses model_scheduler
+        # explicitly for foreground-vs-idle admission.
+        self.generation_executor = self.model_scheduler
+        self.postcommit_executor = None
         self.rate_limiter = _RateLimiter(args.rate_limit)
         self.profile = get_profile(args.profile)
         runtime_label = {
@@ -560,14 +566,19 @@ class ServerState:
         _startup_line("      Model load in progress (this may take a minute).")
         load_heartbeat = _startup_heartbeat("Model still loading")
         try:
-            self.runtime = load(
-                args.model, mtp=bool(args.load_mtp), contract=MTPContract()
-            )
+            self.runtime = self.model_scheduler.submit_foreground(
+                load,
+                args.model,
+                mtp=bool(args.load_mtp),
+                contract=MTPContract(),
+                batch_key="startup.load",
+            ).result()
         except BaseException as exc:
             elapsed_s = time.perf_counter() - started
             _startup_line(
                 f"[5/6] Model load failed after {elapsed_s:.1f}s: {type(exc).__name__}: {exc}"
             )
+            self.model_scheduler.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
             load_heartbeat.set()
@@ -575,14 +586,34 @@ class ServerState:
         _startup_line(f"[5/6] Model loaded in {self.load_time_s:.1f}s")
         _startup_line("[5/6] Installing native-MTP draft head")
         self.draft_lm_head = (
-            _install_draft_lm_head(
+            self.model_scheduler.submit_foreground(
+                _install_draft_lm_head,
                 self.runtime,
                 bits=args.draft_lm_head_bits,
                 group_size=args.draft_lm_head_group_size,
                 mode=args.draft_lm_head_mode,
-            )
+                batch_key="startup.draft_head",
+            ).result()
             if self.runtime.mtp_enabled
             else {"installed": False, "reason": "mtp_disabled"}
+        )
+        self.draft_head_identity = (
+            self.model_scheduler.submit_foreground(
+                _draft_head_identity,
+                self.runtime,
+                batch_key="startup.draft_head_identity",
+            ).result()
+            if self.runtime.mtp_enabled
+            else None
+        )
+        self.template_hash = (
+            self.model_scheduler.submit_foreground(
+                _template_hash,
+                self.runtime.tokenizer,
+                batch_key="startup.template_hash",
+            ).result()
+            if self.runtime is not None
+            else None
         )
         self.draft_sampler = (
             SamplerConfig(
@@ -593,8 +624,6 @@ class ServerState:
             if args.draft_temperature is not None
             else None
         )
-        self.draft_head_identity = _draft_head_identity(self.runtime)
-        self.template_hash = _template_hash(self.runtime.tokenizer)
         self.context_window = (
             int(args.context_window)
             if int(args.context_window) > 0
@@ -609,14 +638,6 @@ class ServerState:
         self.last_request_at: float = 0.0
         self.requests_completed: int = 0
         self.main_system_prompt_hash: str | None = None
-        self.generation_executor = ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="mtplx-generation",
-        )
-        self.postcommit_executor = ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="mtplx-postcommit",
-        )
         self.warmup_status = _run_startup_warmup(self)
 
     def begin_foreground(self) -> None:
@@ -635,6 +656,47 @@ class ServerState:
     def foreground_count(self) -> int:
         with self.foreground_lock:
             return int(self.foreground_active)
+
+
+def _submit_foreground_model_work(
+    state: Any,
+    fn: Callable[..., Any],
+    *args: Any,
+    batch_key: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    scheduler = getattr(state, "model_scheduler", None)
+    if scheduler is not None and hasattr(scheduler, "submit_foreground"):
+        return scheduler.submit_foreground(fn, *args, batch_key=batch_key, **kwargs)
+    executor = getattr(state, "generation_executor", None)
+    if executor is None:
+        raise RuntimeError("state has no model work executor")
+    return executor.submit(fn, *args, **kwargs)
+
+
+def _submit_idle_postcommit_model_work(
+    state: Any,
+    fn: Callable[..., Any],
+    *args: Any,
+    batch_key: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    scheduler = getattr(state, "model_scheduler", None)
+    if scheduler is not None and hasattr(scheduler, "submit_idle_postcommit"):
+        return scheduler.submit_idle_postcommit(fn, *args, batch_key=batch_key, **kwargs)
+    executor = getattr(state, "postcommit_executor", None)
+    if executor is None:
+        executor = getattr(state, "generation_executor", None)
+    if executor is None:
+        raise RuntimeError("state has no idle postcommit executor")
+    return executor.submit(fn, *args, **kwargs)
+
+
+def _foreground_model_work_pending(state: Any) -> bool:
+    scheduler = getattr(state, "model_scheduler", None)
+    if scheduler is not None and hasattr(scheduler, "has_foreground_pending"):
+        return bool(scheduler.has_foreground_pending())
+    return False
 
 
 LOCALHOST_BINDS = {"", "127.0.0.1", "::1", "localhost"}
@@ -2222,6 +2284,7 @@ def _store_retokenized_history_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     acquire_model_lock_blocking: bool = True,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
@@ -2238,6 +2301,7 @@ def _store_retokenized_history_snapshot(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
     history_ids = encoded_with_sentinel
     if not history_ids:
@@ -2310,6 +2374,7 @@ def _history_ids_for_postcommit(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> list[int]:
     history_messages = list(messages) + [
         ChatMessage(
@@ -2324,6 +2389,7 @@ def _history_ids_for_postcommit(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
 
 
@@ -2336,6 +2402,7 @@ def _generation_final_postcommit_compatibility(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if assistant_tool_calls:
         return {
@@ -2387,6 +2454,7 @@ def _generation_final_postcommit_compatibility(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if history_ids == final_token_ids:
         return {
@@ -2432,6 +2500,7 @@ def _store_generation_final_history_snapshot(
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
     policy_fingerprint: str,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "mode": "unsafe", "reason": "no_session_id"}
@@ -2444,6 +2513,7 @@ def _store_generation_final_history_snapshot(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if not bool(compatibility.get("safe")):
         return {
@@ -2520,6 +2590,9 @@ def _schedule_idle_postcommit_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     unsafe_reason: str,
+    tool_specs: list[dict[str, Any]] | None = None,
+    session: Any | None = None,
+    expected_session_revision: int | None = None,
 ) -> dict[str, Any]:
     """Schedule a background SessionBank commit for a response the
     generation-final compatibility check rejected as unsafe (most commonly
@@ -2529,10 +2602,10 @@ def _schedule_idle_postcommit_snapshot(
     The retokenized-history path canonicalises tool_call responses into the
     exact prefix the next request will send, so the commit is safe - it just
     must not run on the request thread (would extend stream latency). This
-    function dispatches that work to the postcommit executor, where it waits
-    for the foreground to go idle and then runs the synchronous retokenized
-    commit. If the foreground stays busy past the deadline we abandon, since
-    a later commit would race the next turn's prefill.
+    function dispatches that work to the low-priority model scheduler lane.
+    The scheduler admits it only after foreground work drains; the job then
+    rechecks that no newer foreground is queued and that the session did not
+    advance before it builds a new cache.
     """
     pending = {
         "stored": False,
@@ -2564,39 +2637,66 @@ def _schedule_idle_postcommit_snapshot(
     def async_postcommit() -> None:
         deadline = time.monotonic() + _IDLE_POSTCOMMIT_MAX_WAIT_S
         try:
-            # Wait for the foreground request to release the model. We poll
-            # both the foreground flag and the model lock; if either is held
-            # the next prefill is imminent or already running and committing
-            # now would either stall it or race it. We bound the wait so a
-            # back-pressured server never accumulates a backlog of stale
-            # commit work.
-            while state.has_foreground() or state.lock.locked():
+            while True:
+                observed_revision = (
+                    getattr(session, "revision", None) if session is not None else None
+                )
+                if (
+                    expected_session_revision is not None
+                    and observed_revision is not None
+                    and int(observed_revision) != int(expected_session_revision)
+                ):
+                    _log(
+                        {
+                            "stored": False,
+                            "mode": "abandoned_stale",
+                            "reason": "stale_session_revision",
+                            "expected_session_revision": int(
+                                expected_session_revision
+                            ),
+                            "observed_session_revision": int(observed_revision),
+                        }
+                    )
+                    return
+                if _foreground_model_work_pending(state):
+                    _log(
+                        {
+                            "stored": False,
+                            "mode": "abandoned_foreground_busy",
+                            "reason": "foreground_pending_before_postcommit",
+                        }
+                    )
+                    return
+                postcommit = _store_retokenized_history_snapshot(
+                    state,
+                    session_id=session_id,
+                    messages=messages,
+                    assistant_content=assistant_content,
+                    assistant_tool_calls=assistant_tool_calls,
+                    thinking_enabled=thinking_enabled,
+                    policy_fingerprint=policy_fingerprint,
+                    acquire_model_lock_blocking=False,
+                    tool_specs=tool_specs,
+                )
+                if postcommit.get("stored"):
+                    _log(postcommit)
+                    return
+                if (
+                    postcommit.get("reason")
+                    != "model_lock_busy_before_retokenized_commit"
+                ):
+                    _log(postcommit)
+                    return
                 if time.monotonic() >= deadline:
                     _log(
                         {
                             "stored": False,
                             "mode": "abandoned_foreground_busy",
-                            "reason": "foreground_busy_past_deadline",
+                            "reason": "model_lock_busy_past_deadline",
                         }
                     )
                     return
                 time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
-
-            # Foreground is idle. Run the canonical retokenized commit with a
-            # non-blocking lock acquire, so a foreground request that wins the
-            # race after the idle check is never delayed by background cache
-            # maintenance.
-            postcommit = _store_retokenized_history_snapshot(
-                state,
-                session_id=session_id,
-                messages=messages,
-                assistant_content=assistant_content,
-                assistant_tool_calls=assistant_tool_calls,
-                thinking_enabled=thinking_enabled,
-                policy_fingerprint=policy_fingerprint,
-                acquire_model_lock_blocking=False,
-            )
-            _log(postcommit)
         except BaseException as exc:
             _log(
                 {
@@ -2606,10 +2706,11 @@ def _schedule_idle_postcommit_snapshot(
                 }
             )
 
-    executor = getattr(state, "postcommit_executor", None)
-    if executor is None:
-        executor = state.generation_executor
-    executor.submit(async_postcommit)
+    _submit_idle_postcommit_model_work(
+        state,
+        async_postcommit,
+        batch_key=f"postcommit:{session_id or 'stateless'}",
+    )
     return pending
 
 
@@ -3034,16 +3135,20 @@ def _run_startup_warmup(state: ServerState) -> dict[str, Any]:
     warmup_heartbeat = _startup_heartbeat("warmup still running", interval_s=5.0)
     try:
         prompt_ids = _encode_prompt(state.runtime.tokenizer, "MTPLX warmup.")
-        generated = _run_generation(
+        generated = _submit_foreground_model_work(
             state,
-            prompt_ids,
-            max_tokens=warmup_tokens,
-            temperature=state.args.temperature,
-            top_p=state.args.top_p,
-            top_k=state.args.top_k,
-            seed=0,
-            request_observability={"warmup": True},
-        )
+            lambda: _run_generation(
+                state,
+                prompt_ids,
+                max_tokens=warmup_tokens,
+                temperature=state.args.temperature,
+                top_p=state.args.top_p,
+                top_k=state.args.top_k,
+                seed=0,
+                request_observability={"warmup": True},
+            ),
+            batch_key="startup.warmup",
+        ).result()
     except BaseException as exc:
         status.update(
             {
@@ -4800,10 +4905,16 @@ def create_app(state: ServerState) -> FastAPI:
         try:
             yield
         finally:
-            postcommit_executor = getattr(state, "postcommit_executor", None)
-            if postcommit_executor is not None:
-                postcommit_executor.shutdown(wait=False, cancel_futures=True)
-            state.generation_executor.shutdown(wait=False, cancel_futures=True)
+            scheduler = getattr(state, "model_scheduler", None)
+            if scheduler is not None:
+                scheduler.shutdown(wait=False, cancel_futures=True)
+            else:
+                postcommit_executor = getattr(state, "postcommit_executor", None)
+                generation_executor = getattr(state, "generation_executor", None)
+                if postcommit_executor is not None:
+                    postcommit_executor.shutdown(wait=False, cancel_futures=True)
+                if generation_executor is not None:
+                    generation_executor.shutdown(wait=False, cancel_futures=True)
 
     app = FastAPI(title="MTPLX OpenAI-compatible server", lifespan=lifespan)
     app.state.mtplx = state
@@ -5176,7 +5287,11 @@ def create_app(state: ServerState) -> FastAPI:
             metadata=metadata,
             main_system_hash=state.main_system_prompt_hash,
         )
-        if background and (state.has_foreground() or state.lock.locked()):
+        if background and (
+            state.has_foreground()
+            or state.lock.locked()
+            or _foreground_model_work_pending(state)
+        ):
             return JSONResponse(
                 status_code=503,
                 headers={"Retry-After": "1"},
@@ -5328,6 +5443,7 @@ def create_app(state: ServerState) -> FastAPI:
                 assistant_content=assistant_content,
                 assistant_tool_calls=assistant_tool_calls,
                 thinking_enabled=thinking_enabled,
+                tool_specs=tool_specs if tools_active else None,
             )
             if compatibility.get("safe"):
                 generated["stats"]["session_postcommit_snapshot"] = {
@@ -5360,20 +5476,26 @@ def create_app(state: ServerState) -> FastAPI:
                         thinking_enabled=thinking_enabled,
                         policy_fingerprint=policy_fingerprint,
                         unsafe_reason=unsafe_reason,
+                        tool_specs=tool_specs if tools_active else None,
+                        session=session,
+                        expected_session_revision=getattr(session, "revision", None),
                     )
                 )
                 return
-            loop = asyncio.get_running_loop()
-            postcommit = await loop.run_in_executor(
-                state.generation_executor,
-                lambda: _store_retokenized_history_snapshot(
+            postcommit = await asyncio.wrap_future(
+                _submit_foreground_model_work(
                     state,
-                    session_id=session_id,
-                    messages=request.messages,
-                    assistant_content=assistant_content,
-                    assistant_tool_calls=assistant_tool_calls,
-                    thinking_enabled=thinking_enabled,
-                    policy_fingerprint=policy_fingerprint,
+                    lambda: _store_retokenized_history_snapshot(
+                        state,
+                        session_id=session_id,
+                        messages=request.messages,
+                        assistant_content=assistant_content,
+                        assistant_tool_calls=assistant_tool_calls,
+                        thinking_enabled=thinking_enabled,
+                        policy_fingerprint=policy_fingerprint,
+                        tool_specs=tool_specs if tools_active else None,
+                    ),
+                    batch_key=f"postcommit.inline:{session_id or 'stateless'}",
                 ),
             )
             generated["stats"]["session_postcommit_snapshot"] = postcommit
@@ -5516,6 +5638,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                     else:
                                         postcommit = _store_generation_final_history_snapshot(
@@ -5528,6 +5651,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                         if not postcommit.get("stored"):
                                             generated["stats"][
@@ -5578,7 +5702,11 @@ def create_app(state: ServerState) -> FastAPI:
                     else:
                         queue.put(("done", generated))
 
-                generation_future = state.generation_executor.submit(worker)
+                generation_future = _submit_foreground_model_work(
+                    state,
+                    worker,
+                    batch_key="chat.stream",
+                )
 
                 def delta_payload_chunk(delta: dict[str, Any]) -> str:
                     payload = {
@@ -5876,6 +6004,11 @@ def create_app(state: ServerState) -> FastAPI:
                                         unsafe_reason=str(
                                             postcommit.get("reason") or "unsafe_history"
                                         ),
+                                        tool_specs=tool_specs if tools_active else None,
+                                        session=session,
+                                        expected_session_revision=getattr(
+                                            session, "revision", None
+                                        ),
                                     )
                                 else:
                                     yield mark_sse_sent(
@@ -5967,11 +6100,13 @@ def create_app(state: ServerState) -> FastAPI:
         def run_nonstream_generation() -> dict[str, Any]:
             return run_generation_for_response()
 
-        loop = asyncio.get_running_loop()
         try:
-            generated = await loop.run_in_executor(
-                state.generation_executor,
-                run_nonstream_generation,
+            generated = await asyncio.wrap_future(
+                _submit_foreground_model_work(
+                    state,
+                    run_nonstream_generation,
+                    batch_key="chat.nonstream",
+                )
             )
         except EngineSessionBusy as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
@@ -6066,16 +6201,22 @@ def create_app(state: ServerState) -> FastAPI:
             request,
             generation_mode=request_generation_mode,
         )
-        generated = _run_generation(
-            state,
-            prompt_ids,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            top_p=request.top_p,
-            top_k=request.top_k,
-            seed=request.seed,
-            generation_mode=request_generation_mode,
-            depth=request_depth,
+        generated = await asyncio.wrap_future(
+            _submit_foreground_model_work(
+                state,
+                lambda: _run_generation(
+                    state,
+                    prompt_ids,
+                    max_tokens=request.max_tokens,
+                    temperature=request.temperature,
+                    top_p=request.top_p,
+                    top_k=request.top_k,
+                    seed=request.seed,
+                    generation_mode=request_generation_mode,
+                    depth=request_depth,
+                ),
+                batch_key="completion",
+            )
         )
         model = request.model or state.model_id
         response_id = f"cmpl-{uuid.uuid4().hex}"

--- a/tests/integration_smoke_cache_hit.sh
+++ b/tests/integration_smoke_cache_hit.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Integration smoke test: prove the tools-plumbing fix delivers cached>0
+# on the second turn of a session that uses tool definitions.
+#
+# Background: pre-fix the postcommit pathways encoded the synthetic
+# history WITHOUT `tools=`, while the next request encoded its prompt
+# WITH `tools=tool_specs`. The Qwen3.6 chat template injects tool
+# definitions into the system message, so the stored snapshot's tokens
+# diverged from the next prompt at the system boundary - SessionBank
+# lookups failed with `cache_miss_reason=prefix_divergence_at_token`.
+#
+# This script:
+#   1. Starts a unique session_id (one per run).
+#   2. Issues turn 1 with a `tools=[...]` array and a simple user message.
+#   3. Sleeps to let the async postcommit settle.
+#   4. Issues turn 2 with the same tools, a synthetic assistant tool_call
+#      reply, plus a new user message.
+#   5. Parses the SSE stream for the final chunk's `mtplx_stats` and
+#      reports PASS if `cached_tokens > 0`, FAIL otherwise.
+#
+# Usage:
+#   ./tests/integration_smoke_cache_hit.sh                # default port 8088
+#   MTPLX_HOST=http://127.0.0.1:8088 ./tests/integration_smoke_cache_hit.sh
+#
+# IMPORTANT: hits MTPLX directly, NOT the dashboard at 9099 (the
+# dashboard proxy may strip `x-mtplx-session-id`).
+
+set -euo pipefail
+
+HOST="${MTPLX_HOST:-http://127.0.0.1:8088}"
+SESSION_ID="smoke-cache-hit-$(date +%s)-$$"
+SLEEP_S="${SMOKE_SLEEP_S:-12}"
+
+echo "[smoke] host=${HOST}"
+echo "[smoke] session_id=${SESSION_ID}"
+echo "[smoke] inter-turn sleep=${SLEEP_S}s"
+echo
+
+TOOLS_JSON='[
+  {
+    "type": "function",
+    "function": {
+      "name": "grep",
+      "description": "Search files for a pattern",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {"type": "string"},
+          "path": {"type": "string"}
+        },
+        "required": ["pattern"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "read_file",
+      "description": "Read file contents",
+      "parameters": {
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"]
+      }
+    }
+  }
+]'
+
+TURN1_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."}
+  ]
+}
+EOF
+)
+
+TURN2_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."},
+    {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [{
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "grep", "arguments": "{\"pattern\":\"session_bank\"}"}
+      }]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_1",
+      "content": "mtplx/session_bank.py:1:class SessionBank: ..."
+    },
+    {"role": "user", "content": "Now read the first matching file."}
+  ]
+}
+EOF
+)
+
+TMPDIR_SMOKE=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_SMOKE}"' EXIT
+
+echo "[smoke] turn 1 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN1_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn1.sse"
+
+echo "[smoke] turn 1 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn1.sse")"
+
+# Pull the session_postcommit_snapshot from turn 1 (best-effort).
+PC1=$(grep -o '"session_postcommit_snapshot":[^}]*}' "${TMPDIR_SMOKE}/turn1.sse" | tail -1 || true)
+echo "[smoke] turn 1 postcommit: ${PC1:-<not present>}"
+
+echo "[smoke] sleeping ${SLEEP_S}s for async postcommit to settle..."
+sleep "${SLEEP_S}"
+
+echo "[smoke] turn 2 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN2_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn2.sse"
+
+echo "[smoke] turn 2 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn2.sse")"
+
+# The stats are emitted on the final chunk as `mtplx_stats`. Pull the
+# last occurrence of cached_tokens / cache_miss_reason from the stream.
+CACHED=$(grep -o '"cached_tokens":[ ]*[0-9]\+' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 | grep -o '[0-9]\+' || true)
+MISS=$(grep -o '"cache_miss_reason":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+RESTORE=$(grep -o '"session_restore_mode":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+HIT=$(grep -o '"session_cache_hit":[ ]*\(true\|false\)' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+
+echo
+echo "[smoke] turn 2 cached_tokens   = ${CACHED:-<missing>}"
+echo "[smoke] turn 2 cache_miss_reason = ${MISS:-<missing>}"
+echo "[smoke] turn 2 session_restore_mode = ${RESTORE:-<missing>}"
+echo "[smoke] turn 2 session_cache_hit    = ${HIT:-<missing>}"
+echo
+echo "[smoke] (raw turn 2 SSE saved at ${TMPDIR_SMOKE}/turn2.sse - inspect if PASS/FAIL is unclear)"
+# Persist the artifacts to a stable path for the user to inspect after
+# the script exits if needed. (Pre-trap.)
+DEST="/tmp/mtplx-smoke-cache-hit-${SESSION_ID}"
+mkdir -p "${DEST}"
+cp "${TMPDIR_SMOKE}/turn1.sse" "${DEST}/turn1.sse"
+cp "${TMPDIR_SMOKE}/turn2.sse" "${DEST}/turn2.sse"
+echo "[smoke] artifacts copied to ${DEST}/"
+
+if [[ -n "${CACHED}" && "${CACHED}" -gt 0 ]]; then
+  echo "[smoke] PASS - cached_tokens=${CACHED} on turn 2 (session_id=${SESSION_ID})"
+  exit 0
+else
+  echo "[smoke] FAIL - turn 2 was cold (cached_tokens=${CACHED:-0}, miss_reason=${MISS})"
+  exit 1
+fi

--- a/tests/test_idle_postcommit_subagent.py
+++ b/tests/test_idle_postcommit_subagent.py
@@ -1,0 +1,230 @@
+"""Regression tests for `_schedule_idle_postcommit_snapshot`.
+
+The async path used to gate on `state.has_foreground()` clearing before it
+ran the retokenized commit. In OpenAI-compatible subagent fan-out (opencode
+researcher / planner / fixer / bug-patcher) the parent re-dispatches the
+next request within milliseconds of the previous response completing, so
+the foreground flag never clears - every subagent's snapshot was abandoned
+with `foreground_busy_past_deadline` and the SessionBank never accumulated
+an entry for those session ids.
+
+These tests cover the post-fix behaviour: the async path now retries the
+existing non-blocking lock acquire inside `_store_retokenized_history_snapshot`
+(which is the real correctness gate) until either the snapshot stores or
+the deadline expires.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+
+
+def _fake_subagent_state(*, foreground_always: bool = False):
+    """Build the minimum stub needed for `_schedule_idle_postcommit_snapshot`.
+
+    `foreground_always=True` simulates the opencode subagent regression:
+    `state.has_foreground()` returns True for the entire test, which under
+    the old code blocked the retokenized commit indefinitely.
+    """
+    foreground_lock = threading.Lock()
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    return SimpleNamespace(
+        lock=foreground_lock,
+        has_foreground=has_foreground,
+        generation_executor=ThreadPoolExecutor(max_workers=1),
+        # Console disabled so `_log` exercises the print branch (and stays
+        # silent under pytest's captured stdout).
+        args=SimpleNamespace(server_console=False),
+    )
+
+
+def _wait_for_executor_drain(state, *, timeout_s: float = 5.0) -> None:
+    """Shut the executor down (waiting for the submitted task to finish).
+
+    Using `executor.shutdown(wait=True)` gives us a deterministic point
+    after which `_log` has already been called for the submitted job.
+    """
+    state.generation_executor.shutdown(wait=True)
+    _ = timeout_s  # symmetric with similar helpers; kept for readability.
+
+
+def _kwargs_for_schedule():
+    return dict(
+        session_id="opencode-researcher",
+        messages=[],
+        assistant_content="<tool_call>...</tool_call>",
+        assistant_tool_calls=[{"name": "grep", "arguments": "{}"}],
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+
+
+def test_idle_postcommit_stores_when_lock_briefly_free(monkeypatch):
+    """Happy path: even if `has_foreground()` says True, a successful store
+    on the first non-blocking lock acquire ends the loop and is logged.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+
+    _wait_for_executor_drain(state)
+
+    assert pending == {
+        "stored": False,
+        "mode": "async_pending",
+        "reason": "retokenized_history_mismatch",
+    }
+    assert len(calls) == 1
+    assert calls[0]["session_id"] == "opencode-researcher"
+    assert calls[0]["acquire_model_lock_blocking"] is False
+
+
+def test_idle_postcommit_retries_until_deadline_under_lock_busy(monkeypatch):
+    """If the lock stays busy the entire deadline, the loop logs
+    `model_lock_busy_past_deadline` and returns - it does NOT spin
+    forever.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    log_lines: list[dict] = []
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
+
+    def capture_console_disabled(_state):
+        # Keep `_log` going through the print branch so we know the
+        # function reached the deadline-abandon log line. We also
+        # monkeypatch the print in the real module so we can inspect.
+        return False
+
+    real_print = openai.print if hasattr(openai, "print") else print
+
+    def captured_print(message, *_args, **_kwargs):
+        # Lines are formatted as
+        # `[mtplx] idle async session postcommit {json...}`.
+        prefix = "[mtplx] idle async session postcommit "
+        if isinstance(message, str) and message.startswith(prefix):
+            import json
+
+            log_lines.append(json.loads(message[len(prefix):]))
+        else:
+            real_print(message, *_args, **_kwargs)
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", capture_console_disabled)
+    monkeypatch.setattr("builtins.print", captured_print)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert pending["mode"] == "async_pending"
+    # Loop should retry many times under the 0.5s deadline / 0.05s poll
+    # interval (we expect ~10 calls; allow generous slack for CI jitter).
+    assert call_count["n"] >= 3, f"expected several retries, got {call_count['n']}"
+    assert elapsed < 5.0, f"loop ran too long: {elapsed:.2f}s"
+    # We must see exactly one terminal log line declaring the deadline
+    # abandon, and crucially the reason must be the new one.
+    assert log_lines, "expected at least one log line"
+    last = log_lines[-1]
+    assert last["mode"] == "abandoned_foreground_busy"
+    assert last["reason"] == "model_lock_busy_past_deadline"
+    assert last["session_id"] == "opencode-researcher"
+
+
+def test_idle_postcommit_returns_immediately_on_non_recoverable_failure(monkeypatch):
+    """`no_session_id` (and similar non-retryable errors) must short-circuit
+    the loop after exactly one call - retrying will not help.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {"stored": False, "reason": "no_session_id"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Use a long deadline so a buggy implementation that DID retry would
+    # show up as call_count["n"] > 1.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 5.0)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.01)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+
+    assert call_count["n"] == 1
+
+
+def test_idle_postcommit_no_longer_blocks_on_has_foreground(monkeypatch):
+    """Regression test: even if `state.has_foreground()` returns True for
+    the entire duration of the test, the snapshot must still be stored.
+
+    Pre-fix this scenario was the bug - the loop would spin on
+    `has_foreground()` until the 30s deadline expired without ever calling
+    `_store_retokenized_history_snapshot`.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 8,
+            "nbytes": 64,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Force tight bounds so a regression to the old wait-on-foreground
+    # code would time out and the snapshot would NOT be stored.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert calls, "snapshot must be attempted even when has_foreground() is True"
+    assert len(calls) == 1
+    assert elapsed < 1.0, (
+        f"snapshot ran too long ({elapsed:.2f}s) - did the loop fall back to "
+        "the deprecated has_foreground() wait?"
+    )

--- a/tests/test_model_scheduler.py
+++ b/tests/test_model_scheduler.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from threading import Event, get_ident
+import time
+from types import SimpleNamespace
+
+from mtplx.model_scheduler import ModelWorkScheduler
+from mtplx.server import openai
+
+
+def test_foreground_runs_before_pending_idle_postcommit():
+    scheduler = ModelWorkScheduler(name="test-model-scheduler", idle_grace_s=0.05)
+    order: list[str] = []
+    try:
+        idle = scheduler.submit_idle_postcommit(lambda: order.append("idle"))
+        foreground = scheduler.submit_foreground(lambda: order.append("foreground"))
+
+        foreground.result(timeout=2)
+        idle.result(timeout=2)
+
+        assert order == ["foreground", "idle"]
+    finally:
+        scheduler.shutdown(wait=True, cancel_futures=True)
+
+
+def test_idle_postcommit_does_not_start_while_foreground_is_queued():
+    scheduler = ModelWorkScheduler(name="test-model-scheduler", idle_grace_s=0.01)
+    started = Event()
+    release = Event()
+    order: list[str] = []
+
+    def first_foreground() -> None:
+        order.append("foreground-1-start")
+        started.set()
+        assert release.wait(timeout=2)
+        order.append("foreground-1-end")
+
+    try:
+        first = scheduler.submit_foreground(first_foreground)
+        assert started.wait(timeout=2)
+        idle = scheduler.submit_idle_postcommit(lambda: order.append("idle"))
+        second = scheduler.submit_foreground(lambda: order.append("foreground-2"))
+        time.sleep(0.05)
+
+        assert not idle.done()
+        release.set()
+        first.result(timeout=2)
+        second.result(timeout=2)
+        idle.result(timeout=2)
+
+        assert order == [
+            "foreground-1-start",
+            "foreground-1-end",
+            "foreground-2",
+            "idle",
+        ]
+    finally:
+        release.set()
+        scheduler.shutdown(wait=True, cancel_futures=True)
+
+
+def test_foreground_fifo_order_is_preserved():
+    scheduler = ModelWorkScheduler(name="test-model-scheduler", idle_grace_s=0.0)
+    order: list[int] = []
+    try:
+        futures = [
+            scheduler.submit_foreground(lambda value=value: order.append(value))
+            for value in (1, 2, 3)
+        ]
+        for future in futures:
+            future.result(timeout=2)
+
+        assert order == [1, 2, 3]
+    finally:
+        scheduler.shutdown(wait=True, cancel_futures=True)
+
+
+def test_model_work_runs_on_one_owner_thread():
+    scheduler = ModelWorkScheduler(name="test-model-scheduler", idle_grace_s=0.0)
+    try:
+        foreground_thread = scheduler.submit_foreground(get_ident).result(timeout=2)
+        idle_thread = scheduler.submit_idle_postcommit(get_ident).result(timeout=2)
+
+        assert foreground_thread == idle_thread
+        assert foreground_thread == scheduler.owner_thread_id
+    finally:
+        scheduler.shutdown(wait=True, cancel_futures=True)
+
+
+def test_idle_postcommit_aborts_when_session_revision_is_stale(monkeypatch):
+    scheduler = ModelWorkScheduler(name="test-model-scheduler", idle_grace_s=0.02)
+    session = SimpleNamespace(revision=0)
+    state = SimpleNamespace(
+        model_scheduler=scheduler,
+        generation_executor=scheduler,
+        lock=None,
+        args=SimpleNamespace(server_console=True),
+    )
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {"stored": True, "mode": "retokenized_history"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+
+    try:
+        pending = openai._schedule_idle_postcommit_snapshot(
+            state,
+            session_id="session-1",
+            messages=[],
+            assistant_content="ok",
+            thinking_enabled=False,
+            policy_fingerprint="policy",
+            unsafe_reason="retokenized_history_mismatch",
+            session=session,
+            expected_session_revision=session.revision,
+        )
+        session.revision += 1
+        scheduler.shutdown(wait=True)
+
+        assert pending["mode"] == "async_pending"
+        assert calls == []
+    finally:
+        scheduler.shutdown(wait=True, cancel_futures=True)

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -346,13 +346,14 @@ def test_idle_async_postcommit_attempts_commit_for_tool_call_responses(
     assert '"stored": true' in log
 
 
-def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
+def test_idle_async_postcommit_abandons_when_model_lock_stays_busy(
     capsys, monkeypatch
 ):
-    """If the foreground never goes idle, the async commit must abandon
-    rather than block forever."""
+    """If the model lock never frees, the async commit must abandon
+    rather than block forever. The loop now drives the non-blocking acquire
+    inside `_store_retokenized_history_snapshot` as the correctness gate."""
     state = _postcommit_state()
-    state.has_foreground = lambda: True  # always busy
+    state.has_foreground = lambda: True  # intentionally ignored by this path
 
     # Make the wait short so the test stays fast.
     monkeypatch.setattr(
@@ -362,15 +363,19 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
         "mtplx.server.openai._IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05
     )
 
-    called = []
+    called: list[dict] = []
 
-    def should_not_be_called(state, **kwargs):
+    def fake_store_lock_busy(state, **kwargs):
         called.append(kwargs)
-        return {"stored": True}
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
 
     monkeypatch.setattr(
         "mtplx.server.openai._store_retokenized_history_snapshot",
-        should_not_be_called,
+        fake_store_lock_busy,
     )
 
     pending = _schedule_idle_postcommit_snapshot(
@@ -384,10 +389,10 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
     )
 
     assert pending["mode"] == "async_pending"
-    assert called == []
+    assert called, "loop must attempt the non-blocking commit before abandoning"
     log = capsys.readouterr().out
     assert "abandoned_foreground_busy" in log
-    assert "foreground_busy_past_deadline" in log
+    assert "model_lock_busy_past_deadline" in log
 
 
 def test_server_security_requires_api_key_for_non_localhost_bind():

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -1,0 +1,428 @@
+"""Regression tests for tool_specs plumbing through the postcommit path.
+
+The next-turn prompt is encoded with `tools=tool_specs` so the chat
+template injects tool definitions into the system message. Pre-fix the
+postcommit pathways (`_history_ids_for_postcommit`,
+`_store_retokenized_history_snapshot`, `_schedule_idle_postcommit_snapshot`)
+encoded the synthetic history WITHOUT `tools=`, which produced a token
+sequence that no longer matched the next prompt's prefix - SessionBank
+lookups failed with `cache_miss_reason=prefix_divergence_at_token` even
+when the snapshot itself stored successfully.
+
+These tests cover:
+
+1. The reachable-prefix invariant: storing a snapshot for messages M
+   plus tools T produces a token sequence that is a STRICT prefix of
+   the next prompt encoded from M' (M with one new appended user
+   message) plus the same tools T.
+2. The async idle-postcommit path forwards tool_specs through to
+   `_store_retokenized_history_snapshot` so the stored sequence
+   contains the tool-definition tokens.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from threading import Lock
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+from mtplx.server.openai import (
+    ChatMessage,
+    _encode_messages,
+    _history_ids_for_postcommit,
+    _schedule_idle_postcommit_snapshot,
+    _store_retokenized_history_snapshot,
+    parse_args,
+)
+
+
+def _ids(text: str) -> list[int]:
+    return [ord(ch) for ch in text]
+
+
+class ToolAwareTokenizer:
+    """A tiny tokenizer that mimics Qwen-style tool-definition injection.
+
+    When `tools=` is passed to `apply_chat_template`, tool definitions are
+    serialised into a synthetic system message prefix. This produces a
+    DIFFERENT, LONGER token sequence than encoding without `tools=` -
+    matching the real-world Qwen3.6 chat template behaviour that triggered
+    `prefix_divergence_at_token`.
+    """
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        tools=None,
+        **_kwargs,
+    ):
+        assert tokenize is True
+        text = ""
+        if tools:
+            # Serialise each tool spec into a deterministic prefix so the
+            # tokens are stable across calls and clearly larger than the
+            # no-tools encoding.
+            tool_lines = ["<tools>"]
+            for spec in tools:
+                fn = spec.get("function") or spec
+                name = fn.get("name") or spec.get("name") or "fn"
+                tool_lines.append(f"<tool name={name}/>")
+            tool_lines.append("</tools>")
+            text += "\n".join(tool_lines) + "\n"
+        text += "\n".join(
+            f"{message['role']}:{message.get('content') or ''}" for message in messages
+        )
+        if add_generation_prompt:
+            text = f"{text}\nassistant:" if text else "assistant:"
+        return _ids(text)
+
+    def encode(self, text, **_kwargs):
+        return _ids(str(text))
+
+    def decode(self, tokens, **_kwargs):
+        return "".join(chr(int(t)) for t in tokens)
+
+
+class RecordingBank:
+    def __init__(self) -> None:
+        self.puts: list[dict] = []
+
+    def put(self, **kwargs):
+        self.puts.append(kwargs)
+        return SimpleNamespace(
+            prefix_len=len(kwargs["token_ids"]),
+            nbytes=123,
+            token_hash="test-token-hash",
+        )
+
+
+def _postcommit_state(*, tokenizer=None):
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=Lock(),
+        generation_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        postcommit_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        has_foreground=lambda: False,
+        begin_foreground=lambda: None,
+        end_foreground=lambda: None,
+    )
+
+
+_TOOL_SPECS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "grep",
+            "description": "Search files",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        },
+    },
+]
+
+
+def test_history_ids_with_tools_is_strict_prefix_of_next_prompt():
+    """The reachable-prefix invariant.
+
+    If turn 1 stores a snapshot for `messages + assistant_response` with
+    `tool_specs=T`, then turn 2's prompt - encoded from the SAME messages
+    plus the assistant response plus a new user message, with the SAME
+    `tool_specs=T` and `add_generation_prompt=True` - must START with the
+    stored token sequence. Otherwise SessionBank's strict-prefix lookup
+    can never reach the snapshot.
+
+    Pre-fix `_history_ids_for_postcommit` did NOT pass `tools=`, so the
+    stored sequence diverged from the next prompt at the system-message
+    boundary (where the chat template injects tool definitions).
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    history_ids = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        tool_specs=_TOOL_SPECS,
+    )
+
+    # Turn 2: same conversation + assistant reply + new user turn, with
+    # the same tool_specs and add_generation_prompt=True (the real
+    # request path).
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids, "history_ids must not be empty"
+    assert len(history_ids) <= len(next_prompt_ids)
+    assert next_prompt_ids[: len(history_ids)] == history_ids, (
+        "stored history snapshot must be a strict token prefix of the "
+        "next-turn prompt; otherwise SessionBank lookups will diverge"
+    )
+
+
+def test_history_ids_without_tools_diverges_from_next_prompt_with_tools():
+    """The bug this fix addresses: pre-fix code stored history WITHOUT
+    `tools=` while the next prompt was encoded WITH `tools=`. Show that
+    the no-tools encoding is NOT a prefix of the with-tools next prompt.
+    This is the exact failure mode that produced
+    `cache_miss_reason=prefix_divergence_at_token`.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Pre-fix encoding (no tools) - what the old `_history_ids_for_postcommit`
+    # produced.
+    history_ids_no_tools = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        # tool_specs left as default None == pre-fix behaviour.
+    )
+
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids_with_tools = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids_no_tools, "history_ids must not be empty"
+    # The no-tools encoding is NOT a prefix of the with-tools next prompt
+    # - this is the divergence the fix targets.
+    assert (
+        next_prompt_ids_with_tools[: len(history_ids_no_tools)]
+        != history_ids_no_tools
+    ), (
+        "regression guard: encoding without tools must diverge from a "
+        "next prompt encoded with tools - this is the prefix_divergence_at_token "
+        "failure mode"
+    )
+
+
+def test_store_retokenized_history_snapshot_includes_tool_definition_tokens(
+    monkeypatch,
+):
+    """`_store_retokenized_history_snapshot` must encode the synthetic
+    history WITH `tools=` so the stored token sequence includes the
+    tool-definition tokens. Encoding the same messages without tools
+    produces a strictly shorter sequence.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Mock the runtime-heavy prefill/cache calls; we are validating
+    # ENCODING + bank.put(token_ids=...), not the runtime KV-cache path.
+    fake_prompt_state = SimpleNamespace(
+        trunk_cache="trunk-cache",
+        logits="logits",
+        hidden="hidden",
+        committed_mtp_cache=None,
+    )
+    monkeypatch.setattr(
+        openai,
+        "restore_or_prefill_prompt_state",
+        lambda *args, **kwargs: fake_prompt_state,
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda cache: None)
+
+    result = _store_retokenized_history_snapshot(
+        state,
+        session_id="test-session",
+        messages=messages,
+        assistant_content=assistant_content,
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        tool_specs=_TOOL_SPECS,
+    )
+
+    assert result["stored"] is True, result
+    assert state.sessions.bank.puts, "bank.put must be called"
+    stored_ids = state.sessions.bank.puts[0]["token_ids"]
+
+    # Encode the same history without tools and confirm the stored
+    # sequence is STRICTLY LONGER (has the tool-definition prefix).
+    history_messages_no_tools = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+    ]
+    no_tools_ids = _encode_messages(
+        state.runtime.tokenizer,
+        history_messages_no_tools,
+        enable_thinking=False,
+        add_generation_prompt=False,
+    )
+
+    assert len(stored_ids) > len(no_tools_ids), (
+        f"stored sequence ({len(stored_ids)} tokens) must be longer than "
+        f"the no-tools encoding ({len(no_tools_ids)} tokens) - the tool "
+        "definitions should add tokens"
+    )
+
+    # And it must be reachable as a prefix of the next-turn prompt.
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+    assert next_prompt_ids[: len(stored_ids)] == stored_ids
+
+
+def _async_state(*, foreground_always: bool = False, tokenizer=None):
+    """A more permissive state for async-path testing that exposes the
+    same surface as `_schedule_idle_postcommit_snapshot` expects."""
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=threading.Lock(),
+        has_foreground=has_foreground,
+        postcommit_executor=None,
+        generation_executor=ThreadPoolExecutor(max_workers=1),
+    )
+
+
+def test_idle_postcommit_async_path_forwards_tool_specs(monkeypatch):
+    """The async idle path must forward `tool_specs` to
+    `_store_retokenized_history_snapshot`. Without the forwarding, the
+    stored sequence would diverge from the next prompt's prefix
+    (`prefix_divergence_at_token`).
+    """
+    state = _async_state(foreground_always=True)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="opencode-researcher",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+        tool_specs=_TOOL_SPECS,
+    )
+    state.generation_executor.shutdown(wait=True)
+
+    assert pending["mode"] == "async_pending"
+    assert len(captured) == 1
+    assert captured[0]["tool_specs"] == _TOOL_SPECS, (
+        "scheduled async commit must receive the same tool_specs that "
+        "produced the request's prompt; otherwise the stored snapshot "
+        "diverges from the next prompt's prefix"
+    )
+
+
+def test_idle_postcommit_default_tool_specs_is_none(monkeypatch):
+    """Backwards compat: the four pre-existing tests in
+    `test_idle_postcommit_subagent.py` do not pass `tool_specs`. Confirm
+    the default value remains `None` so the legacy callers see no
+    behaviour change.
+    """
+    state = _async_state(foreground_always=False)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {"stored": True, "mode": "retokenized_history"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="legacy-session",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+    state.generation_executor.shutdown(wait=True)
+
+    assert captured and captured[0]["tool_specs"] is None


### PR DESCRIPTION
## Summary
- Adds a single-owner `ModelWorkScheduler` for model load, warmup, generation, and SessionBank postcommit cache work.
- Gives foreground generation priority over idle postcommit maintenance, while preserving FIFO order among foreground jobs.
- Carries PR #24's real fixes forward: async postcommit no longer waits forever on `has_foreground()`, tool-bearing postcommit encodes with the request `tool_specs`, and SessionBank cache construction stays on the model owner thread.
- Adds stale session revision checks so old idle postcommit work exits before building a cache.

## Validation
- `uv run --extra dev pytest tests/test_server_openai.py tests/test_openai_bridge.py tests/test_session_bank.py tests/test_tool_aware_stream_translator.py -q`
- `uv run --extra dev pytest tests/test_idle_postcommit_subagent.py tests/test_postcommit_tools_plumbing.py -q`
- `uv run --extra dev pytest tests/test_model_scheduler.py tests/test_idle_postcommit_subagent.py tests/test_postcommit_tools_plumbing.py tests/test_openai_bridge.py -q`
- `uv run python -m py_compile mtplx/server/openai.py mtplx/engine_session.py mtplx/model_scheduler.py`
- `git diff --check`
- `uv run --extra dev pytest -q` reached 100% with the existing MLX/SWIG deprecation warnings.

## Not Run
- `tests/integration_smoke_cache_hit.sh`: no suitable local MTPLX server responded on 8088, 8000, 8080, or 8123, so no live cache-hit QA is claimed.

## Credit
The commit includes `Co-authored-by: Daniel Farina <m3d.webdev@gmail.com>` for the PR #24-derived SessionBank fixes.