### PR TITLE
fix: guard trunk sampler against NaN logits at long context

### DIFF
--- a/mtplx/fast_sampling.py
+++ b/mtplx/fast_sampling.py
@@ -2,10 +2,60 @@
 
 from __future__ import annotations
 
+import os
+
 import mlx.core as mx
 import numpy as np
 
 from .sampling import SamplerConfig, SparseDistribution
+
+
+def _trunk_logits_nan_guard_enabled() -> bool:
+    """Return whether the NaN/Inf guard on trunk logits is active.
+
+    Defaults to enabled. Set ``MTPLX_TRUNK_LOGITS_NAN_GUARD=0`` to disable
+    (only for debugging - disabling re-exposes the long-context
+    ``SparseDistribution probabilities must have positive mass`` 500.).
+    """
+
+    raw = os.environ.get("MTPLX_TRUNK_LOGITS_NAN_GUARD")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _sanitize_logits_row(row: np.ndarray) -> tuple[np.ndarray, bool]:
+    """Replace non-finite entries with ``-inf`` so argpartition/logsumexp behave.
+
+    Returns the (possibly copied) row and a flag indicating whether any
+    sanitization happened. The caller uses the flag to log diagnostic state
+    so we can tie production crashes back to upstream attention NaN sources.
+    """
+
+    finite_mask = np.isfinite(row)
+    if bool(finite_mask.all()):
+        return row, False
+    sanitized = np.where(finite_mask, row, -np.inf)
+    return sanitized, True
+
+
+def _record_trunk_logits_nan(*, batched: bool, rows: int) -> None:
+    """Log a single line per occurrence so operators can see frequency.
+
+    Kept intentionally cheap (one line, no traceback) - the goal is to
+    surface that the guard fired without spamming the log when an entire
+    batch hits the same upstream NaN.
+    """
+
+    if os.environ.get("MTPLX_TRUNK_LOGITS_NAN_GUARD_QUIET"):
+        return
+    import sys
+
+    print(
+        "mtplx_trunk_logits_nan_guard "
+        f"batched={int(bool(batched))} rows_with_nan={int(rows)}",
+        file=sys.stderr,
+    )
 
 
 class BatchedSparseDistributions:
