### PR TITLE
server: auto-tune TurboQuant V-quant from --context-window at startup

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -799,6 +799,7 @@ class ServerState:
             else _resolve_context_window(self.runtime.tokenizer, args.model)
         )
         _startup_line(f"[5/6] Context window: {self.context_window} tokens")
+        _autotune_turboquant_for_context(self.context_window)
         self.sessions = EngineSessionManager()
         self.last_metrics: list[dict[str, Any]] = []
         # Activity timestamps used by the parent-process thermal watchdog to
@@ -936,6 +937,38 @@ class _RateLimiter:
             events.append(timestamp)
             self._events[key] = events
             return True, 0
+
+
+def _autotune_turboquant_for_context(context_window: int) -> None:
+    """Pick a TurboQuant V-quant default based on the configured context
+    window when the user hasn't explicitly set one.
+
+    The TurboQuant paper (arXiv:2504.19874 Section 4.2/4.3) reports
+    "absolute quality neutrality with 3.5 bits per channel" - so 3-bit
+    V-quant is below the cliff and quality drifts at long context.
+    For a server configured with a >16K window, the user clearly intends
+    long-context use, so q5_0 V is the right starting point. For shorter
+    windows the memory savings of q3_0 is fine.
+
+    Only fires when the user hasn't pinned _V_QUANT explicitly. Profile
+    defaults still take precedence over any auto-tune; this just fills
+    the gap when a custom invocation didn't set anything.
+    """
+    if not _autotune_should_set("MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT"):
+        return
+    threshold = 16_384
+    target = "q5_0" if int(context_window) > threshold else "q3_0"
+    os.environ["MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT"] = target
+    _startup_line(
+        f"[5/6] TurboQuant V-quant auto-tuned to {target} for context_window={context_window} (threshold={threshold})"
+    )
+
+
+def _autotune_should_set(env_name: str) -> bool:
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return True
+    return not raw.strip()
 
 
 def _resolve_context_window(tokenizer: Any, model_path: str) -> int:


### PR DESCRIPTION
Picks `q5_0` for `context_window > 16384` (TurboQuant paper's bpw-vs-quality cliff per arXiv:2504.19874 Section 4.2), `q3_0` below. Only fires when the user hasn't pinned `MTPLX_VLLM_METAL_PAGED_TURBOQUANT_V_QUANT` explicitly. Profile defaults still take precedence (#47 sets sustained's default to q5_0 explicitly).

Hooks into `ServerState.__init__` right after `context_window` is resolved and before cache allocation, since dynamic mid-session quant switching isn't possible (KV pages are committed at the chosen quant). Logs the chosen value to startup output for visibility.

Stacked on top of #47 conceptually: that PR makes q5_0 the explicit sustained default; this one makes it the default for *any* invocation that asks for a long context (e.g. throughput/balanced profiles tuned for short context but spun up with --context-window 128000).

Marking draft until #47 lands - if you'd rather I roll this into #47 as a single change, happy to do that.

Test plan:
- [x] Verified at REPL: 20K -> q5_0, 8K -> q3_0, explicit override preserved.
- [ ] CI smoke test (none currently in tree for TurboQuant flag picking).
- [ ] Empirical run on the 27K-context coding-agent reproducer to confirm no regression vs explicit q5_0.