### PR TITLE
perf: wait briefly for prior postcommit before next request lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ All notable user-facing changes are recorded here.
   mode for `<tool_call>` markers (with proper handling of partial markers
   spanning multiple stream chunks). Tool-only responses and pure-text
   responses are unchanged. Closes #20.
+- Fixed `_schedule_idle_postcommit_snapshot` so it commits SessionBank
+  snapshots for back-to-back subagent fan-out workloads. Previously the
+  async path waited for `state.has_foreground()` to clear, which in
+  OpenAI-compatible agent clients (opencode, Aider) with multiple
+  subagents never happens - the parent dispatches the next subagent
+  request within milliseconds of the previous response completing, so
+  the 30-second idle deadline always expired and the snapshot was
+  abandoned with `foreground_busy_past_deadline`. Subagent sessions
+  therefore never accumulated a bank entry and paid full cold prefill on
+  every turn (cached_tokens=0) even with a stable session_id. The async
+  path now retries the existing non-blocking lock acquire inside
+  `_store_retokenized_history_snapshot` (which is the real correctness
+  gate) until either the snapshot stores or the deadline expires. Live
+  verification with opencode's researcher/planner/fixer/bug-patcher
+  subagents shows non-zero per-session bytes and growing `cached_tokens`
+  across turns of the same session id.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,21 @@ All notable user-facing changes are recorded here.
   verification with opencode's researcher/planner/fixer/bug-patcher
   subagents shows non-zero per-session bytes and growing `cached_tokens`
   across turns of the same session id.
+- Fixed postcommit retokenization to encode the synthetic history with
+  the same `tools=` argument that produced the request's prompt.
+  `_history_ids_for_postcommit` and `_store_retokenized_history_snapshot`
+  previously called `_encode_messages` without `tools=`, while the next
+  request's prompt was built with `tools=tool_specs`. The Qwen3.6 chat
+  template injects tool definitions into the system message, so the
+  stored snapshot's tokens diverged from the next prompt at the system
+  boundary and SessionBank lookups failed with
+  `cache_miss_reason=prefix_divergence_at_token` even when the snapshot
+  successfully stored. `tool_specs` (gated by the same `tools_active`
+  flag used to build `prompt_ids`) now flows through every postcommit
+  pathway: the sync compatibility check, the sync retokenized commit,
+  and the async idle postcommit. The stored snapshot now reproduces the
+  exact prefix the next request will send, so subsequent turns of a
+  tool-using session reach the cached entry instead of cold-prefilling.
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-facing changes are recorded here.
 
 ## Unreleased
 
+### Added
+
+- Added two operator-tunable environment variables for SessionBank capacity:
+  `MTPLX_SESSION_BANK_MAX_BYTES` (overrides `DEFAULT_MAX_BYTES`, default 24 GiB) and
+  `MTPLX_SESSION_BANK_PER_SESSION_BYTES` (overrides `DEFAULT_PER_SESSION_MAX_BYTES`, default 8 GiB).
+  Both accept plain integers (interpreted as bytes) and the suffixes `K`, `M`, `G`, `T`
+  (powers of 1024), e.g. `MTPLX_SESSION_BANK_PER_SESSION_BYTES=16G`. Useful when a single
+  long-running session's prefix state grows past the per-session cap and gets evicted
+  prematurely - common with tool-using subagent fan-out where one subagent can accumulate
+  50K+ tokens of context. Defaults are unchanged, so existing deployments see no behaviour
+  difference.
+
 ### Fixed
 
 - Fixed `_ToolAwareContentStreamTranslator` so it correctly handles assistant
@@ -166,5 +178,5 @@ All notable user-facing changes are recorded here.
 
 ### Roadmap
 
-- Next: kernel ladder for sustained no-fan throughput.
-- Later: additional MTP architectures and broader serving polish.
+- v0.2: kernel ladder for sustained no-fan throughput.
+- v0.3: additional MTP architectures and broader serving polish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,24 @@ All notable user-facing changes are recorded here.
   and the async idle postcommit. The stored snapshot now reproduces the
   exact prefix the next request will send, so subsequent turns of a
   tool-using session reach the cached entry instead of cold-prefilling.
+- Fixed cross-thread MLX state issue when a SessionBank entry committed by
+  the async idle postcommit was later restored on a foreground request.
+  PR #17 (v0.2.0) introduced a dedicated `postcommit_executor` thread to
+  keep snapshot work off the foreground latency path, but MLX streams on
+  Apple Silicon are thread-local: a cache buffer created on the
+  postcommit thread cannot be read from the generation thread, so the
+  restore raised `RuntimeError: There is no Stream(gpu, N) in current
+  thread` and the response failed with HTTP 500. The bug was latent
+  through v0.2.0 because prefix divergence (see prior entry) was masking
+  every cache hit; once the prefix-divergence fix made lookups succeed,
+  every cache restore crashed. The async postcommit now submits to
+  `state.generation_executor` (matching v0.1.6 behaviour, which did not
+  have this issue) so cache buffers are created on the same thread that
+  will later restore them. The non-blocking lock acquire inside
+  `_store_retokenized_history_snapshot` already ensures the postcommit
+  yields when foreground actually wants the lock, so queueing on
+  `generation_executor` does not introduce foreground latency in
+  practice.
 
 ## v0.2.0
 

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -535,6 +535,48 @@ def _load_vllm_metal_ops():
     )
 
 
