### PR TITLE
fix: treat profile env vars as defaults, not overrides

### DIFF
--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -392,11 +392,24 @@ def apply_profile_env(
     *,
     environ: MutableMapping[str, str] | None = None,
 ) -> dict[str, str | None]:
+    """Apply ``name``'s profile env, but treat the profile values as
+    defaults: if the caller already has the env var set in ``target``,
+    keep their value.
+
+    The previous behavior blindly overwrote any user-provided env var
+    with the profile's value at startup. That silently erases every
+    documented escape hatch (``MTPLX_MTP_HISTORY_POLICY=committed``,
+    ``MTPLX_VLLM_METAL_PAGED_TURBOQUANT=1``, etc.), so users were
+    running with profile defaults regardless of what they exported.
+    Profile values should be defaults, not overrides.
+    """
     target = os.environ if environ is None else environ
     profile = get_profile(name)
     previous = {key: target.get(key) for key in profile.env_dict()}
     for key, value in profile.env:
-        target[key] = value
+        existing = target.get(key)
+        if existing is None or not str(existing).strip():
+            target[key] = value
     return previous
 
 


### PR DESCRIPTION
**This is a blocker for #46 and #47 to do what they say.**

Discovered while empirically validating PR #46's `MTPLX_MTP_HISTORY_POLICY` env override behavior. Hit `/health` on a running server launched with several env vars set; the response showed the profile defaults, not the launched values:

```
$ MTPLX_MTP_HISTORY_POLICY=committed \
  MTPLX_VLLM_METAL_PAGED_TURBOQUANT=1 \
  mtplx-server --profile sustained ...

$ curl /health | jq '.profile.env'
{
  "MTPLX_MTP_HISTORY_POLICY": "auto",        # !! we set committed
  "MTPLX_VLLM_METAL_PAGED_TURBOQUANT": "0",   # !! we set 1
  ...
}
```

Root cause is in `profiles.py:apply_profile_env`:

```python
for key, value in profile.env:
    target[key] = value   # unconditional overwrite
```

Every profile-managed env var gets stomped at startup, **including the ones the user set on the launch command line**. The documented overrides have been non-functional.

Fix is one-liner: only set the profile default when the env var is unset/empty.

```python
existing = target.get(key)
if existing is None or not str(existing).strip():
    target[key] = value
```

### Why this matters operationally

This invalidates a lot of empirical work I posted on #44 and #47. The TurboQuant V=q5_0 vs V=q3_0 comparison I wrote up - both runs were actually with **TurboQuant OFF**, because the `=1` env var was being erased. The MTPLX_MTP_HISTORY_POLICY=committed workaround everyone has been telling users to use - silently inert. We've been measuring different things than we documented.

### Tests

`tests/test_profiles.py` still passes (7 tests; the test fixtures don't pre-set env vars). The behavior change is conservative - it only triggers when the user has set an env var explicitly, which is the case the previous behavior was wrong on.

Tracking issue: #49. After this lands, the prior empirical work on #44/#46/#47 needs to be re-run with the env vars actually live; I'll do that and update those threads.

`daniel-farina/MTPLX:daniel/dev-stack` will roll this up next.

cc @youssofal