### PR TITLE
Fix SessionBank postcommit prefix reachability

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1559,6 +1559,49 @@ def _message_to_template_dict(
     return None
 
 
+def _coerce_token_ids(encoded: Any) -> list[int]:
+    """Normalize tokenizer outputs to a plain token-id list.
+
+    HF slow tokenizers, fast tokenizers, and mlx-lm's TokenizerWrapper do not
+    all return the same shape from apply_chat_template(). SessionBank prefix
+    comparisons must never depend on that wrapper detail.
+    """
+    if encoded is None:
+        return []
+    if hasattr(encoded, "ids"):
+        return [int(token) for token in getattr(encoded, "ids")]
+    if hasattr(encoded, "tolist"):
+        return _coerce_token_ids(encoded.tolist())
+    if isinstance(encoded, dict):
+        if "input_ids" in encoded:
+            return _coerce_token_ids(encoded["input_ids"])
+        return []
+    if isinstance(encoded, (list, tuple)):
+        tokens: list[int] = []
+        for item in encoded:
+            if isinstance(item, int):
+                tokens.append(int(item))
+            elif hasattr(item, "ids") or hasattr(item, "tolist") or isinstance(
+                item, (list, tuple, dict)
+            ):
+                tokens.extend(_coerce_token_ids(item))
+            else:
+                tokens.append(int(item))
+        return tokens
+    return [int(encoded)]
+
+
+def _encode_rendered_chat_text(tokenizer: Any, text: str) -> list[int]:
+    try:
+        return _coerce_token_ids(tokenizer.encode(text, add_special_tokens=False))
+    except TypeError:
+        return _coerce_token_ids(tokenizer.encode(text))
+
+
+def _encode_plain_text(tokenizer: Any, text: str) -> list[int]:
+    return _coerce_token_ids(tokenizer.encode(text))
+
+
 def _encode_messages(
     tokenizer: Any,
     messages: list[ChatMessage],
@@ -1587,7 +1630,7 @@ def _encode_messages(
     if tools:
         template_kwargs["tools"] = tools
     try:
-        return list(
+        return _coerce_token_ids(
             tokenizer.apply_chat_template(
                 normalized,
                 **template_kwargs,
@@ -1601,7 +1644,7 @@ def _encode_messages(
             }
             if tools:
                 fallback_kwargs["tools"] = tools
-            return list(
+            return _coerce_token_ids(
                 tokenizer.apply_chat_template(
                     normalized,
                     **fallback_kwargs,
@@ -1626,11 +1669,129 @@ def _encode_messages(
                 status_code=500,
                 detail=f"tokenizer chat template failed with tool schemas: {exc}",
             ) from exc
-        pass
+            pass
     prompt = "\n".join(f"{item['role']}: {item['content']}" for item in normalized)
     if add_generation_prompt:
         prompt += "\nassistant:"
-    return list(tokenizer.encode(prompt))
+    return _encode_rendered_chat_text(tokenizer, prompt)
+
+
+def _render_messages_for_postcommit(
+    tokenizer: Any,
+    normalized: list[dict[str, Any]],
+    *,
+    enable_thinking: bool,
+    tools: list[dict[str, Any]] | None,
+) -> str | None:
+    template_kwargs: dict[str, Any] = {
+        "tokenize": False,
+        "add_generation_prompt": False,
+        "enable_thinking": enable_thinking,
+        "preserve_thinking": True,
+    }
+    if tools:
+        template_kwargs["tools"] = tools
+    try:
+        rendered = tokenizer.apply_chat_template(normalized, **template_kwargs)
+    except TypeError:
+        fallback_kwargs: dict[str, Any] = {
+            "tokenize": False,
+            "add_generation_prompt": False,
+        }
+        if tools:
+            fallback_kwargs["tools"] = tools
+        try:
+            rendered = tokenizer.apply_chat_template(normalized, **fallback_kwargs)
+        except Exception:
+            return None
+    except Exception:
+        return None
+    return rendered if isinstance(rendered, str) else None
+
+
+_POSTCOMMIT_SENTINEL_CONTENT = "__MTPLX_POSTCOMMIT_SENTINEL_4f02c7d2__"
+
+
+def _sentinel_next_turn_start(
+    rendered: str,
+    *,
+    sentinel_role: str,
+    sentinel_content: str = _POSTCOMMIT_SENTINEL_CONTENT,
+) -> int | None:
+    sentinel_at = rendered.find(sentinel_content)
+    if sentinel_at < 0:
+        return None
+    role = sentinel_role
+    role_title = role[:1].upper() + role[1:]
+    markers = [
+        f"<|im_start|>{role}\n",
+        f"<|im_start|>{role}\r\n",
+        f"<|start_header_id|>{role}<|end_header_id|>\n\n",
+        f"\n### {role_title}:\n",
+        f"\n{role}:",
+        f"\n{role_title}:",
+        f"{role}:",
+        f"{role_title}:",
+    ]
+    candidates = [
+        idx
+        for marker in markers
+        if (idx := rendered.rfind(marker, 0, sentinel_at)) >= 0
+    ]
+    if not candidates:
+        return None
+    return max(candidates)
+
+
+def _postcommit_next_turn_prefix_ids(
+    tokenizer: Any,
+    history_messages: list[ChatMessage],
+    *,
+    enable_thinking: bool,
+    strip_assistant_reasoning_history: bool,
+    tools: list[dict[str, Any]] | None,
+    assistant_tool_calls: list[dict[str, Any]] | None,
+) -> list[int] | None:
+    sentinel_role = "user"
+    sentinel_message = ChatMessage(role="user", content=_POSTCOMMIT_SENTINEL_CONTENT)
+    if assistant_tool_calls:
+        first_tool_call = assistant_tool_calls[0] if assistant_tool_calls else {}
+        sentinel_role = "tool"
+        sentinel_message = ChatMessage(
+            role="tool",
+            content=_POSTCOMMIT_SENTINEL_CONTENT,
+            tool_call_id=str(first_tool_call.get("id") or "call_mtplx_postcommit"),
+        )
+
+    normalized: list[dict[str, Any]] = []
+    for message in [*history_messages, sentinel_message]:
+        item = _message_to_template_dict(
+            message,
+            strip_assistant_reasoning_history=strip_assistant_reasoning_history,
+        )
+        if item is not None:
+            normalized.append(item)
+    if not normalized:
+        return None
+
+    rendered = _render_messages_for_postcommit(
+        tokenizer,
+        normalized,
+        enable_thinking=enable_thinking,
+        tools=tools,
+    )
+    if not rendered:
+        return None
+    turn_start = _sentinel_next_turn_start(
+        rendered,
+        sentinel_role=sentinel_role,
+    )
+    if turn_start is None:
+        return None
+    prefix_text = rendered[:turn_start]
+    if not prefix_text:
+        return None
+    return _encode_rendered_chat_text(tokenizer, prefix_text)
 
 
 def _encode_prompt(
@@ -1639,12 +1800,15 @@ def _encode_prompt(
     if prompt is None:
         return []
     if isinstance(prompt, str):
-        return list(tokenizer.encode(prompt))
+        return _encode_plain_text(tokenizer, prompt)
     if isinstance(prompt, list) and all(isinstance(item, int) for item in prompt):
         return [int(item) for item in prompt]
     if isinstance(prompt, list):
-        return list(tokenizer.encode("\n".join(str(item) for item in prompt)))
-    return list(tokenizer.encode(str(prompt)))
+        return _encode_plain_text(
+            tokenizer,
+            "\n".join(str(item) for item in prompt),
+        )
+    return _encode_plain_text(tokenizer, str(prompt))
 
 
 def _count_text_tokens(tokenizer: Any, text: str) -> int:
@@ -2288,22 +2452,14 @@ def _store_retokenized_history_snapshot(
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
-    history_messages = list(messages) + [
-        ChatMessage(
-            role="assistant",
-            content=assistant_content,
-            tool_calls=assistant_tool_calls,
-        ),
-    ]
-    encoded_with_sentinel = _encode_messages(
-        state.runtime.tokenizer,
-        history_messages,
-        enable_thinking=thinking_enabled,
-        strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
-        add_generation_prompt=False,
-        tools=tool_specs,
+    history_ids = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=assistant_tool_calls,
+        thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
-    history_ids = encoded_with_sentinel
     if not history_ids:
         return {"stored": False, "reason": "empty_boundary_prefix"}
     started = time.perf_counter()
@@ -2383,6 +2539,16 @@ def _history_ids_for_postcommit(
             tool_calls=assistant_tool_calls,
         ),
     ]
+    next_turn_prefix_ids = _postcommit_next_turn_prefix_ids(
+        state.runtime.tokenizer,
+        history_messages,
+        enable_thinking=thinking_enabled,
+        strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
+        tools=tool_specs,
+        assistant_tool_calls=assistant_tool_calls,
+    )
+    if next_turn_prefix_ids:
+        return next_turn_prefix_ids
     return _encode_messages(
         state.runtime.tokenizer,
         history_messages,

--- a/tests/integration_smoke_cache_hit.sh
+++ b/tests/integration_smoke_cache_hit.sh
@@ -13,8 +13,8 @@
 #   1. Starts a unique session_id (one per run).
 #   2. Issues turn 1 with a `tools=[...]` array and a simple user message.
 #   3. Sleeps to let the async postcommit settle.
-#   4. Issues turn 2 with the same tools, a synthetic assistant tool_call
-#      reply, plus a new user message.
+#   4. Replays the actual assistant message from turn 1, then issues turn 2
+#      with the same tools plus a new user message.
 #   5. Parses the SSE stream for the final chunk's `mtplx_stats` and
 #      reports PASS if `cached_tokens > 0`, FAIL otherwise.
 #
@@ -81,36 +81,6 @@ TURN1_PAYLOAD=$(cat <<EOF
 EOF
 )
 
-TURN2_PAYLOAD=$(cat <<EOF
-{
-  "model": "auto",
-  "stream": true,
-  "max_tokens": 128,
-  "enable_thinking": false,
-  "tools": ${TOOLS_JSON},
-  "messages": [
-    {"role": "system", "content": "You are a helpful coding agent."},
-    {"role": "user", "content": "Find any references to 'session_bank' in the repo."},
-    {
-      "role": "assistant",
-      "content": "",
-      "tool_calls": [{
-        "id": "call_1",
-        "type": "function",
-        "function": {"name": "grep", "arguments": "{\"pattern\":\"session_bank\"}"}
-      }]
-    },
-    {
-      "role": "tool",
-      "tool_call_id": "call_1",
-      "content": "mtplx/session_bank.py:1:class SessionBank: ..."
-    },
-    {"role": "user", "content": "Now read the first matching file."}
-  ]
-}
-EOF
-)
-
 TMPDIR_SMOKE=$(mktemp -d)
 trap 'rm -rf "${TMPDIR_SMOKE}"' EXIT
 
@@ -127,6 +97,56 @@ echo "[smoke] turn 1 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn1.sse")"
 # Pull the session_postcommit_snapshot from turn 1 (best-effort).
 PC1=$(grep -o '"session_postcommit_snapshot":[^}]*}' "${TMPDIR_SMOKE}/turn1.sse" | tail -1 || true)
 echo "[smoke] turn 1 postcommit: ${PC1:-<not present>}"
+
+ASSISTANT_MSG_JSON=$("${PYTHON:-python3}" - "${TMPDIR_SMOKE}/turn1.sse" <<'PY'
+import json
+import sys
+
+content_parts = []
+for raw in open(sys.argv[1], encoding="utf-8"):
+    if not raw.startswith("data: "):
+        continue
+    data = raw[len("data: "):].strip()
+    if not data or data == "[DONE]":
+        continue
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        continue
+    choices = payload.get("choices") or []
+    if not choices:
+        continue
+    delta = choices[0].get("delta") or {}
+    content = delta.get("content")
+    if content:
+        content_parts.append(str(content))
+
+print(
+    json.dumps(
+        {"role": "assistant", "content": "".join(content_parts)},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+)
+PY
+)
+
+TURN2_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."},
+    ${ASSISTANT_MSG_JSON},
+    {"role": "user", "content": "Now read the first matching file."}
+  ]
+}
+EOF
+)
 
 echo "[smoke] sleeping ${SLEEP_S}s for async postcommit to settle..."
 sleep "${SLEEP_S}"

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -31,6 +31,7 @@ from mtplx.server import openai
 from mtplx.server.openai import (
     ChatMessage,
     _encode_messages,
+    _generation_final_postcommit_compatibility,
     _history_ids_for_postcommit,
     _schedule_idle_postcommit_snapshot,
     _store_retokenized_history_snapshot,
@@ -86,6 +87,58 @@ class ToolAwareTokenizer:
 
     def decode(self, tokens, **_kwargs):
         return "".join(chr(int(t)) for t in tokens)
+
+
+class TerminalThinkingTokenizer(ToolAwareTokenizer):
+    """Mimic Qwen no-thinking history encoding.
+
+    Qwen's template emits the empty think block for a terminal assistant
+    message, but not when that same assistant message is followed by the
+    next user/tool turn. A postcommit snapshot built from the terminal
+    assistant rendering can never be a prefix of turn 2.
+    """
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        enable_thinking=False,
+        tools=None,
+        **_kwargs,
+    ):
+        text = ""
+        if tools:
+            tool_lines = ["<tools>"]
+            for spec in tools:
+                fn = spec.get("function") or spec
+                name = fn.get("name") or spec.get("name") or "fn"
+                tool_lines.append(f"<tool name={name}/>")
+            tool_lines.append("</tools>")
+            text += "\n".join(tool_lines) + "\n"
+        rendered_messages: list[str] = []
+        last_idx = len(messages) - 1
+        for idx, message in enumerate(messages):
+            content = message.get("content") or ""
+            if (
+                message["role"] == "assistant"
+                and idx == last_idx
+                and not add_generation_prompt
+                and not enable_thinking
+            ):
+                content = "<think>\n\n</think>\n\n" + content
+            rendered_messages.append(
+                f"<|im_start|>{message['role']}\n{content}<|im_end|>"
+            )
+        text += "\n".join(rendered_messages)
+        if text:
+            text += "\n"
+        if add_generation_prompt:
+            text += "<|im_start|>assistant\n"
+            if not enable_thinking:
+                text += "<think>\n\n</think>\n\n"
+        return _ids(text) if tokenize else text
 
 
 class RecordingBank:
@@ -203,6 +256,84 @@ def test_history_ids_with_tools_is_strict_prefix_of_next_prompt():
         "stored history snapshot must be a strict token prefix of the "
         "next-turn prompt; otherwise SessionBank lookups will diverge"
     )
+
+
+def test_history_ids_use_next_turn_prefix_for_qwen_terminal_thinking_template():
+    """Qwen no-thinking mode renders a terminal assistant differently from
+    an assistant followed by the next turn. Store the next-turn prefix, not
+    the unreachable terminal rendering.
+    """
+    state = _postcommit_state(tokenizer=TerminalThinkingTokenizer())
+    messages = [
+        ChatMessage(role="system", content="You are concise."),
+        ChatMessage(role="user", content="Say OK."),
+    ]
+    assistant_content = "OK"
+
+    history_ids = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        tool_specs=_TOOL_SPECS,
+    )
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now say DONE."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+    terminal_ids = _encode_messages(
+        state.runtime.tokenizer,
+        list(messages) + [ChatMessage(role="assistant", content=assistant_content)],
+        enable_thinking=False,
+        add_generation_prompt=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert next_prompt_ids[: len(history_ids)] == history_ids
+    assert next_prompt_ids[: len(terminal_ids)] != terminal_ids
+
+
+def test_generation_final_rejects_unreachable_qwen_terminal_thinking_prefix():
+    state = _postcommit_state(tokenizer=TerminalThinkingTokenizer())
+    messages = [
+        ChatMessage(role="system", content="You are concise."),
+        ChatMessage(role="user", content="Say OK."),
+    ]
+    prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+    generated_tokens = _ids("OK")
+    generated = {
+        "tokens": generated_tokens,
+        "_final_state": SimpleNamespace(
+            generated_token_ids=tuple(generated_tokens),
+            safe_to_commit=True,
+        ),
+    }
+
+    compatibility = _generation_final_postcommit_compatibility(
+        state,
+        prompt_ids=prompt_ids,
+        generated=generated,
+        messages=messages,
+        assistant_content="OK",
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        tool_specs=_TOOL_SPECS,
+    )
+
+    assert compatibility["safe"] is False
+    assert compatibility["reason"] == "retokenized_history_mismatch"
 
 
 def test_history_ids_without_tools_diverges_from_next_prompt_with_tools():


### PR DESCRIPTION
## Summary
- store SessionBank postcommit snapshots at the next-turn canonical chat-template prefix instead of the terminal assistant rendering
- reject generation-final commits when the final generation boundary is not reachable from the next request prompt
- update the cache-hit smoke to replay the actual first-turn assistant message before checking cached_tokens

## Root Cause
Qwen no-thinking templates can render a terminal assistant message with an empty think block, but render the same assistant differently once a following user/tool turn exists. The old postcommit path could therefore store a valid cache for a token sequence that the next request would never use.

## Validation
- uv run --extra dev pytest tests/test_postcommit_tools_plumbing.py tests/test_openai_bridge.py tests/test_server_openai.py -q
- uv run --extra dev pytest -q
- uv run python -m py_compile mtplx/server/openai.py mtplx/engine_session.py mtplx/model_scheduler.py
- git diff --check
- wheel install from /tmp/mtplx-wheel-qa-final2/mtplx-0.2.1-py3-none-any.whl[server]
- /tmp/mtplx-wheel-qa-final2-venv/bin/mtplx status
- /tmp/mtplx-wheel-qa-final2-venv/bin/mtplx inspect /Users/youssof/.mtplx/models/trevon--Qwen3.5-27B-MLX-MTP
- MTPLX_HOST=http://127.0.0.1:8137 SMOKE_SLEEP_S=1 tests/integration_smoke_cache_hit.sh -> PASS, cached_tokens=356, session_cache_hit=true
