### PR TITLE
perf: postcommit prefix reuse + cache_miss_reason observability (residual of #31)

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2634,6 +2634,21 @@ def _store_retokenized_history_snapshot(
             "reason": "model_lock_busy_before_retokenized_commit",
             "elapsed_s": time.perf_counter() - started,
         }
+    # Pass `session_bank` (and the matching identity / policy fingerprints)
+    # so the postcommit re-prefill reuses the longest matching prefix from
+    # a prior turn instead of re-prefilling the full ~18K-token history
+    # from scratch. On consecutive tool-calling turns this collapses
+    # postcommit cost from ~27 s (full re-prefill) to ~1 s (suffix forward
+    # only). The next foreground request, which the model_scheduler admits
+    # only after this idle task completes, therefore queues ~1 s instead
+    # of ~30 s behind the postcommit.
+    #
+    # The bank already contains an entry for the previous turn's history
+    # (this same function stored it on the prior postcommit). The new
+    # turn's history starts with that previous-turn prefix verbatim
+    # (chat-template encoding is deterministic for the same messages and
+    # tools), so `longest_prefix` matches and only the new user turn +
+    # assistant turn need to be forward-AR'd.
     try:
         with attention_phase("postcommit"):
             prompt_state = restore_or_prefill_prompt_state(
@@ -2641,6 +2656,10 @@ def _store_retokenized_history_snapshot(
                 history_ids,
                 mtp_hidden_variant="post_norm",
                 mtp_history_policy="committed",
+                session_bank=state.sessions.bank,
+                template_hash=state.template_hash,
+                draft_head_identity=state.draft_head_identity,
+                policy_fingerprint=policy_fingerprint,
             )
         mtp_snapshot = (
             snapshot_cache(prompt_state.committed_mtp_cache)
@@ -2681,6 +2700,18 @@ def _store_retokenized_history_snapshot(
         "nbytes": entry.nbytes,
         "elapsed_s": time.perf_counter() - started,
         "token_hash": entry.token_hash,
+        # Observability for the prefix-reuse shortcut: lets operators tell
+        # at a glance (in the `[mtplx] idle async session postcommit ...`
+        # log line) whether a given postcommit hit the warm-prefix path or
+        # had to do a full re-prefill, and if it missed, why. Without
+        # cache_miss_reason a regression where the shortcut stops firing
+        # (e.g. policy mismatch, template mismatch, snapshot desync, or
+        # genuine prefix divergence) is invisible in production logs - all
+        # that surfaces is `elapsed_s` drifting back to ~30 s.
+        "cache_hit": bool(getattr(prompt_state, "cache_hit", False)),
+        "cached_tokens": int(getattr(prompt_state, "cached_tokens", 0) or 0),
+        "suffix_tokens": int(getattr(prompt_state, "suffix_tokens", 0) or 0),
+        "cache_miss_reason": getattr(prompt_state, "cache_miss_reason", None),
     }
 
 

--- a/tests/test_postcommit_prefix_reuse.py
+++ b/tests/test_postcommit_prefix_reuse.py
@@ -1,0 +1,243 @@
+"""Regression tests for the postcommit prefix-reuse + observability plumbing.
+
+`_store_retokenized_history_snapshot` builds a SessionBank entry for the
+turn that just generated. Before this fix that build re-prefilled the FULL
+history from cold, which on multi-turn tool-calling agents costs ~27-29 s
+per postcommit on Qwen3.6-27B at 18-25K-token contexts. The
+`ModelWorkScheduler` admits the next foreground request only after the
+in-flight idle task completes, so the user-visible symptom was a 30 s
+stream-silence between turns.
+
+The fix is to pass `session_bank` (and the matching `template_hash`,
+`draft_head_identity`, `policy_fingerprint`) to
+`restore_or_prefill_prompt_state`. The bank already contains an entry for
+the previous turn's history, the new turn's history starts with that
+verbatim (chat-template encoding is deterministic), so the longest-prefix
+lookup matches and only the suffix needs to be forward-AR'd. Postcommit
+cost collapses to roughly suffix-forward time (~1 s for ~120 new tokens).
+
+These tests pin two invariants:
+
+1. The plumbing: `restore_or_prefill_prompt_state` MUST receive
+   `session_bank`, `template_hash`, `draft_head_identity`, and
+   `policy_fingerprint`. Without ALL of them the bank lookup either does
+   not run (no `session_bank`) or rejects the entry as a mismatch (one of
+   the identity fields missing).
+2. The observability: the result dict MUST surface
+   `cache_hit`, `cached_tokens`, `suffix_tokens`, and `cache_miss_reason`
+   from `prompt_state`. Operators rely on these fields in the
+   `[mtplx] idle async session postcommit ...` log to debug regressions
+   where the prefix shortcut stops firing.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from mtplx.server import openai
+
+
+def _make_state(*, bank: object) -> SimpleNamespace:
+    """Minimum stub of `ServerState` for `_store_retokenized_history_snapshot`.
+
+    The function only reaches `state.runtime.tokenizer`, `state.sessions.bank`,
+    `state.template_hash`, `state.draft_head_identity`, `state.lock`,
+    `state.begin_foreground`, `state.end_foreground`, and
+    `state.args.strip_assistant_reasoning_history`. Everything else is
+    bypassed by the monkeypatched `restore_or_prefill_prompt_state` and
+    `_encode_messages`.
+    """
+
+    class _Tokenizer:
+        def apply_chat_template(self, messages, **_kwargs):
+            return [10, 11, 12, 13, 14]
+
+    args = SimpleNamespace(strip_assistant_reasoning_history=False)
+    return SimpleNamespace(
+        runtime=SimpleNamespace(tokenizer=_Tokenizer()),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="tmpl-abc",
+        draft_head_identity="draft-xyz",
+        lock=threading.Lock(),
+        begin_foreground=lambda: None,
+        end_foreground=lambda: None,
+        args=args,
+    )
+
+
+def test_postcommit_passes_session_bank_and_identities_to_restore(monkeypatch):
+    """Tier 1.2 / Option B plumbing.
+
+    Without `session_bank`, the bank lookup never runs and every postcommit
+    pays a full re-prefill. Without the identity / policy fingerprints, the
+    bank lookup runs but rejects the entry with a TEMPLATE_MISMATCH /
+    POLICY_MISMATCH miss. All four kwargs MUST be present.
+    """
+    captured: dict = {}
+
+    class _PromptState:
+        trunk_cache = "cache"
+        logits = "logits"
+        hidden = "hidden"
+        committed_mtp_cache = None
+        cache_hit = True
+        cached_tokens = 17_500
+        suffix_tokens = 320
+        cache_miss_reason = None
+
+    def fake_restore_or_prefill(*args, **kwargs):
+        captured.update(kwargs)
+        return _PromptState()
+
+    class _Bank:
+        def put(self, **_kwargs):
+            return SimpleNamespace(
+                prefix_len=5,
+                nbytes=42,
+                token_hash="hash",
+            )
+
+    monkeypatch.setattr(
+        openai, "restore_or_prefill_prompt_state", fake_restore_or_prefill
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda c: c)
+    monkeypatch.setattr(openai, "_encode_messages", lambda *a, **k: [10, 11, 12, 13, 14])
+    # _history_ids_for_postcommit goes through the upstream sentinel-based
+    # `_postcommit_next_turn_prefix_ids` helper; bypass it so this test
+    # focuses purely on the restore-call plumbing.
+    monkeypatch.setattr(
+        openai,
+        "_history_ids_for_postcommit",
+        lambda *a, **k: [10, 11, 12, 13, 14],
+    )
+
+    bank = _Bank()
+    state = _make_state(bank=bank)
+
+    result = openai._store_retokenized_history_snapshot(
+        state,
+        session_id="session-A",
+        messages=[],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy-fp",
+    )
+
+    assert result["stored"] is True, result
+    assert captured.get("session_bank") is bank, (
+        "restore_or_prefill_prompt_state must receive `session_bank` so the "
+        "longest_prefix lookup can shortcut a full re-prefill."
+    )
+    assert captured.get("template_hash") == "tmpl-abc", (
+        "template_hash MUST be passed - without it the bank rejects the "
+        "entry as TEMPLATE_MISMATCH."
+    )
+    assert captured.get("draft_head_identity") == "draft-xyz", (
+        "draft_head_identity MUST be passed - without it the bank rejects "
+        "the entry as a draft-head identity mismatch."
+    )
+    assert captured.get("policy_fingerprint") == "policy-fp", (
+        "policy_fingerprint MUST be passed - without it the bank rejects "
+        "the entry as POLICY_MISMATCH."
+    )
+
+
+def test_postcommit_propagates_observability_fields(monkeypatch):
+    """`cache_hit`, `cached_tokens`, `suffix_tokens`, `cache_miss_reason`
+    must propagate from `prompt_state` into the result dict so the
+    `[mtplx] idle async session postcommit ...` log surfaces them.
+    """
+
+    class _PromptState:
+        trunk_cache = "cache"
+        logits = "logits"
+        hidden = "hidden"
+        committed_mtp_cache = None
+        cache_hit = True
+        cached_tokens = 20_594
+        suffix_tokens = 122
+        cache_miss_reason = None
+
+    class _Bank:
+        def put(self, **_kwargs):
+            return SimpleNamespace(prefix_len=20_716, nbytes=4242, token_hash="h")
+
+    monkeypatch.setattr(
+        openai, "restore_or_prefill_prompt_state", lambda *a, **k: _PromptState()
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda c: c)
+    monkeypatch.setattr(openai, "_encode_messages", lambda *a, **k: [10, 11, 12, 13, 14])
+    monkeypatch.setattr(
+        openai,
+        "_history_ids_for_postcommit",
+        lambda *a, **k: [10, 11, 12, 13, 14],
+    )
+
+    state = _make_state(bank=_Bank())
+
+    result = openai._store_retokenized_history_snapshot(
+        state,
+        session_id="session-A",
+        messages=[],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy-fp",
+    )
+
+    assert result["stored"] is True
+    assert result["cache_hit"] is True
+    assert result["cached_tokens"] == 20_594
+    assert result["suffix_tokens"] == 122
+    assert "cache_miss_reason" in result, (
+        "cache_miss_reason must always be present in the result so the "
+        "log line records it (None on hit, a reason string on miss)."
+    )
+    assert result["cache_miss_reason"] is None
+
+
+def test_postcommit_cache_miss_reason_records_miss(monkeypatch):
+    """When the prefix shortcut does NOT fire (e.g. cold session, or
+    template_hash drift), `cache_miss_reason` must record why so operators
+    can debug from logs alone.
+    """
+
+    class _PromptState:
+        trunk_cache = "cache"
+        logits = "logits"
+        hidden = "hidden"
+        committed_mtp_cache = None
+        cache_hit = False
+        cached_tokens = 0
+        suffix_tokens = 18_400
+        cache_miss_reason = "prefix_divergence_at_token"
+
+    class _Bank:
+        def put(self, **_kwargs):
+            return SimpleNamespace(prefix_len=18_400, nbytes=4242, token_hash="h")
+
+    monkeypatch.setattr(
+        openai, "restore_or_prefill_prompt_state", lambda *a, **k: _PromptState()
+    )
+    monkeypatch.setattr(openai, "snapshot_cache", lambda c: c)
+    monkeypatch.setattr(openai, "_encode_messages", lambda *a, **k: [10, 11, 12, 13, 14])
+    monkeypatch.setattr(
+        openai,
+        "_history_ids_for_postcommit",
+        lambda *a, **k: [10, 11, 12, 13, 14],
+    )
+
+    state = _make_state(bank=_Bank())
+
+    result = openai._store_retokenized_history_snapshot(
+        state,
+        session_id="session-A",
+        messages=[],
+        assistant_content="ok",
+        thinking_enabled=False,
+        policy_fingerprint="policy-fp",
+    )
+
+    assert result["stored"] is True
+    assert result["cache_hit"] is False
+    assert result["cache_miss_reason"] == "prefix_divergence_at_token"


### PR DESCRIPTION
## Summary

Two small additions to `_store_retokenized_history_snapshot` in `mtplx/server/openai.py`:

- Pass `session_bank` (with `template_hash`, `draft_head_identity`, `policy_fingerprint`) to `restore_or_prefill_prompt_state`, so the postcommit re-prefill reuses the previous turn's bank entry as a prefix and only forward-AR's the new suffix.
- Surface `cache_hit`, `cached_tokens`, `suffix_tokens`, `cache_miss_reason` from `prompt_state` in the result dict so the `[mtplx] idle async session postcommit ...` log line records whether the shortcut fired and, if not, why.

## Why upstream's current code doesn't cover it

The current `_store_retokenized_history_snapshot` calls `restore_or_prefill_prompt_state` with only `mtp_hidden_variant` and `mtp_history_policy`:

```python
prompt_state = restore_or_prefill_prompt_state(
    state.runtime,
    history_ids,
    mtp_hidden_variant="post_norm",
    mtp_history_policy="committed",
)
```

`session_bank` is not passed, so the bank lookup never runs and every postcommit pays the full ~18K-token re-prefill cost. The `ModelWorkScheduler` introduced in PR #25 / commit 349fdf7 admits the next foreground request only after the in-flight idle task completes, so this directly translates into a ~30 s stream-silence between turns of any tool-using agent loop on Qwen3.6-27B at 18-25K-token contexts.

The miss-reason field is similarly absent: `prompt_state.cache_miss_reason` exists, but the postcommit result dict and the `[mtplx] idle async session postcommit ...` log line do not surface it.

## What's NOT included (compared to the source #31 bundle)

The original #31 bundle also contained an "Option A" two-stage executor split (orchestration loop on a separate `postcommit_executor`, MLX work submitted back to `generation_executor` via `Future.result()`). That is intentionally NOT brought across:

- PR #25's `ModelWorkScheduler` (commit 349fdf7) is single-owner-thread by design (MLX stream affinity).
- With a single owner thread, foreground gen and idle postcommit are serialized at task boundaries; `state.lock` is never contended across threads while an idle task is the active scheduler item.
- `_store_retokenized_history_snapshot`'s `state.lock.acquire(blocking=False)` therefore succeeds on first try and the 250 ms inter-attempt sleep concern that motivated Option A no longer applies.
- Reintroducing a separate `postcommit_executor` would either fight the scheduler unification or require a compat shim for a configuration that does not exist on `main`.

If a future change reintroduces a dedicated postcommit executor, the Option A diff is archived in our split-disposition record and can be reapplied.

## Live motivation

Source-fork measurements after the change (5-turn tool-call ladder on Qwen3.6-27B):

```
T1 (cold)  cache_hit=false miss=prefix_divergence_at_token
           elapsed_s=31.1 (full re-prefill, expected on cold)
T2 (warm)  cache_hit=true  miss=null cached_tokens=20594
           suffix_tokens=122 elapsed_s=0.75 (95-percentile win)
T3 (warm)  cache_hit=true  miss=null cached_tokens=20716
           suffix_tokens=122 elapsed_s=0.74
```

## Test plan

- [x] New `tests/test_postcommit_prefix_reuse.py` (3 tests) pins:
  1. `session_bank`, `template_hash`, `draft_head_identity`, `policy_fingerprint` are all passed to `restore_or_prefill_prompt_state` (without all four the bank lookup either does not run or rejects the entry as a mismatch).
  2. `cache_hit`, `cached_tokens`, `suffix_tokens`, `cache_miss_reason` are propagated to the result dict on a hit.
  3. `cache_miss_reason` records the miss reason (e.g. `prefix_divergence_at_token`) on a miss.
- [x] All existing postcommit tests pass:
  ```
  $ pytest tests/test_postcommit_tools_plumbing.py tests/test_idle_postcommit_subagent.py tests/test_postcommit_wait.py tests/test_postcommit_wait_integration.py tests/test_postcommit_prefix_reuse.py
  35 passed in 0.34s
  ```
- [x] Server / model-scheduler tests still green:
  ```
  $ pytest tests/test_server_openai.py tests/test_openai_bridge.py tests/test_model_scheduler.py
  64 passed in 0.40s
  ```

Closes the prefix-reuse + miss-reason residual from #31.
