### PR TITLE
fix: honor MTPLX_MTP_HISTORY_POLICY env override on 'auto'

### DIFF
--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -161,7 +161,13 @@ def _mtp_history_last_window_tokens() -> int:
 def _resolve_mtp_history_policy(requested_policy: str, prompt_tokens: int) -> str:
     requested = _normalize_mtp_history_policy(requested_policy)
     env_policy = os.environ.get("MTPLX_MTP_HISTORY_POLICY")
-    if env_policy and requested == "committed":
+    # Honor the env-var override whenever the caller requested either the
+    # default "committed" or the auto-resolution path. Previously this only
+    # fired when ``requested == "committed"``, which silently dropped the
+    # override in every server hot path that resolves to "auto" via the
+    # sustained profile (profiles.py:93). Sustained users could not opt
+    # out of the last_window flip without editing the profile.
+    if env_policy and requested in ("committed", "auto"):
         requested = _normalize_mtp_history_policy(env_policy)
     if requested != "auto":
         return requested


### PR DESCRIPTION
## Summary

\`_resolve_mtp_history_policy\` only applied the \`MTPLX_MTP_HISTORY_POLICY\` env override when \`requested == \"committed\"\`. The sustained profile sets the requested policy to \`\"auto\"\`, so the env var was silently dropped on every sustained server hot path. Users had to edit the profile to test alternative policies.

## Fix

Extend the gate to also fire on \`\"auto\"\`. Explicit non-default caller policies (\`last_window\`, \`cycle\`, etc.) still take precedence.

## Use case

Combined with #44, this lets users force \`committed\` policy via env var to work around a separate warm-restore position_offset asymmetry in \`generation.py\`'s \`restore_or_prefill_prompt_state\` (which I'm tracking but not fixing here - it requires threading position_offset through the warm path). Without that workaround, sustained-profile sessions above 16K tokens trigger draft-head misalignment, model emits training-data fragments mid-stream, and clients see 422 \`malformed tool_call\` errors.