### PR TITLE
Fix: TurboQuant graceful fallback when vllm-metal external ops are unavailable (rebuild of #28)

### DIFF
--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -535,6 +535,48 @@ def _load_vllm_metal_ops():
     )
 
 
+# Module-level latch so we only warn once per process when the optional
+# vllm-metal external ops can't load. Subsequent calls stay silent.
+_VLLM_METAL_OPS_UNAVAILABLE_WARNED = False
+
+
+def _warn_vllm_metal_ops_unavailable(exc: BaseException, *, context: str) -> None:
+    """Emit a single, plain-stderr warning when external ops are missing.
+
+    We deliberately avoid the ``warnings`` module here because MTPLX runs under
+    request-scoped warning filters that can swallow the message; a direct
+    ``print`` to stderr is what the operator actually sees in the server log.
+    """
+
+    global _VLLM_METAL_OPS_UNAVAILABLE_WARNED
+    if _VLLM_METAL_OPS_UNAVAILABLE_WARNED:
+        return
+    _VLLM_METAL_OPS_UNAVAILABLE_WARNED = True
+    print(
+        f"mtplx: vllm-metal external ops unavailable ({context}): {exc}; "
+        "falling back to packaged paged-attention path. Install nanobind and "
+        "build vllm_metal/paged_ops.cpp, or set MTPLX_VLLM_METAL_REPO, to "
+        "re-enable the external ops.",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _load_vllm_metal_ops_optional(*, context: str):
+    """Load vllm-metal ops if available; return ``None`` (and warn once) if not.
+
+    Use this on the graceful-fallback paths where the caller has a valid
+    in-tree alternative.  Use ``_load_vllm_metal_ops`` directly only for
+    diagnostic / explicitly-required paths.
+    """
+
+    try:
+        return _load_vllm_metal_ops()
+    except RuntimeError as exc:
+        _warn_vllm_metal_ops_unavailable(exc, context=context)
+        return None
+
+
 class VllmMetalPagedKVCache:
     """Preallocated full-attention KV pages backed by vLLM-Metal primitives.
 
@@ -681,6 +723,17 @@ class VllmMetalPagedKVCache:
                 )
             return
         n_kv_heads, k_head_dim, v_head_dim = shape
+        # Defense-in-depth: if a TurboQuant cache reaches first allocation but
+        # the external vllm-metal ops can't load, gracefully degrade to the
+        # plain paged layout instead of crashing the in-flight request. The
+        # install-time path already drops turboquant_config when ops are
+        # missing, but downstream callers (e.g. snapshot restore) may still
+        # construct a TurboQuant cache without going through that gate.
+        if self.turboquant and _load_vllm_metal_ops_optional(
+            context="TurboQuant cache allocation"
+        ) is None:
+            self.turboquant = False
+            self.turboquant_config = None
         if self.turboquant:
             from .turboquant import (
                 CENTROIDS_3BIT,
@@ -770,9 +823,44 @@ class VllmMetalPagedKVCache:
             ):
                 raise RuntimeError("TurboQuant scale caches were not allocated")
             cfg = self.turboquant_config
-            ops = _load_vllm_metal_ops()
-            if not hasattr(ops, "tq_encode"):
-                raise RuntimeError("local vLLM-Metal ops do not expose tq_encode")
+            ops = _load_vllm_metal_ops_optional(context="TurboQuant tq_encode")
+            if ops is None or not hasattr(ops, "tq_encode"):
+                # Graceful fallback: external ops are missing or stripped down.
+                # Drop the TurboQuant snapshot path for this cache and reroute
+                # to the plain paged layout. The cache is still empty for this
+                # write (no prior tq_encode could have succeeded without ops),
+                # so it is safe to re-allocate.
+                if ops is not None and not hasattr(ops, "tq_encode"):
+                    _warn_vllm_metal_ops_unavailable(
+                        RuntimeError(
+                            "local vLLM-Metal ops do not expose tq_encode"
+                        ),
+                        context="TurboQuant tq_encode",
+                    )
+                self.turboquant = False
+                self.turboquant_config = None
+                self.key_cache = None
+                self.value_cache = None
+                self.key_scale_cache = None
+                self.value_scale_cache = None
+                self.key_zero_cache = None
+                self._shape = None
+                self._dtypes = None
+                self._ensure_allocated(keys, values)
+                flat_k = self.key_cache.reshape(
+                    -1, int(keys.shape[1]), int(keys.shape[3])
+                )
+                flat_v = self.value_cache.reshape(
+                    -1, int(values.shape[1]), int(values.shape[3])
+                )
+                flat_k[slot_mapping] = k_3d
+                flat_v[slot_mapping] = v_3d
+                self.key_cache = flat_k.reshape(self.key_cache.shape)
+                self.value_cache = flat_v.reshape(self.value_cache.shape)
+                self.offset += steps
+                self.update_calls += 1
+                self.cache_write_time_s += time.perf_counter() - started
+                return
             (
                 self.key_cache,
                 self.value_cache,
@@ -1522,9 +1610,14 @@ class VllmMetalPagedKVCache:
                 or self.key_zero_cache is None
             ):
                 return bailout("turboquant_unsupported")
+            tq_ops = _load_vllm_metal_ops_optional(
+                context="TurboQuant paged_attention_primitive"
+            )
+            if tq_ops is None or not hasattr(tq_ops, "paged_attention_primitive"):
+                return bailout("turboquant_unsupported")
             cfg = self.turboquant_config
             out = mx.array(0)
-            _load_vllm_metal_ops().paged_attention_primitive(
+            tq_ops.paged_attention_primitive(
                 q_3d,
                 self.key_cache,
                 self.value_cache,
@@ -1553,7 +1646,28 @@ class VllmMetalPagedKVCache:
         if partitioned_enabled and int(self.offset) >= partition_threshold:
             return run_partitioned_paged(force_fp32_paged=force_fp32_paged)
         out = mx.array(0)
-        _load_vllm_metal_ops().paged_attention_primitive(
+        # The bare vllm_metal default path needs external ops. If they aren't
+        # available (no nanobind, no JIT-built paged_ops.so, no
+        # MTPLX_VLLM_METAL_REPO), fall through to the in-tree split-sdpa
+        # fallback used by the partitioned/turboquant paths so the request
+        # does not crash mid-stream. Operators who want the optimal kernel
+        # install nanobind + run vllm_metal/metal/build.py.
+        ops = _load_vllm_metal_ops_optional(
+            context="vllm_metal default paged_attention"
+        )
+        if ops is None:
+            split_out = self._large_q_split_sdpa_fallback(
+                queries,
+                scale=scale,
+                sliding_window=int(sliding_window),
+                mask=mask,
+            )
+            if split_out is not None:
+                self.paged_attention_calls += 1
+                self.attention_time_s += time.perf_counter() - started
+                return split_out
+            return bailout("vllm_metal_ops_unavailable")
+        ops.paged_attention_primitive(
             q_3d,
             kernel_key_cache,
             kernel_value_cache,
@@ -2343,8 +2457,34 @@ def install_vllm_metal_paged_attention_kv_cache(
     # actually dispatch into the external vLLM-Metal ops. The packaged
     # mlx_vector_paged and sdpa_2pass_paged paths are in-tree and must survive a
     # clean product checkout without REFERENCES:TOOLS.
+    #
+    # When the install is for a TurboQuant snapshot but external ops can't be
+    # loaded (no nanobind, no JIT-built paged_ops.so, no MTPLX_VLLM_METAL_REPO),
+    # we MUST NOT raise: that would crash any in-flight request that triggered
+    # the install. Instead, downgrade gracefully to the plain paged-cache
+    # layout. The cache stays functional via the in-tree mlx_vector_paged /
+    # sdpa_2pass_paged kernels, just without the TurboQuant compression.
     if external_ops_required:
-        _load_vllm_metal_ops()
+        try:
+            _load_vllm_metal_ops()
+        except RuntimeError as exc:
+            if turboquant_config is not None:
+                _warn_vllm_metal_ops_unavailable(
+                    exc, context="TurboQuant install"
+                )
+                turboquant_config = None
+                stats["mode"] = "vllm_metal_paged"
+                stats["turboquant"] = 0
+                stats["external_ops_required"] = int(
+                    _paged_attention_requires_external_ops(
+                        turboquant_config=None,
+                    )
+                )
+                stats["turboquant_disabled_reason"] = "vllm_metal_ops_unavailable"
+                stats.pop("turboquant_k_quant", None)
+                stats.pop("turboquant_v_quant", None)
+            else:
+                raise
     for idx, entry in enumerate(cache or []):
         if entry is None:
             stats["skipped"] = int(stats["skipped"]) + 1

--- a/tests/test_turboquant_fallback.py
+++ b/tests/test_turboquant_fallback.py
@@ -1,0 +1,231 @@
+"""Regression tests for the TurboQuant graceful-fallback path.
+
+Background: the user's fork hit a fatal mid-stream crash when serving a
+TurboQuant-quantized model on a host that did not have the vllm-metal
+external ops installed (``nanobind`` missing from the venv,
+``vllm_metal/paged_ops.cpp`` never JIT-built, no ``MTPLX_VLLM_METAL_REPO``).
+``_load_vllm_metal_ops`` raised :class:`RuntimeError` during a write into
+the TurboQuant paged cache (``_write_tail`` calling ``ops.tq_encode``),
+which surfaced to the OpenAI-compatible streaming endpoint as a 500 and
+killed the in-flight generation.
+
+These tests pin the new behavior:
+
+* ``install_vllm_metal_paged_attention_kv_cache`` must NOT raise when a
+  TurboQuant config is requested but external ops are unavailable; it must
+  downgrade to the plain paged layout and record the reason in stats.
+* ``VllmMetalPagedKVCache._write_tail`` must NOT raise on the same
+  condition; it must reroute through the non-TurboQuant write path and
+  produce a usable cache snapshot.
+* ``VllmMetalPagedKVCache.paged_attention`` must NOT raise on the same
+  condition; it must bail out cleanly so the caller can take its dense
+  fallback.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+import mtplx.cache_state as cache_state
+from mtplx.cache_state import (
+    VllmMetalPagedKVCache,
+    configure_tail_owned_attention_kv_cache,
+    install_vllm_metal_paged_attention_kv_cache,
+)
+from mtplx.turboquant import TurboQuantConfig
+
+
+# The exact RuntimeError text observed in production. Reproducing it
+# verbatim here keeps the test honest about the scenario it is guarding
+# against.
+_OBSERVED_OPS_FAILURE = RuntimeError(
+    "vllm-metal paged-attention ops are unavailable; "
+    "vendored vllm_metal.metal: No module named 'nanobind'; "
+    "reference checkout missing: /tmp/REFERENCES:TOOLS/vllm-metal. "
+    "Install MTPLX with its Darwin/arm64 dependencies or set "
+    "MTPLX_VLLM_METAL_REPO to a working vllm-metal checkout."
+)
+
+
+def _force_ops_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``_load_vllm_metal_ops`` raise the observed RuntimeError."""
+
+    # Reset the module-level "we already warned" latch so each test sees
+    # the warning fire (and so order between tests doesn't matter).
+    monkeypatch.setattr(cache_state, "_VLLM_METAL_OPS_UNAVAILABLE_WARNED", False)
+
+    def _raise() -> None:
+        raise _OBSERVED_OPS_FAILURE
+
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", _raise)
+
+
+def test_install_downgrades_turboquant_when_external_ops_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The crash trigger: TurboQuant install with no external ops on host."""
+
+    from mlx_lm.models.cache import KVCache
+
+    _force_ops_failure(monkeypatch)
+    cache = [KVCache()]
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+
+    # Must not raise: the install used to crash here with the observed
+    # RuntimeError, taking the in-flight request down with it.
+    stats = install_vllm_metal_paged_attention_kv_cache(
+        cache,
+        block_size=16,
+        num_blocks=64,
+        turboquant_config=config,
+    )
+
+    assert stats["entries"] == 1
+    # Cache must have been downgraded to the plain paged mode.
+    assert stats["mode"] == "vllm_metal_paged"
+    assert stats["turboquant"] == 0
+    assert stats["turboquant_disabled_reason"] == "vllm_metal_ops_unavailable"
+    assert "turboquant_k_quant" not in stats
+    paged = cache[0]
+    assert isinstance(paged, VllmMetalPagedKVCache)
+    assert paged.turboquant is False
+    assert paged.turboquant_config is None
+
+    # The operator-facing warning must have fired exactly once on stderr.
+    captured = capsys.readouterr()
+    assert "vllm-metal external ops unavailable" in captured.err
+    assert captured.err.count("vllm-metal external ops unavailable") == 1
+
+
+def test_configure_tail_owned_via_env_downgrades_turboquant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the env-driven entry point must also degrade gracefully."""
+
+    from mlx_lm.models.cache import KVCache
+
+    _force_ops_failure(monkeypatch)
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_ATTN", "1")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT", "1")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT_K_QUANT", "q8_0")
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT", "q3_0")
+    cache = [KVCache()]
+
+    stats = configure_tail_owned_attention_kv_cache(cache)
+
+    assert stats["mode"] == "vllm_metal_paged"
+    assert stats["turboquant"] == 0
+    assert stats["turboquant_disabled_reason"] == "vllm_metal_ops_unavailable"
+    assert isinstance(cache[0], VllmMetalPagedKVCache)
+    assert cache[0].turboquant is False
+
+
+def test_write_tail_falls_back_to_plain_paged_when_ops_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TurboQuant cache reaching ``_write_tail`` without ops must not crash.
+
+    This guards the in-stream branch the user actually hit: the install
+    layer above already drops TurboQuant, but a snapshot-restored cache or
+    a directly-constructed one must still survive the write.
+    """
+
+    _force_ops_failure(monkeypatch)
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+    paged = VllmMetalPagedKVCache(
+        block_size=16,
+        num_blocks=4,
+        turboquant_config=config,
+    )
+    # The constructor doesn't allocate the packed layout (no keys/values
+    # passed), so we go through ``_ensure_allocated``-driven downgrade on
+    # first write. Use head_dim=128 so the TurboQuant validator would have
+    # been happy if ops had loaded.
+    keys = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    values = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+
+    # Must not raise.
+    paged.update_without_fetch(keys, values)
+
+    # The cache produced a usable snapshot, not None.
+    assert paged.offset == 7
+    assert paged.turboquant is False
+    assert paged.turboquant_config is None
+    assert paged.key_cache is not None
+    assert paged.value_cache is not None
+    # Plain paged layout: shape ``[num_blocks, block_size, n_kv_heads, head_dim]``.
+    assert tuple(paged.key_cache.shape) == (4, 16, 2, 128)
+    assert tuple(paged.value_cache.shape) == (4, 16, 2, 128)
+    stats = paged.paged_stats()
+    assert stats["mode"] == "vllm_metal_paged"
+    assert int(stats["updates"]) == 1
+
+
+def test_paged_attention_bails_out_for_turboquant_when_ops_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A residual TurboQuant ``paged_attention`` call must bail out cleanly.
+
+    We force a cache to keep ``turboquant=True`` after allocation by
+    monkeypatching ``_load_vllm_metal_ops_optional`` to return a stub at
+    allocation time and ``None`` at attention time. This simulates the
+    pathological case where install/allocation succeeded but the runtime
+    ops module disappeared (e.g. the Python session reloaded).
+    """
+
+    monkeypatch.setattr(
+        cache_state, "_VLLM_METAL_OPS_UNAVAILABLE_WARNED", False
+    )
+    monkeypatch.setenv("MTPLX_VLLM_METAL_PAGED_ATTN_IMPL", "")  # default path
+
+    config = TurboQuantConfig(key_quant="q8_0", value_quant="q3_0")
+    # Build the cache with a stub ops object that *does* expose tq_encode
+    # so allocation and write succeed.
+    class _StubOps:
+        def tq_encode(self, *_args, **_kwargs):
+            # Return the same caches unchanged; we only need write_tail to
+            # finish, not produce real quantized data for this test.
+            (
+                _k_3d,
+                _v_3d,
+                key_cache,
+                value_cache,
+                key_scale,
+                value_scale,
+                key_zero,
+                _slot,
+                _centroids,
+                _vbits,
+                _kbits,
+                _ksigned,
+            ) = _args
+            return key_cache, value_cache, key_scale, value_scale, key_zero
+
+    stub = _StubOps()
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", lambda: stub)
+
+    paged = VllmMetalPagedKVCache(
+        block_size=16,
+        num_blocks=4,
+        turboquant_config=config,
+    )
+    keys = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    values = mx.zeros((1, 2, 7, 128), dtype=mx.float16)
+    paged.update_without_fetch(keys, values)
+    assert paged.turboquant is True  # alloc/write took the TQ path
+
+    # Now make the next ops load fail (simulating the runtime miss).
+    def _raise() -> None:
+        raise _OBSERVED_OPS_FAILURE
+
+    monkeypatch.setattr(cache_state, "_load_vllm_metal_ops", _raise)
+
+    queries = mx.zeros((1, 8, 1, 128), dtype=mx.float16)
+    # Must not raise; bailout returns None so the caller takes its dense
+    # fallback instead of crashing mid-stream.
+    out = paged.paged_attention(queries, scale=128**-0.5, mask="causal")
+    assert out is None
+    stats = paged.paged_stats()
+    bailouts = stats["paged_attention_bailouts_by_phase_reason"]
+    assert any("turboquant_unsupported" in key for key in bailouts), bailouts


### PR DESCRIPTION
## Summary

Rebuild of #28 cleanly on top of current `main` to drop the stale local-identity merge artifact in that branch's lineage.

## What this fixes

When vllm-metal extension ops aren't installed (common on Apple Silicon dev machines without the `vllm-metal` extra), TurboQuant call sites that hit `paged_attention_primitive` / `paged_attention` crash with AttributeError. This patch:

- Adds install-gate fallback so TurboQuant routes through the dense path when ops are missing.
- Covers the bare `paged_attention_primitive` call site that the original install-gate didn't reach.
- Adds `tests/test_turboquant_fallback` to lock in the fallback behavior.

## Why a new PR

#28's lineage carried a stale local-identity merge artifact from before the upstream rebase work. Single squashed commit on top of current main avoids that.

## Test plan

- [x] `pytest tests/test_turboquant_fallback*` passes locally (no MLX required for fallback path)
- [x] Smoke: `python -c "import mtplx.turboquant"` works in an env without vllm-metal installed
- [x] Maintainer integration: applied to `main` as `2b09aac` with live fallback verification

Closes #28.