### PR TITLE
profiles: bump sustained-profile TurboQuant V-quant default q3_0 -> q5_0

### DIFF
--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -101,6 +101,18 @@ SUSTAINED_PREFILL_ENV = {
     "MTPLX_VLLM_METAL_PAGED_PARTITION_THRESHOLD": "2048",
     "MTPLX_VLLM_METAL_PAGED_PARTITION_SIZE": "512",
     "MTPLX_VLLM_METAL_PAGED_TURBOQUANT": "0",
+    # When TurboQuant is enabled, default V-quant to 5-bit instead of 3-bit.
+    # The 3-bit Lloyd-Max default sits *below* the TurboQuant paper's
+    # 3.5-bpw "absolute quality neutrality" threshold (arXiv:2504.19874
+    # Section 4.2/4.3), so quality drifts at long context - exactly the
+    # use case the sustained profile is meant to target. Empirically,
+    # 27K-context coding-agent runs with K=q8_0 / V=q3_0 produced
+    # malformed tool_call payloads and silent hallucination, while the
+    # same task on the same model with V=q5_0 landed correct edits and
+    # passed the build. q5_0 is still ~2x smaller than full bf16 for
+    # values, so the memory cost of the bump is small.
+    "MTPLX_VLLM_METAL_PAGED_TURBOQUANT_K_QUANT": "q8_0",
+    "MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT": "q5_0",
     "MTPLX_CLEAR_CACHE_EVERY": "auto",
     "MTPLX_CLEAR_CACHE_EVERY_CONTEXT_THRESHOLD": "16384",
     "MTPLX_CLEAR_CACHE_EVERY_LONG_CONTEXT": "256",


### PR DESCRIPTION
## Summary

Pin sustained profile's TurboQuant defaults to `K=q8_0`, `V=q5_0` (the latter being a bump from the implicit `q3_0` default in `turboquant.py`). Aligns the long-context-throughput profile with the TurboQuant paper's quality threshold.

## Why

The [TurboQuant paper](https://arxiv.org/abs/2504.19874) Section 4.2/4.3 reports "absolute quality neutrality with 3.5 bits per channel and marginal quality degradation with 2.5 bits per channel." The current 3-bit V default sits *below* the neutrality line. Per-token quantization error compounds across thousands of attention reads at long context - exactly where the sustained profile is supposed to shine.

## Empirical evidence

Same model (qwen3.6-27b-MTPLX), same 27K-context coding-agent task on a resumed hip session, two-turn run:

| Settings | Tool-call validity | Real edit landed | Trunk crash | Notes |
|---|---|---|---|---|
| TurboQuant OFF | malformed mid-stream | no | `SparseDistribution: positive mass` (NaN) | hard crash before edits |
| ON, K=q8_0, **V=q3_0** (current default) | ~50% malformed | no | `<tool_call>` truncation | model **silently hallucinated** finished work in turn 2 |
| ON, K=q8_0, **V=q5_0** (this PR) | clean | **yes** (+37-line articulated humanoid mesh patch) | NaN still fires later, separate bug | edit landed, build passed |

The `q3_0 -> q5_0` bump alone made the difference between "model invents fictional work" and "model produces a real, correct, well-structured patch and runs the build." Cross-referenced to the [vllm-metal TurboQuant docs](https://docs.vllm.ai/projects/vllm-metal/en/latest/turboquant/) which match the paper's bpw guidance.

## Cost

Memory-wise, q5_0 V is ~67% larger than q3_0 V but still ~40% smaller than full bf16. For a 27K-token KV cache on a 27B model, this is single-digit gigabytes - cheap on Apple Silicon unified memory.

## Followup ideas

The trunk-side `SparseDistribution: positive mass` NaN is a separate long-context bug independent of TurboQuant settings; will file separately. Auto-tuning V-quant from `--context-window` at server start is also possible (server already knows the flag) and would eliminate the manual tradeoff for users; happy to draft that as a follow-up if you'd prefer it over the static default bump here.

Users with extreme memory pressure can still pin V back via `MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT=q3_0`.

## Test plan

- [x] Profile dict imports cleanly, `PROFILES['sustained'].env_dict()` shows the new defaults.
- [x] Empirical 27K-context coding-agent run with the new defaults landed real work.
- [ ] Existing TurboQuant smoke tests (none currently in tree that I found - happy to add one if there's a preferred shape).