### PR TITLE
fix: require exact mtp_history_policy match for SessionBank reuse

### DIFF
--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -928,9 +928,14 @@ class VllmMetalPagedKVCache:
             return False
         if _env_truthy("MTPLX_ALLOW_PAGED_ACTIVE_ARRAY_SNAPSHOT"):
             return False
-        sustained = _env_truthy("MTPLX_SUSTAINED_PREFILL")
+        # Only the QA assertion env var should turn the dense-fallback path
+        # into a hard error. MTPLX_SUSTAINED_PREFILL is a *product* profile
+        # flag (set by `--profile sustained`) and must not abort production
+        # requests when the partitioned-paged kernel returns None - the
+        # caller in attention_split.py already handles None by routing to
+        # scaled_dot_product_attention with cache.state, which is correct.
         asserted = _env_truthy("MTPLX_ASSERT_NO_PAGED_ACTIVE_ARRAYS")
-        return (sustained or asserted) and int(self.offset) >= self._partition_threshold()
+        return asserted and int(self.offset) >= self._partition_threshold()
 
     def long_context_dense_fallback_forbidden(self) -> bool:
         return self._long_context_dense_fallback_forbidden()

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -60,20 +60,25 @@ def _mtp_history_policy_compatible(
     """Return True if a bank entry stored under ``entry_policy`` may be reused
     for a lookup that resolved to ``lookup_policy``.
 
-    Equality is always compatible. Beyond that, ``committed`` and
-    ``last_window`` are treated as interchangeable because both rely on the
-    same committed mtp-history cache shape; the only difference between them
-    is a runtime trim that is applied during prefill, which is moot once the
-    cache is being restored from a stored snapshot.
+    Equality is always compatible. Cross-policy reuse between ``committed``
+    and ``last_window`` was previously allowed on the theory that both share
+    the same committed mtp-history cache shape and the trim is a no-op once
+    we restore from snapshot. In practice the warm-restore path in
+    ``generation.py`` calls ``_append_mtp_history(suffix)`` WITHOUT
+    ``position_offset``, while the cold-prefill path passes it. When a
+    ``committed``-stored entry is reused by a ``last_window`` lookup, the
+    suffix tokens get appended with offset 0 instead of the
+    ``token_start_index``-based offset, and M-RoPE positions on the draft
+    head drift from the trunk. The verifier then accepts plausibly-shaped
+    garbage drafts and the model emits hallucinated training-data fragments
+    mid-stream above the ``..._WINDOW_THRESHOLD`` (16384 tokens).
+
+    Conservative fix until ``_append_mtp_history`` is fixed to take
+    ``position_offset`` on the warm-restore path: require an exact policy
+    match. Cross-policy lookups force a cold prefill, which is slower but
+    correct.
     """
-    if entry_policy == lookup_policy:
-        return True
-    if entry_policy is None or lookup_policy is None:
-        return False
-    return (
-        entry_policy in _COMMITTED_CACHE_POLICIES
-        and lookup_policy in _COMMITTED_CACHE_POLICIES
-    )
+    return entry_policy == lookup_policy
 
 
 def _tree_nbytes(value: Any) -> int:


### PR DESCRIPTION
**Marked draft pending more thorough validation.** Initial repro shows this fixes the symptom but a residual `<|im_start|>` token leak remains - investigating separately.

## Summary

\`_mtp_history_policy_compatible\` (session_bank.py:57) currently treats \`committed\` and \`last_window\` as interchangeable on the theory that the cache shape is identical and the trim is a no-op once we restore from snapshot. That assumption is broken by an asymmetry in \`generation.py\`:

- Warm-restore path at \`generation.py:1395\` calls \`_append_mtp_history(suffix)\` **without** \`position_offset\`.
- Cold-prefill path at \`generation.py:1933\` passes \`position_offset = token_start_index + slice_start - 1\`.

When a \`committed\`-stored bank entry is reused for a \`last_window\` lookup, the suffix is appended at position 0 instead of the offset-based position, so M-RoPE drifts on the draft head while the trunk advances normally. Drafts with mis-positioned KV produce nonsense logits whose top-k coincidentally overlaps the verifier's distribution; the verifier accepts plausibly-shaped tokens that aren't what the trunk would have emitted.

## Symptom

Above the \`MTPLX_MTP_HISTORY_LAST_WINDOW_THRESHOLD\` (16384 tokens by default, set by the sustained profile), the model emits a coherent prefix followed by training-data fragments mid-stream:

\`\`\`
"Let me check if the server is running:\n\n<tool_call>\n== Clarke\n\nI'll do a final syntax check..."
"<tool_call>\n[TrackedtView | Project: 3d-shooter] <url>http://localhost:5533</url>"
\`\`\`

Decode tok/s also collapses (observed 47% -> 27% draft acceptance) because most drafts are mis-positioned and rejected.

Hip clients (the upstream user) see this as 422 \`malformed tool_call: unclosed <tool_call>\` or \`unsupported tool_call payload format\`, since the bad fragments break MTPLX's tool-call parser at \`server/openai.py:1463\`/\`1475\`.

## Fix

Conservative: require exact policy match. Cross-policy lookups force cold prefill (slower but correct).

## Followup

The aggressive fix would thread \`position_offset\` through the warm-restore path so cross-policy reuse can be safe. That's a separate PR - the warm-restore call site needs the cache offset and a way to compute the correct \`mtp_history_position_base\` post-restore.

Could also store \`mtp_history_position_base\` as part of \`SessionBankEntry\` metadata and propagate it through restore.

## Test plan

- [x] Repro on \`fix/sustained-profile-no-bench-abort\` baseline at >25K context with \`--profile sustained --depth 3 --generation-mode mtp\` - hallucination at exactly 29K cumulative tokens.
- [x] Apply this patch + restart, resume the bricked session, send simple prompts: model now emits coherent output and properly-formed \`<tool_call>\` blocks.
- [ ] Validate on longer sessions (>40K context).
- [ ] Investigate residual \`<|im_start|>\` leak observed in one test.
- [ ] Benchmark cold-prefill latency cost vs cross-policy warm restore.