@@ -71,6 +121,21 @@ def sparse_distribution_from_mlx_logits(
     if k <= 0:
         return None
 
+    # Sanitize non-finite logits before argpartition / logsumexp. At long
+    # context (>~25K cumulative) the dense SDPA fallback in
+    # ``cache_state.py:_large_q_split_sdpa_fallback`` and chunked-attention
+    # paths can produce NaN/Inf trunk logits (e.g. fp16 overflow in
+    # `running_acc` or rare divide-by-eps when `running_denom` underflows).
+    # Without this guard the NaN propagates: ``mx.logsumexp`` returns NaN,
+    # ``mx.exp(top_vals - log_total)`` is NaN, and the downstream
+    # ``probs.sum() <= 0`` rescue at the bottom of this function does NOT
+    # catch NaN (NaN <= 0 is False). The result is a 500 raised at
+    # ``sampling.py:40`` (``SparseDistribution probabilities must have
+    # positive mass``). Replacing non-finite entries with a large negative
+    # constant degrades to argmax-over-finite-support without crashing.
+    if _trunk_logits_nan_guard_enabled():
+        flat = mx.where(mx.isfinite(flat), flat, mx.array(-1.0e30, dtype=flat.dtype))
+
     top_idx = mx.argpartition(-flat, kth=k - 1, axis=-1)[:k]
     top_vals = flat[top_idx]
     order = mx.argsort(-top_vals, axis=-1)
@@ -84,6 +149,17 @@ def sparse_distribution_from_mlx_logits(
     token_ids = np.asarray(top_idx, dtype=np.int64).reshape(-1)
     probs_full = np.asarray(top_probs_full, dtype=np.float64).reshape(-1)
 
+    # Defense in depth: if logsumexp itself was non-finite (e.g. every
+    # logit was -inf because every entry was non-finite, or fp32 overflow
+    # produced +inf), report it once and degrade to a uniform distribution
+    # over the top-k support. This must happen BEFORE the top-p mask so
+    # the rescue branch survives the np.cumsum(NaN < top_p) collapse.
+    if not bool(np.all(np.isfinite(probs_full))):
+        _record_trunk_logits_nan(batched=False, rows=1)
+        token_ids = token_ids[:1]
+        probs = np.array([1.0], dtype=np.float64)
+        return SparseDistribution(token_ids=token_ids, probs=probs, vocab_size=vocab_size)
+
     if 0 < config.top_p < 1.0:
         cumulative_before = np.concatenate(([0.0], np.cumsum(probs_full[:-1])))
         keep = cumulative_before < float(config.top_p)
@@ -94,7 +170,10 @@ def sparse_distribution_from_mlx_logits(
 
     token_ids = token_ids[keep]
     probs = probs_full[keep]
-    if probs.sum() <= 0:
+    # Use !(>0) instead of `<= 0` so NaN totals also trip the rescue
+    # branch (NaN <= 0 is False; not (NaN > 0) is True).
+    total = float(probs.sum())
+    if not (total > 0):
         token_ids = token_ids[:1]
         probs = np.array([1.0], dtype=np.float64)
 
@@ -121,6 +200,10 @@ def sparse_distributions_from_mlx_logits(
     if k <= 0:
         return None
 
+    # See sparse_distribution_from_mlx_logits for rationale on this guard.
+    if _trunk_logits_nan_guard_enabled():
+        rows = mx.where(mx.isfinite(rows), rows, mx.array(-1.0e30, dtype=rows.dtype))
+
     top_idx = mx.argpartition(-rows, kth=k - 1, axis=-1)[:, :k]
     top_vals = mx.take_along_axis(rows, top_idx, axis=-1)
     order = mx.argsort(-top_vals, axis=-1)
@@ -134,8 +217,21 @@ def sparse_distributions_from_mlx_logits(
     token_rows = np.asarray(top_idx, dtype=np.int64)
     prob_rows = np.asarray(top_probs_full, dtype=np.float64)
     distributions: list[SparseDistribution] = []
+    nan_rows = 0
 
     for token_ids, probs_full in zip(token_rows, prob_rows, strict=True):
+        if not bool(np.all(np.isfinite(probs_full))):
+            # Degenerate row - degrade to greedy on the top-k argmax.
+            nan_rows += 1
+            distributions.append(
+                SparseDistribution(
+                    token_ids=token_ids[:1],
+                    probs=np.array([1.0], dtype=np.float64),
+                    vocab_size=vocab_size,
+                )
+            )
+            continue
+
         if 0 < config.top_p < 1.0:
             cumulative_before = np.concatenate(([0.0], np.cumsum(probs_full[:-1])))
             keep = cumulative_before < float(config.top_p)
@@ -146,7 +242,9 @@ def sparse_distributions_from_mlx_logits(
 
         kept_ids = token_ids[keep]
         probs = probs_full[keep]
-        if probs.sum() <= 0:
+        # Use !(>0) instead of `<= 0` so NaN totals also rescue.
+        total = float(probs.sum())
+        if not (total > 0):
             kept_ids = kept_ids[:1]
             probs = np.array([1.0], dtype=np.float64)
 
@@ -157,6 +255,9 @@ def sparse_distributions_from_mlx_logits(
                 vocab_size=vocab_size,
             )
         )
+
+    if nan_rows:
+        _record_trunk_logits_nan(batched=True, rows=nan_rows)
 
     return distributions
 
@@ -176,6 +277,10 @@ def batched_sparse_distributions_from_mlx_logits(
     if k <= 0:
         return None
 
+    # See sparse_distribution_from_mlx_logits for rationale on this guard.
+    if _trunk_logits_nan_guard_enabled():
+        rows = mx.where(mx.isfinite(rows), rows, mx.array(-1.0e30, dtype=rows.dtype))
+
     top_idx = mx.argpartition(-rows, kth=k - 1, axis=-1)[:, :k]
     top_vals = mx.take_along_axis(rows, top_idx, axis=-1)
     order = mx.argsort(-top_vals, axis=-1)
@@ -188,6 +293,17 @@ def batched_sparse_distributions_from_mlx_logits(
 
     token_rows = np.asarray(top_idx, dtype=np.int64)
     prob_rows = np.asarray(top_probs_full, dtype=np.float64)
+
+    # Defense in depth: collapse non-finite rows to a one-hot on their
+    # top-1 token before downstream arithmetic. Mirrors the per-row
+    # sanitization in ``sparse_distributions_from_mlx_logits``.
+    finite_per_row = np.all(np.isfinite(prob_rows), axis=1)
+    if not bool(finite_per_row.all()):
+        nan_rows = int((~finite_per_row).sum())
+        _record_trunk_logits_nan(batched=True, rows=nan_rows)
+        bad_rows = ~finite_per_row
+        prob_rows[bad_rows, :] = 0.0
+        prob_rows[bad_rows, 0] = 1.0
 
     if 0 < config.top_p < 1.0:
         cumulative_before = np.concatenate(
@@ -203,7 +319,10 @@ def batched_sparse_distributions_from_mlx_logits(
         prob_rows = np.where(keep, prob_rows, 0.0)
 
     row_sums = prob_rows.sum(axis=1)
-    bad = row_sums <= 0
+    # Use ``not (>0)`` so NaN row-sums also trigger the rescue. NaN <= 0
+    # is False under IEEE-754, which is why the original guard missed
+    # the long-context degenerate-distribution case at sampling.py:40.
+    bad = ~(row_sums > 0)
     if np.any(bad):
         prob_rows[bad, :] = 0.0
         prob_rows[bad, 0] = 1.0

--- a/mtplx/sampling.py
+++ b/mtplx/sampling.py
@@ -62,6 +62,15 @@ Distribution = np.ndarray | SparseDistribution
 
 def softmax(logits: np.ndarray, temperature: float = 1.0) -> np.ndarray:
     logits = np.asarray(logits, dtype=np.float64)
+    # Sanitize non-finite entries before reducing. NaN propagates through
+    # ``np.max`` and would otherwise force the ``not isfinite(total)`` branch
+    # below into a 500. Replacing NaN/Inf with -inf produces a well-defined
+    # softmax that ignores the corrupted positions while preserving relative
+    # mass on the finite logits. This matches the MLX-side guard added in
+    # ``fast_sampling.py``; both paths can be triggered at long context when
+    # the dense SDPA fallback emits non-finite trunk logits.
+    if not bool(np.all(np.isfinite(logits))):
+        logits = np.where(np.isfinite(logits), logits, -np.inf)
     if temperature <= 0:
         out = np.zeros_like(logits, dtype=np.float64)
         out[int(np.argmax(logits))] = 1.0

--- a/tests/test_fast_sampling.py
+++ b/tests/test_fast_sampling.py
@@ -1,0 +1,94 @@
+"""Regression tests for fast_sampling.py NaN/Inf guard.
+
+At long context (>~25K cumulative on the qwen3.6-27b sustained profile)
+the dense SDPA fallback path in cache_state.py can emit non-finite trunk
+logits. Without the guard added in this module, the resulting NaN
+``top_probs_full`` propagates to ``SparseDistribution`` construction and
+the sampler raises a 500 with the misleading message
+``SparseDistribution probabilities must have positive mass``.
+
+These tests pin the recovery semantics: a single non-finite logit must
+not crash the request, and the sampler must degrade to a valid sparse
+distribution over the surviving finite support (or to a one-hot greedy
+distribution when every entry is non-finite).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from mtplx.fast_sampling import (  # noqa: E402  - mx import must precede
+    BatchedSparseDistributions,
+    batched_sparse_distributions_from_mlx_logits,
+    sparse_distribution_from_mlx_logits,
+    sparse_distributions_from_mlx_logits,
+)
+from mtplx.sampling import SamplerConfig, SparseDistribution
+
+
+CFG = SamplerConfig(temperature=0.6, top_p=0.95, top_k=20)
+
+
+def _logits_with_nan(vocab: int = 256) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    base = rng.normal(scale=2.0, size=(vocab,)).astype(np.float32)
+    # Inject one NaN and one +inf, which collectively reproduce the
+    # long-context dense-SDPA-fallback signature.
+    base[7] = np.nan
+    base[42] = np.inf
+    return base
+
+
+def test_sparse_distribution_handles_nan_logits():
+    logits = mx.array(_logits_with_nan())
+    dist = sparse_distribution_from_mlx_logits(logits, CFG)
+    assert isinstance(dist, SparseDistribution)
+    # Probabilities must sum to a finite positive value.
+    assert np.isfinite(dist.probs).all()
+    assert dist.probs.sum() > 0
+    # The poisoned positions must not appear in the support.
+    assert 7 not in dist.token_ids.tolist()
+    assert 42 not in dist.token_ids.tolist()
+
+
+def test_sparse_distribution_all_nan_logits_returns_one_hot():
+    vocab = 64
+    poisoned = mx.array(np.full((vocab,), np.nan, dtype=np.float32))
+    dist = sparse_distribution_from_mlx_logits(poisoned, CFG)
+    # Either we degrade to a one-hot or return None for the dense
+    # numpy path to handle. Both are safe - what we must not do is
+    # raise ``positive mass``.
+    if dist is None:
+        return
+    assert isinstance(dist, SparseDistribution)
+    assert np.isfinite(dist.probs).all()
+    assert np.isclose(dist.probs.sum(), 1.0)
+
+
+def test_sparse_distributions_batched_handles_nan_logits():
+    rng = np.random.default_rng(1)
+    rows = rng.normal(scale=2.0, size=(3, 128)).astype(np.float32)
+    rows[1, 5] = np.nan  # Only the middle row is poisoned.
+    rows[1, 9] = np.inf
+    logits = mx.array(rows)
+    dists = sparse_distributions_from_mlx_logits(logits, CFG)
+    assert dists is not None and len(dists) == 3
+    for d in dists:
+        assert np.isfinite(d.probs).all()
+        assert d.probs.sum() > 0
+
+
+def test_batched_sparse_distributions_handles_nan_logits():
+    rng = np.random.default_rng(2)
+    rows = rng.normal(scale=2.0, size=(4, 64)).astype(np.float32)
+    rows[2, :] = np.nan  # Whole row is poisoned (full SDPA fallout).
+    logits = mx.array(rows)
+    batched = batched_sparse_distributions_from_mlx_logits(logits, CFG)
+    assert isinstance(batched, BatchedSparseDistributions)
+    # All rows must have positive, finite mass after the guard.
+    assert np.all(np.isfinite(batched.probs))
+    row_sums = batched.probs.sum(axis=1)
+    assert np.all(row_sums > 0)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -76,3 +76,45 @@ def test_sparse_distribution_sampling_returns_original_token_ids():
         vocab_size=12,
     )
     assert sample_from_distribution(dist, np.random.default_rng(0)) == 11
+
+
+def test_softmax_recovers_from_partial_nan_logits():
+    """At long context the dense SDPA fallback can emit NaN trunk logits.
+
+    The previous softmax raised ``Cannot normalize logits into a
+    probability distribution`` because ``np.max`` propagated the NaN. We
+    now sanitize non-finite entries to ``-inf`` and degrade gracefully to
+    a softmax over the finite support so the request returns a valid
+    token instead of a 500.
+    """
+    from mtplx.sampling import softmax
+
+    logits = np.array([1.0, np.nan, 3.0, np.inf, -np.inf, 2.0])
+    probs = softmax(logits, temperature=1.0)
+    assert np.isclose(probs.sum(), 1.0)
+    # The +inf and NaN positions must contribute zero mass after sanitization.
+    assert probs[1] == 0.0
+    assert probs[3] == 0.0
+    assert probs[4] == 0.0
+    # The finite-logit positions must keep their relative ordering.
+    assert probs[2] > probs[5] > probs[0]
+
+
+def test_softmax_full_nan_logits_raises_clear_error():
+    """If every logit is non-finite there is no recoverable distribution."""
+    import warnings
+
+    from mtplx.sampling import softmax
+
+    logits = np.array([np.nan, np.nan, np.nan])
+    # The implementation intentionally subtracts the (-inf) max, which
+    # produces an IEEE-754 ``invalid`` warning. Suppress it locally so the
+    # test asserts only on the resulting exception.
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            softmax(logits, temperature=1.0)
+    except ValueError as exc:
+        assert "probability distribution" in str(exc)
+    else:
+        raise AssertionError("softmax must raise on all-non-finite logits")


### PR DESCRIPTION
Tracking issue: youssofal/MTPLX#49.

## Diagnosis

The trunk logit tensor can contain NaN/Inf at long context (typically >25K tokens with sustained profile) due to fp16 cancellation in dense SDPA fallback paths (`cache_state.py:_large_q_split_sdpa_fallback` or `attention_split.py:264`'s SDPA over ~25K-row K). This propagates through the sampler:

```
mx.logsumexp(flat, axis=-1)       -> NaN
mx.exp(top_vals - log_total)      -> NaN probabilities
probs.sum() <= 0                  -> rescue check SKIPPED (IEEE-754: NaN<=0 is False)
SparseDistribution(probs=[NaN])   -> raises at sampling.py:39
```

Result: `ValueError/500: SparseDistribution probabilities must have positive mass`. When only some logit positions are NaN, sampling instead picks an off-grammar token and produces a truncated `<tool_call>` block (`422 malformed tool_call`). Same root cause, two failure modes.

## Fix (sampler-boundary mitigation)

- Sanitize non-finite logits with `mx.where(mx.isfinite, flat, -1e30)` before `argpartition`/`logsumexp` in all three `fast_sampling.py` entry points.
- Replace `<= 0` rescue checks with `not (>0)` so NaN totals trip rescue (IEEE-754 fix).
- Defensive per-row one-hot collapse if residual NaN survives upstream sanitize.
- Mirror the fix in the numpy `softmax` path at `sampling.py:63`.
- Env gate `MTPLX_TRUNK_LOGITS_NAN_GUARD=0` to disable for debugging; `MTPLX_TRUNK_LOGITS_NAN_GUARD_QUIET=1` to silence per-fire log line.

## Empirical validation

Same bricked 27K coding-agent session before/after:

| Probe | Before fix | After fix |
|---|---|---|
| One-shot at 26K | 500 `SparseDistribution` OR 15min stream timeout | 40s, `finish_reason=stop`, ctok=80, real answer |
| Tool-using turn at 26K | 422 `malformed tool_call` on round 1 | 9 valid tool-calling rounds, 422 on round 9, recovered |
| Push to 29K | unreachable | reachable, productivity degrades but no crashes |

The 422 failure mode still surfaces occasionally (the degenerate-but-not-fully-NaN form), but at lower frequency, and is recoverable client-side. The hard 500 NaN is gone.

## Scope

This is intentionally a sampler-boundary mitigation, not the upstream attention fix. The fp16 cancellation in dense SDPA at long context is a deeper bug that wants instrumented forward-pass diagnostics; #49 tracks it as a follow-up.

## Tests

13 sampling/fast-sampling tests pass, including 6 new regression tests covering single-NaN, all-NaN, batched per-row NaN, and full-row NaN cases.

Stacked on `daniel/dev-stack` which also rolls up #44 + #46 + #47 + #48.