### PR TITLE
perf: bounded session-local wait for prior postcommit (rebuild of #34)

### DIFF
--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -153,6 +153,27 @@ def is_background_request(
     )
 
 
+_DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S = 10.0
+
+
+def _postcommit_wait_timeout_s() -> float:
+    """Read MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S from the environment.
+
+    Defaults to 10s. Values <= 0 disable the wait (returns 0.0). Bad values
+    fall back to the default so a typo does not leave the server hanging.
+    """
+    raw = os.environ.get("MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S")
+    if raw is None:
+        return _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S
+    if value < 0:
+        return 0.0
+    return value
+
+
 class EngineSession:
     def __init__(self, session_id: str, *, idle_ttl_s: float = DEFAULT_IDLE_TTL_S) -> None:
         self.session_id = str(session_id)
@@ -170,6 +191,24 @@ class EngineSession:
         self.bytes_estimate = 0
         self.revision = 0
         self._lock = Lock()
+        # Reference to the most recent postcommit work scheduled for this
+        # session. The next request in this session waits briefly on this
+        # before acquiring the session lock so the SessionBank entry is
+        # available when its prefix lookup runs - avoiding the cold-prefill
+        # cascade documented in PR #34. Always written/read while NOT holding
+        # the session lock to preserve the no-deadlock ordering. Type kept as
+        # Any to avoid pulling concurrent.futures into hot import paths.
+        self.pending_postcommit: Any = None
+        # Per-session lock guarding `pending_postcommit` reads/writes. This is
+        # SEPARATE from `_lock` (which guards `in_flight_generation`) so that
+        # `wait_for_pending_postcommit` can serialize access to the future
+        # field without ever contending with the foreground/in-flight lock,
+        # preserving the no-deadlock ordering callers rely on. The lock is
+        # only held while reading or mutating `pending_postcommit` itself,
+        # never while awaiting on the future.
+        self._postcommit_lock = Lock()
+        # Last wait outcome, exposed via to_admin_dict for the metrics endpoint.
+        self.last_postcommit_wait: dict[str, Any] | None = None
 
     @property
     def prefix_len(self) -> int:
@@ -181,6 +220,144 @@ class EngineSession:
     def is_stale(self, *, now_s: float | None = None) -> bool:
         now = time.time() if now_s is None else float(now_s)
         return now - self.last_access_s > self.idle_ttl_s
+
+    def set_pending_postcommit(self, future: Any) -> None:
+        """Record a reference to in-flight postcommit work for this session.
+
+        The next request in this session calls wait_for_pending_postcommit()
+        before acquiring the session lock so the prior turn's SessionBank
+        entry is visible at lookup time. Older references are dropped on each
+        new commit; only the most recent matters for the next turn's lookup.
+
+        The write is guarded by `_postcommit_lock` so it cannot race with a
+        concurrent `wait_for_pending_postcommit` reading the field.
+        """
+        with self._postcommit_lock:
+            self.pending_postcommit = future
+
+    def wait_for_pending_postcommit(
+        self,
+        *,
+        timeout_s: float | None = None,
+    ) -> dict[str, Any]:
+        """Bounded wait for the prior postcommit job to land.
+
+        Returns a small telemetry dict the caller can attach to request stats:
+            {"waited": bool, "elapsed_s": float, "outcome": str,
+             "timeout_s": float}
+
+        `outcome` is one of:
+            - "no_pending"     : nothing was scheduled, no wait performed
+            - "completed"      : the future resolved within the timeout
+            - "timeout"        : the future did not resolve in time; the
+                                 request should fall through to a cold
+                                 prefill rather than hang
+            - "error:<Type>"   : the future raised; we swallow it because the
+                                 postcommit's job is best-effort caching, not
+                                 correctness
+            - "disabled"       : timeout_s <= 0; wait short-circuits
+
+        CRITICAL: This must be called WITHOUT the session lock (`_lock`)
+        held. The postcommit work runs on the model scheduler's owner thread;
+        a foreground request that holds the session lock and then waits on
+        scheduler-bound work risks priority inversion against other
+        same-session commits queued behind it. Callers should invoke this
+        before entering `in_flight_generation()`.
+
+        Concurrency contract (the bug fix from PR #37 review):
+
+        Two concurrent same-session waiters MUST observe the SAME active
+        future and either both report "completed" (on resolve) or both
+        report "timeout" (on timeout). Neither must ever observe
+        "no_pending" while a real postcommit is still in flight.
+
+        We achieve that by capturing the current future under
+        `_postcommit_lock`, releasing the lock BEFORE awaiting on the
+        future (so other same-session waiters can observe the same future),
+        then re-acquiring the lock after the wait and clearing
+        `pending_postcommit` ONLY if it is still the same future identity
+        (`is` comparison). If a newer commit superseded the future while we
+        were waiting, the newer reference belongs to the next caller and we
+        leave it alone.
+        """
+        if timeout_s is None:
+            timeout_s = _postcommit_wait_timeout_s()
+        timeout_s = float(timeout_s)
+        # Capture the current future under the lock so a concurrent
+        # `set_pending_postcommit` cannot tear our read. The lock is released
+        # immediately - we MUST NOT hold it while awaiting on the future, and
+        # leaving it visible on the session is the whole point: a second
+        # same-session waiter must observe the same future, not "no_pending".
+        with self._postcommit_lock:
+            future = self.pending_postcommit
+        if future is None:
+            outcome = {
+                "waited": False,
+                "elapsed_s": 0.0,
+                "outcome": "no_pending",
+                "timeout_s": timeout_s,
+            }
+            self.last_postcommit_wait = outcome
+            return outcome
+        if not hasattr(future, "result"):
+            # Defensive: anything stashed on the session that does not look
+            # like a future is treated as "nothing to wait on". We do NOT
+            # clear it - the field will be overwritten on the next legitimate
+            # set_pending_postcommit call.
+            outcome = {
+                "waited": False,
+                "elapsed_s": 0.0,
+                "outcome": "no_pending",
+                "timeout_s": timeout_s,
+            }
+            self.last_postcommit_wait = outcome
+            return outcome
+        if timeout_s <= 0.0:
+            # Disabled mode: do NOT touch `pending_postcommit`. Operators
+            # toggle this dynamically via MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S; if
+            # they re-enable later we want the existing future still visible
+            # so it is not silently dropped.
+            outcome = {
+                "waited": False,
+                "elapsed_s": 0.0,
+                "outcome": "disabled",
+                "timeout_s": timeout_s,
+            }
+            self.last_postcommit_wait = outcome
+            return outcome
+        t0 = time.monotonic()
+        # We catch BaseException because any failure in the postcommit must
+        # not propagate into the foreground request: the wait is a best-effort
+        # cache warmup, not a correctness dependency. Timeout is the most
+        # common non-success outcome and is reported distinctly so operators
+        # can spot a stuck postcommit lane.
+        try:
+            future.result(timeout=timeout_s)
+            outcome = {
+                "waited": True,
+                "elapsed_s": time.monotonic() - t0,
+                "outcome": "completed",
+                "timeout_s": timeout_s,
+            }
+        except BaseException as exc:
+            label = "timeout" if type(exc).__name__ == "TimeoutError" else f"error:{type(exc).__name__}"
+            outcome = {
+                "waited": True,
+                "elapsed_s": time.monotonic() - t0,
+                "outcome": label,
+                "timeout_s": timeout_s,
+            }
+        # Clear the reference ONLY if it is still the same future we
+        # observed. A concurrent same-session commit may have superseded it
+        # while we were waiting; in that case the newer future belongs to
+        # the next caller and we must not stomp it. Identity check (`is`)
+        # is required: equality could collapse two distinct futures with
+        # the same result.
+        with self._postcommit_lock:
+            if self.pending_postcommit is future:
+                self.pending_postcommit = None
+        self.last_postcommit_wait = outcome
+        return outcome
 
     @contextmanager
     def in_flight_generation(self) -> Iterator["EngineSession"]:
@@ -267,6 +444,8 @@ class EngineSession:
             "in_flight_started_s": self.in_flight_started_s,
             "last_cache_miss_reason": self.last_cache_miss_reason,
             "last_restore_mode": self.last_restore_mode,
+            "last_postcommit_wait": self.last_postcommit_wait,
+            "pending_postcommit": bool(self.pending_postcommit is not None),
             "boundaries": [
                 {
                     "kind": boundary.kind,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -3033,11 +3033,21 @@ def _schedule_idle_postcommit_snapshot(
                 }
             )
 
-    _submit_idle_postcommit_model_work(
+    future = _submit_idle_postcommit_model_work(
         state,
         async_postcommit,
         batch_key=f"postcommit:{session_id or 'stateless'}",
     )
+    # Stash the future on the EngineSession so the next request in this
+    # session can wait briefly for it before acquiring the session lock.
+    # The wait is bounded and best-effort: if the postcommit raises or
+    # times out the next request just falls through to a cold prefill.
+    if session is not None:
+        try:
+            session.set_pending_postcommit(future)
+        except BaseException:
+            # Telemetry plumbing must never break the request path.
+            pass
     return pending
 
 
@@ -5836,6 +5846,39 @@ def create_app(state: ServerState) -> FastAPI:
                 ),
             )
             generated["stats"]["session_postcommit_snapshot"] = postcommit
+
+        # Bounded wait for the prior turn's postcommit to land before we
+        # admit this request to the model scheduler. Done HERE - off the
+        # scheduler-owner thread, before any foreground submit and before
+        # the session lock is acquired - so a slow postcommit cannot deadlock
+        # against this request. The wait is best-effort: timeouts fall
+        # through to a cold prefill, never a hang.
+        postcommit_wait_outcome: dict[str, Any] | None = None
+        if session is not None:
+            postcommit_wait_outcome = await asyncio.to_thread(
+                session.wait_for_pending_postcommit
+            )
+            request_observability["postcommit_wait"] = postcommit_wait_outcome
+            if (
+                postcommit_wait_outcome is not None
+                and postcommit_wait_outcome.get("waited")
+                and not _server_console_enabled(state)
+            ):
+                try:
+                    print(
+                        "[mtplx] postcommit-wait "
+                        + json.dumps(
+                            {
+                                "session_id": session_id,
+                                **postcommit_wait_outcome,
+                            },
+                            sort_keys=True,
+                            default=str,
+                        ),
+                        flush=True,
+                    )
+                except BaseException:
+                    pass
 
         if request.stream:
 

--- a/tests/test_postcommit_wait.py
+++ b/tests/test_postcommit_wait.py
@@ -1,0 +1,391 @@
+"""Tests for the bounded session-local wait for prior postcommit work.
+
+The wait is the rebuild of closed PR #34 against the new model scheduler. It
+sits on EngineSession.wait_for_pending_postcommit(), reads a Future stashed
+when the previous turn's postcommit was scheduled, and is bounded so a stuck
+postcommit never blocks the foreground request indefinitely.
+
+Critical invariants exercised here:
+  - HIT  : the wait completes when the postcommit lands within the timeout
+  - SKIP : the wait short-circuits to "no_pending" when nothing was scheduled
+  - BAIL : the wait reports "timeout" without raising and the request can
+           proceed cold
+  - ORDER: the wait must be done WITHOUT the session lock held - otherwise a
+           same-session concurrent caller (or scheduler-bound work) can
+           deadlock against us. We verify both that wait_for_pending_postcommit
+           does not itself acquire the session lock and that the lock is
+           reusable while a future is pending.
+  - STATS: the wait emits a structured outcome dict the server can attach to
+           request observability and surface in /metrics.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import Future
+from threading import Thread
+
+import pytest
+
+from mtplx.engine_session import (
+    EngineSession,
+    _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S,
+    _postcommit_wait_timeout_s,
+)
+
+
+def _new_session(sid: str = "sess-test") -> EngineSession:
+    return EngineSession(sid)
+
+
+def test_wait_no_pending_short_circuits_without_blocking() -> None:
+    session = _new_session()
+    t0 = time.monotonic()
+    outcome = session.wait_for_pending_postcommit(timeout_s=5.0)
+    elapsed = time.monotonic() - t0
+
+    assert outcome["outcome"] == "no_pending"
+    assert outcome["waited"] is False
+    assert outcome["elapsed_s"] == 0.0
+    # Should be immediate; "no_pending" must never block.
+    assert elapsed < 0.05
+    assert session.last_postcommit_wait == outcome
+
+
+def test_wait_completes_when_postcommit_lands_inside_timeout() -> None:
+    session = _new_session()
+    future: Future = Future()
+    session.set_pending_postcommit(future)
+
+    def producer() -> None:
+        time.sleep(0.05)
+        future.set_result("committed")
+
+    Thread(target=producer, daemon=True).start()
+    outcome = session.wait_for_pending_postcommit(timeout_s=2.0)
+
+    assert outcome["outcome"] == "completed"
+    assert outcome["waited"] is True
+    assert 0.04 < outcome["elapsed_s"] < 1.5
+    # Reference must be cleared so a follow-up call does not double-wait.
+    assert session.pending_postcommit is None
+
+
+def test_wait_times_out_without_raising_and_request_can_proceed_cold() -> None:
+    session = _new_session()
+    future: Future = Future()  # never resolved
+    session.set_pending_postcommit(future)
+
+    t0 = time.monotonic()
+    outcome = session.wait_for_pending_postcommit(timeout_s=0.1)
+    elapsed = time.monotonic() - t0
+
+    assert outcome["outcome"] == "timeout"
+    assert outcome["waited"] is True
+    # Bounded: should not exceed ~3x the timeout under load.
+    assert elapsed < 0.5
+    # The future is dropped even on timeout so we do not re-wait next turn.
+    assert session.pending_postcommit is None
+    # Caller can now proceed; nothing in our state forces a retry.
+
+
+def test_wait_swallows_postcommit_exceptions() -> None:
+    session = _new_session()
+    future: Future = Future()
+    future.set_exception(RuntimeError("scheduler exploded"))
+    session.set_pending_postcommit(future)
+
+    outcome = session.wait_for_pending_postcommit(timeout_s=1.0)
+
+    # We do not surface the underlying error to the foreground request - the
+    # wait is a best-effort cache warmup, not a correctness dependency.
+    assert outcome["outcome"].startswith("error:")
+    assert "RuntimeError" in outcome["outcome"]
+    assert outcome["waited"] is True
+
+
+def test_wait_disabled_when_timeout_zero_or_negative() -> None:
+    session = _new_session()
+    future: Future = Future()
+    session.set_pending_postcommit(future)
+
+    outcome = session.wait_for_pending_postcommit(timeout_s=0.0)
+    assert outcome["outcome"] == "disabled"
+    assert outcome["waited"] is False
+    # The future MUST stay visible on the session: "disabled" means we did
+    # not observe the future, so we cannot claim ownership over clearing
+    # it. If the operator re-enables waiting on the next request, that
+    # request must still find the future and wait on it. (PR #37 review:
+    # only clear `pending_postcommit` after a real resolve/timeout.)
+    assert session.pending_postcommit is future
+
+
+def test_wait_does_not_acquire_session_lock_so_no_foreground_deadlock() -> None:
+    """The wait MUST run without holding the session lock.
+
+    If `wait_for_pending_postcommit` ever acquired the session lock, a
+    same-session concurrent foreground request that already holds the lock
+    would deadlock against the wait, AND any scheduler-bound postcommit
+    work that needs the lock to commit would deadlock against the waiter.
+
+    We verify by holding the session lock from another thread and checking
+    that the wait still progresses (it does not contend on the lock). We
+    also verify the wait does NOT count as in-flight on the session.
+    """
+    session = _new_session()
+    # Hold the lock from another thread to simulate a same-session
+    # concurrent request that has already entered in_flight_generation().
+    with session._lock:
+        future: Future = Future()
+        session.set_pending_postcommit(future)
+
+        def land_postcommit() -> None:
+            time.sleep(0.05)
+            future.set_result(None)
+
+        Thread(target=land_postcommit, daemon=True).start()
+        # If the wait needed the lock, this would block until the outer
+        # `with` releases it - we never do, so the call would hang and the
+        # test would time out via pytest's outer timeout.
+        outcome = session.wait_for_pending_postcommit(timeout_s=2.0)
+
+    assert outcome["outcome"] == "completed"
+    assert session.in_flight is False
+
+
+def test_wait_records_outcome_in_admin_dict_for_metrics_endpoint() -> None:
+    session = _new_session()
+    future: Future = Future()
+    future.set_result(None)
+    session.set_pending_postcommit(future)
+    session.wait_for_pending_postcommit(timeout_s=1.0)
+
+    admin = session.to_admin_dict()
+    assert admin["last_postcommit_wait"] is not None
+    assert admin["last_postcommit_wait"]["outcome"] == "completed"
+    # No future left dangling once we have observed it.
+    assert admin["pending_postcommit"] is False
+
+
+def test_set_pending_postcommit_overwrites_prior_reference() -> None:
+    """A second commit on the same session supersedes the first.
+
+    Only the most recent postcommit's bank entry matters for the next
+    request's lookup, so we drop older references rather than chaining.
+    """
+    session = _new_session()
+    first: Future = Future()
+    second: Future = Future()
+    second.set_result(None)
+    session.set_pending_postcommit(first)
+    session.set_pending_postcommit(second)
+
+    outcome = session.wait_for_pending_postcommit(timeout_s=0.5)
+    assert outcome["outcome"] == "completed"
+    # First future is never observed by the wait, but is also no longer
+    # referenced by the session.
+    assert session.pending_postcommit is None
+
+
+def test_postcommit_wait_timeout_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S", raising=False)
+    assert _postcommit_wait_timeout_s() == _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("0", 0.0),
+    ("0.5", 0.5),
+    ("3", 3.0),
+    ("15", 15.0),
+])
+def test_postcommit_wait_timeout_env_override(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: float
+) -> None:
+    monkeypatch.setenv("MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S", raw)
+    assert _postcommit_wait_timeout_s() == expected
+
+
+def test_postcommit_wait_timeout_env_invalid_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S", "not-a-number")
+    assert _postcommit_wait_timeout_s() == _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S
+
+
+def test_postcommit_wait_timeout_env_negative_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S", "-1")
+    assert _postcommit_wait_timeout_s() == 0.0
+
+
+def test_in_flight_generation_does_not_implicitly_wait_on_postcommit() -> None:
+    """The wait is the chat handler's responsibility, not the session lock.
+
+    The OLD PR #34 implementation wove the wait into the in_flight_generation
+    context manager. That coupling is fragile because in_flight_generation is
+    also used by code paths that legitimately do not have a session-bound
+    postcommit (e.g. tests). We keep the wait at the call site and verify
+    here that EngineSession's lock acquisition is independent.
+    """
+    session = _new_session()
+    future: Future = Future()  # never resolves
+    session.set_pending_postcommit(future)
+
+    # Entering in_flight_generation must not block on the future.
+    started = time.monotonic()
+    with session.in_flight_generation():
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.1
+        assert session.in_flight is True
+    assert session.in_flight is False
+    # The future is still pending on the session for the next caller to
+    # observe via wait_for_pending_postcommit().
+    assert session.pending_postcommit is future
+
+
+def test_wait_then_lock_then_wait_again_simulates_two_turn_sequence() -> None:
+    """End-to-end: turn 1 schedules postcommit, turn 2 waits-then-locks."""
+    session = _new_session()
+
+    # Turn 1: simulate that a postcommit was scheduled at the end of the turn.
+    turn1_future: Future = Future()
+    session.set_pending_postcommit(turn1_future)
+
+    def land_turn1_postcommit() -> None:
+        time.sleep(0.05)
+        turn1_future.set_result(None)
+
+    Thread(target=land_turn1_postcommit, daemon=True).start()
+
+    # Turn 2: BEFORE acquiring the session lock, wait for turn 1's commit.
+    pre_lock = session.wait_for_pending_postcommit(timeout_s=2.0)
+    assert pre_lock["outcome"] == "completed"
+
+    # Now turn 2 enters in_flight_generation and runs.
+    with session.in_flight_generation():
+        assert session.in_flight is True
+
+    # Turn 2 schedules its own postcommit at the end.
+    turn2_future: Future = Future()
+    session.set_pending_postcommit(turn2_future)
+    assert session.pending_postcommit is turn2_future
+
+
+def test_wait_for_pending_postcommit_concurrent_same_session() -> None:
+    """Two concurrent same-session waiters must observe the same future.
+
+    Regression for the PR #37 review bug: the original implementation cleared
+    `self.pending_postcommit` BEFORE waiting on it. A second concurrent
+    same-session caller saw the field empty and returned ``no_pending`` even
+    while the postcommit was still in flight, defeating the cache-warmup
+    purpose of the wait.
+
+    The fix is:
+      - keep the future visible on the session until resolve OR timeout,
+      - clear it only if it is still the same future identity after the
+        wait completes,
+      - guard reads/writes with a per-session lock.
+
+    This test exercises the three invariants the maintainer asked for:
+
+    (a) on resolve, BOTH waiters see ``completed``;
+    (b) ``no_pending`` is NEVER reported while the future is unresolved;
+    (c) on timeout, BOTH waiters see ``timeout`` deterministically.
+    """
+    # --- (a) + (b): both waiters see "completed" on resolve, neither sees
+    # "no_pending" while the future is still in flight.
+    session = _new_session("concurrent-resolve")
+    future: Future = Future()
+    session.set_pending_postcommit(future)
+
+    outcomes: dict[int, dict] = {}
+    start_barrier = threading.Barrier(2)
+
+    def waiter(idx: int) -> None:
+        # Both waiters arrive at the wait call as close to simultaneously as
+        # we can arrange in CPython, so they both observe the same active
+        # future on the session.
+        start_barrier.wait(timeout=2.0)
+        outcomes[idx] = session.wait_for_pending_postcommit(timeout_s=2.0)
+
+    threads = [Thread(target=waiter, args=(i,), daemon=True) for i in (0, 1)]
+    for t in threads:
+        t.start()
+
+    # Give both waiters a chance to enter the wait. While they are waiting,
+    # `pending_postcommit` MUST stay visible on the session - the original
+    # bug was that the first waiter cleared it up front, causing the second
+    # waiter (or a third concurrent peek) to see "no_pending".
+    deadline = time.monotonic() + 0.5
+    saw_pending_during_wait = False
+    while time.monotonic() < deadline and not future.done():
+        if session.pending_postcommit is future:
+            saw_pending_during_wait = True
+        time.sleep(0.005)
+    # The wait should still be in flight at this point; the future has not
+    # been resolved yet, so the field MUST still point at it.
+    assert saw_pending_during_wait, (
+        "pending_postcommit was cleared before the future resolved - this is "
+        "exactly the race PR #37 review flagged"
+    )
+    assert session.pending_postcommit is future
+
+    # Resolve the future and let both waiters complete.
+    future.set_result("done")
+    for t in threads:
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "waiter thread did not return in time"
+
+    assert outcomes[0]["outcome"] == "completed", outcomes
+    assert outcomes[1]["outcome"] == "completed", outcomes
+    # Neither waiter must report no_pending while the future was active.
+    assert outcomes[0]["outcome"] != "no_pending"
+    assert outcomes[1]["outcome"] != "no_pending"
+    # After both have observed the resolve, the field is cleared exactly
+    # once (by whichever waiter re-acquired the postcommit lock first); the
+    # other no-ops because identity no longer matches.
+    assert session.pending_postcommit is None
+
+    # --- (c): on timeout, both waiters observe "timeout" deterministically.
+    timeout_session = _new_session("concurrent-timeout")
+    stuck_future: Future = Future()  # never resolves
+    timeout_session.set_pending_postcommit(stuck_future)
+
+    timeout_outcomes: dict[int, dict] = {}
+    timeout_barrier = threading.Barrier(2)
+
+    def timeout_waiter(idx: int) -> None:
+        timeout_barrier.wait(timeout=2.0)
+        timeout_outcomes[idx] = timeout_session.wait_for_pending_postcommit(
+            timeout_s=0.1
+        )
+
+    timeout_threads = [
+        Thread(target=timeout_waiter, args=(i,), daemon=True) for i in (0, 1)
+    ]
+    started = time.monotonic()
+    for t in timeout_threads:
+        t.start()
+    for t in timeout_threads:
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "timeout waiter did not return"
+    elapsed = time.monotonic() - started
+
+    assert timeout_outcomes[0]["outcome"] == "timeout", timeout_outcomes
+    assert timeout_outcomes[1]["outcome"] == "timeout", timeout_outcomes
+    # Both must have actually waited (elapsed_s > 0) and reported the
+    # configured timeout in their envelope - the metric shape is unchanged.
+    for outcome in timeout_outcomes.values():
+        assert outcome["waited"] is True
+        assert outcome["timeout_s"] == 0.1
+        assert set(outcome.keys()) == {"waited", "elapsed_s", "outcome", "timeout_s"}
+    # Bounded: both waiters must finish within a small multiple of the
+    # timeout - if either had observed "no_pending" early it would have
+    # returned ~immediately, but more importantly neither must hang past
+    # the timeout.
+    assert elapsed < 1.0, f"timeout waiters took too long: {elapsed:.3f}s"
+    # After timeout, the field is cleared (one of the waiters won the
+    # identity race; the other no-oped).
+    assert timeout_session.pending_postcommit is None

--- a/tests/test_postcommit_wait_integration.py
+++ b/tests/test_postcommit_wait_integration.py
@@ -1,0 +1,145 @@
+"""Integration tests: scheduler-side wiring of postcommit-wait.
+
+These tests exercise the seam between `_schedule_idle_postcommit_snapshot`
+and `EngineSession.set_pending_postcommit`. Together they prove that:
+
+  1. Scheduling an idle postcommit stashes the work future on the session.
+  2. The next request's `wait_for_pending_postcommit()` observes the same
+     future and bails out cleanly when the postcommit returns.
+  3. A foreground submission (chat handler path) does not need to wait on
+     idle work that the scheduler has not started yet, because the
+     foreground lane has admission priority - we only assert wiring here.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.engine_session import EngineSession
+from mtplx.server import openai
+
+
+def _fake_state_with_executor():
+    """Stand up a state object good enough for `_schedule_idle_postcommit_snapshot`.
+
+    `_submit_idle_postcommit_model_work` falls back to `state.generation_executor`
+    when no model_scheduler is present. Tests run cheaply against this seam
+    rather than spinning up the real ModelWorkScheduler.
+    """
+    return SimpleNamespace(
+        lock=threading.Lock(),
+        has_foreground=lambda: False,
+        generation_executor=ThreadPoolExecutor(max_workers=1),
+        postcommit_executor=None,
+        model_scheduler=None,
+        args=SimpleNamespace(server_console=False),
+    )
+
+
+def _kwargs(session_id: str = "sess-int", session: EngineSession | None = None):
+    return dict(
+        session_id=session_id,
+        messages=[],
+        assistant_content="hello",
+        assistant_tool_calls=None,
+        thinking_enabled=False,
+        policy_fingerprint="test-policy",
+        unsafe_reason="retokenized_history_mismatch",
+        session=session,
+        expected_session_revision=getattr(session, "revision", 0) if session else None,
+    )
+
+
+def test_scheduling_stashes_future_on_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _fake_state_with_executor()
+    barrier = threading.Event()
+
+    def fake_store(*_args, **_kwargs):
+        # Block until the test releases us so the future is observably
+        # pending on the session for at least one wait cycle.
+        barrier.wait(timeout=2.0)
+        return {
+            "stored": True,
+            "mode": "retokenized_history",
+            "prefix_len": 1,
+            "nbytes": 1,
+        }
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    session = EngineSession("sess-int")
+    assert session.pending_postcommit is None
+
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs(session=session))
+
+    # The schedule call returns immediately; the future is on the session.
+    assert session.pending_postcommit is not None
+
+    # Release the worker; the wait observes a clean completion.
+    barrier.set()
+    outcome = session.wait_for_pending_postcommit(timeout_s=2.0)
+    assert outcome["outcome"] == "completed"
+    assert session.pending_postcommit is None
+
+    state.generation_executor.shutdown(wait=True)
+
+
+def test_wait_times_out_when_postcommit_hangs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator safety net: if the postcommit job hangs (e.g. the scheduler
+    has a foreground backlog draining), the next request bails out and
+    proceeds cold instead of stalling.
+    """
+    state = _fake_state_with_executor()
+    block_forever = threading.Event()
+
+    def fake_store(*_args, **_kwargs):
+        # Simulate a postcommit job that is stuck (e.g. waiting on lock).
+        block_forever.wait(timeout=5.0)
+        return {"stored": False, "reason": "stuck"}
+
+    monkeypatch.setattr(openai, "_store_retokenized_history_snapshot", fake_store)
+    monkeypatch.setattr(openai, "_server_console_enabled", lambda _state: True)
+
+    session = EngineSession("sess-int-timeout")
+    openai._schedule_idle_postcommit_snapshot(state, **_kwargs(session=session))
+    assert session.pending_postcommit is not None
+
+    started = time.monotonic()
+    outcome = session.wait_for_pending_postcommit(timeout_s=0.1)
+    elapsed = time.monotonic() - started
+
+    assert outcome["outcome"] == "timeout"
+    assert outcome["waited"] is True
+    assert elapsed < 0.5, "wait must be bounded by the timeout"
+    # Future stays referenced by the executor but is removed from the
+    # session - the request can now proceed cold without re-blocking.
+    assert session.pending_postcommit is None
+
+    block_forever.set()
+    state.generation_executor.shutdown(wait=True)
+
+
+def test_wait_metrics_attach_to_request_observability_shape() -> None:
+    """The chat handler attaches the wait outcome to request_observability
+    which then merges into the metrics envelope. We assert the shape here
+    rather than spin up a full FastAPI test client - the shape is what
+    /metrics consumers depend on.
+    """
+    session = EngineSession("sess-int-metrics")
+    # Simulate "no_pending" path the chat handler hits on a brand-new session.
+    outcome = session.wait_for_pending_postcommit(timeout_s=1.0)
+
+    # request_observability is just a plain dict in the handler; we mimic that.
+    request_observability: dict = {}
+    request_observability["postcommit_wait"] = outcome
+
+    assert "postcommit_wait" in request_observability
+    pw = request_observability["postcommit_wait"]
+    assert set(pw.keys()) == {"waited", "elapsed_s", "outcome", "timeout_s"}
+    assert pw["outcome"] == "no_pending"


### PR DESCRIPTION
Rebuild of closed #34 against current `main` (`d4315b7`) using the new
`ModelWorkScheduler` abstraction landed in `349fdf7`.

## Background

Closed in #34 with this feedback from @youssofal:

> The problem is real where fast follow-up turns can arrive before the prior postcommit lands, causing cache-miss cascades. But this branch is stacked on stale SessionBank/TurboQuant history and conflicts with the currrent main and predates the current model scheduler/postcommit architecture.
>
> I'd prefer this be rebuilt as a clean PR on current `main`, using the existing scheduler abstraction. The intended behavior should be a bounded session-local wait for the prior postcommit, with timeout/stats, no foreground deadlock risk, and tests proving it works with the current scheduler.

This PR is that rebuild. It is NOT a cherry-pick of #34; the architecture
moved (postcommit work now goes through `ModelWorkScheduler.submit_idle_postcommit`
instead of a `postcommit_executor` ThreadPoolExecutor), so the idea is
ported to the new abstraction.

## Design

- `EngineSession.set_pending_postcommit(future)` stashes a reference to
  the most recent postcommit job scheduled for this session. Set inside
  `_schedule_idle_postcommit_snapshot` right after
  `_submit_idle_postcommit_model_work` returns the work future.

- `EngineSession.wait_for_pending_postcommit()` bounded-waits on that
  future. Default timeout 10s, override via `MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S`
  (set to `0` or negative to disable). Returns a small dict:

  ```
  {\"waited\": bool, \"elapsed_s\": float, \"outcome\": str, \"timeout_s\": float}
  ```

  with `outcome` in `completed | timeout | no_pending | disabled | error:<Type>`.
  Exceptions from the postcommit are swallowed - the wait is best-effort
  cache warmup, not a correctness dependency.

- The chat handler calls `wait_for_pending_postcommit` BEFORE submitting
  any foreground work to the scheduler and BEFORE entering
  `in_flight_generation()`. This is the same critical ordering #34
  arrived at after a redesign: waiting from the scheduler-owner thread
  (or with the session lock held) deadlocks against same-session
  postcommit work that the scheduler itself needs to complete. The wait
  runs on a worker thread via `asyncio.to_thread` so the FastAPI event
  loop is never blocked.

- The wait outcome is attached to `request_observability` and merges
  into the existing metrics envelope, so it shows up under
  `postcommit_wait` in `/metrics`. `EngineSession.to_admin_dict()` also
  exposes `last_postcommit_wait` and `pending_postcommit` for
  `/admin/sessions`.

## New scheduler hook point

`mtplx/server/openai.py:_schedule_idle_postcommit_snapshot` (lines 2948-2965):
the future returned by `_submit_idle_postcommit_model_work` is now
stashed on the session via `session.set_pending_postcommit(future)`.

The wait is wired in at `mtplx/server/openai.py` just before the
`if request.stream:` branch in the chat handler, so both streaming and
non-streaming paths pick it up before any work is submitted to the
scheduler.

## Verification

### Tests

20 new tests, all passing. Full suite (including `test_openai_bridge.py`
and `test_idle_postcommit_subagent.py`) green.

- `tests/test_postcommit_wait.py` (17 tests): HIT path, `no_pending`
  short-circuit, timeout bail-out (no hang), exception swallowing,
  disabled mode, lock-independence (proves no deadlock under
  same-session lock), admin-dict surfacing, env-var parsing
  (default / override / invalid / negative), two-turn end-to-end
  sequence, supersession (newer commit overwrites older future).
- `tests/test_postcommit_wait_integration.py` (3 tests): scheduling
  stashes the future on the session, wait times out cleanly when
  postcommit hangs, metrics shape matches `request_observability`
  contract.

### Manual evidence (real opencode traffic)

Pulled from #36's real-traffic run on this rebuilt + the rest of the
series applied:

| Agent | TTFT pattern observed |
|---|---|
| `researcher` | T1 cold (~10s on 7K ctx) -> T2+ HIT at 0.2-5s on 8K-45K ctx |
| `planner` | T1 cold -> T2 HIT at 0.5s |
| `fixer` | 0.2-0.3s instant warms throughout the orchestration loop |
| `bug-patcher` | Cold per-file (different prefix each), warm within-file at 0.2-3s |
| `parent` (3dworld-loop) | 0.3-3s warm hits at 16-25K context |

| Headline metric | Before | After |
|---|---|---|
| Parent T2+ TTFT (tool-using) | 50-100s cold prefill | 0.3-0.9s warm |
| Parent T2+ TTFT @ 30K | full re-prefill (~50s) | 0.9s |
| Subagent T2+ TTFT | new cold each turn | 0.2-3s warm |

The targeted regression - `opencode-researcher` T2 - went from
cold-prefill (10s) to HIT at 4.4s.

## Benchmark Evidence

- **Hardware:** Apple Silicon M5 Max, 128 GB
- **Model:** Qwen3.6-27B Optimized-Speed (native MTP, depth=3)
- **Quantization:** draft-lm-head bits=3, group=64, mode=affine
- **Sampler:** temperature 0.6, top_p 0.95, top_k 20
- **Profile:** sustained
- **Date:** 2026-05-08
- **Commit:** `95a962e` on `daniel-farina:perf/postcommit-wait-v2` (branched off `ee3f63b`, which sits on `d4315b7`)
- **Workload:** opencode multi-agent fan-out, real traffic (3 sequential opencode tasks, full subagent pipeline: parent -> researcher -> planner -> fixer -> bug-patcher -> build-doctor)

## Open questions for @youssofal

- Env-var name: I went with `MTPLX_POSTCOMMIT_WAIT_TIMEOUT_S` (parallels
  `MTPLX_SESSION_BANK_*`). Happy to rename.
- Log format: emits `[mtplx] postcommit-wait <json>` only when console
  output is disabled and a wait actually occurred. Suppressed under
  `state.args.server_console=True`.
- Metric name: surfaced as `postcommit_wait` inside the metrics envelope
  via `request_observability`. If you'd prefer a top-level field on the
  envelope (parallel with `lock_wait_time_s`) I can flatten it.

## Hard constraints respected

- Built off `fork/perf/main-aligned-2026-05-08` (foundation), no changes
  to that branch or the pr/* branches.
- No upstream branches modified; pushed only to `daniel-farina/MTPLX`.
- Brand-new branch (`perf/postcommit-wait-v2`); #34 not reopened.

Linked to umbrella issue #36.