### PR TITLE
Commit only client-visible content to SessionBank, not reasoning (fixes #54)

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6453,35 +6453,36 @@ def create_app(state: ServerState) -> FastAPI:
                     return chunks
 
                 def streamed_history_content() -> str:
-                    # Always capture the natural-language portion of the
-                    # response. Previously this returned "" whenever
-                    # tool_stream.has_tool_calls, which dropped any preamble
-                    # text (e.g. "Let me check..." before <tool_call>) from
-                    # the stored assistant_content. The next turn's lookup
-                    # encodes the same assistant message WITH the preamble
-                    # (clients echo back content + tool_calls), so the
-                    # prefix diverged and every tool-using turn paid a cold
-                    # prefill. tool_call markup itself is captured in
-                    # tool_stream and not in history_content_chunks, so
-                    # this is safe to return for the tool-call case too.
-                    reasoning = (
-                        "".join(history_reasoning_chunks)
-                        .replace(THINK_OPEN, "")
-                        .replace(THINK_CLOSE, "")
-                        .strip()
-                    )
-                    content = (
+                    # The bank commit's assistant_content must match what the
+                    # client actually received and will echo back on the next
+                    # turn, otherwise the committed tokens are not a prefix
+                    # of the next request and the cache always misses.
+                    #
+                    # With the reasoning parser active (qwen3 etc.), the SSE
+                    # stream is split into `delta.content` (what most clients
+                    # read into their stored assistant message) and a
+                    # separate `delta.reasoning_content` (a special field
+                    # that the OpenAI-style schema does not require clients
+                    # to round-trip). Clients like hip and opencode store
+                    # only `content`. Their next-turn assistant message
+                    # therefore re-renders with an EMPTY <think></think>
+                    # block. If we bake the real reasoning into the bank
+                    # commit, the commit tokens diverge from every
+                    # subsequent request and every long-lived session
+                    # cache-misses at the assistant boundary.
+                    #
+                    # Commit only `history_content_chunks` to match what the
+                    # client stored. Preamble text and tool_call preambles
+                    # are in history_content_chunks (tool_call markup is
+                    # captured separately in tool_stream), so this still
+                    # preserves the preamble-fix this function was added
+                    # to address.
+                    return (
                         "".join(history_content_chunks)
                         .replace(THINK_OPEN, "")
                         .replace(THINK_CLOSE, "")
                         .strip()
                     )
-                    pieces: list[str] = []
-                    if reasoning:
-                        pieces.append(f"{THINK_OPEN}\n{reasoning}\n{THINK_CLOSE}")
-                    if content:
-                        pieces.append(content)
-                    return "\n\n".join(pieces)
 
                 for field, text in splitter.start():
                     if text:


### PR DESCRIPTION
Fixes #54.

## Problem

`streamed_history_content()` always splices `history_reasoning_chunks` into the assistant_content used for the SessionBank commit. Clients receive content and reasoning as two SSE fields (`delta.content`, `delta.reasoning_content`); per the OpenAI schema they don't round-trip the reasoning field, so the next-turn request renders an empty `<think></think>` block instead of the real thinking. The committed token sequence is therefore not a prefix of the next request and every multi-turn cache lookup misses with `prefix_divergence_at_token`. Full diagnostic (token-level decode side-by-side, hip persisted conv dump, bank/admin output) is in #54.

## Fix

Commit only `history_content_chunks`. That matches what `delta.content` carried and what the client stores and echoes back. tool_call markup is in `tool_stream` and preamble text is in `history_content_chunks`, so the preamble-loss cache-fix this function was originally introduced for is preserved.

## Verification

Repro per #54 (4-turn `--resume` session against `mtplx-qwen36-27b-optimized-speed` with `--reasoning-parser qwen3`):

| turn | prompt_tok | cached_tok | prefill_tok | ttft | restore |
|------|-----------|-----------|------------|------|---------|
| 1 (cold) | 2129 | 0 | 2129 | 2.49s | cold |
| 2 | 2167 | 2154 | 13 | 0.11s | reference_lease |
| 3 | 2206 | 2192 | 14 | 0.25s | reference_lease |
| 4 | 2240 | 2229 | 11 | 0.13s | reference_lease |

22x TTFT speedup on warm turns, ~99% prefill reduction. Cache hits sustained across the conversation.

Also tested with `enable_thinking` toggled on/off and with tool-call turns; both paths now produce commit tokens that match the subsequent request prefix.

## Test plan

- [x] 4-turn pure-text `--resume` session warms after turn 1 (above)
- [x] code editor persisted conv shows only `content` field, confirming bug premise
- [x] Bank entries via `/admin/sessions` show `hits > 0` after warm turns (was 0 before)
- [ ] Suggest also auditing the non-streaming `_display_text` path for the same issue when `normalize_thinking_tags` is off - flagged in #54.

## Related

- d4315b7 added the sentinel-based postcommit prefix path. That path is correct - the issue was the assistant_content fed into it. PR keeps the sentinel path unchanged.