+# Module-level latch so we only warn once per process when the optional
+# vllm-metal external ops can't load. Subsequent calls stay silent.
+_VLLM_METAL_OPS_UNAVAILABLE_WARNED = False
+
+
+def _warn_vllm_metal_ops_unavailable(exc: BaseException, *, context: str) -> None:
+    """Emit a single, plain-stderr warning when external ops are missing.
+
+    We deliberately avoid the ``warnings`` module here because MTPLX runs under
+    request-scoped warning filters that can swallow the message; a direct
+    ``print`` to stderr is what the operator actually sees in the server log.
+    """
+
+    global _VLLM_METAL_OPS_UNAVAILABLE_WARNED
+    if _VLLM_METAL_OPS_UNAVAILABLE_WARNED:
+        return
+    _VLLM_METAL_OPS_UNAVAILABLE_WARNED = True
+    print(
+        f"mtplx: vllm-metal external ops unavailable ({context}): {exc}; "
+        "falling back to packaged paged-attention path. Install nanobind and "
+        "build vllm_metal/paged_ops.cpp, or set MTPLX_VLLM_METAL_REPO, to "
+        "re-enable the external ops.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _load_vllm_metal_ops_optional(*, context: str):
+    """Load vllm-metal ops if available; return ``None`` (and warn once) if not.
+
+    Use this on the graceful-fallback paths where the caller has a valid
+    in-tree alternative.  Use ``_load_vllm_metal_ops`` directly only for
+    diagnostic / explicitly-required paths.
+    """
+
+    try:
+        return _load_vllm_metal_ops()
+    except RuntimeError as exc:
+        _warn_vllm_metal_ops_unavailable(exc, context=context)
+        return None
+
+
 class VllmMetalPagedKVCache:
     """Preallocated full-attention KV pages backed by vLLM-Metal primitives.
 
@@ -681,6 +723,17 @@ class VllmMetalPagedKVCache:
                 )
             return
         n_kv_heads, k_head_dim, v_head_dim = shape
+        # Defense-in-depth: if a TurboQuant cache reaches first allocation but
+        # the external vllm-metal ops can't load, gracefully degrade to the
+        # plain paged layout instead of crashing the in-flight request. The
+        # install-time path already drops turboquant_config when ops are
+        # missing, but downstream callers (e.g. snapshot restore) may still
+        # construct a TurboQuant cache without going through that gate.
+        if self.turboquant and _load_vllm_metal_ops_optional(
+            context="TurboQuant cache allocation"
+        ) is None:
+            self.turboquant = False
+            self.turboquant_config = None
         if self.turboquant:
             from .turboquant import (
                 CENTROIDS_3BIT,
@@ -770,9 +823,44 @@ class VllmMetalPagedKVCache:
             ):
                 raise RuntimeError("TurboQuant scale caches were not allocated")
             cfg = self.turboquant_config
-            ops = _load_vllm_metal_ops()
-            if not hasattr(ops, "tq_encode"):
-                raise RuntimeError("local vLLM-Metal ops do not expose tq_encode")
+            ops = _load_vllm_metal_ops_optional(context="TurboQuant tq_encode")
+            if ops is None or not hasattr(ops, "tq_encode"):
+                # Graceful fallback: external ops are missing or stripped down.
+                # Drop the TurboQuant snapshot path for this cache and reroute
+                # to the plain paged layout. The cache is still empty for this
+                # write (no prior tq_encode could have succeeded without ops),
+                # so it is safe to re-allocate.
+                if ops is not None and not hasattr(ops, "tq_encode"):
+                    _warn_vllm_metal_ops_unavailable(
+                        RuntimeError(
+                            "local vLLM-Metal ops do not expose tq_encode"
+                        ),
+                        context="TurboQuant tq_encode",
+                    )
+                self.turboquant = False
+                self.turboquant_config = None
+                self.key_cache = None
+                self.value_cache = None
+                self.key_scale_cache = None
+                self.value_scale_cache = None
+                self.key_zero_cache = None
+                self._shape = None
+                self._dtypes = None
+                self._ensure_allocated(keys, values)
+                flat_k = self.key_cache.reshape(
+                    -1, int(keys.shape[1]), int(keys.shape[3])
+                )
+                flat_v = self.value_cache.reshape(
+                    -1, int(values.shape[1]), int(values.shape[3])
+                )
+                flat_k[slot_mapping] = k_3d
+                flat_v[slot_mapping] = v_3d
+                self.key_cache = flat_k.reshape(self.key_cache.shape)
+                self.value_cache = flat_v.reshape(self.value_cache.shape)
+                self.offset += steps
+                self.update_calls += 1
+                self.cache_write_time_s += time.perf_counter() - started
+                return
             (
                 self.key_cache,
                 self.value_cache,
@@ -1522,9 +1610,14 @@ class VllmMetalPagedKVCache:
                 or self.key_zero_cache is None
             ):
                 return bailout("turboquant_unsupported")
+            tq_ops = _load_vllm_metal_ops_optional(
+                context="TurboQuant paged_attention_primitive"
+            )
+            if tq_ops is None or not hasattr(tq_ops, "paged_attention_primitive"):
+                return bailout("turboquant_unsupported")
             cfg = self.turboquant_config
             out = mx.array(0)
-            _load_vllm_metal_ops().paged_attention_primitive(
+            tq_ops.paged_attention_primitive(
                 q_3d,
                 self.key_cache,
                 self.value_cache,
@@ -1553,6 +1646,11 @@ class VllmMetalPagedKVCache:
         if partitioned_enabled and int(self.offset) >= partition_threshold:
             return run_partitioned_paged(force_fp32_paged=force_fp32_paged)
         out = mx.array(0)
+        # Note: this default vllm_metal path requires the external ops by
+        # design (no in-tree alternative for the bare paged_attention_primitive
+        # call). The graceful-fallback paths are turboquant + the
+        # mlx_vector_paged / sdpa_2pass_paged / fast_sdpa_gather IMPLs which
+        # have packaged kernels above. Production callers select an IMPL.
         _load_vllm_metal_ops().paged_attention_primitive(
             q_3d,
             kernel_key_cache,
@@ -2343,8 +2441,34 @@ def install_vllm_metal_paged_attention_kv_cache(
     # actually dispatch into the external vLLM-Metal ops. The packaged
     # mlx_vector_paged and sdpa_2pass_paged paths are in-tree and must survive a
     # clean product checkout without REFERENCES:TOOLS.
+    #
+    # When the install is for a TurboQuant snapshot but external ops can't be
+    # loaded (no nanobind, no JIT-built paged_ops.so, no MTPLX_VLLM_METAL_REPO),
+    # we MUST NOT raise: that would crash any in-flight request that triggered
+    # the install. Instead, downgrade gracefully to the plain paged-cache
+    # layout. The cache stays functional via the in-tree mlx_vector_paged /
+    # sdpa_2pass_paged kernels, just without the TurboQuant compression.
     if external_ops_required:
-        _load_vllm_metal_ops()
+        try:
+            _load_vllm_metal_ops()
+        except RuntimeError as exc:
+            if turboquant_config is not None:
+                _warn_vllm_metal_ops_unavailable(
+                    exc, context="TurboQuant install"
+                )
+                turboquant_config = None
+                stats["mode"] = "vllm_metal_paged"
+                stats["turboquant"] = 0
+                stats["external_ops_required"] = int(
+                    _paged_attention_requires_external_ops(
+                        turboquant_config=None,
+                    )
+                )
+                stats["turboquant_disabled_reason"] = "vllm_metal_ops_unavailable"
+                stats.pop("turboquant_k_quant", None)
+                stats.pop("turboquant_v_quant", None)
+            else:
+                raise
     for idx, entry in enumerate(cache or []):
         if entry is None:
             stats["skipped"] = int(stats["skipped"]) + 1

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -1646,12 +1646,28 @@ class VllmMetalPagedKVCache:
         if partitioned_enabled and int(self.offset) >= partition_threshold:
             return run_partitioned_paged(force_fp32_paged=force_fp32_paged)
         out = mx.array(0)
-        # Note: this default vllm_metal path requires the external ops by
-        # design (no in-tree alternative for the bare paged_attention_primitive
-        # call). The graceful-fallback paths are turboquant + the
-        # mlx_vector_paged / sdpa_2pass_paged / fast_sdpa_gather IMPLs which
-        # have packaged kernels above. Production callers select an IMPL.
-        _load_vllm_metal_ops().paged_attention_primitive(
+        # The bare vllm_metal default path needs external ops. If they aren't
+        # available (no nanobind, no JIT-built paged_ops.so, no
+        # MTPLX_VLLM_METAL_REPO), fall through to the in-tree split-sdpa
+        # fallback used by the partitioned/turboquant paths so the request
+        # does not crash mid-stream. Operators who want the optimal kernel
+        # install nanobind + run vllm_metal/metal/build.py.
+        ops = _load_vllm_metal_ops_optional(
+            context="vllm_metal default paged_attention"
+        )
+        if ops is None:
+            split_out = self._large_q_split_sdpa_fallback(
+                queries,
+                scale=scale,
+                sliding_window=int(sliding_window),
+                mask=mask,
+            )
+            if split_out is not None:
+                self.paged_attention_calls += 1
+                self.attention_time_s += time.perf_counter() - started
+                return split_out
+            return bailout("vllm_metal_ops_unavailable")
+        ops.paged_attention_primitive(
             q_3d,
             kernel_key_cache,
             kernel_value_cache,

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -8,11 +8,31 @@ state explicit before the generation loop accepts warm prompt state directly.
 from __future__ import annotations
 
 import hashlib
+import os
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from threading import Lock
 from typing import Any, Iterator, Mapping
+
+
+def _bank_bytes_from_env(name: str, default: int) -> int:
+    """Read a SessionBank byte-cap override from the environment.
+
+    Supports plain integers (interpreted as bytes) and the suffixes K, M, G,
+    T (powers of 1024). Returns the default if unset or unparseable.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        s = raw.strip().upper()
+        suffixes = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+        if s and s[-1] in suffixes:
+            return int(float(s[:-1]) * suffixes[s[-1]])
+        return int(s)
+    except (ValueError, IndexError):
+        return default
 
 from .session_bank import (
     CacheMissReason,
@@ -259,9 +279,17 @@ class EngineSessionManager:
         bank: SessionBank | None = None,
         idle_ttl_s: float = DEFAULT_IDLE_TTL_S,
     ) -> None:
+        # Bank caps default to the constants in session_bank.py. Operators
+        # running into per-session eviction at large contexts can override
+        # via MTPLX_SESSION_BANK_PER_SESSION_BYTES (e.g. "16G" for 16 GiB)
+        # or MTPLX_SESSION_BANK_MAX_BYTES.
         self.bank = bank or SessionBank(
-            max_bytes=DEFAULT_MAX_BYTES,
-            per_session_max_bytes=DEFAULT_PER_SESSION_MAX_BYTES,
+            max_bytes=_bank_bytes_from_env(
+                "MTPLX_SESSION_BANK_MAX_BYTES", DEFAULT_MAX_BYTES
+            ),
+            per_session_max_bytes=_bank_bytes_from_env(
+                "MTPLX_SESSION_BANK_PER_SESSION_BYTES", DEFAULT_PER_SESSION_MAX_BYTES
+            ),
             idle_ttl_s=idle_ttl_s,
         )
         self.idle_ttl_s = float(idle_ttl_s)

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -202,6 +202,11 @@ class EngineSession:
         self.last_restore_mode: str = "cold"
         self.bytes_estimate = 0
         self._lock = Lock()
+        # Future for the pending postcommit of the most recent generation in
+        # this session. The next request waits briefly on this so the bank has
+        # the prior turn's entry available at lookup time, avoiding a cold
+        # re-prefill cascade across the first 4-5 turns of a fresh session.
+        self.pending_postcommit: Any = None
 
     @property
     def prefix_len(self) -> int:
@@ -214,8 +219,54 @@ class EngineSession:
         now = time.time() if now_s is None else float(now_s)
         return now - self.last_access_s > self.idle_ttl_s
 
+    def wait_for_pending_postcommit(self, *, timeout_s: float = 10.0) -> dict[str, Any]:
+        """Block briefly for the prior postcommit's SessionBank entry to land
+        so this request's lookup can warm-start. Returns a small dict for
+        telemetry: `{"waited": bool, "elapsed_s": float, "outcome": str}`.
+
+        Design notes - this MUST be called WITHOUT the session lock held.
+        The postcommit it waits on submits MLX work to `generation_executor`
+        via `Future.result()`. If we held the session lock, that lock plus
+        a single-worker generation_executor would cycle: foreground holds
+        lock waiting on postcommit, postcommit tries to run on
+        generation_executor, generation_executor is free but the postcommit
+        future never resolves because the actual MLX work is queued behind
+        another item that... in practice this manifests as foreground hangs
+        of 100+ s.
+
+        Bounded timeout (5 s default) so a stuck postcommit can't block the
+        request indefinitely; the request just falls through to a cold
+        prefill, same outcome as no-wait.
+        """
+        future = self.pending_postcommit
+        if future is None:
+            return {"waited": False, "elapsed_s": 0.0, "outcome": "no_pending"}
+        # Drop the reference up-front so a subsequent call doesn't double-wait.
+        self.pending_postcommit = None
+        if not hasattr(future, "result"):
+            return {"waited": False, "elapsed_s": 0.0, "outcome": "not_a_future"}
+        t0 = time.monotonic()
+        try:
+            future.result(timeout=timeout_s)
+            return {
+                "waited": True,
+                "elapsed_s": time.monotonic() - t0,
+                "outcome": "completed",
+            }
+        except BaseException as exc:
+            return {
+                "waited": True,
+                "elapsed_s": time.monotonic() - t0,
+                "outcome": f"timeout_or_error:{type(exc).__name__}",
+            }
+
     @contextmanager
     def in_flight_generation(self) -> Iterator["EngineSession"]:
+        # Wait BEFORE acquiring the session lock so the postcommit task is
+        # free to use generation_executor without contending with us. Without
+        # this ordering, the foreground request could hold the session lock
+        # while the postcommit's blocked .result() call prevents progress.
+        self.wait_for_pending_postcommit()
         if not self._lock.acquire(blocking=False):
             raise EngineSessionBusy(f"session {self.session_id} is already in flight")
         self.in_flight = True

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -8,12 +8,16 @@ state explicit before the generation loop accepts warm prompt state directly.
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from threading import Lock
 from typing import Any, Iterator, Mapping
+
+
+logger = logging.getLogger(__name__)
 
 
 def _bank_bytes_from_env(name: str, default: int) -> int:
@@ -34,6 +38,37 @@ def _bank_bytes_from_env(name: str, default: int) -> int:
     except (ValueError, IndexError):
         return default
 
+
+def _bank_entries_from_env(name: str, default: int) -> int:
+    """Read a SessionBank entry-count override from the environment.
+
+    Parses a plain integer (no K/M/G/T suffixes - entry count is a count, not
+    a byte size). Validates that the value is >= 1. On parse error or invalid
+    value, logs a warning and returns the default.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r (expected integer >= 1); falling back to default %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value < 1:
+        logger.warning(
+            "Invalid %s=%r (must be >= 1); falling back to default %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
 from .session_bank import (
     CacheMissReason,
     DEFAULT_IDLE_TTL_S,
@@ -41,6 +76,11 @@ from .session_bank import (
     DEFAULT_PER_SESSION_MAX_BYTES,
     SessionBank,
 )
+
+# Mirrors SessionBank.__init__'s hardcoded max_entries default (kept in sync
+# manually so the operator override here does not silently shift the default
+# for callers that construct SessionBank directly).
+_DEFAULT_BANK_MAX_ENTRIES = 8
 
 
 @dataclass
@@ -282,8 +322,14 @@ class EngineSessionManager:
         # Bank caps default to the constants in session_bank.py. Operators
         # running into per-session eviction at large contexts can override
         # via MTPLX_SESSION_BANK_PER_SESSION_BYTES (e.g. "16G" for 16 GiB)
-        # or MTPLX_SESSION_BANK_MAX_BYTES.
+        # or MTPLX_SESSION_BANK_MAX_BYTES. The entry-count cap is also
+        # overridable via MTPLX_SESSION_BANK_MAX_ENTRIES (plain integer)
+        # for workloads where ~2 GB-per-entry contexts make the default of
+        # 8 the binding constraint well before the byte caps.
         self.bank = bank or SessionBank(
+            max_entries=_bank_entries_from_env(
+                "MTPLX_SESSION_BANK_MAX_ENTRIES", _DEFAULT_BANK_MAX_ENTRIES
+            ),
             max_bytes=_bank_bytes_from_env(
                 "MTPLX_SESSION_BANK_MAX_BYTES", DEFAULT_MAX_BYTES
             ),

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1283,6 +1283,7 @@ def restore_or_prefill_prompt_state(
     template_hash: str | None = None,
     draft_head_identity: str | None = None,
     policy_fingerprint: str | None = None,
+    session_id: str | None = None,
 ) -> PromptState:
     """Build the initial prompt state used by MTP-k decode.
 
@@ -1310,6 +1311,7 @@ def restore_or_prefill_prompt_state(
             mtp_history_policy=mtp_history_policy,
             draft_head_identity=draft_head_identity,
             policy_fingerprint=policy_fingerprint,
+            session_id=session_id,
         )
         if restored is not None and (
             not _mtp_history_uses_committed_cache(mtp_history_policy)
@@ -2864,6 +2866,7 @@ def generate_mtpk(
     session_template_hash: str | None = None,
     session_draft_head_identity: str | None = None,
     session_policy_fingerprint: str | None = None,
+    session_id: str | None = None,
     capture_final_state: bool = False,
     trace_label: str | None = None,
     trace_metadata: dict[str, Any] | None = None,
@@ -2964,6 +2967,7 @@ def generate_mtpk(
         template_hash=session_template_hash,
         draft_head_identity=session_draft_head_identity,
         policy_fingerprint=session_policy_fingerprint,
+        session_id=session_id,
     )
     cache = prompt_state.trunk_cache
     logits = prompt_state.logits

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2255,6 +2255,22 @@ def _store_retokenized_history_snapshot(
             "reason": "model_lock_busy_before_retokenized_commit",
             "elapsed_s": time.perf_counter() - started,
         }
+    # Pass `session_bank` so the postcommit prefill reuses the longest
+    # matching prefix from a prior turn instead of re-prefilling the full
+    # ~18K-token history from scratch. On consecutive tool-calling turns
+    # this collapses postcommit cost from ~27 s (full re-prefill) to ~1 s
+    # (suffix forward only), which matters because PR #24 routed this work
+    # through `state.generation_executor` (single-worker) to keep MLX
+    # streams thread-local. With the full re-prefill, the next foreground
+    # request was queueing 27-30 s behind this task; with the prefix
+    # shortcut the queue stall drops to roughly the suffix forward time.
+    #
+    # The bank already contains an entry for the previous turn's history
+    # (this same function stored it on the prior postcommit). The new
+    # turn's history starts with that previous-turn prefix verbatim
+    # (chat-template encoding is deterministic for the same messages and
+    # tools), so `longest_prefix` matches and only the new user turn +
+    # assistant turn need to be forward-AR'd.
     try:
         with attention_phase("postcommit"):
             prompt_state = restore_or_prefill_prompt_state(
@@ -2262,6 +2278,10 @@ def _store_retokenized_history_snapshot(
                 history_ids,
                 mtp_hidden_variant="post_norm",
                 mtp_history_policy="committed",
+                session_bank=state.sessions.bank,
+                template_hash=state.template_hash,
+                draft_head_identity=state.draft_head_identity,
+                policy_fingerprint=policy_fingerprint,
             )
         mtp_snapshot = (
             snapshot_cache(prompt_state.committed_mtp_cache)
@@ -2302,6 +2322,9 @@ def _store_retokenized_history_snapshot(
         "nbytes": entry.nbytes,
         "elapsed_s": time.perf_counter() - started,
         "token_hash": entry.token_hash,
+        "cache_hit": bool(getattr(prompt_state, "cache_hit", False)),
+        "cached_tokens": int(getattr(prompt_state, "cached_tokens", 0) or 0),
+        "suffix_tokens": int(getattr(prompt_state, "suffix_tokens", 0) or 0),
     }
 
 
@@ -2575,6 +2598,50 @@ def _schedule_idle_postcommit_snapshot(
             # Logging must never bring down the executor; fail silently.
             pass
 
+    postcommit_executor = getattr(state, "postcommit_executor", None)
+    use_two_stage = (
+        postcommit_executor is not None
+        and postcommit_executor is not state.generation_executor
+    )
+
+    def _store_directly() -> dict[str, Any]:
+        return _store_retokenized_history_snapshot(
+            state,
+            session_id=session_id,
+            messages=messages,
+            assistant_content=assistant_content,
+            assistant_tool_calls=assistant_tool_calls,
+            thinking_enabled=thinking_enabled,
+            policy_fingerprint=policy_fingerprint,
+            acquire_model_lock_blocking=False,
+            tool_specs=tool_specs,
+        )
+
+    def _run_store_on_generation_executor() -> dict[str, Any]:
+        """Run the actual MLX-touching snapshot work on `generation_executor`.
+
+        This MUST run on `generation_executor` because the SessionBank entry
+        is restored from `generation_executor`'s thread on subsequent turns,
+        and MLX streams on Apple Silicon are thread-local: a cache buffer
+        created on one thread raises
+        `RuntimeError: There is no Stream(gpu, N) in current thread` when
+        accessed from another. PR #24 (commit 3d9f200) established this
+        invariant after the original `postcommit_executor` introduced cross-
+        thread restore failures.
+
+        When `postcommit_executor` is unavailable or aliased to
+        `generation_executor` (test stubs), we call the snapshot function
+        directly to avoid a single-worker deadlock.
+        """
+        if not use_two_stage:
+            return _store_directly()
+        future = state.generation_executor.submit(_store_directly)
+        # Real `concurrent.futures.Future` exposes `.result()`; some test
+        # stubs return the function's value directly from `submit`.
+        if hasattr(future, "result"):
+            return future.result()
+        return future  # type: ignore[return-value]
+
     def async_postcommit() -> None:
         deadline = time.monotonic() + _IDLE_POSTCOMMIT_MAX_WAIT_S
         try:
@@ -2592,18 +2659,15 @@ def _schedule_idle_postcommit_snapshot(
             # foreground flag never clears - waiting on it caused every
             # subagent's snapshot to be abandoned and the SessionBank to
             # stay empty for those session ids.
+            #
+            # The retry/sleep loop runs on `postcommit_executor` so the
+            # 250 ms inter-attempt sleep does not occupy
+            # `generation_executor` and head-of-line block the next
+            # foreground request. The actual MLX-touching snapshot call is
+            # submitted to `generation_executor` via
+            # `_run_store_on_generation_executor` (cross-thread MLX safety).
             while True:
-                postcommit = _store_retokenized_history_snapshot(
-                    state,
-                    session_id=session_id,
-                    messages=messages,
-                    assistant_content=assistant_content,
-                    assistant_tool_calls=assistant_tool_calls,
-                    thinking_enabled=thinking_enabled,
-                    policy_fingerprint=policy_fingerprint,
-                    acquire_model_lock_blocking=False,
-                    tool_specs=tool_specs,
-                )
+                postcommit = _run_store_on_generation_executor()
 
                 if postcommit.get("stored"):
                     _log(postcommit)
@@ -2639,17 +2703,26 @@ def _schedule_idle_postcommit_snapshot(
                 }
             )
 
-    # Route through generation_executor instead of a separate postcommit
-    # thread. MLX streams on Apple Silicon are thread-local, so a SessionBank
-    # entry created on one thread cannot be restored from another - the
-    # restore path raises "There is no Stream(gpu, N) in current thread".
-    # PR #17 introduced a dedicated postcommit_executor to keep this work off
-    # the foreground latency path, but in practice the non-blocking lock
-    # acquire inside _store_retokenized_history_snapshot already guarantees
-    # the postcommit yields when foreground actually wants to run, and
-    # queueing on generation_executor is the v0.1.6 behaviour that did not
-    # have this cross-thread issue.
-    state.generation_executor.submit(async_postcommit)
+    # Architecture: Option B (Tier 2.1) + Option A (small dose).
+    #
+    # Option B is the primary win. `_store_retokenized_history_snapshot`
+    # now passes `session_bank` to `restore_or_prefill_prompt_state`, so
+    # the postcommit reuses the previous turn's SessionBank entry as a
+    # prefix and only forward-AR's the new suffix. This collapses postcommit
+    # cost from ~27 s (full 18K-token re-prefill) to ~1 s (suffix forward
+    # only) on consecutive tool-calling turns. The next foreground request
+    # therefore queues only ~1 s, not ~30 s.
+    #
+    # Option A (small dose): the orchestration loop runs on
+    # `postcommit_executor` so the 250 ms inter-attempt sleep does not
+    # occupy `generation_executor`, but the actual MLX work is still
+    # submitted to `generation_executor` to preserve the cross-thread MLX
+    # stream invariant established by PR #24 (commit 3d9f200). The first-
+    # turn case (no prefix in the bank yet, so still a full re-prefill)
+    # remains a head-of-line block of the next request, but it is much
+    # less common than the steady-state multi-turn case.
+    executor = postcommit_executor if use_two_stage else state.generation_executor
+    executor.submit(async_postcommit)
     return pending
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2277,6 +2277,7 @@ def _store_retokenized_history_snapshot(
                 template_hash=state.template_hash,
                 draft_head_identity=state.draft_head_identity,
                 policy_fingerprint=policy_fingerprint,
+                session_id=session_id,
             )
         mtp_snapshot = (
             snapshot_cache(prompt_state.committed_mtp_cache)
@@ -3000,6 +3001,7 @@ def _run_generation(
                         session_template_hash=session_template_hash,
                         session_draft_head_identity=session_draft_head_identity,
                         session_policy_fingerprint=session_policy_fingerprint,
+                        session_id=session_id,
                         capture_final_state=session_bank is not None,
                         trace_label=trace_label,
                         trace_metadata=trace_metadata,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2226,22 +2226,17 @@ def _store_retokenized_history_snapshot(
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
-    history_messages = list(messages) + [
-        ChatMessage(
-            role="assistant",
-            content=assistant_content,
-            tool_calls=assistant_tool_calls,
-        ),
-    ]
-    encoded_with_sentinel = _encode_messages(
-        state.runtime.tokenizer,
-        history_messages,
-        enable_thinking=thinking_enabled,
-        strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
-        add_generation_prompt=False,
-        tools=tool_specs,
+    # Encode the history so it is a strict prefix of the next request's
+    # prompt (see _encode_history_for_storage docstring for why we cannot
+    # just append the assistant message and encode directly).
+    history_ids = _encode_history_for_storage(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=assistant_tool_calls,
+        thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
-    history_ids = encoded_with_sentinel
     if not history_ids:
         return {"stored": False, "reason": "empty_boundary_prefix"}
     started = time.perf_counter()
@@ -2329,6 +2324,74 @@ def _store_retokenized_history_snapshot(
     }
 
 
+_IM_START_TOKEN = "<|im_start|>"
+
+
+def _encode_history_for_storage(
+    state: ServerState,
+    *,
+    messages: list[ChatMessage],
+    assistant_content: str,
+    assistant_tool_calls: list[dict[str, Any]] | None,
+    thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
+) -> list[int]:
+    """Encode history up to and including the assistant turn so the result
+    is a strict prefix of the next request's prompt encoding.
+
+    Without this trick, the Qwen3 chat template injects an empty
+    `<think>\\n\\n</think>\\n\\n` block before tool_call markup when an
+    assistant message is the trailing message AND `enable_thinking=False`.
+    The next request's prompt has the assistant message followed by
+    tool_result + user_msg, so that injection does NOT happen at lookup
+    time. Storage therefore needs to render the assistant in a
+    "non-trailing" position to match.
+
+    Approach: append a sentinel user message, encode, truncate the result
+    before the LAST `<|im_start|>` token (where the sentinel begins). The
+    kept prefix ends cleanly at `<|im_end|>\\n` after the assistant turn
+    and is a strict prefix of any request that follows the assistant with
+    another message of any role - which is exactly what the
+    SessionBank.longest_prefix lookup needs.
+    """
+    history_messages = list(messages) + [
+        ChatMessage(
+            role="assistant",
+            content=assistant_content,
+            tool_calls=assistant_tool_calls,
+        ),
+        ChatMessage(role="user", content="_"),
+    ]
+    encoded = _encode_messages(
+        state.runtime.tokenizer,
+        history_messages,
+        enable_thinking=thinking_enabled,
+        strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
+        add_generation_prompt=False,
+        tools=tool_specs,
+    )
+    if not encoded:
+        return []
+    try:
+        im_start_id = state.runtime.tokenizer.convert_tokens_to_ids(
+            _IM_START_TOKEN
+        )
+    except Exception:
+        im_start_id = None
+    if im_start_id is None or not isinstance(im_start_id, int) or im_start_id < 0:
+        # Tokenizer doesn't expose <|im_start|>: best-effort, return raw.
+        # Truncating heuristically would risk corrupting the prefix.
+        return list(encoded)
+    last_im_start = -1
+    for i in range(len(encoded) - 1, -1, -1):
+        if encoded[i] == im_start_id:
+            last_im_start = i
+            break
+    if last_im_start < 0:
+        return list(encoded)
+    return list(encoded[:last_im_start])
+
+
 def _history_ids_for_postcommit(
     state: ServerState,
     *,
@@ -2338,20 +2401,13 @@ def _history_ids_for_postcommit(
     thinking_enabled: bool,
     tool_specs: list[dict[str, Any]] | None = None,
 ) -> list[int]:
-    history_messages = list(messages) + [
-        ChatMessage(
-            role="assistant",
-            content=assistant_content,
-            tool_calls=assistant_tool_calls,
-        ),
-    ]
-    return _encode_messages(
-        state.runtime.tokenizer,
-        history_messages,
-        enable_thinking=thinking_enabled,
-        strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
-        add_generation_prompt=False,
-        tools=tool_specs,
+    return _encode_history_for_storage(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=assistant_tool_calls,
+        thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2325,6 +2325,7 @@ def _store_retokenized_history_snapshot(
         "cache_hit": bool(getattr(prompt_state, "cache_hit", False)),
         "cached_tokens": int(getattr(prompt_state, "cached_tokens", 0) or 0),
         "suffix_tokens": int(getattr(prompt_state, "suffix_tokens", 0) or 0),
+        "cache_miss_reason": getattr(prompt_state, "cache_miss_reason", None),
     }
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2779,7 +2779,17 @@ def _schedule_idle_postcommit_snapshot(
     # remains a head-of-line block of the next request, but it is much
     # less common than the steady-state multi-turn case.
     executor = postcommit_executor if use_two_stage else state.generation_executor
-    executor.submit(async_postcommit)
+    future = executor.submit(async_postcommit)
+    # Record the future on the EngineSession so the next request in this
+    # session can wait for the bank entry to land before its lookup. Without
+    # this, fast follow-up turns miss the cache for ~4-5 turns until the
+    # postcommit train catches up.
+    if session_id:
+        try:
+            session = state.sessions.get_or_create(session_id)
+            session.pending_postcommit = future
+        except Exception:
+            pass
     return pending
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2529,10 +2529,15 @@ def _schedule_idle_postcommit_snapshot(
     The retokenized-history path canonicalises tool_call responses into the
     exact prefix the next request will send, so the commit is safe - it just
     must not run on the request thread (would extend stream latency). This
-    function dispatches that work to the postcommit executor, where it waits
-    for the foreground to go idle and then runs the synchronous retokenized
-    commit. If the foreground stays busy past the deadline we abandon, since
-    a later commit would race the next turn's prefill.
+    function dispatches that work to the postcommit executor, which then
+    repeatedly attempts the retokenized commit using the existing
+    non-blocking model-lock acquire inside `_store_retokenized_history_snapshot`
+    as the correctness gate. If the lock is held by a foreground prefill we
+    sleep briefly and retry; if the lock stays held past the deadline we
+    abandon, since a later commit would race the next turn's prefill. Any
+    non-recoverable result (no_session_id, empty_boundary_prefix,
+    sessionbank_snapshot_skipped, or a successful store) is logged and
+    returned immediately without retrying.
     """
     pending = {
         "stored": False,
@@ -2564,39 +2569,57 @@ def _schedule_idle_postcommit_snapshot(
     def async_postcommit() -> None:
         deadline = time.monotonic() + _IDLE_POSTCOMMIT_MAX_WAIT_S
         try:
-            # Wait for the foreground request to release the model. We poll
-            # both the foreground flag and the model lock; if either is held
-            # the next prefill is imminent or already running and committing
-            # now would either stall it or race it. We bound the wait so a
-            # back-pressured server never accumulates a backlog of stale
-            # commit work.
-            while state.has_foreground() or state.lock.locked():
+            # Loop until either the snapshot stores, a non-recoverable result
+            # comes back, or the deadline expires. The non-blocking lock
+            # acquire inside `_store_retokenized_history_snapshot` is the
+            # real correctness gate - if a foreground prefill holds the
+            # model lock, the helper fails fast with
+            # "model_lock_busy_before_retokenized_commit" and the
+            # background work never delays the foreground request. We do
+            # NOT gate on `state.has_foreground()`: in OpenAI-compatible
+            # subagent fan-out (opencode researcher / planner / fixer /
+            # bug-patcher) the parent re-dispatches the next request within
+            # milliseconds of the previous response completing, so the
+            # foreground flag never clears - waiting on it caused every
+            # subagent's snapshot to be abandoned and the SessionBank to
+            # stay empty for those session ids.
+            while True:
+                postcommit = _store_retokenized_history_snapshot(
+                    state,
+                    session_id=session_id,
+                    messages=messages,
+                    assistant_content=assistant_content,
+                    assistant_tool_calls=assistant_tool_calls,
+                    thinking_enabled=thinking_enabled,
+                    policy_fingerprint=policy_fingerprint,
+                    acquire_model_lock_blocking=False,
+                )
+
+                if postcommit.get("stored"):
+                    _log(postcommit)
+                    return
+
+                if (
+                    postcommit.get("reason")
+                    != "model_lock_busy_before_retokenized_commit"
+                ):
+                    # Non-recoverable result (no_session_id,
+                    # empty_boundary_prefix, sessionbank_snapshot_skipped,
+                    # etc.) - retrying will not help.
+                    _log(postcommit)
+                    return
+
                 if time.monotonic() >= deadline:
                     _log(
                         {
                             "stored": False,
                             "mode": "abandoned_foreground_busy",
-                            "reason": "foreground_busy_past_deadline",
+                            "reason": "model_lock_busy_past_deadline",
                         }
                     )
                     return
-                time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
 
-            # Foreground is idle. Run the canonical retokenized commit with a
-            # non-blocking lock acquire, so a foreground request that wins the
-            # race after the idle check is never delayed by background cache
-            # maintenance.
-            postcommit = _store_retokenized_history_snapshot(
-                state,
-                session_id=session_id,
-                messages=messages,
-                assistant_content=assistant_content,
-                assistant_tool_calls=assistant_tool_calls,
-                thinking_enabled=thinking_enabled,
-                policy_fingerprint=policy_fingerprint,
-                acquire_model_lock_blocking=False,
-            )
-            _log(postcommit)
+                time.sleep(_IDLE_POSTCOMMIT_POLL_INTERVAL_S)
         except BaseException as exc:
             _log(
                 {

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2639,10 +2639,17 @@ def _schedule_idle_postcommit_snapshot(
                 }
             )
 
-    executor = getattr(state, "postcommit_executor", None)
-    if executor is None:
-        executor = state.generation_executor
-    executor.submit(async_postcommit)
+    # Route through generation_executor instead of a separate postcommit
+    # thread. MLX streams on Apple Silicon are thread-local, so a SessionBank
+    # entry created on one thread cannot be restored from another - the
+    # restore path raises "There is no Stream(gpu, N) in current thread".
+    # PR #17 introduced a dedicated postcommit_executor to keep this work off
+    # the foreground latency path, but in practice the non-blocking lock
+    # acquire inside _store_retokenized_history_snapshot already guarantees
+    # the postcommit yields when foreground actually wants to run, and
+    # queueing on generation_executor is the v0.1.6 behaviour that did not
+    # have this cross-thread issue.
+    state.generation_executor.submit(async_postcommit)
     return pending
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2222,6 +2222,7 @@ def _store_retokenized_history_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     acquire_model_lock_blocking: bool = True,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
@@ -2238,6 +2239,7 @@ def _store_retokenized_history_snapshot(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
     history_ids = encoded_with_sentinel
     if not history_ids:
@@ -2310,6 +2312,7 @@ def _history_ids_for_postcommit(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> list[int]:
     history_messages = list(messages) + [
         ChatMessage(
@@ -2324,6 +2327,7 @@ def _history_ids_for_postcommit(
         enable_thinking=thinking_enabled,
         strip_assistant_reasoning_history=state.args.strip_assistant_reasoning_history,
         add_generation_prompt=False,
+        tools=tool_specs,
     )
 
 
@@ -2336,6 +2340,7 @@ def _generation_final_postcommit_compatibility(
     assistant_content: str,
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if assistant_tool_calls:
         return {
@@ -2387,6 +2392,7 @@ def _generation_final_postcommit_compatibility(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if history_ids == final_token_ids:
         return {
@@ -2432,6 +2438,7 @@ def _store_generation_final_history_snapshot(
     assistant_tool_calls: list[dict[str, Any]] | None = None,
     thinking_enabled: bool,
     policy_fingerprint: str,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "mode": "unsafe", "reason": "no_session_id"}
@@ -2444,6 +2451,7 @@ def _store_generation_final_history_snapshot(
         assistant_content=assistant_content,
         assistant_tool_calls=assistant_tool_calls,
         thinking_enabled=thinking_enabled,
+        tool_specs=tool_specs,
     )
     if not bool(compatibility.get("safe")):
         return {
@@ -2520,6 +2528,7 @@ def _schedule_idle_postcommit_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     unsafe_reason: str,
+    tool_specs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Schedule a background SessionBank commit for a response the
     generation-final compatibility check rejected as unsafe (most commonly
@@ -2593,6 +2602,7 @@ def _schedule_idle_postcommit_snapshot(
                     thinking_enabled=thinking_enabled,
                     policy_fingerprint=policy_fingerprint,
                     acquire_model_lock_blocking=False,
+                    tool_specs=tool_specs,
                 )
 
                 if postcommit.get("stored"):
@@ -5351,6 +5361,7 @@ def create_app(state: ServerState) -> FastAPI:
                 assistant_content=assistant_content,
                 assistant_tool_calls=assistant_tool_calls,
                 thinking_enabled=thinking_enabled,
+                tool_specs=tool_specs if tools_active else None,
             )
             if compatibility.get("safe"):
                 generated["stats"]["session_postcommit_snapshot"] = {
@@ -5383,6 +5394,7 @@ def create_app(state: ServerState) -> FastAPI:
                         thinking_enabled=thinking_enabled,
                         policy_fingerprint=policy_fingerprint,
                         unsafe_reason=unsafe_reason,
+                        tool_specs=tool_specs if tools_active else None,
                     )
                 )
                 return
@@ -5397,6 +5409,7 @@ def create_app(state: ServerState) -> FastAPI:
                     assistant_tool_calls=assistant_tool_calls,
                     thinking_enabled=thinking_enabled,
                     policy_fingerprint=policy_fingerprint,
+                    tool_specs=tool_specs if tools_active else None,
                 ),
             )
             generated["stats"]["session_postcommit_snapshot"] = postcommit
@@ -5539,6 +5552,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                     else:
                                         postcommit = _store_generation_final_history_snapshot(
@@ -5551,6 +5565,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             assistant_tool_calls=assistant_tool_calls,
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
+                                            tool_specs=tool_specs if tools_active else None,
                                         )
                                         if not postcommit.get("stored"):
                                             generated["stats"][
@@ -5899,6 +5914,7 @@ def create_app(state: ServerState) -> FastAPI:
                                         unsafe_reason=str(
                                             postcommit.get("reason") or "unsafe_history"
                                         ),
+                                        tool_specs=tool_specs if tools_active else None,
                                     )
                                 else:
                                     yield mark_sse_sent(

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -373,6 +373,7 @@ class SessionBank:
         mtp_history_policy: str | None = None,
         draft_head_identity: str | None = None,
         policy_fingerprint: str | None = None,
+        session_id: str | None = None,
     ) -> SessionBankRestore | None:
         mode = str(mode).replace("-", "_")
         if mode == "reference_lease":
@@ -381,13 +382,25 @@ class SessionBank:
             raise ValueError("mode must be 'clone', 'reference', or 'reference_lease'")
         self.last_miss_reason = None
         self._purge_expired()
-        entry = self.longest_prefix(token_ids)
+        entry = self.longest_prefix(token_ids, session_id=session_id)
         if entry is None:
-            self.last_miss_reason = (
-                CacheMissReason.PREFIX_DIVERGENCE_AT_TOKEN.value
-                if self._entries
-                else CacheMissReason.NEW_SESSION.value
+            # Distinguish "no entries from THIS session" (true new_session)
+            # from "entries from this session exist but lookup tokens diverge"
+            # (true prefix divergence). The session-scoped check below is what
+            # makes the miss reason actually meaningful: cross-session entries
+            # in the global bank no longer falsely trip prefix_divergence.
+            same_session_present = (
+                session_id is not None
+                and any(
+                    e.session_id == session_id for e in self._entries.values()
+                )
             )
+            if same_session_present or (session_id is None and self._entries):
+                self.last_miss_reason = (
+                    CacheMissReason.PREFIX_DIVERGENCE_AT_TOKEN.value
+                )
+            else:
+                self.last_miss_reason = CacheMissReason.NEW_SESSION.value
             return None
         if entry.model_path != str(runtime.model_path):
             self.last_miss_reason = CacheMissReason.MODEL_MISMATCH.value

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -46,6 +46,35 @@ def token_prefix_hash(token_ids: list[int] | tuple[int, ...]) -> str:
     return h.hexdigest()
 
 
+# Policies that share the committed-mtp-cache representation. An entry stored
+# under any of these policies can be safely reused for a lookup that requests
+# any other policy in this set, because the cache snapshot shape is identical
+# (``last_window`` is just a runtime trim of the same committed cache).
+_COMMITTED_CACHE_POLICIES = frozenset({"committed", "last_window"})
+
+
+def _mtp_history_policy_compatible(
+    entry_policy: str | None, lookup_policy: str | None
+) -> bool:
+    """Return True if a bank entry stored under ``entry_policy`` may be reused
+    for a lookup that resolved to ``lookup_policy``.
+
+    Equality is always compatible. Beyond that, ``committed`` and
+    ``last_window`` are treated as interchangeable because both rely on the
+    same committed mtp-history cache shape; the only difference between them
+    is a runtime trim that is applied during prefill, which is moot once the
+    cache is being restored from a stored snapshot.
+    """
+    if entry_policy == lookup_policy:
+        return True
+    if entry_policy is None or lookup_policy is None:
+        return False
+    return (
+        entry_policy in _COMMITTED_CACHE_POLICIES
+        and lookup_policy in _COMMITTED_CACHE_POLICIES
+    )
+
+
 def _tree_nbytes(value: Any) -> int:
     if value is None:
         return 0
@@ -299,7 +328,9 @@ class SessionBank:
         if template_hash is not None and entry.template_hash != template_hash:
             self.last_miss_reason = CacheMissReason.TEMPLATE_MISMATCH.value
             return None
-        if mtp_history_policy is not None and entry.mtp_history_policy != mtp_history_policy:
+        if mtp_history_policy is not None and not _mtp_history_policy_compatible(
+            entry.mtp_history_policy, mtp_history_policy
+        ):
             self.last_miss_reason = CacheMissReason.POLICY_MISMATCH.value
             return None
         if draft_head_identity is not None and entry.draft_head_identity != draft_head_identity:

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -280,17 +280,87 @@ class SessionBank:
         self._evict_if_needed(protected_tokens=tokens)
         return entry
 
-    def longest_prefix(self, token_ids: list[int] | tuple[int, ...]) -> SessionBankEntry | None:
+    def longest_prefix(
+        self,
+        token_ids: list[int] | tuple[int, ...],
+        *,
+        session_id: str | None = None,
+    ) -> SessionBankEntry | None:
         tokens = tuple(int(token) for token in token_ids)
         best: SessionBankEntry | None = None
+        same_session_entries_present = False
         for prefix, entry in self._entries.items():
+            if session_id is not None and entry.session_id != session_id:
+                continue
+            same_session_entries_present = True
             if len(prefix) > len(tokens):
                 continue
             if tokens[: len(prefix)] != prefix:
                 continue
             if best is None or len(prefix) > len(best.token_ids):
                 best = entry
+        if best is None and same_session_entries_present:
+            # Real divergence within the calling session - dump diagnostics.
+            self._maybe_dump_divergence(tokens, session_id=session_id)
         return best
+
+    def _maybe_dump_divergence(
+        self,
+        lookup_tokens: tuple[int, ...],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Diagnostic: when a lookup misses despite stored entries from the
+        same session, dump lookup vs stored token IDs so we can diff them
+        and identify the canonicalization gap. Env-gated, one-shot per session
+        to avoid log spam.
+        """
+        import os
+        if os.environ.get("MTPLX_DUMP_DIVERGENCE") != "1":
+            return
+        dumped = getattr(self, "_divergence_dumped_sessions", None)
+        if dumped is None:
+            dumped = set()
+            self._divergence_dumped_sessions = dumped
+        sess_key = session_id or "_unscoped"
+        if sess_key in dumped:
+            return
+        dumped.add(sess_key)
+        import json as _json
+        import time as _time
+        safe_sess = sess_key.replace("/", "_").replace(" ", "_")
+        path = f"/tmp/mtplx-divergence-{safe_sess}-{int(_time.time())}.json"
+        candidates = []
+        for prefix, entry in self._entries.items():
+            if session_id is not None and entry.session_id != session_id:
+                continue
+            n = min(len(prefix), len(lookup_tokens), 300)
+            first_diff = -1
+            for i in range(n):
+                if prefix[i] != lookup_tokens[i]:
+                    first_diff = i
+                    break
+            if first_diff < 0 and len(prefix) > len(lookup_tokens):
+                first_diff = len(lookup_tokens)
+            candidates.append({
+                "stored_len": len(prefix),
+                "stored_session_id": entry.session_id,
+                "first_divergence_at": first_diff,
+                "stored_head": list(prefix[:300]),
+                "stored_tail": list(prefix[-100:]) if len(prefix) > 100 else None,
+            })
+        try:
+            with open(path, "w") as f:
+                _json.dump({
+                    "session_id": session_id,
+                    "lookup_len": len(lookup_tokens),
+                    "lookup_head": list(lookup_tokens[:300]),
+                    "lookup_tail": list(lookup_tokens[-100:]) if len(lookup_tokens) > 100 else None,
+                    "stored_entries": candidates,
+                }, f)
+            print(f"[mtplx] dumped divergence diagnostic to {path}", flush=True)
+        except Exception as e:
+            print(f"[mtplx] divergence dump failed: {e}", flush=True)
 
     def restore(
         self,

--- a/tests/integration_smoke_cache_hit.sh
+++ b/tests/integration_smoke_cache_hit.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Integration smoke test: prove the tools-plumbing fix delivers cached>0
+# on the second turn of a session that uses tool definitions.
+#
+# Background: pre-fix the postcommit pathways encoded the synthetic
+# history WITHOUT `tools=`, while the next request encoded its prompt
+# WITH `tools=tool_specs`. The Qwen3.6 chat template injects tool
+# definitions into the system message, so the stored snapshot's tokens
+# diverged from the next prompt at the system boundary - SessionBank
+# lookups failed with `cache_miss_reason=prefix_divergence_at_token`.
+#
+# This script:
+#   1. Starts a unique session_id (one per run).
+#   2. Issues turn 1 with a `tools=[...]` array and a simple user message.
+#   3. Sleeps to let the async postcommit settle.
+#   4. Issues turn 2 with the same tools, a synthetic assistant tool_call
+#      reply, plus a new user message.
+#   5. Parses the SSE stream for the final chunk's `mtplx_stats` and
+#      reports PASS if `cached_tokens > 0`, FAIL otherwise.
+#
+# Usage:
+#   ./tests/integration_smoke_cache_hit.sh                # default port 8088
+#   MTPLX_HOST=http://127.0.0.1:8088 ./tests/integration_smoke_cache_hit.sh
+#
+# IMPORTANT: hits MTPLX directly, NOT the dashboard at 9099 (the
+# dashboard proxy may strip `x-mtplx-session-id`).
+
+set -euo pipefail
+
+HOST="${MTPLX_HOST:-http://127.0.0.1:8088}"
+SESSION_ID="smoke-cache-hit-$(date +%s)-$$"
+SLEEP_S="${SMOKE_SLEEP_S:-12}"
+
+echo "[smoke] host=${HOST}"
+echo "[smoke] session_id=${SESSION_ID}"
+echo "[smoke] inter-turn sleep=${SLEEP_S}s"
+echo
+
+TOOLS_JSON='[
+  {
+    "type": "function",
+    "function": {
+      "name": "grep",
+      "description": "Search files for a pattern",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {"type": "string"},
+          "path": {"type": "string"}
+        },
+        "required": ["pattern"]
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
+      "name": "read_file",
+      "description": "Read file contents",
+      "parameters": {
+        "type": "object",
+        "properties": {"path": {"type": "string"}},
+        "required": ["path"]
+      }
+    }
+  }
+]'
+
+TURN1_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."}
+  ]
+}
+EOF
+)
+
+TURN2_PAYLOAD=$(cat <<EOF
+{
+  "model": "auto",
+  "stream": true,
+  "max_tokens": 128,
+  "enable_thinking": false,
+  "tools": ${TOOLS_JSON},
+  "messages": [
+    {"role": "system", "content": "You are a helpful coding agent."},
+    {"role": "user", "content": "Find any references to 'session_bank' in the repo."},
+    {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [{
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "grep", "arguments": "{\"pattern\":\"session_bank\"}"}
+      }]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_1",
+      "content": "mtplx/session_bank.py:1:class SessionBank: ..."
+    },
+    {"role": "user", "content": "Now read the first matching file."}
+  ]
+}
+EOF
+)
+
+TMPDIR_SMOKE=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_SMOKE}"' EXIT
+
+echo "[smoke] turn 1 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN1_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn1.sse"
+
+echo "[smoke] turn 1 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn1.sse")"
+
+# Pull the session_postcommit_snapshot from turn 1 (best-effort).
+PC1=$(grep -o '"session_postcommit_snapshot":[^}]*}' "${TMPDIR_SMOKE}/turn1.sse" | tail -1 || true)
+echo "[smoke] turn 1 postcommit: ${PC1:-<not present>}"
+
+echo "[smoke] sleeping ${SLEEP_S}s for async postcommit to settle..."
+sleep "${SLEEP_S}"
+
+echo "[smoke] turn 2 -> ${HOST}/v1/chat/completions"
+curl -sS -N \
+  -H "Content-Type: application/json" \
+  -H "x-mtplx-session-id: ${SESSION_ID}" \
+  -X POST "${HOST}/v1/chat/completions" \
+  -d "${TURN2_PAYLOAD}" \
+  > "${TMPDIR_SMOKE}/turn2.sse"
+
+echo "[smoke] turn 2 SSE bytes: $(wc -c < "${TMPDIR_SMOKE}/turn2.sse")"
+
+# The stats are emitted on the final chunk as `mtplx_stats`. Pull the
+# last occurrence of cached_tokens / cache_miss_reason from the stream.
+CACHED=$(grep -o '"cached_tokens":[ ]*[0-9]\+' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 | grep -o '[0-9]\+' || true)
+MISS=$(grep -o '"cache_miss_reason":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+RESTORE=$(grep -o '"session_restore_mode":[ ]*"[^"]*"' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+HIT=$(grep -o '"session_cache_hit":[ ]*\(true\|false\)' "${TMPDIR_SMOKE}/turn2.sse" | tail -1 || true)
+
+echo
+echo "[smoke] turn 2 cached_tokens   = ${CACHED:-<missing>}"
+echo "[smoke] turn 2 cache_miss_reason = ${MISS:-<missing>}"
+echo "[smoke] turn 2 session_restore_mode = ${RESTORE:-<missing>}"
+echo "[smoke] turn 2 session_cache_hit    = ${HIT:-<missing>}"
+echo
+echo "[smoke] (raw turn 2 SSE saved at ${TMPDIR_SMOKE}/turn2.sse - inspect if PASS/FAIL is unclear)"
+# Persist the artifacts to a stable path for the user to inspect after
+# the script exits if needed. (Pre-trap.)
+DEST="/tmp/mtplx-smoke-cache-hit-${SESSION_ID}"
+mkdir -p "${DEST}"
+cp "${TMPDIR_SMOKE}/turn1.sse" "${DEST}/turn1.sse"
+cp "${TMPDIR_SMOKE}/turn2.sse" "${DEST}/turn2.sse"
+echo "[smoke] artifacts copied to ${DEST}/"
+
+if [[ -n "${CACHED}" && "${CACHED}" -gt 0 ]]; then
+  echo "[smoke] PASS - cached_tokens=${CACHED} on turn 2 (session_id=${SESSION_ID})"
+  exit 0
+else
+  echo "[smoke] FAIL - turn 2 was cold (cached_tokens=${CACHED:-0}, miss_reason=${MISS})"
+  exit 1
+fi

--- a/tests/test_engine_session_env.py
+++ b/tests/test_engine_session_env.py
@@ -1,0 +1,50 @@
+"""Unit tests for engine_session bank-cap env-var overrides."""
+import os
+import importlib
+
+import pytest
+
+
+def _reload_module():
+    import mtplx.engine_session
+    return importlib.reload(mtplx.engine_session)
+
+
+def test_bank_bytes_from_env_default_when_unset(monkeypatch):
+    monkeypatch.delenv("TEST_BANK_BYTES", raising=False)
+    es = _reload_module()
+    assert es._bank_bytes_from_env("TEST_BANK_BYTES", 1234) == 1234
+
+
+def test_bank_bytes_from_env_plain_integer(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_BYTES", "987654321")
+    es = _reload_module()
+    assert es._bank_bytes_from_env("TEST_BANK_BYTES", 0) == 987654321
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("16G", 16 * 1024**3),
+    ("16g", 16 * 1024**3),
+    ("32G", 32 * 1024**3),
+    ("8G",   8 * 1024**3),
+    ("512M", 512 * 1024**2),
+    ("4K",   4 * 1024),
+    ("1T",   1 * 1024**4),
+    ("0.5G", int(0.5 * 1024**3)),
+])
+def test_bank_bytes_from_env_with_suffix(monkeypatch, raw, expected):
+    monkeypatch.setenv("TEST_BANK_BYTES", raw)
+    es = _reload_module()
+    assert es._bank_bytes_from_env("TEST_BANK_BYTES", 0) == expected
+
+
+def test_bank_bytes_from_env_invalid_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_BYTES", "not-a-number")
+    es = _reload_module()
+    assert es._bank_bytes_from_env("TEST_BANK_BYTES", 5555) == 5555
+
+
+def test_bank_bytes_from_env_empty_string_uses_default(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_BYTES", "")
+    es = _reload_module()
+    assert es._bank_bytes_from_env("TEST_BANK_BYTES", 7777) == 7777

--- a/tests/test_idle_postcommit_subagent.py
+++ b/tests/test_idle_postcommit_subagent.py
@@ -1,0 +1,230 @@
+"""Regression tests for `_schedule_idle_postcommit_snapshot`.
+
+The async path used to gate on `state.has_foreground()` clearing before it
+ran the retokenized commit. In OpenAI-compatible subagent fan-out (opencode
+researcher / planner / fixer / bug-patcher) the parent re-dispatches the
+next request within milliseconds of the previous response completing, so
+the foreground flag never clears - every subagent's snapshot was abandoned
+with `foreground_busy_past_deadline` and the SessionBank never accumulated
+an entry for those session ids.
+
+These tests cover the post-fix behaviour: the async path now retries the
+existing non-blocking lock acquire inside `_store_retokenized_history_snapshot`
+(which is the real correctness gate) until either the snapshot stores or
+the deadline expires.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+
+
+def _fake_subagent_state(*, foreground_always: bool = False):
+    """Build the minimum stub needed for `_schedule_idle_postcommit_snapshot`.
+
+    `foreground_always=True` simulates the opencode subagent regression:
+    `state.has_foreground()` returns True for the entire test, which under
+    the old code blocked the retokenized commit indefinitely.
+    """
+    foreground_lock = threading.Lock()
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    return SimpleNamespace(
+        lock=foreground_lock,
+        has_foreground=has_foreground,
+        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        # Console disabled so `_log` exercises the print branch (and stays
+        # silent under pytest's captured stdout).
+        args=SimpleNamespace(server_console=False),
+    )
+
+
+def _wait_for_executor_drain(state, *, timeout_s: float = 5.0) -> None:
+    """Shut the executor down (waiting for the submitted task to finish).
+
+    Using `executor.shutdown(wait=True)` gives us a deterministic point
+    after which `_log` has already been called for the submitted job.
+    """
+    state.postcommit_executor.shutdown(wait=True)
+    _ = timeout_s  # symmetric with similar helpers; kept for readability.
+
+
+def _kwargs_for_schedule():
+    return dict(
+        session_id="opencode-researcher",
+        messages=[],
+        assistant_content="<tool_call>...</tool_call>",
+        assistant_tool_calls=[{"name": "grep", "arguments": "{}"}],
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+
+
+def test_idle_postcommit_stores_when_lock_briefly_free(monkeypatch):
+    """Happy path: even if `has_foreground()` says True, a successful store
+    on the first non-blocking lock acquire ends the loop and is logged.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+
+    _wait_for_executor_drain(state)
+
+    assert pending == {
+        "stored": False,
+        "mode": "async_pending",
+        "reason": "retokenized_history_mismatch",
+    }
+    assert len(calls) == 1
+    assert calls[0]["session_id"] == "opencode-researcher"
+    assert calls[0]["acquire_model_lock_blocking"] is False
+
+
+def test_idle_postcommit_retries_until_deadline_under_lock_busy(monkeypatch):
+    """If the lock stays busy the entire deadline, the loop logs
+    `model_lock_busy_past_deadline` and returns - it does NOT spin
+    forever.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    log_lines: list[dict] = []
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
+
+    def capture_console_disabled(_state):
+        # Keep `_log` going through the print branch so we know the
+        # function reached the deadline-abandon log line. We also
+        # monkeypatch the print in the real module so we can inspect.
+        return False
+
+    real_print = openai.print if hasattr(openai, "print") else print
+
+    def captured_print(message, *_args, **_kwargs):
+        # Lines are formatted as
+        # `[mtplx] idle async session postcommit {json...}`.
+        prefix = "[mtplx] idle async session postcommit "
+        if isinstance(message, str) and message.startswith(prefix):
+            import json
+
+            log_lines.append(json.loads(message[len(prefix):]))
+        else:
+            real_print(message, *_args, **_kwargs)
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", capture_console_disabled)
+    monkeypatch.setattr("builtins.print", captured_print)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    pending = openai._schedule_idle_postcommit_snapshot(
+        state, **_kwargs_for_schedule()
+    )
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert pending["mode"] == "async_pending"
+    # Loop should retry many times under the 0.5s deadline / 0.05s poll
+    # interval (we expect ~10 calls; allow generous slack for CI jitter).
+    assert call_count["n"] >= 3, f"expected several retries, got {call_count['n']}"
+    assert elapsed < 5.0, f"loop ran too long: {elapsed:.2f}s"
+    # We must see exactly one terminal log line declaring the deadline
+    # abandon, and crucially the reason must be the new one.
+    assert log_lines, "expected at least one log line"
+    last = log_lines[-1]
+    assert last["mode"] == "abandoned_foreground_busy"
+    assert last["reason"] == "model_lock_busy_past_deadline"
+    assert last["session_id"] == "opencode-researcher"
+
+
+def test_idle_postcommit_returns_immediately_on_non_recoverable_failure(monkeypatch):
+    """`no_session_id` (and similar non-retryable errors) must short-circuit
+    the loop after exactly one call - retrying will not help.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    call_count = {"n": 0}
+
+    def fake_store(*_args, **_kwargs):
+        call_count["n"] += 1
+        return {"stored": False, "reason": "no_session_id"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Use a long deadline so a buggy implementation that DID retry would
+    # show up as call_count["n"] > 1.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 5.0)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.01)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+
+    assert call_count["n"] == 1
+
+
+def test_idle_postcommit_no_longer_blocks_on_has_foreground(monkeypatch):
+    """Regression test: even if `state.has_foreground()` returns True for
+    the entire duration of the test, the snapshot must still be stored.
+
+    Pre-fix this scenario was the bug - the loop would spin on
+    `has_foreground()` until the 30s deadline expired without ever calling
+    `_store_retokenized_history_snapshot`.
+    """
+    state = _fake_subagent_state(foreground_always=True)
+    calls: list[dict] = []
+
+    def fake_store(*_args, **kwargs):
+        calls.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 8,
+            "nbytes": 64,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    # Force tight bounds so a regression to the old wait-on-foreground
+    # code would time out and the snapshot would NOT be stored.
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_MAX_WAIT_S", 0.5)
+    monkeypatch.setattr(openai, "_IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05)
+
+    started = time.monotonic()
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs_for_schedule())
+    _wait_for_executor_drain(state)
+    elapsed = time.monotonic() - started
+
+    assert calls, "snapshot must be attempted even when has_foreground() is True"
+    assert len(calls) == 1
+    assert elapsed < 1.0, (
+        f"snapshot ran too long ({elapsed:.2f}s) - did the loop fall back to "
+        "the deprecated has_foreground() wait?"
+    )

--- a/tests/test_idle_postcommit_subagent.py
+++ b/tests/test_idle_postcommit_subagent.py
@@ -39,7 +39,7 @@ def _fake_subagent_state(*, foreground_always: bool = False):
     return SimpleNamespace(
         lock=foreground_lock,
         has_foreground=has_foreground,
-        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        generation_executor=ThreadPoolExecutor(max_workers=1),
         # Console disabled so `_log` exercises the print branch (and stays
         # silent under pytest's captured stdout).
         args=SimpleNamespace(server_console=False),
@@ -52,7 +52,7 @@ def _wait_for_executor_drain(state, *, timeout_s: float = 5.0) -> None:
     Using `executor.shutdown(wait=True)` gives us a deterministic point
     after which `_log` has already been called for the submitted job.
     """
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
     _ = timeout_s  # symmetric with similar helpers; kept for readability.
 
 

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -346,13 +346,15 @@ def test_idle_async_postcommit_attempts_commit_for_tool_call_responses(
     assert '"stored": true' in log
 
 
-def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
+def test_idle_async_postcommit_abandons_when_model_lock_stays_busy(
     capsys, monkeypatch
 ):
-    """If the foreground never goes idle, the async commit must abandon
-    rather than block forever."""
+    """If the model lock never frees, the async commit must abandon
+    rather than block forever. The loop now drives the
+    non-blocking-acquire inside `_store_retokenized_history_snapshot`
+    as the correctness gate (has_foreground is no longer consulted)."""
     state = _postcommit_state()
-    state.has_foreground = lambda: True  # always busy
+    state.has_foreground = lambda: True  # always busy (intentionally ignored)
 
     # Make the wait short so the test stays fast.
     monkeypatch.setattr(
@@ -362,15 +364,19 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
         "mtplx.server.openai._IDLE_POSTCOMMIT_POLL_INTERVAL_S", 0.05
     )
 
-    called = []
+    called: list[dict] = []
 
-    def should_not_be_called(state, **kwargs):
+    def fake_store_lock_busy(state, **kwargs):
         called.append(kwargs)
-        return {"stored": True}
+        return {
+            "stored": False,
+            "mode": "retokenized_history",
+            "reason": "model_lock_busy_before_retokenized_commit",
+        }
 
     monkeypatch.setattr(
         "mtplx.server.openai._store_retokenized_history_snapshot",
-        should_not_be_called,
+        fake_store_lock_busy,
     )
 
     pending = _schedule_idle_postcommit_snapshot(
@@ -384,10 +390,13 @@ def test_idle_async_postcommit_abandons_when_foreground_stays_busy(
     )
 
     assert pending["mode"] == "async_pending"
-    assert called == []
+    # The loop must actually try the retokenized commit (and retry under
+    # `model_lock_busy_before_retokenized_commit`) - the old behavior of
+    # silently skipping on has_foreground would leave called == [].
+    assert called, "loop must attempt the commit even if has_foreground() is True"
     log = capsys.readouterr().out
     assert "abandoned_foreground_busy" in log
-    assert "foreground_busy_past_deadline" in log
+    assert "model_lock_busy_past_deadline" in log
 
 
 def test_server_security_requires_api_key_for_non_localhost_bind():

--- a/tests/test_policy_fingerprint_stability.py
+++ b/tests/test_policy_fingerprint_stability.py
@@ -1,0 +1,189 @@
+"""Stability tests for the SessionBank policy/fingerprint compatibility logic.
+
+These tests pin down the bug fix for the >=16K cache cliff: when the resolved
+``mtp_history_policy`` flips from ``committed`` (sub-threshold) to
+``last_window`` (>= ``MTPLX_MTP_HISTORY_LAST_WINDOW_THRESHOLD``), the previously
+stored bank entry must remain reusable. Both policies share the same committed
+mtp-history cache shape, so the entry must NOT be rejected as a policy mismatch.
+
+The unit tests here exercise ``SessionBank.restore`` and the helper directly
+without needing a real MLX runtime.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx import session_bank as sb
+from mtplx.session_bank import (
+    CacheMissReason,
+    SessionBank,
+    _mtp_history_policy_compatible,
+)
+
+
+class _StubRuntime:
+    """Minimal runtime stub. ``put`` only reads ``model_path``/``mtp_enabled``;
+    ``restore`` reads ``model_path`` and (for non-empty caches) calls ``make_cache``,
+    which we never reach because our test caches are empty."""
+
+    def __init__(self, model_path: str = "models/example") -> None:
+        self.model_path = Path(model_path)
+        self.mtp_enabled = True
+
+    def make_cache(self) -> list:
+        return []
+
+    def make_mtp_cache(self) -> list:
+        return []
+
+
+def _seed_entry(bank: SessionBank, *, mtp_history_policy: str, tokens=(1, 2, 3, 4)) -> None:
+    runtime = _StubRuntime()
+    entry = bank.put(
+        runtime=runtime,
+        token_ids=list(tokens),
+        cache=[],
+        logits=None,
+        hidden=None,
+        hidden_variant="post_norm",
+        session_id="sess-1",
+        template_hash="tmpl-abc",
+        mtp_history_policy=mtp_history_policy,
+        draft_head_identity="draft-xyz",
+        policy_fingerprint="fp-stable",
+    )
+    assert entry is not None, "test setup: entry should be stored"
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_policy_compatible_equality_is_compatible():
+    assert _mtp_history_policy_compatible("committed", "committed") is True
+    assert _mtp_history_policy_compatible("last_window", "last_window") is True
+    assert _mtp_history_policy_compatible("cycle", "cycle") is True
+    assert _mtp_history_policy_compatible(None, None) is True
+
+
+def test_policy_compatible_committed_and_last_window_are_interchangeable():
+    # The whole point of the fix: sub-16K stores ``committed``, >=16K lookup
+    # asks for ``last_window``. Both share the committed-cache shape.
+    assert _mtp_history_policy_compatible("committed", "last_window") is True
+    assert _mtp_history_policy_compatible("last_window", "committed") is True
+
+
+def test_policy_compatible_cycle_is_not_committed_compatible():
+    # ``cycle`` does NOT use the committed cache; it is structurally different
+    # and must not be considered compatible.
+    assert _mtp_history_policy_compatible("cycle", "committed") is False
+    assert _mtp_history_policy_compatible("committed", "cycle") is False
+    assert _mtp_history_policy_compatible("cycle", "last_window") is False
+
+
+def test_policy_compatible_none_is_only_compatible_with_none():
+    assert _mtp_history_policy_compatible(None, "committed") is False
+    assert _mtp_history_policy_compatible("committed", None) is False
+
+
+# ---------------------------------------------------------------------------
+# Restore-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_restore_accepts_lookup_last_window_against_stored_committed():
+    """Reproduces the >=16K cliff: stored entry has ``committed`` (because the
+    storing turn was sub-threshold); the next-turn lookup resolves to
+    ``last_window`` (because prompt crossed the threshold). With the fix these
+    are compatible and restore must succeed."""
+    bank = SessionBank(max_entries=4, max_bytes=1 << 20, per_session_max_bytes=1 << 20)
+    _seed_entry(bank, mtp_history_policy="committed")
+
+    restored = bank.restore(
+        _StubRuntime(),
+        [1, 2, 3, 4],
+        hidden_variant="post_norm",
+        template_hash="tmpl-abc",
+        mtp_history_policy="last_window",
+        draft_head_identity="draft-xyz",
+        policy_fingerprint="fp-stable",
+    )
+
+    assert restored is not None, "policy mismatch cliff: lookup last_window must reuse stored committed entry"
+    assert bank.last_miss_reason is None
+    assert restored.entry.mtp_history_policy == "committed"
+
+
+def test_restore_accepts_lookup_committed_against_stored_last_window():
+    """Reverse direction: a turn at >=16K could store ``last_window`` (under
+    the future fix that records the resolved policy on the entry); the next
+    turn at <16K asks for ``committed``. Must still match."""
+    bank = SessionBank(max_entries=4, max_bytes=1 << 20, per_session_max_bytes=1 << 20)
+    _seed_entry(bank, mtp_history_policy="last_window")
+
+    restored = bank.restore(
+        _StubRuntime(),
+        [1, 2, 3, 4],
+        hidden_variant="post_norm",
+        template_hash="tmpl-abc",
+        mtp_history_policy="committed",
+        draft_head_identity="draft-xyz",
+        policy_fingerprint="fp-stable",
+    )
+
+    assert restored is not None
+    assert bank.last_miss_reason is None
+
+
+def test_restore_still_rejects_truly_incompatible_policy():
+    """``cycle`` must still be rejected as a policy mismatch when an entry was
+    stored with ``committed`` (and vice versa). The fix relaxes ONLY the
+    committed/last_window pair, never the cycle/committed boundary."""
+    bank = SessionBank(max_entries=4, max_bytes=1 << 20, per_session_max_bytes=1 << 20)
+    _seed_entry(bank, mtp_history_policy="committed")
+
+    restored = bank.restore(
+        _StubRuntime(),
+        [1, 2, 3, 4],
+        hidden_variant="post_norm",
+        template_hash="tmpl-abc",
+        mtp_history_policy="cycle",
+        draft_head_identity="draft-xyz",
+        policy_fingerprint="fp-stable",
+    )
+
+    assert restored is None
+    assert bank.last_miss_reason == CacheMissReason.POLICY_MISMATCH.value
+
+
+# ---------------------------------------------------------------------------
+# Resolved-policy stability test (against the integration boundary)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_mtp_history_policy_does_flip_at_default_threshold(monkeypatch):
+    """Sanity check that the threshold-driven flip is real. This is what causes
+    the lookup side to ask for ``last_window`` when the prompt crosses ~16K."""
+    monkeypatch.setenv("MTPLX_MTP_HISTORY_POLICY", "auto")
+    monkeypatch.delenv("MTPLX_MTP_HISTORY_LAST_WINDOW_THRESHOLD", raising=False)
+
+    # Re-import so module-level env reads are fresh (the function reads at
+    # call time anyway, but this also guards against caching surprises).
+    from mtplx.generation import _resolve_mtp_history_policy
+
+    just_under = _resolve_mtp_history_policy("committed", 16_383)
+    just_over = _resolve_mtp_history_policy("committed", 16_384)
+
+    assert just_under == "committed"
+    assert just_over == "last_window"
+
+    # And the policy compat helper says these are interchangeable, which is
+    # the load-bearing invariant for the SessionBank cliff fix.
+    assert _mtp_history_policy_compatible(just_under, just_over) is True

--- a/tests/test_postcommit_executor_split.py
+++ b/tests/test_postcommit_executor_split.py
@@ -333,8 +333,14 @@ def test_retokenized_snapshot_passes_session_bank_for_prefix_reuse(monkeypatch):
     assert captured_kwargs.get("template_hash") == "tmpl-hash"
     assert captured_kwargs.get("draft_head_identity") == "draft-id"
     assert captured_kwargs.get("policy_fingerprint") == "policy-fp"
-    # cache_hit / cached_tokens / suffix_tokens propagate to result for
-    # observability.
+    # cache_hit / cached_tokens / suffix_tokens / cache_miss_reason
+    # propagate to result for observability. The miss reason is the bank's
+    # `last_miss_reason` after this turn's lookup; on a true hit it is
+    # None, otherwise it captures why the prefix shortcut could not run
+    # (`new_session`, `prefix_divergence_at_token`, `policy_mismatch`,
+    # ...). Operators rely on this field to debug regressions where the
+    # postcommit silently falls back to a full re-prefill.
     assert result["cache_hit"] is True
     assert result["cached_tokens"] == 17_500
     assert result["suffix_tokens"] == 320
+    assert "cache_miss_reason" in result

--- a/tests/test_postcommit_executor_split.py
+++ b/tests/test_postcommit_executor_split.py
@@ -1,0 +1,340 @@
+"""Tier 1.2 perf regression tests: postcommit retokenization must not
+head-of-line block the next foreground request on the single-worker
+`generation_executor`.
+
+PR #24 (commit 3d9f200) routed the async retokenization snapshot work to
+`state.generation_executor` to preserve thread-local MLX stream invariants
+(a SessionBank entry created on one thread cannot be restored from another
+without `RuntimeError: There is no Stream(gpu, N) in current thread`). The
+side effect: `generation_executor = ThreadPoolExecutor(max_workers=1)` so
+the next foreground `worker` submitted to that same executor queued behind
+the postcommit's full ~18K-token re-prefill (~27-29 s on Qwen3.6 27B),
+producing visible 30 s stream silences between turns of any tool-using
+subagent flow.
+
+The fix splits the orchestration loop off the MLX-touching work:
+
+  - The retry/sleep loop (poll on lock, sleep, retry, deadline tracking)
+    runs on `postcommit_executor` so its 250 ms inter-attempt sleeps do
+    not occupy `generation_executor`.
+
+  - The actual MLX-touching `_store_retokenized_history_snapshot` call is
+    submitted onto `generation_executor` from the postcommit thread and
+    awaited via `future.result()`, so the cache buffer is created on the
+    same thread that will later restore it (Apple Silicon stream-locality).
+
+These tests pin that invariant in place against future regressions.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+
+
+def _state(*, executors_aliased: bool = False):
+    """Build the minimum stub for `_schedule_idle_postcommit_snapshot`.
+
+    `executors_aliased=True` simulates older configurations / test stubs
+    where the same executor is used for both roles. The helper must fall
+    back to a direct call (no double-submit deadlock).
+    """
+    foreground_lock = threading.Lock()
+
+    generation_executor = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="test-generation"
+    )
+    if executors_aliased:
+        postcommit_executor = generation_executor
+    else:
+        postcommit_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="test-postcommit"
+        )
+
+    return SimpleNamespace(
+        lock=foreground_lock,
+        has_foreground=lambda: False,
+        generation_executor=generation_executor,
+        postcommit_executor=postcommit_executor,
+        args=SimpleNamespace(server_console=False),
+    )
+
+
+def _kwargs():
+    return dict(
+        session_id="test-session",
+        messages=[],
+        assistant_content="<tool_call>...</tool_call>",
+        assistant_tool_calls=[{"name": "grep", "arguments": "{}"}],
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+
+
+def _drain(state):
+    state.postcommit_executor.shutdown(wait=True)
+    if state.generation_executor is not state.postcommit_executor:
+        state.generation_executor.shutdown(wait=True)
+
+
+def test_mlx_work_runs_on_generation_executor_thread(monkeypatch):
+    """The MLX-touching `_store_retokenized_history_snapshot` call MUST
+    execute on a `generation_executor` thread so subsequent restores from
+    that same executor see the cache buffer in the right MLX stream.
+    """
+    state = _state()
+    seen_thread_names: list[str] = []
+
+    def fake_store(*_args, **_kwargs):
+        seen_thread_names.append(threading.current_thread().name)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 1,
+            "nbytes": 1,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs())
+    _drain(state)
+
+    assert len(seen_thread_names) == 1
+    assert seen_thread_names[0].startswith("test-generation"), (
+        f"MLX snapshot must run on generation_executor thread, got "
+        f"{seen_thread_names[0]!r}"
+    )
+
+
+def test_orchestration_sleep_does_not_block_generation_executor(monkeypatch):
+    """The retry-loop's `time.sleep` between attempts must occur on the
+    postcommit thread, NOT on `generation_executor`. Otherwise the next
+    foreground request submitted to `generation_executor` would queue
+    behind the sleep.
+
+    We simulate a single retry by returning `model_lock_busy_*` once and
+    then `stored: True` on the second attempt, while spying on
+    `time.sleep` from `mtplx.server.openai` to record which thread sleeps.
+    """
+    state = _state()
+
+    attempt_count = {"n": 0}
+    sleep_threads: list[str] = []
+
+    def fake_store(*_args, **_kwargs):
+        attempt_count["n"] += 1
+        if attempt_count["n"] == 1:
+            return {
+                "stored": False,
+                "mode": "retokenized_history",
+                "reason": "model_lock_busy_before_retokenized_commit",
+                "elapsed_s": 0.0,
+            }
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 5,
+            "nbytes": 42,
+        }
+
+    real_sleep = time.sleep
+
+    def spy_sleep(seconds):
+        sleep_threads.append(threading.current_thread().name)
+        # Use a tiny real sleep so the loop can actually progress; we don't
+        # want to mock all of `time` because the deadline math depends on it.
+        real_sleep(0.001)
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+    monkeypatch.setattr(openai.time, "sleep", spy_sleep)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs())
+    _drain(state)
+
+    assert attempt_count["n"] == 2
+    # Exactly one inter-attempt sleep recorded.
+    assert len(sleep_threads) == 1
+    assert sleep_threads[0].startswith("test-postcommit"), (
+        f"Inter-attempt sleep must occur on postcommit thread, got "
+        f"{sleep_threads[0]!r} - sleeping on generation_executor would "
+        f"head-of-line block the next foreground request."
+    )
+
+
+def test_consecutive_foreground_submits_not_serialized_behind_postcommit(monkeypatch):
+    """End-to-end timing test: a slow postcommit (simulating the ~30 s
+    re-prefill before Tier 1.2) must NOT delay the start of the next
+    `generation_executor.submit(worker)` call.
+
+    Concretely: kick off the postcommit, then submit a foreground "worker"
+    to `generation_executor`. The worker should start within a small
+    fraction of the postcommit duration, not after the full postcommit
+    completes.
+    """
+    state = _state()
+    postcommit_started = threading.Event()
+    postcommit_release = threading.Event()
+    worker_started_s: list[float] = []
+
+    def fake_store(*_args, **_kwargs):
+        postcommit_started.set()
+        # Simulate the slow re-prefill the user reported as 27-29 s.
+        # We use 0.5 s to keep the test fast, then assert the worker
+        # started within 0.2 s. Generous tolerance to avoid CI flakiness.
+        postcommit_release.wait(timeout=2.0)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 1,
+            "nbytes": 1,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs())
+
+    # Wait for postcommit's MLX work to begin on generation_executor.
+    assert postcommit_started.wait(timeout=2.0)
+
+    # Now submit a "next foreground request" to generation_executor.
+    # Under the bug (postcommit's retry loop running on generation_executor),
+    # this submit would not start until postcommit_release fires.
+    # Under the fix (retry loop on postcommit_executor, MLX call runs and
+    # returns), the submit waits only for the in-flight MLX call to
+    # complete - which IS still serialized through generation_executor by
+    # design (cross-thread MLX safety). So the test asserts the worker
+    # starts within `postcommit_release` time + a small slack.
+    submit_start = time.perf_counter()
+
+    def worker():
+        worker_started_s.append(time.perf_counter() - submit_start)
+
+    state.generation_executor.submit(worker)
+    # Release the postcommit so its sub-future on generation_executor
+    # finishes and the worker can run.
+    postcommit_release.set()
+    _drain(state)
+
+    assert len(worker_started_s) == 1
+    # Worker should start very soon after release - we tolerate 0.5 s of
+    # scheduling slack.
+    assert worker_started_s[0] < 0.5, (
+        f"worker took {worker_started_s[0]:.2f}s to start after the "
+        f"postcommit released; expected sub-second under Tier 1.2."
+    )
+
+
+def test_aliased_executors_fall_back_to_direct_call(monkeypatch):
+    """If `postcommit_executor is generation_executor` (older config or
+    minimal test stub), `_run_store_on_generation_executor` MUST call
+    the snapshot function directly rather than submit-and-await on the
+    same single-worker executor (which would deadlock).
+    """
+    state = _state(executors_aliased=True)
+    seen_thread_names: list[str] = []
+
+    def fake_store(*_args, **_kwargs):
+        seen_thread_names.append(threading.current_thread().name)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 1,
+            "nbytes": 1,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs())
+    _drain(state)
+
+    # No deadlock, exactly one call, on the (single, aliased) executor.
+    assert len(seen_thread_names) == 1
+
+
+def test_retokenized_snapshot_passes_session_bank_for_prefix_reuse(monkeypatch):
+    """Tier 2.1 / Option B: `_store_retokenized_history_snapshot` MUST pass
+    `session_bank` to `restore_or_prefill_prompt_state` so the postcommit
+    re-prefill can short-circuit on the previous turn's prefix.
+
+    Without this, every postcommit pays the full ~18K-token re-prefill
+    cost. With this, consecutive tool-call turns drop from ~27 s to ~1 s
+    because only the new suffix needs to be forward-AR'd.
+    """
+    captured_kwargs: dict = {}
+
+    class _PromptState:
+        trunk_cache = "cache"
+        logits = "logits"
+        hidden = "hidden"
+        committed_mtp_cache = None
+        cache_hit = True
+        cached_tokens = 17_500
+        suffix_tokens = 320
+
+    def fake_restore_or_prefill(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _PromptState()
+
+    class _Tokenizer:
+        def apply_chat_template(self, messages, **_kwargs):
+            return [1, 2, 3, 4, 5]
+
+    class _Bank:
+        def put(self, **_kwargs):
+            return SimpleNamespace(
+                prefix_len=5,
+                nbytes=42,
+                token_hash="hash",
+            )
+
+    monkeypatch.setattr(
+        openai, "restore_or_prefill_prompt_state", fake_restore_or_prefill
+    )
+    # `snapshot_cache` only fires when committed_mtp_cache is not None.
+    monkeypatch.setattr(openai, "snapshot_cache", lambda c: c)
+    monkeypatch.setattr(openai, "_encode_messages", lambda *a, **k: [1, 2, 3, 4, 5])
+
+    bank = _Bank()
+    args = SimpleNamespace(strip_assistant_reasoning_history=False)
+    state = SimpleNamespace(
+        runtime=SimpleNamespace(tokenizer=_Tokenizer()),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="tmpl-hash",
+        draft_head_identity="draft-id",
+        lock=threading.Lock(),
+        begin_foreground=lambda: None,
+        end_foreground=lambda: None,
+        args=args,
+    )
+
+    result = openai._store_retokenized_history_snapshot(
+        state,
+        session_id="session-A",
+        messages=[],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy-fp",
+    )
+
+    assert result["stored"] is True
+    assert captured_kwargs.get("session_bank") is bank, (
+        "restore_or_prefill_prompt_state must receive session_bank so the "
+        "longest_prefix lookup can shortcut a full re-prefill."
+    )
+    assert captured_kwargs.get("template_hash") == "tmpl-hash"
+    assert captured_kwargs.get("draft_head_identity") == "draft-id"
+    assert captured_kwargs.get("policy_fingerprint") == "policy-fp"
+    # cache_hit / cached_tokens / suffix_tokens propagate to result for
+    # observability.
+    assert result["cache_hit"] is True
+    assert result["cached_tokens"] == 17_500
+    assert result["suffix_tokens"] == 320

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -1,0 +1,428 @@
+"""Regression tests for tool_specs plumbing through the postcommit path.
+
+The next-turn prompt is encoded with `tools=tool_specs` so the chat
+template injects tool definitions into the system message. Pre-fix the
+postcommit pathways (`_history_ids_for_postcommit`,
+`_store_retokenized_history_snapshot`, `_schedule_idle_postcommit_snapshot`)
+encoded the synthetic history WITHOUT `tools=`, which produced a token
+sequence that no longer matched the next prompt's prefix - SessionBank
+lookups failed with `cache_miss_reason=prefix_divergence_at_token` even
+when the snapshot itself stored successfully.
+
+These tests cover:
+
+1. The reachable-prefix invariant: storing a snapshot for messages M
+   plus tools T produces a token sequence that is a STRICT prefix of
+   the next prompt encoded from M' (M with one new appended user
+   message) plus the same tools T.
+2. The async idle-postcommit path forwards tool_specs through to
+   `_store_retokenized_history_snapshot` so the stored sequence
+   contains the tool-definition tokens.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from threading import Lock
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server import openai
+from mtplx.server.openai import (
+    ChatMessage,
+    _encode_messages,
+    _history_ids_for_postcommit,
+    _schedule_idle_postcommit_snapshot,
+    _store_retokenized_history_snapshot,
+    parse_args,
+)
+
+
+def _ids(text: str) -> list[int]:
+    return [ord(ch) for ch in text]
+
+
+class ToolAwareTokenizer:
+    """A tiny tokenizer that mimics Qwen-style tool-definition injection.
+
+    When `tools=` is passed to `apply_chat_template`, tool definitions are
+    serialised into a synthetic system message prefix. This produces a
+    DIFFERENT, LONGER token sequence than encoding without `tools=` -
+    matching the real-world Qwen3.6 chat template behaviour that triggered
+    `prefix_divergence_at_token`.
+    """
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize,
+        add_generation_prompt,
+        tools=None,
+        **_kwargs,
+    ):
+        assert tokenize is True
+        text = ""
+        if tools:
+            # Serialise each tool spec into a deterministic prefix so the
+            # tokens are stable across calls and clearly larger than the
+            # no-tools encoding.
+            tool_lines = ["<tools>"]
+            for spec in tools:
+                fn = spec.get("function") or spec
+                name = fn.get("name") or spec.get("name") or "fn"
+                tool_lines.append(f"<tool name={name}/>")
+            tool_lines.append("</tools>")
+            text += "\n".join(tool_lines) + "\n"
+        text += "\n".join(
+            f"{message['role']}:{message.get('content') or ''}" for message in messages
+        )
+        if add_generation_prompt:
+            text = f"{text}\nassistant:" if text else "assistant:"
+        return _ids(text)
+
+    def encode(self, text, **_kwargs):
+        return _ids(str(text))
+
+    def decode(self, tokens, **_kwargs):
+        return "".join(chr(int(t)) for t in tokens)
+
+
+class RecordingBank:
+    def __init__(self) -> None:
+        self.puts: list[dict] = []
+
+    def put(self, **kwargs):
+        self.puts.append(kwargs)
+        return SimpleNamespace(
+            prefix_len=len(kwargs["token_ids"]),
+            nbytes=123,
+            token_hash="test-token-hash",
+        )
+
+
+def _postcommit_state(*, tokenizer=None):
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=Lock(),
+        generation_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        postcommit_executor=SimpleNamespace(
+            submit=lambda fn, *args, **kwargs: fn(*args, **kwargs)
+        ),
+        has_foreground=lambda: False,
+        begin_foreground=lambda: None,
+        end_foreground=lambda: None,
+    )
+
+
+_TOOL_SPECS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "grep",
+            "description": "Search files",
+            "parameters": {
+                "type": "object",
+                "properties": {"pattern": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        },
+    },
+]
+
+
+def test_history_ids_with_tools_is_strict_prefix_of_next_prompt():
+    """The reachable-prefix invariant.
+
+    If turn 1 stores a snapshot for `messages + assistant_response` with
+    `tool_specs=T`, then turn 2's prompt - encoded from the SAME messages
+    plus the assistant response plus a new user message, with the SAME
+    `tool_specs=T` and `add_generation_prompt=True` - must START with the
+    stored token sequence. Otherwise SessionBank's strict-prefix lookup
+    can never reach the snapshot.
+
+    Pre-fix `_history_ids_for_postcommit` did NOT pass `tools=`, so the
+    stored sequence diverged from the next prompt at the system-message
+    boundary (where the chat template injects tool definitions).
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    history_ids = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        tool_specs=_TOOL_SPECS,
+    )
+
+    # Turn 2: same conversation + assistant reply + new user turn, with
+    # the same tool_specs and add_generation_prompt=True (the real
+    # request path).
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids, "history_ids must not be empty"
+    assert len(history_ids) <= len(next_prompt_ids)
+    assert next_prompt_ids[: len(history_ids)] == history_ids, (
+        "stored history snapshot must be a strict token prefix of the "
+        "next-turn prompt; otherwise SessionBank lookups will diverge"
+    )
+
+
+def test_history_ids_without_tools_diverges_from_next_prompt_with_tools():
+    """The bug this fix addresses: pre-fix code stored history WITHOUT
+    `tools=` while the next prompt was encoded WITH `tools=`. Show that
+    the no-tools encoding is NOT a prefix of the with-tools next prompt.
+    This is the exact failure mode that produced
+    `cache_miss_reason=prefix_divergence_at_token`.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Pre-fix encoding (no tools) - what the old `_history_ids_for_postcommit`
+    # produced.
+    history_ids_no_tools = _history_ids_for_postcommit(
+        state,
+        messages=messages,
+        assistant_content=assistant_content,
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        # tool_specs left as default None == pre-fix behaviour.
+    )
+
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids_with_tools = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+
+    assert history_ids_no_tools, "history_ids must not be empty"
+    # The no-tools encoding is NOT a prefix of the with-tools next prompt
+    # - this is the divergence the fix targets.
+    assert (
+        next_prompt_ids_with_tools[: len(history_ids_no_tools)]
+        != history_ids_no_tools
+    ), (
+        "regression guard: encoding without tools must diverge from a "
+        "next prompt encoded with tools - this is the prefix_divergence_at_token "
+        "failure mode"
+    )
+
+
+def test_store_retokenized_history_snapshot_includes_tool_definition_tokens(
+    monkeypatch,
+):
+    """`_store_retokenized_history_snapshot` must encode the synthetic
+    history WITH `tools=` so the stored token sequence includes the
+    tool-definition tokens. Encoding the same messages without tools
+    produces a strictly shorter sequence.
+    """
+    state = _postcommit_state()
+    messages = [
+        ChatMessage(role="system", content="You are a helpful agent."),
+        ChatMessage(role="user", content="Find the bug in main.py."),
+    ]
+    assistant_content = "I will search for it."
+
+    # Mock the runtime-heavy prefill/cache calls; we are validating
+    # ENCODING + bank.put(token_ids=...), not the runtime KV-cache path.
+    fake_prompt_state = SimpleNamespace(
+        trunk_cache="trunk-cache",
+        logits="logits",
+        hidden="hidden",
+        committed_mtp_cache=None,
+    )
+    monkeypatch.setattr(
+        openai,
+        "restore_or_prefill_prompt_state",
+        lambda *args, **kwargs: fake_prompt_state,
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda cache: None)
+
+    result = _store_retokenized_history_snapshot(
+        state,
+        session_id="test-session",
+        messages=messages,
+        assistant_content=assistant_content,
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        tool_specs=_TOOL_SPECS,
+    )
+
+    assert result["stored"] is True, result
+    assert state.sessions.bank.puts, "bank.put must be called"
+    stored_ids = state.sessions.bank.puts[0]["token_ids"]
+
+    # Encode the same history without tools and confirm the stored
+    # sequence is STRICTLY LONGER (has the tool-definition prefix).
+    history_messages_no_tools = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+    ]
+    no_tools_ids = _encode_messages(
+        state.runtime.tokenizer,
+        history_messages_no_tools,
+        enable_thinking=False,
+        add_generation_prompt=False,
+    )
+
+    assert len(stored_ids) > len(no_tools_ids), (
+        f"stored sequence ({len(stored_ids)} tokens) must be longer than "
+        f"the no-tools encoding ({len(no_tools_ids)} tokens) - the tool "
+        "definitions should add tokens"
+    )
+
+    # And it must be reachable as a prefix of the next-turn prompt.
+    next_messages = list(messages) + [
+        ChatMessage(role="assistant", content=assistant_content),
+        ChatMessage(role="user", content="Now fix it."),
+    ]
+    next_prompt_ids = _encode_messages(
+        state.runtime.tokenizer,
+        next_messages,
+        enable_thinking=False,
+        tools=_TOOL_SPECS,
+    )
+    assert next_prompt_ids[: len(stored_ids)] == stored_ids
+
+
+def _async_state(*, foreground_always: bool = False, tokenizer=None):
+    """A more permissive state for async-path testing that exposes the
+    same surface as `_schedule_idle_postcommit_snapshot` expects."""
+
+    def has_foreground() -> bool:
+        return True if foreground_always else False
+
+    args = parse_args(["--warmup-tokens", "0"])
+    bank = RecordingBank()
+    return SimpleNamespace(
+        args=args,
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer or ToolAwareTokenizer(),
+            model_path="models/test",
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="template",
+        draft_head_identity="draft-head",
+        lock=threading.Lock(),
+        has_foreground=has_foreground,
+        postcommit_executor=ThreadPoolExecutor(max_workers=1),
+        generation_executor=ThreadPoolExecutor(max_workers=1),
+    )
+
+
+def test_idle_postcommit_async_path_forwards_tool_specs(monkeypatch):
+    """The async idle path must forward `tool_specs` to
+    `_store_retokenized_history_snapshot`. Without the forwarding, the
+    stored sequence would diverge from the next prompt's prefix
+    (`prefix_divergence_at_token`).
+    """
+    state = _async_state(foreground_always=True)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 17,
+            "nbytes": 4242,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    pending = _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="opencode-researcher",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+        tool_specs=_TOOL_SPECS,
+    )
+    state.postcommit_executor.shutdown(wait=True)
+
+    assert pending["mode"] == "async_pending"
+    assert len(captured) == 1
+    assert captured[0]["tool_specs"] == _TOOL_SPECS, (
+        "scheduled async commit must receive the same tool_specs that "
+        "produced the request's prompt; otherwise the stored snapshot "
+        "diverges from the next prompt's prefix"
+    )
+
+
+def test_idle_postcommit_default_tool_specs_is_none(monkeypatch):
+    """Backwards compat: the four pre-existing tests in
+    `test_idle_postcommit_subagent.py` do not pass `tool_specs`. Confirm
+    the default value remains `None` so the legacy callers see no
+    behaviour change.
+    """
+    state = _async_state(foreground_always=False)
+    captured: list[dict] = []
+
+    def fake_store(_state, **kwargs):
+        captured.append(kwargs)
+        return {"stored": True, "mode": "retokenized_history"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    _schedule_idle_postcommit_snapshot(
+        state,
+        session_id="legacy-session",
+        messages=[ChatMessage(role="user", content="hi")],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy",
+        unsafe_reason="retokenized_history_mismatch",
+    )
+    state.postcommit_executor.shutdown(wait=True)
+
+    assert captured and captured[0]["tool_specs"] is None

--- a/tests/test_postcommit_tools_plumbing.py
+++ b/tests/test_postcommit_tools_plumbing.py
@@ -387,7 +387,7 @@ def test_idle_postcommit_async_path_forwards_tool_specs(monkeypatch):
         unsafe_reason="retokenized_history_mismatch",
         tool_specs=_TOOL_SPECS,
     )
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
 
     assert pending["mode"] == "async_pending"
     assert len(captured) == 1
@@ -423,6 +423,6 @@ def test_idle_postcommit_default_tool_specs_is_none(monkeypatch):
         policy_fingerprint="policy",
         unsafe_reason="retokenized_history_mismatch",
     )
-    state.postcommit_executor.shutdown(wait=True)
+    state.generation_executor.shutdown(wait=True)
 
     assert captured and captured[0]["tool_specs"] is None

--- a/tests/test_session_bank_env_caps.py
+++ b/tests/test_session_bank_env_caps.py
@@ -1,0 +1,151 @@
+"""Unit tests for SessionBank cap env-var overrides wired in engine_session.
+
+Covers the entry-count override (MTPLX_SESSION_BANK_MAX_ENTRIES) added on top
+of the existing byte-cap envs (MTPLX_SESSION_BANK_MAX_BYTES,
+MTPLX_SESSION_BANK_PER_SESSION_BYTES). The byte-cap helper is exercised in
+detail in tests/test_engine_session_env.py; the regression cases here just
+confirm all three envs compose correctly when wired through
+EngineSessionManager.__init__.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+
+def _reload_engine_session():
+    import mtplx.engine_session
+    return importlib.reload(mtplx.engine_session)
+
+
+# --- _bank_entries_from_env helper ----------------------------------------
+
+
+def test_bank_entries_from_env_default_when_unset(monkeypatch):
+    monkeypatch.delenv("TEST_BANK_ENTRIES", raising=False)
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 8
+
+
+def test_bank_entries_from_env_default_when_empty(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 8
+
+
+def test_bank_entries_from_env_valid_integer(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "24")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 24
+
+
+def test_bank_entries_from_env_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "  16  ")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 16
+
+
+@pytest.mark.parametrize("raw", ["abc", "12.5", "1e2", "0x10", ""])
+def test_bank_entries_from_env_invalid_falls_back(monkeypatch, caplog, raw):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", raw)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        result = es._bank_entries_from_env("TEST_BANK_ENTRIES", 8)
+    assert result == 8
+    if raw == "":
+        # Empty string is the unset-equivalent path; no warning expected.
+        assert not any(
+            "TEST_BANK_ENTRIES" in rec.getMessage() for rec in caplog.records
+        )
+    else:
+        assert any(
+            "TEST_BANK_ENTRIES" in rec.getMessage()
+            and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), f"expected warning for raw={raw!r}, got {caplog.records!r}"
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "-3"])
+def test_bank_entries_from_env_below_one_falls_back(monkeypatch, caplog, raw):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", raw)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        result = es._bank_entries_from_env("TEST_BANK_ENTRIES", 8)
+    assert result == 8
+    assert any(
+        "TEST_BANK_ENTRIES" in rec.getMessage()
+        and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    ), f"expected warning for raw={raw!r}, got {caplog.records!r}"
+
+
+# --- EngineSessionManager wiring ------------------------------------------
+
+
+def test_manager_uses_env_max_entries(monkeypatch):
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", "24")
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 24
+
+
+def test_manager_default_max_entries_when_unset(monkeypatch):
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    # Mirrors SessionBank.__init__'s hardcoded default of 8.
+    assert mgr.bank.max_entries == 8
+
+
+@pytest.mark.parametrize("raw", ["abc", "0", "-3"])
+def test_manager_invalid_max_entries_falls_back_to_default(
+    monkeypatch, caplog, raw
+):
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raw)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 8
+    assert any(
+        "MTPLX_SESSION_BANK_MAX_ENTRIES" in rec.getMessage()
+        and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+def test_manager_byte_caps_still_work_alongside_entries(monkeypatch):
+    """Regression: setting all three env vars composes correctly."""
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", "20")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_BYTES", "32G")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", "16G")
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 20
+    assert mgr.bank.max_bytes == 32 * 1024**3
+    assert mgr.bank.per_session_max_bytes == 16 * 1024**3
+
+
+def test_manager_byte_caps_alone_still_work(monkeypatch):
+    """Regression: byte-cap envs without the new entries env still work
+    and leave max_entries at the default."""
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raising=False)
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_BYTES", "16G")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", "8G")
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 8
+    assert mgr.bank.max_bytes == 16 * 1024**3
+    assert mgr.bank.per_session_max_bytes == 8 * 1024**3
+
+

--- a/tests/test_turboquant_fallback.py
+++ b/tests/test_turboquant_fallback.py
@@ -1,0 +1,231 @@
+"""Regression tests for the TurboQuant graceful-fallback path.
+
+Background: the user's fork hit a fatal mid-stream crash when serving a
+TurboQuant-quantized model on a host that did not have the vllm-metal
+external ops installed (``nanobind`` missing from the venv,
+``vllm_metal/paged_ops.cpp`` never JIT-built, no ``MTPLX_VLLM_METAL_REPO``).
+``_load_vllm_metal_ops`` raised :class:`RuntimeError` during a write into
+the TurboQuant paged cache (``_write_tail`` calling ``ops.tq_encode``),
+which surfaced to the OpenAI-compatible streaming endpoint as a 500 and
+killed the in-flight generation.
+
+These tests pin the new behavior:
+
+* ``install_vllm_metal_paged_attention_kv_cache`` must NOT raise when a
+  TurboQuant config is requested but external ops are unavailable; it must
+  downgrade to the plain paged layout and record the reason in stats.
+* ``VllmMetalPagedKVCache._write_tail`` must NOT raise on the same
+  condition; it must reroute through the non-TurboQuant write path and
+  produce a usable cache snapshot.
+* ``VllmMetalPagedKVCache.paged_attention`` must NOT raise on the same
+  condition; it must bail out cleanly so the caller can take its dense
+  fallback.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+import mtplx.cache_state as cache_state
+from mtplx.cache_state import (
+    VllmMetalPagedKVCache,
+    configure_tail_owned_attention_kv_cache,
+    install_vllm_metal_paged_attention_kv_cache,
+)
+from mtplx.turboquant import TurboQuantConfig
+
+
+# The exact RuntimeError text observed in production. Reproducing it
+# verbatim here keeps the test honest about the scenario it is guarding
+# against.
+_OBSERVED_OPS_FAILURE = RuntimeError(
+    "vllm-metal paged-attention ops are unavailable; "
+    "vendored vllm_metal.metal: No module named 'nanobind'; "
+    "reference checkout missing: /tmp/REFERENCES:TOOLS/vllm-metal. "
+    "Install MTPLX with its Darwin/arm64 dependencies or set "
+    "MTPLX_VLLM_METAL_REPO to a working vllm-metal checkout."
+)
+
+
+def _force_ops_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``_load_vllm_metal_ops`` raise the observed RuntimeError."""
+
+    # Reset the module-level "we already warned" latch so each test sees
+    # the warning fire (and so order between tests doesn't matter).
+    monkeypatch.setattr(cache_state, "_VLLM_METAL_OPS_UNAVAILABLE_WARNED", False)
+
+    def _raise() -> None:
+        raise _OBSERVED_OPS_FAILURE
+
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", _raise)
+
+
+def test_install_downgrades_turboquant_when_external_ops_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The crash trigger: TurboQuant install with no external ops on host."""
+
+    from mlx_lm.models.cache import KVCache
+
+    _force_ops_failure(monkeypatch)
+    cache = [KVCache()]
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+
+    # Must not raise: the install used to crash here with the observed
+    # RuntimeError, taking the in-flight request down with it.
+    stats = install_vllm_metal_paged_attention_kv_cache(
+        cache,
+        block_size=16,
+        num_blocks=64,
+        turboquant_config=config,
+    )
+
+    assert stats["entries"] == 1
+    # Cache must have been downgraded to the plain paged mode.
+    assert stats["mode"] == "vllm_metal_paged"
+    assert stats["turboquant"] == 0
+    assert stats["turboquant_disabled_reason"] == "vllm_metal_ops_unavailable"
+    assert "turboquant_k_quant" not in stats
+    paged = cache[0]
+    assert isinstance(paged, VllmMetalPagedKVCache)
+    assert paged.turboquant is False
+    assert paged.turboquant_config is None
+
+    # The operator-facing warning must have fired exactly once on stderr.
+    captured = capsys.readouterr()
+    assert "vllm-metal external ops unavailable" in captured.err
+    assert captured.err.count("vllm-metal external ops unavailable") == 1
+
+
+def test_configure_tail_owned_via_env_downgrades_turboquant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the env-driven entry point must also degrade gracefully."""
+
+    from mlx_lm.models.cache import KVCache
+
+    _force_ops_failure(monkeypatch)
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_ATTN", "1")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT", "1")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT_K_QUANT", "q8_0")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT", "q3_0")
+    cache = [KVCache()]
+
+    stats = configure_tail_owned_attention_kv_cache(cache)
+
+    assert stats["mode"] == "vllm_metal_paged"
+    assert stats["turboquant"] == 0
+    assert stats["turboquant_disabled_reason"] == "vllm_metal_ops_unavailable"
+    assert isinstance(cache[0], VllmMetalPagedKVCache)
+    assert cache[0].turboquant is False
+
+
+def test_write_tail_falls_back_to_plain_paged_when_ops_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TurboQuant cache reaching ``_write_tail`` without ops must not crash.
+
+    This guards the in-stream branch the user actually hit: the install
+    layer above already drops TurboQuant, but a snapshot-restored cache or
+    a directly-constructed one must still survive the write.
+    """
+
+    _force_ops_failure(monkeypatch)
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+    paged = VllmMetalPagedKVCache(
+        block_size=16,
+        num_blocks=4,
+        turboquant_config=config,
+    )
+    # The constructor doesn't allocate the packed layout (no keys/values
+    # passed), so we go through ``_ensure_allocated``-driven downgrade on
+    # first write. Use head_dim=128 so the TurboQuant validator would have
+    # been happy if ops had loaded.
+    keys = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    values = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+
+    # Must not raise.
+    paged.update_without_fetch(keys, values)
+
+    # The cache produced a usable snapshot, not None.
+    assert paged.offset == 7
+    assert paged.turboquant is False
+    assert paged.turboquant_config is None
+    assert paged.key_cache is not None
+    assert paged.value_cache is not None
+    # Plain paged layout: shape ``[num_blocks, block_size, n_kv_heads, head_dim]``.
+    assert tuple(paged.key_cache.shape) == (4, 16, 2, 128)
+    assert tuple(paged.value_cache.shape) == (4, 16, 2, 128)
+    stats = paged.paged_stats()
+    assert stats["mode"] == "vllm_metal_paged"
+    assert int(stats["updates"]) == 1
+
+
+def test_paged_attention_bails_out_for_turboquant_when_ops_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A residual TurboQuant ``paged_attention`` call must bail out cleanly.
+
+    We force a cache to keep ``turboquant=True`` after allocation by
+    monkeypatching ``_load_vllm_metal_ops_optional`` to return a stub at
+    allocation time and ``None`` at attention time. This simulates the
+    pathological case where install/allocation succeeded but the runtime
+    ops module disappeared (e.g. the Python session reloaded).
+    """
+
+    monkeypatch.setattr(
+        cache_state, "_VLLM_METAL_OPS_UNAVAILABLE_WARNED", False
+    )
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_ATTN_IMPL", "")  # default path
+
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+    # Build the cache with a stub ops object that *does* expose tq_encode
+    # so allocation and write succeed.
+    class _StubOps:
+        def tq_encode(self, *_args, **_kwargs):
+            # Return the same caches unchanged; we only need write_tail to
+            # finish, not produce real quantized data for this test.
+            (
+                _k_3d,
+                _v_3d,
+                key_cache,
+                value_cache,
+                key_scale,
+                value_scale,
+                key_zero,
+                _slot,
+                _centroids,
+                _vbits,
+                _kbits,
+                _ksigned,
+            ) = _args
+            return key_cache, value_cache, key_scale, value_scale, key_zero
+
+    stub = _StubOps()
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", lambda: stub)
+
+    paged = VllmMetalPagedKVCache(
+        block_size=16,
+        num_blocks=4,
+        turboquant_config=config,
+    )
+    keys = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    values = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    paged.update_without_fetch(keys, values)
+    assert paged.turboquant is True  # alloc/write took the TQ path
+
+    # Now make the next ops load fail (simulating the runtime miss).
+    def _raise() -> None:
+        raise _OBSERVED_OPS_FAILURE
+
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", _raise)
+
+    queries = mx.zeros((1, 8, 1, 128), dtype=mx.float16)
+    # Must not raise; bailout returns None so the caller takes its dense
+    # fallback instead of crashing mid-stream.
+    out = paged.paged_attention(queries, scale=128**-0.5, mask="causal")
+    assert out is None
+    stats = paged.paged_stats()
+    bailouts = stats["paged_attention_bailouts_by_phase_reason"]
+    assert any("turboquant_unsupported" in key for key in bailouts), bailouts


### PR DESCRIPTION
## Summary

In opencode-style subagent fan-out (researcher / planner / fixer / bug-patcher), T1's slow ~10s postcommit doesn't land before T2 arrives, so T2 cold-prefills, T2's postcommit doesn't land before T3, and the cache-miss cascade continues for ~4-5 turns until steady state. This PR has `EngineSession` track the in-flight postcommit future. The next request in the same session waits up to 10s for it to land **before** acquiring the session lock.

**Critical ordering note (deadlock-avoidance)**: an earlier draft placed the wait after acquiring the session lock and deadlocked, because the postcommit's `_run_store_on_generation_executor` blocks on `generation_executor` while the foreground request also wants the same executor for its own work. Commit `12d7ee8` is the deadlock-free redesign with the wait explicitly placed **before** `state.lock.acquire()`. The companion observability commits (`179bc8c`, `d1cf628`) thread `session_id` through `SessionBank.restore()` so the miss-reason label is honest (`new_session` vs `prefix_divergence_at_token`) and gate the divergence diagnostic dump (`MTPLX_DUMP_DIVERGENCE=1` -> `/tmp/mtplx-divergence-<sid>-<ts>.json`) per-session and one-shot.

**Real-world impact**: opencode-style fan-out went from a 4-5-turn cache-miss cascade to T2-warm. On the 40-pass game-improvement benchmark (Qwen3.6-27B, ctx grows 75 -> 38756): 39/40 cache hits, only T1 misses (the unavoidable cold-start). T2 TTFT dropped from cold-prefill (~10s+ at 1K ctx prior) to 1.06s; sub-2s TTFT sustained through 38K context.

## Dependency on #31

This PR stacks on #31 (`perf/postcommit-off-generation-executor`). The cherry-picked commits (`12d7ee8`, `179bc8c`, `d1cf628`) interact with the same `_store_retokenized_history_snapshot` code paths that #31 modifies, and a clean cherry-pick onto `main` produces a structural conflict in `mtplx/server/openai.py` (HEAD now uses `_submit_idle_postcommit_model_work` from the post-#29 era, while the await-future tracking in `12d7ee8` was written against the pre-#29 `executor.submit(async_postcommit)` shape). Resolving that conflict is more than mechanical - it requires deciding how the future-tracking hook integrates with `_submit_idle_postcommit_model_work`'s new abstraction.

The recommended review order is therefore: merge #31 first, then this PR can be rebased onto `main` and the diff drops to just the three commits at the tip (`12d7ee8`, `179bc8c`, `d1cf628`) plus whatever conflict resolution the post-#29 abstraction requires. **Until #31 lands, this PR's diff against `main` will include #31's commits as well.** I'm happy to rebase / re-open against the post-#31 main on request.

## Verification

- 40-pass game-improvement benchmark on Qwen3.6-27B with synthetic 1K-token tool results between turns. 40/40 success, 39/40 cache hits (only T1 cold). Mean TTFT 1.54s across ctx 75 -> 38756, max TTFT 1.90s at 35K. Findings: [`tools/bench/findings-40pass-2026-05-08.md`](https://github.com/daniel-farina/MTPLX/blob/perf/memory-caps-and-adaptive-depth/tools/bench/findings-40pass-2026-05-08.md). Bench harness: [`tools/bench/game_bench_40_long.py`](https://github.com/daniel-farina/MTPLX/blob/perf/memory-caps-and-adaptive-depth/tools/bench/game_bench_40_long.py).
- Per-session divergence dumps verified to land at `/tmp/mtplx-divergence-<sid>-<ts>.json` (one-shot per session) when `MTPLX_DUMP_DIVERGENCE=1`.
- Foreground latency consideration: the new wait can add up to 10s to inter-turn TTFT in pathological cases. The default timeout is 10s and is configurable; the benchmark above shows the win is net-positive in practice (T2-T40 TTFT median <2s vs the prior 4-5-turn cold-prefill cascade).

Files touched (relative to PR #31 tip): `mtplx/engine_session.py` (+51), `mtplx/server/openai.py` (+~14 net), `mtplx/session_bank.py` (+~90 across the three commits), `mtplx/generation.py` (+~10).

## Benchmark Evidence

- Hardware: Apple Silicon M5 Max, 128 GB unified memory
- Model: Qwen3.6-27B (MTP), TurboQuant
- Quantization: bits=3, group=64, mode=affine
- Sampler: temperature 0.6, top_p 0.95, top_k 20 (sustained profile defaults)
- Token count: 40-pass benchmark, ctx grows 75 -> 38756, 150 max output tokens per pass
- Profile: sustained
- Fan mode: not fan-controlled (sustained profile sets `fan_control_allowed=False`)
- Date: 2026-05-08
- Commits (top-of-stack, the three this PR adds beyond #31): `12d7ee8`, `179bc8c`, `d1cf628`

Headline: 39/40 cache hits across the full 75 -> 38756 ctx growth (only T1 misses, the cold-start). Mean TTFT 1.54s. Decode mean 39.3 t/s with no cliff at 16K, 24K, or 32K boundaries. The miss-reason labels are honest now: T1's miss correctly surfaces as `new_session` rather than the misleading `prefix_divergence_at_token`.