### PR TITLE
perf: env-overridable SessionBank.max_entries (final piece of #31 split)

### DIFF
--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -8,6 +8,7 @@ state explicit before the generation loop accepts warm prompt state directly.
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import time
 from contextlib import contextmanager
@@ -22,6 +23,15 @@ from .session_bank import (
     DEFAULT_PER_SESSION_MAX_BYTES,
     SessionBank,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+# Mirrors SessionBank.__init__'s hardcoded max_entries default (kept in sync
+# manually so the operator override here does not silently shift the default
+# for callers that construct SessionBank directly).
+_DEFAULT_BANK_MAX_ENTRIES = 8
 
 
 def _bank_bytes_from_env(name: str, default: int) -> int:
@@ -46,6 +56,37 @@ def _bank_bytes_from_env(name: str, default: int) -> int:
     except (OverflowError, ValueError, IndexError):
         return default
     if value < 1:
+        return default
+    return value
+
+
+def _bank_entries_from_env(name: str, default: int) -> int:
+    """Read a SessionBank entry-count override from the environment.
+
+    Parses a plain integer (no K/M/G/T suffixes - entry count is a count, not
+    a byte size). Validates that the value is >= 1. On parse error or invalid
+    value, logs a warning and returns the default.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r (expected integer >= 1); falling back to default %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if value < 1:
+        logger.warning(
+            "Invalid %s=%r (must be >= 1); falling back to default %d",
+            name,
+            raw,
+            default,
+        )
         return default
     return value
 
@@ -471,8 +512,14 @@ class EngineSessionManager:
         # Bank caps default to the constants in session_bank.py. Operators
         # running into per-session eviction at large contexts can override
         # via MTPLX_SESSION_BANK_PER_SESSION_BYTES (e.g. "16G" for 16 GiB)
-        # or MTPLX_SESSION_BANK_MAX_BYTES.
+        # or MTPLX_SESSION_BANK_MAX_BYTES. The entry-count cap is also
+        # overridable via MTPLX_SESSION_BANK_MAX_ENTRIES (plain integer)
+        # for workloads where ~2 GB-per-entry contexts make the default of
+        # 8 the binding constraint well before the byte caps.
         self.bank = bank or SessionBank(
+            max_entries=_bank_entries_from_env(
+                "MTPLX_SESSION_BANK_MAX_ENTRIES", _DEFAULT_BANK_MAX_ENTRIES
+            ),
             max_bytes=_bank_bytes_from_env(
                 "MTPLX_SESSION_BANK_MAX_BYTES", DEFAULT_MAX_BYTES
             ),

--- a/tests/test_session_bank_env_caps.py
+++ b/tests/test_session_bank_env_caps.py
@@ -1,0 +1,149 @@
+"""Unit tests for SessionBank cap env-var overrides wired in engine_session.
+
+Covers the entry-count override (MTPLX_SESSION_BANK_MAX_ENTRIES) added on top
+of the existing byte-cap envs (MTPLX_SESSION_BANK_MAX_BYTES,
+MTPLX_SESSION_BANK_PER_SESSION_BYTES). The byte-cap helper is exercised in
+detail in tests/test_engine_session_env.py; the regression cases here just
+confirm all three envs compose correctly when wired through
+EngineSessionManager.__init__.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+
+import pytest
+
+
+def _reload_engine_session():
+    import mtplx.engine_session
+    return importlib.reload(mtplx.engine_session)
+
+
+# --- _bank_entries_from_env helper ----------------------------------------
+
+
+def test_bank_entries_from_env_default_when_unset(monkeypatch):
+    monkeypatch.delenv("TEST_BANK_ENTRIES", raising=False)
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 8
+
+
+def test_bank_entries_from_env_default_when_empty(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 8
+
+
+def test_bank_entries_from_env_valid_integer(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "24")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 24
+
+
+def test_bank_entries_from_env_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", "  16  ")
+    es = _reload_engine_session()
+    assert es._bank_entries_from_env("TEST_BANK_ENTRIES", 8) == 16
+
+
+@pytest.mark.parametrize("raw", ["abc", "12.5", "1e2", "0x10", ""])
+def test_bank_entries_from_env_invalid_falls_back(monkeypatch, caplog, raw):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", raw)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        result = es._bank_entries_from_env("TEST_BANK_ENTRIES", 8)
+    assert result == 8
+    if raw == "":
+        # Empty string is the unset-equivalent path; no warning expected.
+        assert not any(
+            "TEST_BANK_ENTRIES" in rec.getMessage() for rec in caplog.records
+        )
+    else:
+        assert any(
+            "TEST_BANK_ENTRIES" in rec.getMessage()
+            and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), f"expected warning for raw={raw!r}, got {caplog.records!r}"
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "-3"])
+def test_bank_entries_from_env_below_one_falls_back(monkeypatch, caplog, raw):
+    monkeypatch.setenv("TEST_BANK_ENTRIES", raw)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        result = es._bank_entries_from_env("TEST_BANK_ENTRIES", 8)
+    assert result == 8
+    assert any(
+        "TEST_BANK_ENTRIES" in rec.getMessage()
+        and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    ), f"expected warning for raw={raw!r}, got {caplog.records!r}"
+
+
+# --- EngineSessionManager wiring ------------------------------------------
+
+
+def test_manager_uses_env_max_entries(monkeypatch):
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", "24")
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 24
+
+
+def test_manager_default_max_entries_when_unset(monkeypatch):
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    # Mirrors SessionBank.__init__'s hardcoded default of 8.
+    assert mgr.bank.max_entries == 8
+
+
+@pytest.mark.parametrize("raw", ["abc", "0", "-3"])
+def test_manager_invalid_max_entries_falls_back_to_default(
+    monkeypatch, caplog, raw
+):
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raw)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", raising=False)
+    es = _reload_engine_session()
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="mtplx.engine_session"):
+        mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 8
+    assert any(
+        "MTPLX_SESSION_BANK_MAX_ENTRIES" in rec.getMessage()
+        and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+def test_manager_byte_caps_still_work_alongside_entries(monkeypatch):
+    """Regression: setting all three env vars composes correctly."""
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_ENTRIES", "20")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_BYTES", "32G")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", "16G")
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 20
+    assert mgr.bank.max_bytes == 32 * 1024**3
+    assert mgr.bank.per_session_max_bytes == 16 * 1024**3
+
+
+def test_manager_byte_caps_alone_still_work(monkeypatch):
+    """Regression: byte-cap envs without the new entries env still work
+    and leave max_entries at the default."""
+    monkeypatch.delenv("MTPLX_SESSION_BANK_MAX_ENTRIES", raising=False)
+    monkeypatch.setenv("MTPLX_SESSION_BANK_MAX_BYTES", "16G")
+    monkeypatch.setenv("MTPLX_SESSION_BANK_PER_SESSION_BYTES", "8G")
+    es = _reload_engine_session()
+    mgr = es.EngineSessionManager()
+    assert mgr.bank.max_entries == 8
+    assert mgr.bank.max_bytes == 16 * 1024**3
+    assert mgr.bank.per_session_max_bytes == 8 * 1024**3


