### PR TITLE
perf: keep tool-call preamble text in stored assistant_content

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6018,8 +6018,17 @@ def create_app(state: ServerState) -> FastAPI:
                     return chunks
 
                 def streamed_history_content() -> str:
-                    if tool_stream.has_tool_calls:
-                        return ""
+                    # Always capture the natural-language portion of the
+                    # response. Previously this returned "" whenever
+                    # tool_stream.has_tool_calls, which dropped any preamble
+                    # text (e.g. "Let me check..." before <tool_call>) from
+                    # the stored assistant_content. The next turn's lookup
+                    # encodes the same assistant message WITH the preamble
+                    # (clients echo back content + tool_calls), so the
+                    # prefix diverged and every tool-using turn paid a cold
+                    # prefill. tool_call markup itself is captured in
+                    # tool_stream and not in history_content_chunks, so
+                    # this is safe to return for the tool-call case too.
                     reasoning = (
                         "".join(history_reasoning_chunks)
                         .replace(THINK_OPEN, "")

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -934,6 +934,77 @@ def test_chat_stream_tool_calls_emit_delta_tool_calls(monkeypatch):
     assert "<tool_call>" not in response.text
 
 
+def test_chat_stream_tool_call_preamble_is_stored_for_postcommit(monkeypatch):
+    state = _fake_streaming_session_state()
+    state.args.stream_interval = 1
+    captured_generation_final: list[dict] = []
+    scheduled: list[dict] = []
+
+    def fake_store_generation_final(*_args, **kwargs):
+        captured_generation_final.append(kwargs)
+        return {
+            "stored": False,
+            "mode": "unsafe",
+            "reason": "tool_call_history_rewrite",
+        }
+
+    def fake_schedule(*_args, **kwargs):
+        scheduled.append(kwargs)
+        return {
+            "stored": False,
+            "mode": "async_pending",
+            "reason": kwargs["unsafe_reason"],
+        }
+
+    monkeypatch.setattr(
+        openai, "_store_generation_final_history_snapshot", fake_store_generation_final
+    )
+    monkeypatch.setattr(openai, "_schedule_idle_postcommit_snapshot", fake_schedule)
+    monkeypatch.setattr(
+        openai,
+        "_run_generation",
+        _fake_streaming_generation(
+            "Let me research first.\n\n"
+            "<tool_call>\n<function=session_status>\n</function>\n</tool_call>"
+        ),
+    )
+
+    with TestClient(create_app(state)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"x-mtplx-session-id": "stream-tool-preamble"},
+            json={
+                "messages": [{"role": "user", "content": "Status."}],
+                "tools": [_tool_schema()],
+                "tool_choice": "auto",
+                "stream": True,
+                "max_tokens": 64,
+                "enable_thinking": False,
+            },
+        )
+
+    assert response.status_code == 200
+    assert '"tool_calls"' in response.text
+    assert '"finish_reason": "tool_calls"' in response.text
+    streamed_content = "".join(
+        payload["choices"][0]["delta"]["content"]
+        for payload in _stream_payloads(response.text)
+        if payload["choices"][0]["delta"].get("content")
+    )
+    assert streamed_content == "Let me research first.\n\n"
+    assert "<tool_call>" not in response.text
+
+    assert captured_generation_final
+    assert scheduled
+    for call in (captured_generation_final[0], scheduled[0]):
+        assert call["assistant_content"] == "Let me research first."
+        assert "<tool_call>" not in call["assistant_content"]
+        assert call["assistant_tool_calls"][0]["function"] == {
+            "name": "session_status",
+            "arguments": "{}",
+        }
+
+
 def test_chat_stream_tools_plain_content_stays_incremental(monkeypatch):
     state = _fake_state()
     state.args.stream_interval = 1


### PR DESCRIPTION
## Summary

When a streamed response contains both natural-language preamble text and `<tool_call>` markup (e.g. `"Let me research the road implementation first.\n\n<tool_call>...</tool_call>"`), `streamed_history_content()` returned `""` as soon as `tool_stream.has_tool_calls` was true. The result: the natural-language preamble was dropped from `assistant_content` at storage time, while clients echoed the same assistant message back on the next turn WITH the preamble in `content`. The encoded prefix diverged and every tool-using turn paid a cold prefill.

PR #21 fixed an analogous gap in the streaming display path; this is the matching gap in the postcommit storage path.

## Verification

- Captured the divergence on a real opencode session via the per-session dump diagnostic added in PR #34 / fork tooling. The dump showed the exact byte difference: stored ended with `</think>\n\n<tool_call>...`, lookup ended with `</think>\n\nLet me research...\n\n<tool_call>...`.
- After the fix, the same session's parent agent went from `prefix_divergence_at_token` cold-prefills (~17s for 13K-token contexts) to `cache_hit: true` warm starts (0.3-0.9s TTFT at 23-30K context).
- Tool-call markup itself is captured in `tool_stream` and not in `history_content_chunks`, so always returning the natural-language buffer is safe for both content-only and content+tool_calls responses.

## Benchmark Evidence

- Hardware: Apple Silicon M5 Max 128GB
- Model: Qwen3.6-27B Optimized-Speed (native MTP)
- Quantization: draft-lm-head bits=3, group=64, mode=affine
- Sampler: temperature 0.6, top_p 0.95, top_k 20
- Profile: sustained
- Fan-mode: not fan-controlled (sustained sets `fan_control_allowed=False`)
- Date: 2026-05-08
- Commit: `2eb6016` (cherry of `19b2849` from `daniel-farina/MTPLX:perf/memory-caps-and-adaptive-depth`)
- Workload: opencode session with 7 distinct subagent types (parent, title, researcher, planner, fixer, bug-patcher, build-doctor)

| Pattern | Before | After |
|---|---|---|
| Tool-using parent T2+ | cold prefill 16-50s | warm 0.3-3s TTFT |
| 23K parent ctx | full re-prefill | 0.6s TTFT |
| 30K parent ctx | full re-prefill | 0.9s TTFT |

Real-traffic results recorded across mountains/sky/water improvement runs against the 3dworld test repository.

## Related

- Builds on PR #21 (mixed text + tool_call streaming)
- Independent of #32 / #33 / #34 (different file, different code path)