### PR TITLE
fix: don't abort sustained-profile sessions on dense paged-attention fallback

### DIFF
--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -928,9 +928,14 @@ class VllmMetalPagedKVCache:
             return False
         if _env_truthy("MTPLX_ALLOW_PAGED_ACTIVE_ARRAY_SNAPSHOT"):
             return False
-        sustained = _env_truthy("MTPLX_SUSTAINED_PREFILL")
+        # Only the QA assertion env var should turn the dense-fallback path
+        # into a hard error. MTPLX_SUSTAINED_PREFILL is a *product* profile
+        # flag (set by `--profile sustained`) and must not abort production
+        # requests when the partitioned-paged kernel returns None - the
+        # caller in attention_split.py already handles None by routing to
+        # scaled_dot_product_attention with cache.state, which is correct.
         asserted = _env_truthy("MTPLX_ASSERT_NO_PAGED_ACTIVE_ARRAYS")
-        return (sustained or asserted) and int(self.offset) >= self._partition_threshold()
+        return asserted and int(self.offset) >= self._partition_threshold()
 
     def long_context_dense_fallback_forbidden(self) -> bool:
         return self._long_context_dense_fallback_forbidden()


### PR DESCRIPTION
## Summary

\`long_context_dense_fallback_forbidden\` (cache_state.py:926-933) raises when either \`MTPLX_SUSTAINED_PREFILL\` (the product flag set by \`--profile sustained\`) OR \`MTPLX_ASSERT_NO_PAGED_ACTIVE_ARRAYS\` (QA bench assertion) is set and the cache offset crosses the partition threshold (default 2048 tokens, set by the \`sustained\` profile in profiles.py:51).

Coupling those two flags means every sustained-profile user hits a benchmark abort in production as soon as they get past 2048 cached tokens AND any layer's partitioned-paged kernel returns None. The dense \`scaled_dot_product_attention\` fallback right below the abort in attention_split.py:260-263 is a correct continuation — the trip-wire is leftover from kernel qualification.

## Repro

Run a long-form interactive chat session with \`--profile sustained --context-window 128000\`. Around round 2-3 (well below the 128K limit, e.g. 25K context) a request fails fast (~1s, before any tokens stream) with:

\`\`\`
RuntimeError/500: Sustained long-context paged attention attempted dense cache.state fallback after the partition threshold
\`\`\`

Subsequent requests on the same session keep failing the same way until the session is rotated.

## Fix

Drop \`MTPLX_SUSTAINED_PREFILL\` from the disjunction. Only QA benches that explicitly set \`MTPLX_ASSERT_NO_PAGED_ACTIVE_ARRAYS\` still trip the assertion. Production sustained sessions degrade gracefully to dense SDPA on partitioned-kernel misses.

## Test plan

- [ ] Restart server with \`--profile sustained\` (no env vars), run interactive chat past 2048 tokens, observe \`mtplx_paged_attention_bailout\` events but no errors and continued generation.
- [ ] Re-run the QA bench with \`MTPLX_ASSERT_NO_PAGED_ACTIVE_ARRAYS=1\` set, verify the assertion still trips as intended.
- [ ] Confirm \`MTPLX_ALLOW_LONG_CONTEXT_DENSE_FALLBACK=1\` continues to work as a per-session escape hatch.