### PR DESCRIPTION
## Summary

Adds an `MTPLX_SESSION_BANK_MAX_ENTRIES` env var that mirrors the existing `MTPLX_SESSION_BANK_*_BYTES` overrides from PR #18 (`87af6be`) and the guard tightening in `9d92dac`. Default behavior unchanged (8 entries).

## Why upstream's current code doesn't cover it

`mtplx/engine_session.py` on `main` exposes `_bank_bytes_from_env` for the byte caps but the `max_entries` axis is hard-coded to `SessionBank.__init__`'s default of 8. At ~2 GB per entry on Qwen3.6-27B with 25-50K-token prefixes, 8 entries binds the bank to ~16 GB even when `MTPLX_SESSION_BANK_MAX_BYTES` is set higher; the binding constraint becomes entry count well before bytes, and the LRU starts evicting the longest-matched prefix per session. Operators with headroom need a way to lift this without recompiling. Entry count is a different axis from byte cap; the existing `_bank_bytes_from_env` cannot be reused (K/M/G/T suffixes don't make sense for a count).

The new `_bank_entries_from_env` helper:
- parses a plain integer (no suffix),
- logs a warning + falls back to default on parse error or value < 1 (matches the safety semantics of the byte-cap guards in `9d92dac`),
- treats unset / empty as "use default" without warning.

## Live motivation

5+ opencode subagents x 2-3 prefixes each pushes the bank past 8 entries; without this knob the longest-matched prefix gets evicted every turn and TTFT regresses to cold-prefill cost.

## Test plan

- [x] 19 new unit tests in `tests/test_session_bank_env_caps.py` covering:
  - default when unset / empty
  - valid integer parse (incl. whitespace stripping)
  - invalid value (parametrized: `"abc"`, `"12.5"`, `"1e2"`, `"0x10"`, `""`) -> warning + fallback
  - value < 1 (parametrized: `"0"`, `"-1"`, `"-3"`) -> warning + fallback
  - `EngineSessionManager` wiring (custom value, default, invalid fallback, composition with both byte-cap envs, byte-cap envs alone still work).
- [x] All 35 tests pass alongside the existing `tests/test_engine_session_env.py`:
  ```
  $ pytest tests/test_session_bank_env_caps.py tests/test_engine_session_env.py
  ============================== 35 passed in 0.08s ==============================
  ```

## Background

This is one of three residual pieces from #31 that got split off (disposition recorded separately). #31 itself was opened on stale lineage, and the 16K-cliff piece already landed as #39 cleanly. This is the entry-cap piece.

Closes the entry-cap residual from #31.
