### PR TITLE
Release v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable user-facing changes are recorded here.
   stack, and settings.
 - Added first-run Web UI and CLI tuning affordance so new installs can opt into
   the measured best depth without hiding the default startup path.
+- Added hardware diagnostics to `mtplx bench tune`: each AR/D1/D2/D3 candidate
+  now records MX Power Gadget-style power, frequency, temperature, utilization,
+  thermal-pressure, and fan samples where macOS exposes them.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ All notable user-facing changes are recorded here.
   the current speed artifact is labeled as Q4 target + Q4 MTP, and an already
   installed local verified artifact is preferred over prompting to download the
   Hugging Face mirror again.
+- Fixed first-run Tune from `mtplx start` when launched outside the repo:
+  candidate artifacts now use absolute paths, Tune prints per-candidate
+  progress, and candidate failures are reported as failures instead of a false
+  "no MTP depth beat AR" result.
+- Fixed served model-id detection for the installed Optimized Speed artifact so
+  mixed Q4/Q8 speed configs do not get mislabeled as Optimized Quality.
 
 ## v0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable user-facing changes are recorded here.
   candidate artifacts now use absolute paths, Tune prints per-candidate
   progress, and candidate failures are reported as failures instead of a false
   "no MTP depth beat AR" result.
+- Moved Tune's "close heavy apps / fans may get loud" warning to the pre-run
+  progress output so the final results screen does not give stale advice after
+  measurement is already over.
 - Fixed served model-id detection for the installed Optimized Speed artifact so
   mixed Q4/Q8 speed configs do not get mislabeled as Optimized Quality.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable user-facing changes are recorded here.
 - Added hardware diagnostics to `mtplx bench tune`: each AR/D1/D2/D3 candidate
   now records MX Power Gadget-style power, frequency, temperature, utilization,
   thermal-pressure, and fan samples where macOS exposes them.
+- `mtplx bench tune` now labels telemetry scope and prefers generation-window
+  power/GPU utilization when samples land inside the actual token generation
+  span; `--no-telemetry` keeps the same candidate machinery for cleaner speed
+  comparisons.
 
 ### Fixed
 
@@ -49,6 +53,9 @@ All notable user-facing changes are recorded here.
   measurement is already over.
 - Fixed served model-id detection for the installed Optimized Speed artifact so
   mixed Q4/Q8 speed configs do not get mislabeled as Optimized Quality.
+- Fixed no-argument `mtplx bench tune` confusion by printing the exact model path
+  and warning when `~/.mtplx/config.toml` selects a different artifact than the
+  verified default shown by `mtplx start`.
 
 ## v0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,37 @@
 
 All notable user-facing changes are recorded here.
 
-## Unreleased
+## v0.3.6
+
+### Added
+
+- Added `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` to compare AR
+  against D1/D2/D3 on a short coding prompt, keep AR as the `1.00x` baseline,
+  and save only a depth that actually beats AR for the current model, Mac, MLX
+  stack, and settings.
+- Added first-run Web UI tuning affordance so new installs can opt into the
+  measured best depth without hiding the default startup path.
+
+### Fixed
+
+- Fixed Qwen XML streaming tool calls so arguments are emitted as one complete,
+  schema-typed JSON object instead of string-fragment XML parameters. This fixes
+  OpenCode `bash.timeout` arriving as `"60000"` and `question.questions`
+  arriving as a stringified array.
+- Fixed restored-prefix suffix extension so warm SessionBank hits advance the
+  suffix in prefill chunks, with abort checks between chunks, instead of one
+  long hidden/logits AR call that could leave GPU work running after stop.
+- Fixed OpenCode stop-boundary postcommit churn: after the foreground prompt
+  prefix is committed, tiny final assistant turns no longer schedule a full
+  retokenized-history GPU prefill just to resolve a stop-token mismatch.
+- Fixed cold benchmark / one-off request memory growth when clients request
+  very large response budgets such as `max_tokens=65536`: dynamic paged KV now
+  reserves a bounded initial decode window and grows only if the model actually
+  reaches it.
+- Fixed anonymous SessionBank entries retaining full-capacity live paged-KV
+  buffers for no-reuse workloads, and tightened high-RAM default MLX Metal caps
+  so 512 GB Apple Silicon systems do not drift into hundreds of GiB of wired
+  allocator memory by default.
 
 ## v0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable user-facing changes are recorded here.
   against D1/D2/D3 on a short coding prompt, keep AR as the `1.00x` baseline,
   and save only a depth that actually beats AR for the current model, Mac, MLX
   stack, and settings.
-- Added first-run Web UI tuning affordance so new installs can opt into the
-  measured best depth without hiding the default startup path.
+- Added first-run Web UI and CLI tuning affordance so new installs can opt into
+  the measured best depth without hiding the default startup path.
 
 ### Fixed
 
@@ -33,6 +33,10 @@ All notable user-facing changes are recorded here.
   buffers for no-reuse workloads, and tightened high-RAM default MLX Metal caps
   so 512 GB Apple Silicon systems do not drift into hundreds of GiB of wired
   allocator memory by default.
+- Fixed verified-default onboarding copy and resolution for Optimized Speed:
+  the current speed artifact is labeled as Q4 target + Q4 MTP, and an already
+  installed local verified artifact is preferred over prompting to download the
+  Hugging Face mirror again.
 
 ## v0.3.5
 

--- a/LOG.md
+++ b/LOG.md
@@ -88,6 +88,36 @@ from_home_real_short_tune=MTPLX_TUNE_STATE=/tmp/mtplx-tune-home-real-state.json 
 thermalforge post-run status -> fans mode=auto actual=0 target=0
 ```
 
+## 2026-05-15 00:10 BST - v0.3.6 Tune Results Copy Fix
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+trigger=user noted Tune printed "Close heavy apps for cleaner results" after the benchmark had already completed
+public_release_done=false
+```
+
+Fix:
+
+```text
+tune_pre_run_copy=print close-heavy-apps/fans-may-get-loud warnings before fan ramp and candidate measurements start
+tune_results_copy=final Tune output now shows results/artifact path only; no stale pre-run advice after measurements are over
+```
+
+Validation:
+
+```text
+python3 -m py_compile mtplx/commands/public.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m ruff check mtplx/commands/public.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m pytest tests/test_public_cli.py::test_tune_human_reports_candidate_errors_instead_of_false_no_win tests/test_public_cli.py::test_tune_human_results_do_not_give_pre_run_advice_afterward tests/test_public_cli.py::test_tune_candidate_outputs_are_absolute_from_non_repo_cwd -q -> pass
+uv run --extra dev python -m build -> pass; rebuilt dist/mtplx-0.3.6.tar.gz and dist/mtplx-0.3.6-py3-none-any.whl
+uv run --extra dev python -m twine check dist/* -> pass
+/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --force-reinstall --no-deps dist/mtplx-0.3.6-py3-none-any.whl -> pass
+global packaged Tune result-render smoke -> final output says "Results written to ..." and contains no "Close heavy apps" or "Fans may get loud"
+```
+
 ## 2026-05-14 22:05 BST - v0.3.6 Release Candidate Assembly
 
 Scope:

--- a/LOG.md
+++ b/LOG.md
@@ -315,3 +315,67 @@ m3_ultra_512gb_target_gate=not run on this machine; still required before public
 before_v0.3.5_comparison=not rerun locally in this pass; candidate evidence is local after/fix evidence plus production-path behavior
 mlx_fast_fork=not active in this venv (stock MLX 0.31.2 observed), so local speed numbers are QA evidence, not public headline-speed proof
 ```
+
+## 2026-05-15 00:20 BST - Bench Tune Model/Telemetry UX Fix, No Public Release
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+user_gate=no merge, tag, GitHub release, PyPI, or Homebrew publish until user approves
+problem=mtplx bench tune looked less efficient than mtplx start/tune and reported a near-tie D2 win over D3
+```
+
+Diagnosis:
+
+```text
+no_args_bench_tune_model=/Users/youssof/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed
+source=~/.mtplx/config.toml
+start_verified_default_model=/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized
+result=the confusing run was not an explicit same-artifact comparison with the start path
+user_reported_d2_vs_d3_gap=54.67 vs 54.34 tok/s, about 0.6 percent
+interpretation=within short-run noise, not a meaningful architectural D2 win
+overlap_check=candidates still run as blocking isolated subprocesses; no candidate overlap evidence
+```
+
+Fix:
+
+```text
+mtplx bench tune now prints the exact model path before model load
+no-arg bench tune warns when ~/.mtplx/config.toml selects a path different from the verified default shown by start
+mtplx bench tune --no-telemetry added for clean speed comparison without power sampler diagnostics
+bench tune dry-run JSON includes telemetry mode and model-source notes
+5.0s settle delay added between AR/D1/D2/D3 candidate subprocesses
+near-tie policy added: if a deeper MTP depth is within 2.0 percent of raw fastest, prefer the deeper depth and report the tie-break
+```
+
+Real same-artifact checks on `/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized`:
+
+```text
+clean_tune_run=outputs/cli/tune-comparison/clean-tune-20260515-001540
+clean_tune=D3 best, AR 23.53 tok/s, D1 41.83, D2 48.42, D3 54.55, 2.32x AR
+
+bench_no_telemetry_run=outputs/cli/tune-comparison/bench-no-telemetry-20260515-001633
+bench_no_telemetry=D3 best, AR 24.62 tok/s, D1 41.61, D2 48.58, D3 54.52, 2.21x AR
+
+bench_telemetry_run=outputs/cli/tune-comparison/bench-telemetry-20260515-001729
+bench_telemetry=D3 best, AR 24.44 tok/s, D1 41.85, D2 48.25, D3 54.48, 2.23x AR
+
+conclusion=bench wrapper is not materially slower when telemetry is disabled; telemetry run also stayed effectively identical on this short check
+fan_restore=thermalforge status after runs showed both fans in auto mode
+```
+
+Validation:
+
+```text
+python3 -m compileall -q mtplx tests -> pass
+uv run --extra dev python -m pytest tests/test_public_cli.py -q -> pass
+uv run --extra dev python -m ruff check mtplx/commands/public.py mtplx/cli.py tests/test_public_cli.py -> pass
+git diff --check -> pass
+uv run --extra dev python -m build -> pass
+uv run --extra dev python -m twine check dist/* -> pass
+global install=/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --force-reinstall --no-deps dist/mtplx-0.3.6-py3-none-any.whl
+global smoke=mtplx --version -> mtplx 0.3.6 (0.3.6)
+global dry-run=mtplx bench tune --dry-run --no-telemetry --json shows configured model path, telemetry-disabled description, and verified-default mismatch note
+```

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,49 @@
 # MTPLX Release Log
 
+## 2026-05-14 23:47 BST - v0.3.6 Bench Tune Hardware Telemetry
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+trigger=user reported mtplx bench tune was not diagnostic enough for M3/M4/M5 chip behavior; wanted MX Power Gadget-style power, temperature, frequency, and utilization during AR/D1/D2/D3 tests
+public_release_done=false
+```
+
+Implementation:
+
+```text
+bench_tune_telemetry=enabled only for mtplx bench tune, not normal mtplx tune
+candidate_scope=each isolated candidate subprocess gets its own telemetry sampler and row-level JSON summary
+powermetrics_fields=package/cpu/gpu/ane watts, P/M/GPU GHz, P/M/GPU utilization, thermal pressure
+thermalforge_fields=fan RPM plus CPU/core and GPU temperature summaries with latest raw sensor values
+human_output=per-candidate progress and verbose results now include power/frequency/temp/utilization/fan samples
+fallback_policy=if powermetrics is unavailable or sudo -n is not configured, bench tune still reports thermalforge temps/fans and records the reason
+```
+
+Validation:
+
+```text
+python3 -m py_compile mtplx/commands/public.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m ruff check mtplx/commands/public.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m pytest tests/test_public_cli.py -q -> pass
+uv run --extra dev python -m pytest tests/test_default_models.py -q -> pass
+uv run --extra dev python -m pytest tests/test_onboarding.py::test_quickstart_applies_saved_tuned_depth tests/test_onboarding.py::test_quickstart_tuning_prompt_can_save_and_apply tests/test_onboarding.py::test_quickstart_explicit_depth_never_uses_tuning -q -> pass
+git diff --check -> pass
+non_model_probe=thermalforge and powermetrics parsers returned watts/GHz/C/utilization/fan fields on this Mac
+real_short_bench_tune=MTPLX_TUNE_STATE=/tmp/mtplx-bench-tune-telemetry-state.json uv run --extra dev python -m mtplx.cli bench tune --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --limit 1 --max-tokens 16 --depths 1 --retune --no-save --run-id telemetry-smoke-20260514 --output-dir /tmp/mtplx-bench-tune-telemetry --yes
+real_short_result=AR 16.98 tok/s; D1 24.30 tok/s; output printed package/cpu/ane/gpu watts, P/M/GPU GHz, core/GPU temps, P/M/GPU utilization, fan RPM, and sample counts for both candidates
+thermal_restore=post-run thermalforge status fan_modes auto/auto
+uv run --extra dev python -m build -> pass; rebuilt dist/mtplx-0.3.6.tar.gz and dist/mtplx-0.3.6-py3-none-any.whl
+uv run --extra dev python -m twine check dist/* -> pass
+/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --force-reinstall --no-deps dist/mtplx-0.3.6-py3-none-any.whl -> pass
+global_mtplx_version=mtplx 0.3.6
+global_real_short_bench_tune=MTPLX_TUNE_STATE=/tmp/mtplx-bench-tune-global-telemetry-state.json mtplx bench tune --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --limit 1 --max-tokens 8 --depths 1 --retune --no-save --run-id global-telemetry-smoke-20260514 --output-dir /tmp/mtplx-bench-tune-global-telemetry --yes
+global_real_short_result=AR 13.42 tok/s; D1 17.41 tok/s; global PATH output printed power/frequency/temp/utilization/fan telemetry for both candidates
+global_thermal_restore=post-run thermalforge status fan_modes auto/auto
+```
+
 ## 2026-05-14 23:31 BST - v0.3.6 Onboarding Regression Fix Before User Test
 
 Scope:

--- a/LOG.md
+++ b/LOG.md
@@ -43,6 +43,51 @@ mtplx start cli --dry-run --json -> model=/Users/youssof/.mtplx/hf-upload/Qwen3.
 global pseudo-tty mtplx start --fresh -> Step 1 shows Q4 target + Q4 MTP, no BF16, no missing/download prompt, CLI selected, Step 4 Tune prompt appears before model chat starts
 ```
 
+## 2026-05-14 23:55 BST - v0.3.6 Tune UX And Served Model-Id Regression Fix
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+trigger=user-tested mtplx start from home directory; Tune appeared to hang silently after fan ramp, then printed n/a for every candidate and "tuning did not finish"; server banner mislabeled the installed speed artifact as mtplx-qwen36-27b-optimized-quality
+public_release_done=false
+```
+
+Root cause:
+
+```text
+tune_artifacts=_cmd_tune built output_root as a relative path from the caller cwd, but _run_tune_candidates launched subprocesses with cwd=repo_root; child candidate outputs were therefore addressed relative to a different directory, so the parent could not see the artifacts
+tune_ux=_run_tune_candidates captured child stdout and printed no per-candidate progress, making isolated model-load/timing work look frozen after fan ramp
+tune_error_copy=all-missing candidate artifacts were summarized as "No MTP depth beat AR" instead of an actual Tune failure with log paths
+served_model_id=_public_model_id_from_metadata treated any 8-bit layer inside the quantization config as Optimized Quality; the installed speed artifact is mixed Q4/Q8, so the server banner incorrectly said optimized-quality
+```
+
+Fix:
+
+```text
+tune_paths=normalize Tune output_dir/output/candidate paths to absolute user paths before spawning candidate subprocesses
+tune_progress=print artifacts path and AR/D1/D2/D3 per-candidate start/finish/fail lines to stderr during Tune
+tune_errors=report candidate artifact failures as Tune failures with log paths; quickstart now says "tuning failed; using default depth"
+served_model_id=classify mixed Q4/Q8 metadata as Optimized Speed and all-INT8/Flat8 metadata as Optimized Quality; verified_on.model speed metadata also maps to Optimized Speed
+```
+
+Validation:
+
+```text
+python3 -m py_compile mtplx/default_models.py mtplx/commands/public.py tests/test_default_models.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m ruff check mtplx/default_models.py mtplx/commands/public.py tests/test_default_models.py tests/test_public_cli.py -> pass
+uv run --extra dev python -m pytest tests/test_default_models.py tests/test_public_cli.py::test_tune_candidate_outputs_are_absolute_from_non_repo_cwd tests/test_public_cli.py::test_tune_human_reports_candidate_errors_instead_of_false_no_win tests/test_public_cli.py::test_serve_uses_quality_public_model_id_for_quality_local_path tests/test_public_cli.py::test_serve_uses_legacy_public_model_id_for_legacy_optimized_local_path -q -> pass
+uv run --extra dev python -m pytest tests/test_onboarding.py tests/test_public_cli.py -q -> pass
+uv run python -m mtplx.cli start web --dry-run --json --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --yes -> openwebui.model_id=mtplx-qwen36-27b-optimized-speed
+uv run --extra dev python -m build -> pass; rebuilt dist/mtplx-0.3.6.tar.gz and dist/mtplx-0.3.6-py3-none-any.whl
+uv run --extra dev python -m twine check dist/* -> pass
+/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --force-reinstall --no-deps dist/mtplx-0.3.6-py3-none-any.whl -> pass
+from_home_global_dry_run=mtplx tune --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --dry-run --run-id smoke-path --output-dir /tmp/mtplx-tune-from-home-check -> candidate --_candidate-output paths are absolute under /tmp/mtplx-tune-from-home-check/smoke-path
+from_home_real_short_tune=MTPLX_TUNE_STATE=/tmp/mtplx-tune-home-real-state.json mtplx tune --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --limit 1 --max-tokens 32 --depths 1 --seed 0 --retune --no-save --run-id home-real-smoke --output-dir /tmp/mtplx-tune-home-real --yes -> AR=20.25 tok/s, D1=30.31 tok/s, best=D1 1.50x, artifacts written under /tmp/mtplx-tune-home-real/home-real-smoke, no n/a rows
+thermalforge post-run status -> fans mode=auto actual=0 target=0
+```
+
 ## 2026-05-14 22:05 BST - v0.3.6 Release Candidate Assembly
 
 Scope:

--- a/LOG.md
+++ b/LOG.md
@@ -379,3 +379,44 @@ global install=/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --for
 global smoke=mtplx --version -> mtplx 0.3.6 (0.3.6)
 global dry-run=mtplx bench tune --dry-run --no-telemetry --json shows configured model path, telemetry-disabled description, and verified-default mismatch note
 ```
+
+## 2026-05-15 00:34 BST - Bench Tune Generation-Window Telemetry Fix, No Public Release
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+user_gate=no merge, tag, GitHub release, PyPI, or Homebrew publish until user approves
+problem=bench tune telemetry showed misleading low GPU utilization because parent-side samples covered subprocess setup/teardown and one tail-idle powermetrics sample could land inside the old broad window
+```
+
+Fix:
+
+```text
+mtp_depth_sweep rows now include generation_started_at, generation_ended_at, and generation_window_s
+bench tune telemetry now reports scope=generation when powermetrics/thermalforge samples land inside the actual generation window
+scope=candidate is still shown when no generation-window sample is available, so the output does not pretend broad telemetry is generation telemetry
+powermetrics samples are timestamped at the midpoint of the actual telemetry capture, preventing end-of-generation idle samples from dragging D3 GPU utilization down
+```
+
+Real verification on `/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized`:
+
+```text
+command=uv run --extra dev python -m mtplx.cli bench tune --model /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized --limit 1 --max-tokens 192 --depths 1,2,3 --seed 0 --retune --no-save --yes --output-dir outputs/cli/tune-comparison --run-id bench-generation-midpoint-20260515-003100
+artifact=outputs/cli/tune-comparison/bench-generation-midpoint-20260515-003100/tune.json
+AR=24.52 tok/s, telemetry scope=generation, gpu=15.7W, GPU=98.9%, samples=5, window=7.8s
+D1=41.95 tok/s, telemetry scope=generation, gpu=53.1W, GPU=97.8%, samples=3, window=4.6s
+D2=48.51 tok/s, telemetry scope=generation, gpu=53.5W, GPU=81.3%, samples=3, window=4.0s
+D3=54.51 tok/s, telemetry scope=generation, gpu=72.0W, GPU=98.4%, samples=2, window=3.5s
+fan_restore=thermalforge status after run showed both fans in auto mode
+```
+
+Validation:
+
+```text
+python3 -m compileall -q mtplx tests -> pass
+uv run --extra dev python -m pytest tests/test_public_cli.py tests/test_mtp_depth_sweep.py -q -> pass
+uv run --extra dev python -m ruff check mtplx/benchmarks/runners/mtp_depth_sweep.py mtplx/commands/public.py tests/test_public_cli.py -> pass
+git diff --check -> pass
+```

--- a/LOG.md
+++ b/LOG.md
@@ -420,3 +420,39 @@ uv run --extra dev python -m pytest tests/test_public_cli.py tests/test_mtp_dept
 uv run --extra dev python -m ruff check mtplx/benchmarks/runners/mtp_depth_sweep.py mtplx/commands/public.py tests/test_public_cli.py -> pass
 git diff --check -> pass
 ```
+
+## 2026-05-15 00:45 BST - Release Copy Honesty Pass
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+user_gate=user approved continuing to public release, with production gates still required before publish
+public_state=GitHub/PyPI/Homebrew latest all still v0.3.5 / 0.3.5
+target_version=0.3.6
+```
+
+Changes:
+
+```text
+README no longer calls the 2.24x multiplier hardware-independent; it now says paired same-machine multiplier and tells users to run Tune on their own Mac
+README now documents bench tune generation-window telemetry scope
+CHANGELOG v0.3.6 now includes bench tune model-source warning, --no-telemetry, and generation-window telemetry fixes
+```
+
+Verification:
+
+```text
+python3 -m compileall -q mtplx tests scripts -> pass
+uv run --extra dev python -m ruff check -> pass
+uv run --extra dev python -m pytest -q -> pass
+uv run --extra dev python -m twine check dist/* -> pass
+scripts/fresh_venv_smoke.sh -> pass
+git diff --check -> pass
+mtplx --version -> mtplx 0.3.6 (0.3.6)
+mtplx start opencode --dry-run --json --model models/example --yes -> pass
+mtplx start pi --dry-run --json --model models/example --yes -> pass
+mtplx-tune --model models/not-loaded-in-dry-run --dry-run --yes -> pass
+mtplx bench tune --model models/not-loaded-in-dry-run --dry-run --json --yes --no-telemetry -> pass
+```

--- a/LOG.md
+++ b/LOG.md
@@ -1,0 +1,155 @@
+# MTPLX Release Log
+
+## 2026-05-14 22:05 BST - v0.3.6 Release Candidate Assembly
+
+Scope:
+
+```text
+branch=codex/release-v0.3.6
+base=origin/main 253e7ebd50ddc79e684a775ab85402c43b4702e2
+target_version=0.3.6
+release_contract=protect decode TPS, prefill/TTFT, memory, and CLI UX together
+```
+
+Integrated slices:
+
+```text
+memory=dynamic initial paged-KV new-token reserve for huge max_tokens; anonymous no-reuse sessions do not keep live full-capacity cache refs; high-RAM MLX Metal caps remain a safety rail
+opencode=tool-result turns reuse stable SessionBank prefixes; Qwen XML tool-call arguments are emitted as schema-typed OpenAI tool-call JSON
+tune=mtplx tune, mtplx-tune, bench tune; AR remains the 1.00x baseline; D1/D2/D3 run in isolated subprocesses; losing depths are not saved
+cli_ux=Tune added to public help/parser, first-run Web UI can offer tuning, start/pi/opencode/swival surfaces preserved
+```
+
+Focused validation completed before full release QA:
+
+```text
+python3 -m py_compile mtplx/cli.py mtplx/commands/public.py mtplx/ui/onboarding.py mtplx/config.py mtplx/thermal.py mtplx/benchmarks/runners/mtp_depth_sweep.py tests/test_public_cli.py tests/test_onboarding.py tests/test_config.py tests/test_thermal.py
+uv run --extra dev python -m ruff check mtplx/cli.py mtplx/commands/public.py mtplx/ui/onboarding.py mtplx/config.py mtplx/thermal.py mtplx/benchmarks/runners/mtp_depth_sweep.py tests/test_public_cli.py tests/test_onboarding.py tests/test_config.py tests/test_thermal.py
+uv run --extra dev python -m pytest tests/test_config.py tests/test_thermal.py tests/test_public_cli.py tests/test_onboarding.py -q
+uv run python -m mtplx.cli tune --model models/not-loaded-in-dry-run --dry-run --yes
+uv run python -m mtplx.cli bench tune --model models/not-loaded-in-dry-run --dry-run --json --yes
+```
+
+Open items before publish:
+
+```text
+full_static_package_cli_qa=pending
+real_tune_gate=pending
+aime20_memory_gate=pending
+coding_control_gate=pending
+opencode_cli_gate=pending
+m3_ultra_512gb_target_gate=pending
+pypi_homebrew_publish=pending
+```
+
+## 2026-05-14 22:44 BST - v0.3.6 Candidate QA, No Public Release
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+base_commit=253e7ebd50ddc79e684a775ab85402c43b4702e2
+user_gate=no merge, tag, GitHub release, PyPI, or Homebrew publish until user tests and approves
+machine=Apple M5 Max, 128 GB unified memory
+model=/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized
+server_profile=sustained max native-MTP
+```
+
+Static/package gates:
+
+```text
+python3 -m compileall -q mtplx tests scripts -> pass
+uv run --extra dev python -m ruff check -> pass
+uv run --extra dev python -m pytest -q -> pass
+git diff --check -> pass
+uv run --extra dev python -m build -> built dist/mtplx-0.3.6.tar.gz and dist/mtplx-0.3.6-py3-none-any.whl
+uv run --extra dev python -m twine check dist/* -> pass
+scripts/fresh_venv_smoke.sh -> pass
+fresh wheel no-deps CLI smoke -> mtplx --version 0.3.6, mtplx-tune dry-run pass, bench tune dry-run JSON pass
+```
+
+Tune regression found and fixed:
+
+```text
+first_real_tune_gate=failed
+failure=mtplx.benchmarks.runners.mtp_depth_sweep imported scripts.probe_draft_lm_head_requant, which is not packaged in the release checkout
+fix=use mtplx.draft_lm_head._install_draft_lm_head from package code; update scripts/probe_mx_compile_buckets.py compatibility import
+test_added=tests/test_mtp_depth_sweep.py::test_depth_sweep_uses_packaged_draft_lm_head_helper
+focused_gate=py_compile + ruff + pytest tests/test_mtp_depth_sweep.py -> pass
+```
+
+Real AIME-shaped memory gate on this M5 Max:
+
+```text
+command=scripts/aime_shape_memory_bench.py run --suite aime10 --repeat 2 --limit 20 --max-tokens 65536 --temperature 0 --disable-thinking --prompt-mode answer-only
+artifact=outputs/release-v0.3.6/253e7eb-dirty-m5max/after/aime20/after-aime10-summary.json
+requests=20
+decode_tok_s_mean=39.6237
+ttft_s_mean=0.1758
+prefill_tok_s_mean=346.6311
+completion_tokens_total=64
+process_rss_bytes_max=21357150208
+process_rss_bytes_slope_per_request=753664
+peak_memory_bytes_max=22779758600
+dynamic_requested_new_tokens_max=65536
+dynamic_reserved_new_tokens_max=16384
+dynamic_reservation_capped_count=20
+session_keep_live_ref_values=False
+result=bounded locally; no hundreds-of-GB growth on this M5 Max run
+```
+
+Real coding-control gate on this M5 Max:
+
+```text
+command=scripts/aime_shape_memory_bench.py run --suite coding3 --limit 3 --max-tokens 4096 --temperature 0 --disable-thinking
+artifact=outputs/release-v0.3.6/253e7eb-dirty-m5max/after/coding3/after-coding3-summary.json
+requests=3
+decode_tok_s_mean=44.7730
+ttft_s_mean=0.2173
+prefill_tok_s_mean=271.2125
+completion_tokens_total=2445
+dynamic_reserved_new_tokens_max=4096
+dynamic_reservation_capped_count=0
+process_rss_bytes_max=21357871104
+process_rss_bytes_slope_per_request=188416
+session_keep_live_ref_values=False
+result=normal max_tokens path did not get capped and memory slope stayed flat locally
+```
+
+Real OpenCode CLI gate:
+
+```text
+opencode_binary=/opt/homebrew/bin/opencode
+project=/tmp/mtplx-v036-opencode-project
+config_home=/tmp/mtplx-v036-opencode-home
+command=opencode run --model mtplx/mtplx-qwen36-27b-optimized --format json --dangerously-skip-permissions "Create a file named hello_mtplx.txt..."
+artifact=outputs/release-v0.3.6/253e7eb-dirty-m5max/after/opencode-run.jsonl
+file_created=/tmp/mtplx-v036-opencode-project/hello_mtplx.txt
+file_contents="MTPLX OpenCode QA v0.3.6"
+tool_result_turn=session_cache_hit true; session_restore_mode reference_lease; request_session_source pending_postcommit_near_prefix; postcommit_wait completed
+result=OpenCode tool-result turn reused SessionBank instead of cold-prefilling the 10.7k-token history
+```
+
+Real Tune gate:
+
+```text
+command=MTPLX_TUNE_STATE=outputs/release-v0.3.6/253e7eb-dirty-m5max/after/tune/tuning-state.json mtplx tune --limit 1 --max-tokens 192 --depths 1,2,3 --seed 0 --retune
+artifact=outputs/release-v0.3.6/253e7eb-dirty-m5max/after/tune/tune-summary-rerun.json
+thermal=max-fan verified before child model loads; restore ok; post-run max status auto with no marker
+AR=24.5833 tok/s, 1.00x
+D1=41.5 tok/s, 1.69x
+D2=46.2 tok/s, 1.88x
+D3=49.8756 tok/s, 2.03x, best
+saved=true
+cache_check=second run without --retune reused saved tuning cleanly
+```
+
+Important non-claims / blockers:
+
+```text
+public_release_done=false
+m3_ultra_512gb_target_gate=not run on this machine; still required before public memory claim against Ivan's failure class
+before_v0.3.5_comparison=not rerun locally in this pass; candidate evidence is local after/fix evidence plus production-path behavior
+mlx_fast_fork=not active in this venv (stock MLX 0.31.2 observed), so local speed numbers are QA evidence, not public headline-speed proof
+```

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,48 @@
 # MTPLX Release Log
 
+## 2026-05-14 23:31 BST - v0.3.6 Onboarding Regression Fix Before User Test
+
+Scope:
+
+```text
+worktree=/Users/youssof/Documents/MTPLX-release/mtplx-v0.3.6
+branch=codex/release-v0.3.6
+trigger=user-tested global mtplx start wizard and found the verified default labeled BF16, prompting a download despite the local Optimized Speed artifact, and missing the CLI Tune offer
+public_release_done=false
+```
+
+Root cause:
+
+```text
+default_model_metadata=stale v0.3.0 BF16 wording still labeled the current Optimized Speed default as BF16 on M3/M4/M5-class Macs
+default_model_resolution=select_default_model returned the Hugging Face repo id even when /Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized was already installed and complete
+cli_tune_prompt=_quickstart_apply_tuned_depth returned immediately for target=terminal, so first-run Tune was offered only for Web UI
+```
+
+Fix:
+
+```text
+speed_default_label=Q4 target with Q4 MTP sidecar
+local_speed_preference=prefer complete local Optimized Speed artifacts from ~/.mtplx/hf-upload, ~/.mtplx/models, and repo-local models before the HF mirror
+legacy_bf16_env_alias=MTPLX_DEFAULT_MODEL_VARIANT=bf16 remains accepted but maps to optimized speed and no longer prints BF16 to users
+cli_tune_prompt=first-run Tune offer now applies to CLI/terminal as well as Web UI
+tests_added_or_updated=default speed local preference, no BF16 label, legacy alias behavior, verified legacy local path, terminal Tune application
+```
+
+Validation:
+
+```text
+python3 -m py_compile mtplx/default_models.py mtplx/commands/public.py mtplx/ui/onboarding.py tests/test_default_models.py tests/test_onboarding.py -> pass
+uv run --extra dev python -m ruff check mtplx/default_models.py mtplx/commands/public.py mtplx/ui/onboarding.py tests/test_default_models.py tests/test_onboarding.py -> pass
+uv run --extra dev python -m pytest tests/test_default_models.py tests/test_onboarding.py -q -> pass
+uv run --extra dev python -m build -> pass; rebuilt dist/mtplx-0.3.6.tar.gz and dist/mtplx-0.3.6-py3-none-any.whl
+uv run --extra dev python -m twine check dist/* -> pass
+/opt/homebrew/opt/python@3.14/bin/python3.14 -m pip install --force-reinstall --no-deps dist/mtplx-0.3.6-py3-none-any.whl -> pass
+mtplx --version -> mtplx 0.3.6
+mtplx start cli --dry-run --json -> model=/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized; download_if_missing=false; precision=Q4 target with Q4 MTP sidecar
+global pseudo-tty mtplx start --fresh -> Step 1 shows Q4 target + Q4 MTP, no BF16, no missing/download prompt, CLI selected, Step 4 Tune prompt appears before model chat starts
+```
+
 ## 2026-05-14 22:05 BST - v0.3.6 Release Candidate Assembly
 
 Scope:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include CITATION.cff
+include CHANGELOG.md
+include LOG.md
+recursive-include scripts *.py *.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ mtplx tune --model /path/to/model --retune
 
 Tune compares AR, D1, D2, and D3 with thinking disabled, keeps AR as the `1.00x`
 baseline, and only saves a recommendation when an MTP depth is actually faster.
+For hardware diagnosis, `mtplx bench tune` prints and saves per-candidate
+power, frequency, temperature, utilization, fan, and thermal-pressure telemetry
+when `thermalforge` and macOS `powermetrics` are available.
 
 ---
 
@@ -65,7 +68,7 @@ baseline, and only saves a recommendation when an MTP depth is actually faster.
   - `Stable` — hidden compatibility flag (`--profile stable` / `--profile safe`) for the exact/staged long-reply path.
 - **Crash-safe fan control.** When Sustained Max or Burst is on, MTPLX spawns a detached watchdog that restores fans to auto if the parent dies for any reason — including `kill -9` and "I closed the terminal". Verified live on hardware.
 - **Idle-aware fan-backed modes.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
-- **Per-Mac Tune.** `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` compare AR/D1/D2/D3 in isolated subprocesses and persist the winning depth per model, hardware, software, and settings. If no MTP depth beats AR, nothing worse is saved.
+- **Per-Mac Tune.** `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` compare AR/D1/D2/D3 in isolated subprocesses and persist the winning depth per model, hardware, software, and settings. If no MTP depth beats AR, nothing worse is saved. `mtplx bench tune` also records MX Power Gadget-style power, frequency, temperature, utilization, fan, and thermal-pressure telemetry per candidate for chip-level diagnosis.
 - **Four-tier model compatibility contract.** `mtplx inspect <model>` reports: verified / arch-compatible-unverified / incompatible-architecture / no-MTP. No silent garbage runs.
 - **Lazy imports.** `mtplx --help`, `doctor`, `inspect`, `init`, `setup` work on a fresh venv *without MLX installed*. Generation and serving pull in MLX only when needed.
 - **v0.3.6 memory, Tune, and OpenCode fixes.** Large `max_tokens` one-off requests no longer reserve the full decode KV window up front, anonymous no-reuse sessions do not retain full-capacity live cache refs, OpenCode tool-result turns reuse the stable cached prefix instead of cold-prefilling the full history, and Tune is available from the packaged CLI.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **~2.24× over no-MTP AR at `temp=0.6`** on Qwen3.6-27B · math-correct rejection sampling · MLX-native · zero external drafter
 
-<sub>Multiplier is hardware-independent. Absolute tok/s scales with memory bandwidth — current public record on M5 Max: **63.056 / 62.886 tok/s** D3, [`Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`](https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed).</sub>
+<sub>Multiplier is measured in paired same-machine runs. Absolute tok/s scales with memory bandwidth — current public record on M5 Max: **63.056 / 62.886 tok/s** D3, [`Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`](https://huggingface.co/Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed).</sub>
 
 [![CI](https://github.com/youssofal/mtplx/actions/workflows/ci.yml/badge.svg)](https://github.com/youssofal/mtplx/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/mtplx?label=PyPI)](https://pypi.org/project/mtplx/)
@@ -46,7 +46,9 @@ Tune compares AR, D1, D2, and D3 with thinking disabled, keeps AR as the `1.00x`
 baseline, and only saves a recommendation when an MTP depth is actually faster.
 For hardware diagnosis, `mtplx bench tune` prints and saves per-candidate
 power, frequency, temperature, utilization, fan, and thermal-pressure telemetry
-when `thermalforge` and macOS `powermetrics` are available.
+when `thermalforge` and macOS `powermetrics` are available. Telemetry is labeled
+as `scope=generation` when samples land inside the actual generation window;
+otherwise it is reported as broader candidate-process telemetry.
 
 ---
 
@@ -54,7 +56,7 @@ when `thermalforge` and macOS `powermetrics` are available.
 
 - **Native MTP speculative decoding.** Built-in MTP heads, no external drafter, no RAM hit for a second model.
 - **Math-correct sampling at T=0.6.** Probability-ratio acceptance with residual correction. Verified `max_diff = 0.0` against reference single-token AR on the verified Qwen3.6-27B path.
-- **~2.24× over no-MTP AR at `temp=0.6`.** The hardware-independent number, which the CLI reports as `mean_speedup_vs_ar`. Verified contract on the public default `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`: `63.056 / 62.886 tok/s` MTP-D3 vs `28.156 tok/s` no-MTP AR, on Apple Silicon M5 Max with `--max` fans, target sampler `temp=0.6 top_p=0.95 top_k=20`, draft sampler `temp=0.70`. Absolute tok/s scales with memory bandwidth; the 2.24× multiplier doesn't.
+- **~2.24× over no-MTP AR at `temp=0.6`.** This is a paired same-machine multiplier, which the CLI reports as `mean_speedup_vs_ar`. Verified contract on the public default `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`: `63.056 / 62.886 tok/s` MTP-D3 vs `28.156 tok/s` no-MTP AR, on Apple Silicon M5 Max with `--max` fans, target sampler `temp=0.6 top_p=0.95 top_k=20`, draft sampler `temp=0.70`. Absolute tok/s scales with memory bandwidth.
 - **Real serving surface.** OpenAI-compatible `/v1/chat/completions` + `/v1/completions` + `/v1/models`, Anthropic-compatible `/v1/messages` (streaming SSE), `/health`, `/metrics`. Plug it into Pi, Open WebUI, OpenClaw, Claude Code, Cline, Continue, or anything that speaks OpenAI.
 - **Agent tool calls.** OpenAI-style `tools` / `tool_choice`, structured `message.tool_calls`, streaming `delta.tool_calls`, and tool-result history are supported so agent clients execute tools instead of printing Qwen tool markup.
 - **In-browser chat UI** with auto-detected model context (256k for Qwen3.6), live tokens-per-second, markdown rendering, code-block copy buttons, a stop button, an MTP on/off toggle, and a settings sidebar that persists per-machine.
@@ -68,7 +70,7 @@ when `thermalforge` and macOS `powermetrics` are available.
   - `Stable` — hidden compatibility flag (`--profile stable` / `--profile safe`) for the exact/staged long-reply path.
 - **Crash-safe fan control.** When Sustained Max or Burst is on, MTPLX spawns a detached watchdog that restores fans to auto if the parent dies for any reason — including `kill -9` and "I closed the terminal". Verified live on hardware.
 - **Idle-aware fan-backed modes.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
-- **Per-Mac Tune.** `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` compare AR/D1/D2/D3 in isolated subprocesses and persist the winning depth per model, hardware, software, and settings. If no MTP depth beats AR, nothing worse is saved. `mtplx bench tune` also records MX Power Gadget-style power, frequency, temperature, utilization, fan, and thermal-pressure telemetry per candidate for chip-level diagnosis.
+- **Per-Mac Tune.** `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` compare AR/D1/D2/D3 in isolated subprocesses and persist the winning depth per model, hardware, software, and settings. If no MTP depth beats AR, nothing worse is saved. `mtplx bench tune` also records MX Power Gadget-style power, frequency, temperature, utilization, fan, and thermal-pressure telemetry per candidate for chip-level diagnosis, with generation-window scope when available.
 - **Four-tier model compatibility contract.** `mtplx inspect <model>` reports: verified / arch-compatible-unverified / incompatible-architecture / no-MTP. No silent garbage runs.
 - **Lazy imports.** `mtplx --help`, `doctor`, `inspect`, `init`, `setup` work on a fresh venv *without MLX installed*. Generation and serving pull in MLX only when needed.
 - **v0.3.6 memory, Tune, and OpenCode fixes.** Large `max_tokens` one-off requests no longer reserve the full decode KV window up front, anonymous no-reuse sessions do not retain full-capacity live cache refs, OpenCode tool-result turns reuse the stable cached prefix instead of cold-prefilling the full history, and Tune is available from the packaged CLI.
@@ -150,7 +152,7 @@ The math-correctness wedge is real. At `temperature=0.6`, the difference between
 
 **Verified evidence (current public default `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`):**
 - **~2.24× over matched no-MTP AR at `temp=0.6`** on Apple Silicon M5 Max: `63.056 / 62.886 tok/s` MTP-D3 paired runs vs `28.156 tok/s` no-MTP AR, same machine, same target sampler (`temp=0.6 top_p=0.95 top_k=20`), draft sampler `temp=0.70 top_p=0.95 top_k=20`, performance-cold profile, fans pinned by `--max`, thinking mode off. Recorded in `mtplx_runtime.json` under the model.
-- The multiplier is what the CLI reports as `mean_speedup_vs_ar`. Absolute tok/s above is M5-Max-with-614-GB/s-bandwidth-specific; if your Mac is slower you keep the **2.24×** ratio, the absolute number drops with bandwidth.
+- The multiplier is what the CLI reports as `mean_speedup_vs_ar` for a paired same-machine run. Absolute tok/s above is M5-Max-with-614-GB/s-bandwidth-specific; slower memory bandwidth lowers the absolute number, and users should run `mtplx tune` / `mtplx bench tune` to measure their own Mac.
 - Per-position acceptance on the recorded prompt: `[100%, 97.96%, 93.88%]` at D3 (corrections=3 over 49 verify calls).
 - Distribution exactness vs reference single-token AR: `max_diff = 0.0`. Greedy diagnostic on the same cleaned window: `60.108 tok/s`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![PyPI](https://img.shields.io/pypi/v/mtplx?label=PyPI)](https://pypi.org/project/mtplx/)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![macOS Apple Silicon](https://img.shields.io/badge/macOS-Apple%20Silicon-black?logo=apple)](https://developer.apple.com/metal/)
-[![Status](https://img.shields.io/badge/status-v0.3.5-blue)](CHANGELOG.md)
+[![Status](https://img.shields.io/badge/status-v0.3.6-blue)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](LICENSE)
 
 </div>
@@ -36,6 +36,15 @@ The Homebrew installer sets up the `mtplx` command in `/opt/homebrew/bin` and bo
 
 That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`), runtime mode (Sustained / Sustained Max / Burst), and surface (browser chat at `127.0.0.1:8000/`, terminal chat, Pi, OpenCode, or Swival) on first run. On every subsequent run it asks "same as last time?" so you're one keypress from chatting.
 
+For a measured depth choice on your own Mac, run:
+
+```bash
+mtplx tune --model /path/to/model --retune
+```
+
+Tune compares AR, D1, D2, and D3 with thinking disabled, keeps AR as the `1.00x`
+baseline, and only saves a recommendation when an MTP depth is actually faster.
+
 ---
 
 ## What you get
@@ -56,9 +65,10 @@ That's it. The wizard handles the default speed model (`Youssofal/Qwen3.6-27B-MT
   - `Stable` — hidden compatibility flag (`--profile stable` / `--profile safe`) for the exact/staged long-reply path.
 - **Crash-safe fan control.** When Sustained Max or Burst is on, MTPLX spawns a detached watchdog that restores fans to auto if the parent dies for any reason — including `kill -9` and "I closed the terminal". Verified live on hardware.
 - **Idle-aware fan-backed modes.** Server tracks request activity; after 15 minutes of no chat, fans drop to auto, then ramp back up on the next message.
+- **Per-Mac Tune.** `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` compare AR/D1/D2/D3 in isolated subprocesses and persist the winning depth per model, hardware, software, and settings. If no MTP depth beats AR, nothing worse is saved.
 - **Four-tier model compatibility contract.** `mtplx inspect <model>` reports: verified / arch-compatible-unverified / incompatible-architecture / no-MTP. No silent garbage runs.
 - **Lazy imports.** `mtplx --help`, `doctor`, `inspect`, `init`, `setup` work on a fresh venv *without MLX installed*. Generation and serving pull in MLX only when needed.
-- **v0.3.5 OpenCode agent fixes.** Tool-result turns now reuse the stable cached prefix instead of cold-prefilling the full OpenCode history, unsafe stream postcommit anchoring is fixed, and consecutive XML tool-call regressions are locked down.
+- **v0.3.6 memory, Tune, and OpenCode fixes.** Large `max_tokens` one-off requests no longer reserve the full decode KV window up front, anonymous no-reuse sessions do not retain full-capacity live cache refs, OpenCode tool-result turns reuse the stable cached prefix instead of cold-prefilling the full history, and Tune is available from the packaged CLI.
 
 > **Release honesty.** Burst is the old fan-backed headline lane and is capped in the UI at short contexts only. Sustained is the explicit long-context memory-safety lane; it is not an AR downgrade. Long no-fan decode decay remains a future runtime track; see [Roadmap](#roadmap).
 
@@ -86,6 +96,7 @@ mtplx start cli                             # terminal chat directly
 mtplx start pi                              # configure Pi and start MTPLX for Pi
 mtplx start opencode                        # configure OpenCode Desktop
 mtplx start swival                          # print the Swival generic-provider handoff
+mtplx tune --model /path/to/model --retune  # compare AR/D1/D2/D3 and save a real winner
 mtplx start cli --no-mtp                    # target-only AR generation
 mtplx start --profile sustained             # long-context native-MTP mode
 mtplx start --max                           # Sustained Max browser chat with fan boost
@@ -203,6 +214,8 @@ mtplx init                  # write ~/.mtplx/config.toml
 mtplx setup                 # download verified model, prepare cache
 mtplx pull                  # download the default HF model safely
 mtplx models                # cached models, validation, size, delete command
+mtplx tune                  # compare AR/D1/D2/D3; saves only a depth that beats AR
+mtplx-tune                  # same Tune command as a dedicated console script
 mtplx run "..."             # one-shot ask
 mtplx chat                  # terminal chat
 mtplx start                 # OpenAI/Anthropic-compatible server
@@ -223,9 +236,9 @@ The architectural achievement is **a single-model native-MTP runtime that's math
 
 ### 0. MLX runtime layer (the kernel stack we own)
 
-MTPLX is not a thin wrapper over stock MLX — the speed lane sits on top of an **MLX source fork** plus a small set of **custom Metal kernels** registered as primitives. Stock `mlx-lm` cannot reproduce the multiplier above; the runtime layer is what makes the speculative cycle in §2 tractable on Apple Silicon.
+MTPLX is not a thin wrapper over stock MLX. The recorded speed lane was measured with the runtime environment described below plus custom Metal kernels registered as primitives. Public wheels do not silently bundle an extra MLX fork; `mtplx doctor --deep --json` reports whether an optional fast MLX fork is active on the user's machine. Treat the fork details here as measured-environment evidence, not an install-time promise that every package manager has replaced MLX under you.
 
-What we changed at the MLX source level (fork: `mlx-mtplx-0.31.2-qmm`, commit `2377a99f` "Tune small-M qmv for MTPLX 60TPS path"):
+Measured MLX source-level environment for the public record (optional fork: `mlx-mtplx-0.31.2-qmm`, commit `2377a99f` "Tune small-M qmv for MTPLX 60TPS path"):
 
 - **Small-M `qmv` retuning.** The verify forward is dominated by quantized-matrix-vector ops at `M ≈ 3..6` (one position per accepted draft). Stock MLX's `qmv_fast_impl` is tuned for large M and stalls dispatch at small M. Our fork: `BN16` group-size, **4-simdgroup** instead of 2-simdgroup, `unroll_count(4)` on the inner loop. Cuts the verify-MLP region by enough to be the difference between "MTP loses to AR" and "MTP at ~2.24×".
 - **Source-primitive registration.** Custom kernels (below) are registered through `mlx.core.fast.metal_kernel` and integrated into MLX's graph the same way stock primitives are, so `mx.compile` can fuse around them and `mx.eval` doesn't see them as opaque blocks.

--- a/mtplx/benchmarks/runners/mtp_depth_sweep.py
+++ b/mtplx/benchmarks/runners/mtp_depth_sweep.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import statistics
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -157,6 +158,7 @@ def run_mtp_depth_sweep(
     ar_rows: list[dict[str, Any]] = []
     if compare_ar:
         for index, (case, ids) in enumerate(encoded):
+            generation_started_at = time.time()
             ar = generate_ar(
                 rt,
                 ids,
@@ -164,10 +166,14 @@ def run_mtp_depth_sweep(
                 sampler=sampler,
                 seed=seed + index,
             )
+            generation_ended_at = time.time()
             ar_rows.append(
                 {
                     "prompt_id": case.id,
                     "category": case.category,
+                    "generation_started_at": generation_started_at,
+                    "generation_ended_at": generation_ended_at,
+                    "generation_window_s": generation_ended_at - generation_started_at,
                     "generated_tokens": ar.stats.generated_tokens,
                     "tok_s": ar.stats.tok_s,
                     "tokens": ar.tokens,
@@ -179,6 +185,7 @@ def run_mtp_depth_sweep(
     for depth in depth_values:
         rows = []
         for index, (case, ids) in enumerate(encoded):
+            generation_started_at = time.time()
             out = generate_mtpk(
                 rt,
                 ids,
@@ -211,6 +218,7 @@ def run_mtp_depth_sweep(
                 adapter_ensemble_min_depth=adapter_ensemble_min_depth,
                 mtp_topk_reranker=mtp_topk_reranker,
             )
+            generation_ended_at = time.time()
             validations = [
                 asdict(validation)
                 for validation in validate_benchmark_output(
@@ -225,6 +233,9 @@ def run_mtp_depth_sweep(
                     "prompt_id": case.id,
                     "category": case.category,
                     "prompt_sha256": case.prompt_sha256,
+                    "generation_started_at": generation_started_at,
+                    "generation_ended_at": generation_ended_at,
+                    "generation_window_s": generation_ended_at - generation_started_at,
                     "generated_tokens": out.stats.generated_tokens,
                     "elapsed_s": out.stats.elapsed_s,
                     "tok_s": out.stats.tok_s,

--- a/mtplx/benchmarks/runners/mtp_depth_sweep.py
+++ b/mtplx/benchmarks/runners/mtp_depth_sweep.py
@@ -51,6 +51,7 @@ def run_mtp_depth_sweep(
     limit: int | None = None,
     enable_thinking: bool | None = None,
     compare_ar: bool = False,
+    ar_only: bool = False,
     mtp_hidden_variant: str = "post_norm",
     mtp_cache_policy: str = "persistent",
     mtp_history_policy: str = "cycle",
@@ -101,7 +102,7 @@ def run_mtp_depth_sweep(
     )
     draft_lm_head_report: dict[str, Any] | None = None
     if draft_lm_head_bits is not None:
-        from scripts.probe_draft_lm_head_requant import _install_draft_lm_head
+        from mtplx.draft_lm_head import _install_draft_lm_head
 
         draft_lm_head_report = _install_draft_lm_head(
             rt,
@@ -122,7 +123,9 @@ def run_mtp_depth_sweep(
         mtp_corrector_path,
         blend=mtp_corrector_blend,
     )
-    depth_values = _parse_depths(depths)
+    if ar_only and not compare_ar:
+        raise ValueError("ar_only requires compare_ar=True")
+    depth_values = [] if ar_only else _parse_depths(depths)
     mtp_topk_reranker = (
         TopKProposalReranker.from_calibration(
             mtp_topk_reranker_calib,
@@ -257,6 +260,11 @@ def run_mtp_depth_sweep(
                         else None
                     ),
                     "verify_time_s": out.stats.verify_time_s,
+                    "verify_forward_time_s": out.stats.verify_forward_time_s,
+                    "verify_eval_time_s": out.stats.verify_eval_time_s,
+                    "verify_hidden_eval_time_s": out.stats.verify_hidden_eval_time_s,
+                    "verify_joint_eval_time_s": out.stats.verify_joint_eval_time_s,
+                    "verify_target_distribution_time_s": out.stats.verify_target_distribution_time_s,
                     "draft_time_s": out.stats.draft_time_s,
                     "target_forward_time_s": out.stats.target_forward_time_s,
                     "snapshot_time_s": out.stats.snapshot_time_s,
@@ -325,6 +333,13 @@ def run_mtp_depth_sweep(
                         else None
                     ),
                     "verify_time_s": sum(row["verify_time_s"] for row in rows),
+                    "verify_forward_time_s": sum(row["verify_forward_time_s"] for row in rows),
+                    "verify_eval_time_s": sum(row["verify_eval_time_s"] for row in rows),
+                    "verify_hidden_eval_time_s": sum(row["verify_hidden_eval_time_s"] for row in rows),
+                    "verify_joint_eval_time_s": sum(row["verify_joint_eval_time_s"] for row in rows),
+                    "verify_target_distribution_time_s": sum(
+                        row["verify_target_distribution_time_s"] for row in rows
+                    ),
                     "draft_time_s": sum(row["draft_time_s"] for row in rows),
                     "target_forward_time_s": sum(row["target_forward_time_s"] for row in rows),
                     "snapshot_time_s": sum(row["snapshot_time_s"] for row in rows),
@@ -388,6 +403,7 @@ def run_mtp_depth_sweep(
         "seed": seed,
         "enable_thinking": enable_thinking,
         "compare_ar": compare_ar,
+        "ar_only": ar_only,
         "mtp_hidden_variant": mtp_hidden_variant,
         "mtp_cache_policy": mtp_cache_policy,
         "mtp_history_policy": mtp_history_policy,

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -2246,6 +2246,7 @@ def build_parser() -> argparse.ArgumentParser:
     bench_p.add_argument("--verbose", action="store_true", help="Show detailed tuner diagnostics where supported")
     bench_p.add_argument("--no-save", action="store_true", help="Do not save tuner recommendations")
     bench_p.add_argument("--retune", action="store_true", help="Ignore saved tuner results where supported")
+    bench_p.add_argument("--no-telemetry", action="store_true", help="Disable bench tune power telemetry for cleaner speed comparison")
     bench_p.add_argument("--before", help="Baseline envelope or nightly summary for bench compare")
     bench_p.add_argument("--after", help="Candidate envelope or nightly summary for bench compare")
     bench_p.add_argument("--strict-exactness", action="store_true", help="Require exactness gate pass in envelope compare mode")

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -62,6 +62,7 @@ NATIVE_MTP_60_MODEL = DEFAULT_MODEL_ID
 
 PUBLIC_COMMANDS = (
     ("start", "Interactive setup → chat (model · mode · web/CLI/Pi/OpenCode/Swival)"),
+    ("tune", "Find the fastest AR/D1/D2/D3 depth for this Mac"),
     ("help", "Detailed help; `help commands` / `help flags` / `help <name>`"),
     ("setup", "Prepare config and the model cache"),
     ("quickstart", "Run the local OpenAI/Anthropic server"),
@@ -536,6 +537,12 @@ def _add_mtp_toggle_args(parser: argparse.ArgumentParser) -> None:
 
 def cmd_bench_public(args: argparse.Namespace) -> int:
     from .commands.public import cmd_bench_public as handler
+
+    return handler(args)
+
+
+def cmd_tune_public(args: argparse.Namespace) -> int:
+    from .commands.public import cmd_tune_public as handler
 
     return handler(args)
 
@@ -1879,6 +1886,28 @@ def build_parser() -> argparse.ArgumentParser:
     doctor_p.add_argument("--include-paths", action="store_true", help="Keep local paths in --bundle output")
     doctor_p.set_defaults(func=cmd_doctor)
 
+    tune_p = sub.add_parser("tune", help="Find the fastest AR/D1/D2/D3 depth for this Mac")
+    tune_p.add_argument("--model", default=default_model)
+    tune_p.add_argument("--cache-dir")
+    tune_p.add_argument("--depths", default="1,2,3", help="Comma-separated MTP depths to compare against AR")
+    tune_p.add_argument("--max-tokens", type=int, default=192)
+    tune_p.add_argument("--limit", type=int, default=1)
+    tune_p.add_argument("--seed", type=int, default=0)
+    tune_p.add_argument("--run-id")
+    tune_p.add_argument("--output-dir")
+    tune_p.add_argument("--output")
+    tune_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    tune_p.add_argument("--verbose", action="store_true", help="Show verify and acceptance details")
+    tune_p.add_argument("--dry-run", action="store_true", help="Show candidate commands without loading MLX")
+    tune_p.add_argument("--no-save", action="store_true", help="Do not save the winning depth")
+    tune_p.add_argument("--retune", action="store_true", help="Ignore saved tuning and measure again")
+    tune_p.add_argument("--unsafe-force-unverified", action="store_true")
+    tune_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")
+    tune_p.add_argument("--profile", choices=PROFILE_CHOICES, default="performance-cold", help=argparse.SUPPRESS)
+    tune_p.add_argument("--_candidate", choices=["ar", "1", "2", "3"], dest="_tune_candidate", help=argparse.SUPPRESS)
+    tune_p.add_argument("--_candidate-output", dest="_tune_candidate_output", help=argparse.SUPPRESS)
+    tune_p.set_defaults(func=cmd_tune_public)
+
     report_p = sub.add_parser("report", help="Create a redacted MTPLX support bundle")
     report_p.add_argument("--project-root", default=".")
     report_p.add_argument("--smc-path", default=os.environ.get("MTPLX_SMC_PATH") or shutil.which("smc") or "")
@@ -2117,6 +2146,7 @@ def build_parser() -> argparse.ArgumentParser:
         choices=[
             "run",
             "context",
+            "tune",
             "prefill-ladder",
             "nightly",
             "compare",
@@ -2213,6 +2243,9 @@ def build_parser() -> argparse.ArgumentParser:
     bench_p.add_argument("--output")
     bench_p.add_argument("--out", dest="output", help="Alias for --output")
     bench_p.add_argument("--json", action="store_true", help="Accepted for friendly scripts; benchmark commands already print JSON")
+    bench_p.add_argument("--verbose", action="store_true", help="Show detailed tuner diagnostics where supported")
+    bench_p.add_argument("--no-save", action="store_true", help="Do not save tuner recommendations")
+    bench_p.add_argument("--retune", action="store_true", help="Ignore saved tuner results where supported")
     bench_p.add_argument("--before", help="Baseline envelope or nightly summary for bench compare")
     bench_p.add_argument("--after", help="Candidate envelope or nightly summary for bench compare")
     bench_p.add_argument("--strict-exactness", action="store_true", help="Require exactness gate pass in envelope compare mode")
@@ -2231,6 +2264,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Sampler seed. Defaults are harness-aware: 42 for long direct-HTTP runs, 0 for cold depth-sweep runs.",
     )
     bench_p.add_argument("--max-tokens", type=int, default=128)
+    bench_p.add_argument(
+        "--depths",
+        help="Comma-separated MTP depths for bench tune/depth diagnostics; defaults to 1,2,3 for tune.",
+    )
     bench_p.add_argument(
         "--contexts",
         help="Comma-separated prompt token contexts for bench prefill-ladder, e.g. 512,1k,32k",
@@ -2390,7 +2427,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable Qwen thinking in bench prefill-ladder chat formatting.",
     )
-    bench_p.add_argument("--speculative-depth", type=int, default=0)
+    bench_p.add_argument(
+        "--speculative-depth",
+        "--depth",
+        dest="speculative_depth",
+        type=int,
+        default=0,
+        help="Speculative MTP depth for depth-sweep benchmark runs; 0 uses the model contract default.",
+    )
     bench_p.add_argument(
         "--vary-seed-by-context",
         action="store_true",
@@ -3175,6 +3219,11 @@ def main(argv: list[str] | None = None) -> int:
 
     apply_user_config(args)
     return int(args.func(args))
+
+
+def main_tune(argv: list[str] | None = None) -> int:
+    raw_args = list(sys.argv[1:] if argv is None else argv)
+    return main(["tune", *raw_args])
 
 
 def _explicit_cli_flags(raw_args: list[str]) -> set[str]:

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -1674,6 +1674,19 @@ def _series_stats(values: list[Any]) -> dict[str, Any] | None:
     }
 
 
+def _generation_windows_from_rows(rows: list[dict[str, Any]]) -> list[dict[str, float]]:
+    windows: list[dict[str, float]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        start = _float_or_none(row.get("generation_started_at"))
+        end = _float_or_none(row.get("generation_ended_at"))
+        if start is None or end is None or end <= start:
+            continue
+        windows.append({"start": start, "end": end, "duration_s": end - start})
+    return windows
+
+
 def _convert_power_to_watts(value: str, unit: str | None) -> float:
     watts = float(value)
     if (unit or "").lower() == "mw":
@@ -1924,12 +1937,14 @@ def _summarize_tune_telemetry_samples(
 
     summary: dict[str, Any] = {
         "enabled": True,
+        "scope": "candidate_process",
         "sample_count": len(samples),
         "duration_s": (
             float(ended_at - started_at)
             if started_at is not None and ended_at is not None
             else None
         ),
+        "samples": samples,
         "sources": {
             "thermalforge": any(sample.get("thermalforge_ok") for sample in samples),
             "powermetrics": any(sample.get("powermetrics_ok") for sample in samples),
@@ -2016,6 +2031,61 @@ def _summarize_tune_telemetry_samples(
     return summary
 
 
+def _sample_in_any_window(sample: dict[str, Any], windows: list[dict[str, float]]) -> bool:
+    timestamp = _float_or_none(sample.get("timestamp"))
+    if timestamp is None:
+        return False
+    return any(window["start"] <= timestamp <= window["end"] for window in windows)
+
+
+def _attach_generation_telemetry(
+    telemetry: dict[str, Any] | None,
+    row: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not isinstance(telemetry, dict):
+        return telemetry
+    windows = [
+        window
+        for window in row.get("generation_windows", [])
+        if isinstance(window, dict)
+        and isinstance(window.get("start"), (int, float))
+        and isinstance(window.get("end"), (int, float))
+        and float(window["end"]) > float(window["start"])
+    ]
+    if not windows:
+        telemetry["generation"] = {
+            "enabled": True,
+            "scope": "generation_window",
+            "sample_count": 0,
+            "note": "candidate artifact did not include generation timing windows",
+        }
+        return telemetry
+    samples = [
+        sample
+        for sample in telemetry.get("samples", [])
+        if isinstance(sample, dict) and _sample_in_any_window(sample, windows)
+    ]
+    started_at = min(float(window["start"]) for window in windows)
+    ended_at = max(float(window["end"]) for window in windows)
+    generation = _summarize_tune_telemetry_samples(
+        samples,
+        errors=telemetry.get("errors") or [],
+        started_at=started_at,
+        ended_at=ended_at,
+    )
+    generation["scope"] = "generation_window"
+    generation["windows"] = windows
+    generation["window_count"] = len(windows)
+    generation["window_duration_s"] = sum(
+        float(window["end"]) - float(window["start"])
+        for window in windows
+    )
+    if not samples:
+        generation["note"] = "no powermetrics/thermalforge sample landed inside the generation window"
+    telemetry["generation"] = generation
+    return telemetry
+
+
 class _TuneTelemetrySampler:
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
@@ -2055,7 +2125,8 @@ class _TuneTelemetrySampler:
         next_powermetrics = 0.0
         while not self._stop.is_set():
             now = time.monotonic()
-            sample: dict[str, Any] = {"timestamp": time.time()}
+            sample_started_at = time.time()
+            sample: dict[str, Any] = {}
             thermal = _sample_thermalforge_status()
             if thermal.get("error"):
                 self._add_error(f"thermalforge: {thermal.get('error')}")
@@ -2078,6 +2149,10 @@ class _TuneTelemetrySampler:
                     ):
                         if key in power:
                             sample[key] = power[key]
+            sample_ended_at = time.time()
+            sample["sample_started_at"] = sample_started_at
+            sample["sample_ended_at"] = sample_ended_at
+            sample["timestamp"] = (sample_started_at + sample_ended_at) / 2.0
             with self._lock:
                 self._samples.append(sample)
             self._stop.wait(TUNE_TELEMETRY_SAMPLE_INTERVAL_S)
@@ -2146,7 +2221,7 @@ def _run_tune_candidates(
             command=command,
         )
         if telemetry is not None:
-            row["telemetry"] = telemetry
+            row["telemetry"] = _attach_generation_telemetry(telemetry, row)
         rows.append(row)
         if progress is not None:
             if isinstance(row.get("tok_s"), (int, float)):
@@ -2231,16 +2306,26 @@ def _tune_candidate_summary(
             for row in ar_rows
             if isinstance(row.get("tok_s"), (int, float))
         ]
+        generation_windows = _generation_windows_from_rows(ar_rows)
         return {
             **base,
             "tok_s": (sum(tok_values) / len(tok_values)) if tok_values else None,
             "generated_tokens": sum(int(row.get("generated_tokens") or 0) for row in ar_rows),
+            "generation_windows": generation_windows,
+            "generation_window_s": sum(window["duration_s"] for window in generation_windows),
             "verify_ms_per_call": None,
             "quality_passed": True if ar_rows else None,
         }
     depth_rows = data.get("depths") or data.get("depth_results") or []
     row = depth_rows[0] if depth_rows else {}
     summary = row.get("summary") or {}
+    generation_rows = [
+        result_row
+        for depth_row in depth_rows
+        for result_row in depth_row.get("rows", [])
+        if isinstance(result_row, dict)
+    ]
+    generation_windows = _generation_windows_from_rows(generation_rows)
     verify_calls = int(summary.get("verify_calls") or 0)
     validations = [
         validation
@@ -2259,6 +2344,8 @@ def _tune_candidate_summary(
         "tok_s": summary.get("mean_tok_s"),
         "generated_tokens": summary.get("generated_tokens"),
         "elapsed_s": summary.get("elapsed_s"),
+        "generation_windows": generation_windows,
+        "generation_window_s": sum(window["duration_s"] for window in generation_windows),
         "verify_time_s": summary.get("verify_time_s"),
         "verify_calls": verify_calls,
         "verify_ms_per_call": _ms_per_call(summary.get("verify_time_s"), verify_calls),
@@ -2435,8 +2522,14 @@ def _stat_avg(stats: Any) -> float | None:
 def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
     if not isinstance(telemetry, dict) or not telemetry.get("enabled"):
         return None
+    display = telemetry
+    scope = "candidate"
+    generation = telemetry.get("generation")
+    if isinstance(generation, dict) and generation.get("sample_count"):
+        display = generation
+        scope = "generation"
     parts: list[str] = []
-    power = telemetry.get("power_w") or {}
+    power = display.get("power_w") or {}
     power_parts = []
     for label, key in (("pkg", "package"), ("cpu", "cpu"), ("ane", "ane"), ("gpu", "gpu")):
         value = _stat_avg(power.get(key))
@@ -2445,7 +2538,7 @@ def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
     if power_parts:
         parts.append("power " + " ".join(power_parts))
 
-    frequency = telemetry.get("frequency_ghz") or {}
+    frequency = display.get("frequency_ghz") or {}
     frequency_parts = []
     for label, key in (("P", "p_cluster"), ("M", "m_cluster"), ("GPU", "gpu")):
         value = _stat_avg(frequency.get(key))
@@ -2454,7 +2547,7 @@ def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
     if frequency_parts:
         parts.append("freq " + " ".join(frequency_parts))
 
-    temperature = telemetry.get("temperature_c") or {}
+    temperature = display.get("temperature_c") or {}
     temp_parts = []
     core_avg = _stat_avg(temperature.get("core_avg"))
     core_max = _stat_avg(temperature.get("core_max"))
@@ -2468,7 +2561,7 @@ def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
     if temp_parts:
         parts.append("temp " + " ".join(temp_parts))
 
-    utilization = telemetry.get("utilization_pct") or {}
+    utilization = display.get("utilization_pct") or {}
     utilization_parts = []
     for label, key in (("P", "p_core"), ("M", "m_core"), ("GPU", "gpu")):
         value = _stat_avg(utilization.get(key))
@@ -2477,21 +2570,25 @@ def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
     if utilization_parts:
         parts.append("util " + " ".join(utilization_parts))
 
-    fans = telemetry.get("fans_rpm") or {}
+    fans = display.get("fans_rpm") or {}
     fan_avg = _stat_avg(fans.get("avg"))
     if fan_avg is not None:
         parts.append(f"fans={fan_avg:.0f}rpm")
 
-    sample_count = telemetry.get("sample_count")
+    sample_count = display.get("sample_count")
     if isinstance(sample_count, int):
         parts.append(f"samples={sample_count}")
-    errors = telemetry.get("errors") or []
+    window_duration = display.get("window_duration_s")
+    if scope == "generation" and isinstance(window_duration, (int, float)):
+        parts.append(f"window={float(window_duration):.1f}s")
+    errors = display.get("errors") or telemetry.get("errors") or []
     if parts and errors:
         parts.append("notes=" + "; ".join(str(error) for error in errors[:2]))
     if not parts:
         if errors:
             return f"unavailable ({'; '.join(str(error) for error in errors[:2])})"
         return None
+    parts.insert(0, f"scope={scope}")
     return " | ".join(parts)
 
 

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -23,7 +23,7 @@ import importlib.util
 import webbrowser
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 from mtplx.artifacts import inspect_model
 from mtplx.benchmarks.validators.basic import (
@@ -126,6 +126,13 @@ TUNE_STATE_PATH = Path("~/.mtplx/tuning.json").expanduser()
 GENERATION_MODE_MTP = "mtp"
 GENERATION_MODE_AR = "ar"
 GENERATION_MODES = {GENERATION_MODE_MTP, GENERATION_MODE_AR}
+
+
+def _absolute_user_path(path: str | Path) -> Path:
+    expanded = Path(path).expanduser()
+    if expanded.is_absolute():
+        return expanded
+    return (Path.cwd() / expanded).resolve()
 
 
 def _print(value: Any) -> None:
@@ -1183,8 +1190,9 @@ def _cmd_tune(
     model = getattr(args, "model", None) or DEFAULT_CHAMPION
     settings = _tune_settings(args, depths=depths)
     run_id = getattr(args, "run_id", None) or f"tune-{time.strftime('%Y%m%d-%H%M%S')}"
-    output_root = Path(getattr(args, "output_dir", None) or "outputs/cli/tune") / run_id
-    output_path = Path(getattr(args, "output", None)) if getattr(args, "output", None) else output_root / "tune.json"
+    output_dir = _absolute_user_path(getattr(args, "output_dir", None) or "outputs/cli/tune")
+    output_root = output_dir / run_id
+    output_path = _absolute_user_path(getattr(args, "output")) if getattr(args, "output", None) else output_root / "tune.json"
     json_output = bool(getattr(args, "json", False))
     verbose = bool(getattr(args, "verbose", verbose_default) or verbose_default)
 
@@ -1256,6 +1264,9 @@ def _cmd_tune(
         )
 
     try:
+        if not json_output:
+            _emit(f"[tune] artifacts: {output_root}")
+            _emit("[tune] running isolated candidates: AR, " + ", ".join(f"D{depth}" for depth in depths))
         candidate_rows = _run_tune_candidates(
             args,
             runtime_model=runtime_model,
@@ -1263,6 +1274,7 @@ def _cmd_tune(
             output_root=output_root,
             depths=depths,
             settings=settings,
+            progress=_emit if not json_output else None,
         )
     finally:
         max_session.stop()
@@ -1292,7 +1304,9 @@ def _cmd_tune(
     else:
         payload["saved"] = False
         payload["state_path"] = str(_tune_state_path())
-        if not payload.get("best"):
+        if not any(isinstance(row.get("tok_s"), (int, float)) for row in candidate_rows):
+            payload["save_skipped_reason"] = "tune failed; no candidate produced usable tokens"
+        elif not payload.get("best"):
             payload["save_skipped_reason"] = "no MTP depth beat AR"
         elif bool(getattr(args, "no_save", False)) or not save_default:
             payload["save_skipped_reason"] = "save disabled"
@@ -1515,9 +1529,12 @@ def _run_tune_candidates(
     output_root: Path,
     depths: list[int],
     settings: dict[str, Any],
+    progress: Callable[[str], None] | None = None,
 ) -> list[dict[str, Any]]:
+    output_root = _absolute_user_path(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
     rows: list[dict[str, Any]] = []
+    total = 1 + len(depths)
     for candidate in ["ar", *[str(depth) for depth in depths]]:
         label = _tune_candidate_label(candidate)
         candidate_output = output_root / f"{label.lower()}.json"
@@ -1529,6 +1546,9 @@ def _run_tune_candidates(
             output=candidate_output,
             settings=settings,
         )
+        if progress is not None:
+            progress(f"[tune] {label} ({len(rows) + 1}/{total}) starting; log: {stdout_path}")
+        started = time.monotonic()
         proc = subprocess.run(
             command,
             cwd=repo_root(),
@@ -1538,16 +1558,21 @@ def _run_tune_candidates(
             stderr=subprocess.STDOUT,
             check=False,
         )
+        elapsed_s = time.monotonic() - started
         stdout_path.write_text(proc.stdout, encoding="utf-8")
-        rows.append(
-            _tune_candidate_summary(
-                candidate,
-                candidate_output,
-                returncode=proc.returncode,
-                stdout_path=stdout_path,
-                command=command,
-            )
+        row = _tune_candidate_summary(
+            candidate,
+            candidate_output,
+            returncode=proc.returncode,
+            stdout_path=stdout_path,
+            command=command,
         )
+        rows.append(row)
+        if progress is not None:
+            if isinstance(row.get("tok_s"), (int, float)):
+                progress(f"[tune] {label} finished in {elapsed_s:.1f}s: {float(row['tok_s']):.2f} tok/s")
+            else:
+                progress(f"[tune] {label} failed in {elapsed_s:.1f}s: {row.get('error') or 'no token rate'}")
     return rows
 
 
@@ -1729,6 +1754,13 @@ def _annotate_multipliers(results: list[dict[str, Any]]) -> list[dict[str, Any]]
 def _best_multiplier_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
     annotated = _annotate_multipliers(results)
     ar = next((row for row in annotated if row.get("mode") == "AR"), None)
+    if not ar or not isinstance(ar.get("tok_s"), (int, float)):
+        return {
+            "available": False,
+            "ar_tok_s": None,
+            "winner": None,
+            "verdict": "tune_failed_no_ar_result",
+        }
     candidates = [
         row
         for row in annotated
@@ -1782,7 +1814,12 @@ def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None
         marker = "  BEST" if best.get("mode") == mode else ""
         print(f"{mode:<4} {tok_s:>6} tok/s   {multiplier}x{marker}")
     print()
-    if best:
+    errors = [row for row in payload.get("results", []) if row.get("error")]
+    if errors:
+        print("Tune failed for one or more candidates:")
+        for row in errors:
+            print(f"  {row.get('mode')}: {row.get('error')} (log: {row.get('stdout')})")
+    elif best:
         print(
             f"Best for this Mac: {best.get('mode')}, "
             f"{_fmt_metric(best.get('multiplier_vs_ar'), digits=2)}x AR"
@@ -6481,7 +6518,7 @@ def _quickstart_apply_tuned_depth(
         verbose_default=False,
     )
     if code != 0:
-        _quickstart_line("tuning did not finish; using default depth")
+        _quickstart_line("tuning failed; using default depth")
         return
     record = _load_tune_record(state_key)
     payload = record.get("payload") if isinstance(record, dict) else None

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -1252,6 +1252,9 @@ def _cmd_tune(
     def _emit(line: str) -> None:
         print(line, file=sys.stderr, flush=True)
 
+    if not json_output:
+        _emit("[tune] close heavy apps now for cleaner results before measurements start")
+        _emit("[tune] fans may get loud during tuning and will be restored afterward")
     max_session = MaxSession(log=_emit)
     if not max_session.start():
         verified = max_session.thermal.get("verified") or {}
@@ -1804,7 +1807,9 @@ def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None
     if payload.get("from_cache"):
         print("Using saved tuning. Run `mtplx tune --retune` to measure again.")
     else:
-        print("Close heavy apps for cleaner results. Fans may get loud during tuning.")
+        artifacts = payload.get("artifacts") or {}
+        if artifacts.get("root"):
+            print(f"Results written to {artifacts.get('root')}")
     print()
     best = payload.get("best") or {}
     for row in payload.get("results", []):

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -20,6 +20,7 @@ import urllib.request
 import importlib
 import importlib.metadata
 import importlib.util
+import re
 import webbrowser
 from pathlib import Path
 from types import SimpleNamespace
@@ -123,6 +124,8 @@ TUNE_DEFAULT_MAX_TOKENS = 192
 TUNE_DEFAULT_LIMIT = 1
 TUNE_DEFAULT_SEED = 0
 TUNE_STATE_PATH = Path("~/.mtplx/tuning.json").expanduser()
+TUNE_TELEMETRY_SAMPLE_INTERVAL_S = 0.75
+TUNE_POWERMETRICS_SAMPLE_INTERVAL_S = 1.5
 GENERATION_MODE_MTP = "mtp"
 GENERATION_MODE_AR = "ar"
 GENERATION_MODES = {GENERATION_MODE_MTP, GENERATION_MODE_AR}
@@ -1278,6 +1281,7 @@ def _cmd_tune(
             depths=depths,
             settings=settings,
             progress=_emit if not json_output else None,
+            collect_telemetry=action == "bench tune",
         )
     finally:
         max_session.stop()
@@ -1521,7 +1525,451 @@ def _tune_dry_run_payload(
         "state_path": str(_tune_state_path()),
         "save_default": save_default,
         "fan_control": "verified max-fan required before model load",
+        "diagnostics": (
+            "bench tune records per-candidate power, frequency, temperature, "
+            "utilization, and fan telemetry when not in dry-run"
+            if action == "bench tune"
+            else None
+        ),
     }
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _avg(values: list[float]) -> float | None:
+    return (sum(values) / len(values)) if values else None
+
+
+def _series_stats(values: list[Any]) -> dict[str, Any] | None:
+    numeric = [float(value) for value in values if isinstance(value, (int, float))]
+    if not numeric:
+        return None
+    return {
+        "avg": sum(numeric) / len(numeric),
+        "min": min(numeric),
+        "max": max(numeric),
+        "last": numeric[-1],
+        "samples": len(numeric),
+    }
+
+
+def _convert_power_to_watts(value: str, unit: str | None) -> float:
+    watts = float(value)
+    if (unit or "").lower() == "mw":
+        watts /= 1000.0
+    return watts
+
+
+def _convert_frequency_to_ghz(value: str, unit: str | None) -> float:
+    ghz = float(value)
+    if (unit or "").lower() == "mhz":
+        ghz /= 1000.0
+    return ghz
+
+
+def _parse_powermetrics_text(text: str) -> dict[str, Any]:
+    """Extract the MX Power Gadget-style rails from macOS powermetrics text."""
+
+    power: dict[str, float] = {}
+    for match in re.finditer(
+        r"(?m)^(CPU|GPU|ANE) Power:\s*([0-9]+(?:\.[0-9]+)?)\s*(mW|W)\b",
+        text,
+    ):
+        rail = match.group(1).lower()
+        power[rail] = _convert_power_to_watts(match.group(2), match.group(3))
+    package_match = re.search(
+        r"(?m)^Combined Power \(CPU \+ GPU \+ ANE\):\s*"
+        r"([0-9]+(?:\.[0-9]+)?)\s*(mW|W)\b",
+        text,
+    )
+    if package_match:
+        power["package"] = _convert_power_to_watts(
+            package_match.group(1),
+            package_match.group(2),
+        )
+
+    p_frequencies: list[float] = []
+    m_frequencies: list[float] = []
+    p_utilization: list[float] = []
+    m_utilization: list[float] = []
+    for match in re.finditer(
+        r"(?m)^([A-Za-z0-9]+)-Cluster HW active frequency:\s*"
+        r"([0-9]+(?:\.[0-9]+)?)\s*(MHz|GHz)\b",
+        text,
+    ):
+        name = match.group(1).upper()
+        ghz = _convert_frequency_to_ghz(match.group(2), match.group(3))
+        if name == "P":
+            p_frequencies.append(ghz)
+        else:
+            m_frequencies.append(ghz)
+    for match in re.finditer(
+        r"(?m)^([A-Za-z0-9]+)-Cluster HW active residency:\s*"
+        r"([0-9]+(?:\.[0-9]+)?)%",
+        text,
+    ):
+        name = match.group(1).upper()
+        residency = float(match.group(2))
+        if name == "P":
+            p_utilization.append(residency)
+        else:
+            m_utilization.append(residency)
+
+    frequency: dict[str, float] = {}
+    utilization: dict[str, float] = {}
+    p_cluster = _avg(p_frequencies)
+    m_cluster = _avg(m_frequencies)
+    p_core = _avg(p_utilization)
+    m_core = _avg(m_utilization)
+    if p_cluster is not None:
+        frequency["p_cluster"] = p_cluster
+    if m_cluster is not None:
+        frequency["m_cluster"] = m_cluster
+    if p_core is not None:
+        utilization["p_core"] = p_core
+    if m_core is not None:
+        utilization["m_core"] = m_core
+
+    gpu_freq_match = re.search(
+        r"(?m)^GPU HW active frequency:\s*([0-9]+(?:\.[0-9]+)?)\s*(MHz|GHz)\b",
+        text,
+    )
+    if gpu_freq_match:
+        frequency["gpu"] = _convert_frequency_to_ghz(
+            gpu_freq_match.group(1),
+            gpu_freq_match.group(2),
+        )
+    gpu_residency_match = re.search(
+        r"(?m)^GPU HW active residency:\s*([0-9]+(?:\.[0-9]+)?)%",
+        text,
+    )
+    if gpu_residency_match:
+        utilization["gpu"] = float(gpu_residency_match.group(1))
+
+    payload: dict[str, Any] = {
+        "source": "powermetrics",
+        "power_w": power,
+        "frequency_ghz": frequency,
+        "utilization_pct": utilization,
+    }
+    pressure_match = re.search(r"(?m)^Current pressure level:\s*(.+)$", text)
+    if pressure_match:
+        payload["thermal_pressure"] = pressure_match.group(1).strip()
+    return payload
+
+
+def _thermalforge_binary() -> str | None:
+    owned = Path("~/.mtplx/bin/thermalforge").expanduser()
+    if owned.exists():
+        return str(owned)
+    return shutil.which("thermalforge")
+
+
+def _temperature_groups_from_thermalforge(
+    temperatures: dict[str, Any],
+) -> tuple[list[float], list[float]]:
+    core_values: list[float] = []
+    fallback_core_values: list[float] = []
+    gpu_values: list[float] = []
+    for key, raw_value in temperatures.items():
+        value = _float_or_none(raw_value)
+        if value is None:
+            continue
+        name = str(key)
+        upper = name.upper()
+        if upper.startswith("TG") or name.startswith("Tg"):
+            gpu_values.append(value)
+        elif upper.startswith("TC") or name.startswith(("Tp", "Tm")):
+            core_values.append(value)
+        else:
+            fallback_core_values.append(value)
+    return core_values or fallback_core_values, gpu_values
+
+
+def _sample_thermalforge_status() -> dict[str, Any]:
+    binary = _thermalforge_binary()
+    if not binary:
+        return {"source": "thermalforge", "error": "thermalforge not found"}
+    try:
+        proc = subprocess.run(
+            [binary, "status"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=1.0,
+        )
+    except Exception as exc:
+        return {"source": "thermalforge", "error": str(exc)}
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return {"source": "thermalforge", "error": detail or f"exit {proc.returncode}"}
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return {"source": "thermalforge", "error": f"invalid JSON: {exc}"}
+
+    fans = data.get("fans") if isinstance(data, dict) else []
+    fan_rpms: list[float] = []
+    if isinstance(fans, dict):
+        fans = list(fans.values())
+    for fan in fans if isinstance(fans, list) else []:
+        if not isinstance(fan, dict):
+            continue
+        rpm = _float_or_none(fan.get("actual_rpm"))
+        if rpm is None:
+            rpm = _float_or_none(fan.get("target_rpm"))
+        if rpm is not None:
+            fan_rpms.append(rpm)
+
+    temperatures = data.get("temperatures") if isinstance(data, dict) else {}
+    core_values, gpu_values = (
+        _temperature_groups_from_thermalforge(temperatures)
+        if isinstance(temperatures, dict)
+        else ([], [])
+    )
+    temperature: dict[str, float] = {}
+    if core_values:
+        temperature["core_avg"] = sum(core_values) / len(core_values)
+        temperature["core_max"] = max(core_values)
+        temperature["core_min"] = min(core_values)
+    if gpu_values:
+        temperature["gpu_avg"] = sum(gpu_values) / len(gpu_values)
+
+    payload: dict[str, Any] = {
+        "source": "thermalforge",
+        "fans_rpm": {
+            "min": min(fan_rpms),
+            "max": max(fan_rpms),
+            "avg": sum(fan_rpms) / len(fan_rpms),
+        }
+        if fan_rpms
+        else {},
+        "temperature_c": temperature,
+    }
+    if isinstance(temperatures, dict):
+        payload["temperature_sensors_c"] = {
+            str(key): value
+            for key, value in temperatures.items()
+            if isinstance(value, (int, float))
+        }
+    return payload
+
+
+def _sample_powermetrics_once() -> dict[str, Any]:
+    if not shutil.which("powermetrics"):
+        return {"source": "powermetrics", "error": "powermetrics not found"}
+    if not shutil.which("sudo"):
+        return {"source": "powermetrics", "error": "sudo not found"}
+    command = [
+        "sudo",
+        "-n",
+        "powermetrics",
+        "-n",
+        "1",
+        "-i",
+        "250",
+        "--samplers",
+        "cpu_power,gpu_power,ane_power,thermal",
+    ]
+    try:
+        proc = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=2.0,
+        )
+    except Exception as exc:
+        return {"source": "powermetrics", "error": str(exc)}
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return {"source": "powermetrics", "error": detail or f"exit {proc.returncode}"}
+    return _parse_powermetrics_text(proc.stdout)
+
+
+def _summarize_tune_telemetry_samples(
+    samples: list[dict[str, Any]],
+    *,
+    errors: list[str] | None = None,
+    started_at: float | None = None,
+    ended_at: float | None = None,
+) -> dict[str, Any]:
+    power_keys = ("package", "cpu", "ane", "gpu")
+    frequency_keys = ("p_cluster", "m_cluster", "gpu")
+    temperature_keys = ("core_avg", "core_max", "core_min", "gpu_avg")
+    utilization_keys = ("p_core", "m_core", "gpu")
+
+    summary: dict[str, Any] = {
+        "enabled": True,
+        "sample_count": len(samples),
+        "duration_s": (
+            float(ended_at - started_at)
+            if started_at is not None and ended_at is not None
+            else None
+        ),
+        "sources": {
+            "thermalforge": any(sample.get("thermalforge_ok") for sample in samples),
+            "powermetrics": any(sample.get("powermetrics_ok") for sample in samples),
+        },
+    }
+    errors = list(errors or [])
+    if errors:
+        summary["errors"] = sorted(set(errors))
+
+    power = {
+        key: _series_stats(
+            [
+                ((sample.get("power_w") or {}).get(key))
+                for sample in samples
+            ]
+        )
+        for key in power_keys
+    }
+    frequency = {
+        key: _series_stats(
+            [
+                ((sample.get("frequency_ghz") or {}).get(key))
+                for sample in samples
+            ]
+        )
+        for key in frequency_keys
+    }
+    temperature = {
+        key: _series_stats(
+            [
+                ((sample.get("temperature_c") or {}).get(key))
+                for sample in samples
+            ]
+        )
+        for key in temperature_keys
+    }
+    utilization = {
+        key: _series_stats(
+            [
+                ((sample.get("utilization_pct") or {}).get(key))
+                for sample in samples
+            ]
+        )
+        for key in utilization_keys
+    }
+    fans = {
+        key: _series_stats(
+            [
+                ((sample.get("fans_rpm") or {}).get(key))
+                for sample in samples
+            ]
+        )
+        for key in ("avg", "min", "max")
+    }
+    summary["power_w"] = {key: value for key, value in power.items() if value}
+    summary["frequency_ghz"] = {key: value for key, value in frequency.items() if value}
+    summary["temperature_c"] = {key: value for key, value in temperature.items() if value}
+    summary["utilization_pct"] = {
+        key: value for key, value in utilization.items() if value
+    }
+    summary["fans_rpm"] = {key: value for key, value in fans.items() if value}
+
+    pressures = [
+        str(sample.get("thermal_pressure"))
+        for sample in samples
+        if sample.get("thermal_pressure")
+    ]
+    if pressures:
+        summary["thermal_pressure"] = {
+            "last": pressures[-1],
+            "observed": sorted(set(pressures)),
+        }
+
+    latest_sensors = next(
+        (
+            sample.get("temperature_sensors_c")
+            for sample in reversed(samples)
+            if sample.get("temperature_sensors_c")
+        ),
+        None,
+    )
+    if isinstance(latest_sensors, dict):
+        summary["latest_temperature_sensors_c"] = latest_sensors
+    return summary
+
+
+class _TuneTelemetrySampler:
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._samples: list[dict[str, Any]] = []
+        self._errors: list[str] = []
+        self._lock = threading.Lock()
+        self._powermetrics_disabled = False
+        self._started_at: float | None = None
+
+    def start(self) -> None:
+        if not self.enabled:
+            return
+        self._started_at = time.monotonic()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> dict[str, Any] | None:
+        if not self.enabled:
+            return None
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=3.0)
+        ended_at = time.monotonic()
+        with self._lock:
+            samples = list(self._samples)
+            errors = list(self._errors)
+        return _summarize_tune_telemetry_samples(
+            samples,
+            errors=errors,
+            started_at=self._started_at,
+            ended_at=ended_at,
+        )
+
+    def _loop(self) -> None:
+        next_powermetrics = 0.0
+        while not self._stop.is_set():
+            now = time.monotonic()
+            sample: dict[str, Any] = {"timestamp": time.time()}
+            thermal = _sample_thermalforge_status()
+            if thermal.get("error"):
+                self._add_error(f"thermalforge: {thermal.get('error')}")
+            else:
+                sample["thermalforge_ok"] = True
+                sample.update({k: v for k, v in thermal.items() if k != "source"})
+            if not self._powermetrics_disabled and now >= next_powermetrics:
+                power = _sample_powermetrics_once()
+                next_powermetrics = now + TUNE_POWERMETRICS_SAMPLE_INTERVAL_S
+                if power.get("error"):
+                    self._powermetrics_disabled = True
+                    self._add_error(f"powermetrics: {power.get('error')}")
+                else:
+                    sample["powermetrics_ok"] = True
+                    for key in (
+                        "power_w",
+                        "frequency_ghz",
+                        "utilization_pct",
+                        "thermal_pressure",
+                    ):
+                        if key in power:
+                            sample[key] = power[key]
+            with self._lock:
+                self._samples.append(sample)
+            self._stop.wait(TUNE_TELEMETRY_SAMPLE_INTERVAL_S)
+
+    def _add_error(self, message: str) -> None:
+        with self._lock:
+            if message not in self._errors:
+                self._errors.append(message)
 
 
 def _run_tune_candidates(
@@ -1533,6 +1981,7 @@ def _run_tune_candidates(
     depths: list[int],
     settings: dict[str, Any],
     progress: Callable[[str], None] | None = None,
+    collect_telemetry: bool = False,
 ) -> list[dict[str, Any]]:
     output_root = _absolute_user_path(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
@@ -1552,15 +2001,20 @@ def _run_tune_candidates(
         if progress is not None:
             progress(f"[tune] {label} ({len(rows) + 1}/{total}) starting; log: {stdout_path}")
         started = time.monotonic()
-        proc = subprocess.run(
-            command,
-            cwd=repo_root(),
-            env={**os.environ, "MTPLX_TUNE_CHILD": "1"},
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            check=False,
-        )
+        telemetry_sampler = _TuneTelemetrySampler(enabled=collect_telemetry)
+        telemetry_sampler.start()
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=repo_root(),
+                env={**os.environ, "MTPLX_TUNE_CHILD": "1"},
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        finally:
+            telemetry = telemetry_sampler.stop()
         elapsed_s = time.monotonic() - started
         stdout_path.write_text(proc.stdout, encoding="utf-8")
         row = _tune_candidate_summary(
@@ -1570,12 +2024,17 @@ def _run_tune_candidates(
             stdout_path=stdout_path,
             command=command,
         )
+        if telemetry is not None:
+            row["telemetry"] = telemetry
         rows.append(row)
         if progress is not None:
             if isinstance(row.get("tok_s"), (int, float)):
                 progress(f"[tune] {label} finished in {elapsed_s:.1f}s: {float(row['tok_s']):.2f} tok/s")
             else:
                 progress(f"[tune] {label} failed in {elapsed_s:.1f}s: {row.get('error') or 'no token rate'}")
+            telemetry_line = _format_tune_telemetry_inline(row.get("telemetry"))
+            if telemetry_line:
+                progress(f"[tune] {label} telemetry: {telemetry_line}")
     return rows
 
 
@@ -1802,6 +2261,75 @@ def _print_tune_dry_run_human(payload: dict[str, Any]) -> None:
         print(f"  {row.get('candidate')}: {shlex.join(row.get('command') or [])}")
 
 
+def _stat_avg(stats: Any) -> float | None:
+    if isinstance(stats, dict) and isinstance(stats.get("avg"), (int, float)):
+        return float(stats["avg"])
+    return None
+
+
+def _format_tune_telemetry_inline(telemetry: Any) -> str | None:
+    if not isinstance(telemetry, dict) or not telemetry.get("enabled"):
+        return None
+    parts: list[str] = []
+    power = telemetry.get("power_w") or {}
+    power_parts = []
+    for label, key in (("pkg", "package"), ("cpu", "cpu"), ("ane", "ane"), ("gpu", "gpu")):
+        value = _stat_avg(power.get(key))
+        if value is not None:
+            power_parts.append(f"{label}={value:.1f}W")
+    if power_parts:
+        parts.append("power " + " ".join(power_parts))
+
+    frequency = telemetry.get("frequency_ghz") or {}
+    frequency_parts = []
+    for label, key in (("P", "p_cluster"), ("M", "m_cluster"), ("GPU", "gpu")):
+        value = _stat_avg(frequency.get(key))
+        if value is not None:
+            frequency_parts.append(f"{label}={value:.2f}GHz")
+    if frequency_parts:
+        parts.append("freq " + " ".join(frequency_parts))
+
+    temperature = telemetry.get("temperature_c") or {}
+    temp_parts = []
+    core_avg = _stat_avg(temperature.get("core_avg"))
+    core_max = _stat_avg(temperature.get("core_max"))
+    gpu_avg = _stat_avg(temperature.get("gpu_avg"))
+    if core_avg is not None:
+        temp_parts.append(f"core_avg={core_avg:.1f}C")
+    if core_max is not None:
+        temp_parts.append(f"core_max={core_max:.1f}C")
+    if gpu_avg is not None:
+        temp_parts.append(f"gpu_avg={gpu_avg:.1f}C")
+    if temp_parts:
+        parts.append("temp " + " ".join(temp_parts))
+
+    utilization = telemetry.get("utilization_pct") or {}
+    utilization_parts = []
+    for label, key in (("P", "p_core"), ("M", "m_core"), ("GPU", "gpu")):
+        value = _stat_avg(utilization.get(key))
+        if value is not None:
+            utilization_parts.append(f"{label}={value:.1f}%")
+    if utilization_parts:
+        parts.append("util " + " ".join(utilization_parts))
+
+    fans = telemetry.get("fans_rpm") or {}
+    fan_avg = _stat_avg(fans.get("avg"))
+    if fan_avg is not None:
+        parts.append(f"fans={fan_avg:.0f}rpm")
+
+    sample_count = telemetry.get("sample_count")
+    if isinstance(sample_count, int):
+        parts.append(f"samples={sample_count}")
+    errors = telemetry.get("errors") or []
+    if parts and errors:
+        parts.append("notes=" + "; ".join(str(error) for error in errors[:2]))
+    if not parts:
+        if errors:
+            return f"unavailable ({'; '.join(str(error) for error in errors[:2])})"
+        return None
+    return " | ".join(parts)
+
+
 def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None:
     print("MTPLX Tune")
     if payload.get("from_cache"):
@@ -1838,12 +2366,14 @@ def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None
     if verbose:
         print()
         for row in payload.get("results", []):
-            if row.get("depth") is None:
-                continue
-            print(
-                f"{row.get('mode')}: verify_ms={_fmt_metric(row.get('verify_ms_per_call'), digits=2)} "
-                f"acceptance={_format_depth_acceptance(row)}"
-            )
+            if row.get("depth") is not None:
+                print(
+                    f"{row.get('mode')}: verify_ms={_fmt_metric(row.get('verify_ms_per_call'), digits=2)} "
+                    f"acceptance={_format_depth_acceptance(row)}"
+                )
+            telemetry_line = _format_tune_telemetry_inline(row.get("telemetry"))
+            if telemetry_line:
+                print(f"{row.get('mode')}: telemetry={telemetry_line}")
         artifacts = payload.get("artifacts") or {}
         if artifacts:
             print(f"artifacts: {artifacts.get('root')}")

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -126,6 +126,9 @@ TUNE_DEFAULT_SEED = 0
 TUNE_STATE_PATH = Path("~/.mtplx/tuning.json").expanduser()
 TUNE_TELEMETRY_SAMPLE_INTERVAL_S = 0.75
 TUNE_POWERMETRICS_SAMPLE_INTERVAL_S = 1.5
+TUNE_CANDIDATE_SETTLE_S = 5.0
+TUNE_TIE_PREFER_DEEPER_WITHIN_PCT = 2.0
+TUNE_TELEMETRY_ENV = "MTPLX_BENCH_TUNE_TELEMETRY"
 GENERATION_MODE_MTP = "mtp"
 GENERATION_MODE_AR = "ar"
 GENERATION_MODES = {GENERATION_MODE_MTP, GENERATION_MODE_AR}
@@ -1198,8 +1201,10 @@ def _cmd_tune(
     output_path = _absolute_user_path(getattr(args, "output")) if getattr(args, "output", None) else output_root / "tune.json"
     json_output = bool(getattr(args, "json", False))
     verbose = bool(getattr(args, "verbose", verbose_default) or verbose_default)
+    collect_telemetry = _tune_collect_telemetry(args, action=action)
 
     if bool(getattr(args, "dry_run", False)):
+        model_source_notes = _tune_model_source_notes(args, runtime_model=model)
         payload = _tune_dry_run_payload(
             args,
             action=action,
@@ -1210,6 +1215,8 @@ def _cmd_tune(
             settings=settings,
             depths=depths,
             save_default=save_default,
+            collect_telemetry=collect_telemetry,
+            model_source_notes=model_source_notes,
         )
         if json_output or action == "bench tune":
             _print(payload)
@@ -1227,6 +1234,7 @@ def _cmd_tune(
             detail=resolve_error.get("detail"),
             json_output=json_output,
         )
+    model_source_notes = _tune_model_source_notes(args, runtime_model=runtime_model)
 
     profile = get_profile("performance-cold")
     hardware = _apple_hardware_context()
@@ -1256,6 +1264,14 @@ def _cmd_tune(
         print(line, file=sys.stderr, flush=True)
 
     if not json_output:
+        _emit(f"[tune] model: {runtime_model}")
+        for note in model_source_notes:
+            _emit(note)
+        if action == "bench tune":
+            if collect_telemetry:
+                _emit("[tune] diagnostic telemetry active; use --no-telemetry for clean speed comparison")
+            else:
+                _emit("[tune] diagnostic telemetry disabled; speed comparison is cleaner")
         _emit("[tune] close heavy apps now for cleaner results before measurements start")
         _emit("[tune] fans may get loud during tuning and will be restored afterward")
     max_session = MaxSession(log=_emit)
@@ -1281,7 +1297,7 @@ def _cmd_tune(
             depths=depths,
             settings=settings,
             progress=_emit if not json_output else None,
-            collect_telemetry=action == "bench tune",
+            collect_telemetry=collect_telemetry,
         )
     finally:
         max_session.stop()
@@ -1299,6 +1315,11 @@ def _cmd_tune(
         backend=backend,
         thermal=max_session.thermal,
         state_key=state_key,
+        diagnostics={
+            "telemetry_enabled": collect_telemetry,
+            "telemetry_env": TUNE_TELEMETRY_ENV,
+            "model_source_notes": model_source_notes,
+        },
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     write_json(output_path, payload)
@@ -1392,6 +1413,79 @@ def _parse_tune_depths(raw: Any) -> list[int]:
     return depths
 
 
+def _tune_env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    text = str(raw).strip().lower()
+    if text in {"0", "off", "false", "none", "no"}:
+        return 0.0
+    try:
+        return float(text)
+    except ValueError:
+        return default
+
+
+def _tune_env_bool(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    text = str(raw).strip().lower()
+    if text in {"1", "true", "yes", "on", "enabled"}:
+        return True
+    if text in {"0", "false", "no", "off", "disabled", "none"}:
+        return False
+    return default
+
+
+def _tune_collect_telemetry(args: Any, *, action: str) -> bool:
+    return (
+        action == "bench tune"
+        and not bool(getattr(args, "no_telemetry", False))
+        and _tune_env_bool(TUNE_TELEMETRY_ENV, default=True)
+    )
+
+
+def _normalize_model_ref_for_compare(value: str | Path | None) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if text.startswith(("~", "/", "./", "../")):
+        path = Path(text).expanduser()
+        try:
+            return str(path.resolve())
+        except OSError:
+            return str(path)
+    return text
+
+
+def _same_model_ref(left: str | Path | None, right: str | Path | None) -> bool:
+    return _normalize_model_ref_for_compare(left) == _normalize_model_ref_for_compare(right)
+
+
+def _tune_model_source_notes(args: Any, *, runtime_model: str) -> list[str]:
+    cli_flags = getattr(args, "_cli_flags", set()) or set()
+    if "model" in cli_flags:
+        return []
+    config = getattr(args, "mtplx_config", None)
+    config_model = config.get("model") if isinstance(config, dict) else None
+    if not config_model or not _same_model_ref(runtime_model, config_model):
+        return []
+    try:
+        default_selection = select_default_model()
+    except Exception:
+        return []
+    default_model = default_selection.model
+    if _same_model_ref(runtime_model, default_model):
+        return []
+    config_path = config.get("path") if isinstance(config, dict) else "~/.mtplx/config.toml"
+    return [
+        f"[tune] using configured model from {config_path}: {runtime_model}",
+        f"[tune] verified default for this Mac is: {default_model}",
+        "[tune] pass --model <path> to benchmark a different artifact explicitly",
+    ]
+
+
 def _tune_settings(args: Any, *, depths: list[int]) -> dict[str, Any]:
     return {
         "profile": "performance-cold",
@@ -1401,6 +1495,17 @@ def _tune_settings(args: Any, *, depths: list[int]) -> dict[str, Any]:
         "limit": int(getattr(args, "limit", TUNE_DEFAULT_LIMIT) or TUNE_DEFAULT_LIMIT),
         "seed": int(getattr(args, "seed", TUNE_DEFAULT_SEED) or TUNE_DEFAULT_SEED),
         "thinking": "disabled",
+        "candidate_settle_s": max(
+            0.0,
+            _tune_env_float("MTPLX_TUNE_CANDIDATE_SETTLE_S", TUNE_CANDIDATE_SETTLE_S),
+        ),
+        "tie_prefer_deeper_within_pct": max(
+            0.0,
+            _tune_env_float(
+                "MTPLX_TUNE_TIE_PREFER_DEEPER_WITHIN_PCT",
+                TUNE_TIE_PREFER_DEEPER_WITHIN_PCT,
+            ),
+        ),
     }
 
 
@@ -1497,6 +1602,8 @@ def _tune_dry_run_payload(
     settings: dict[str, Any],
     depths: list[int],
     save_default: bool,
+    collect_telemetry: bool,
+    model_source_notes: list[str] | None = None,
 ) -> dict[str, Any]:
     commands = []
     for candidate in ["ar", *[str(depth) for depth in depths]]:
@@ -1525,12 +1632,21 @@ def _tune_dry_run_payload(
         "state_path": str(_tune_state_path()),
         "save_default": save_default,
         "fan_control": "verified max-fan required before model load",
-        "diagnostics": (
-            "bench tune records per-candidate power, frequency, temperature, "
-            "utilization, and fan telemetry when not in dry-run"
-            if action == "bench tune"
-            else None
-        ),
+        "diagnostics": {
+            "telemetry_enabled": collect_telemetry,
+            "telemetry_env": TUNE_TELEMETRY_ENV,
+            "model_source_notes": model_source_notes or [],
+            "description": (
+                "bench tune records per-candidate power, frequency, temperature, "
+                "utilization, and fan telemetry when not in dry-run"
+                if action == "bench tune" and collect_telemetry
+                else (
+                    "bench tune telemetry disabled; candidate commands match clean tune timing more closely"
+                    if action == "bench tune"
+                    else None
+                )
+            ),
+        },
     }
 
 
@@ -1987,6 +2103,7 @@ def _run_tune_candidates(
     output_root.mkdir(parents=True, exist_ok=True)
     rows: list[dict[str, Any]] = []
     total = 1 + len(depths)
+    settle_s = float(settings.get("candidate_settle_s") or 0.0)
     for candidate in ["ar", *[str(depth) for depth in depths]]:
         label = _tune_candidate_label(candidate)
         candidate_output = output_root / f"{label.lower()}.json"
@@ -1998,6 +2115,10 @@ def _run_tune_candidates(
             output=candidate_output,
             settings=settings,
         )
+        if rows and settle_s > 0.0:
+            if progress is not None:
+                progress(f"[tune] settling {settle_s:.1f}s before {label}")
+            time.sleep(settle_s)
         if progress is not None:
             progress(f"[tune] {label} ({len(rows) + 1}/{total}) starting; log: {stdout_path}")
         started = time.monotonic()
@@ -2171,6 +2292,7 @@ def _tune_payload(
     backend: dict[str, Any],
     thermal: dict[str, Any],
     state_key: str,
+    diagnostics: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     rows = _annotate_multipliers(rows)
     best = _best_multiplier_summary(rows)
@@ -2188,6 +2310,7 @@ def _tune_payload(
         "software": software,
         "backend": backend,
         "thermal": thermal,
+        "diagnostics": diagnostics or {},
         "state_key": state_key,
         "artifacts": {
             "root": str(output_root),
@@ -2230,7 +2353,33 @@ def _best_multiplier_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
         and isinstance(row.get("multiplier_vs_ar"), (int, float))
         and float(row["multiplier_vs_ar"]) > 1.0
     ]
-    winner = max(candidates, key=lambda row: float(row["multiplier_vs_ar"]), default=None)
+    raw_winner = max(candidates, key=lambda row: float(row["multiplier_vs_ar"]), default=None)
+    winner = raw_winner
+    tie_margin_pct = max(
+        0.0,
+        _tune_env_float(
+            "MTPLX_TUNE_TIE_PREFER_DEEPER_WITHIN_PCT",
+            TUNE_TIE_PREFER_DEEPER_WITHIN_PCT,
+        ),
+    )
+    if raw_winner is not None and tie_margin_pct > 0.0:
+        raw_tok_s = raw_winner.get("tok_s")
+        if isinstance(raw_tok_s, (int, float)) and float(raw_tok_s) > 0.0:
+            floor = float(raw_tok_s) * (1.0 - tie_margin_pct / 100.0)
+            tied = [
+                row
+                for row in candidates
+                if isinstance(row.get("tok_s"), (int, float))
+                and float(row["tok_s"]) >= floor
+            ]
+            winner = max(
+                tied,
+                key=lambda row: (
+                    int(row.get("depth") or 0),
+                    float(row.get("tok_s") or 0.0),
+                ),
+                default=raw_winner,
+            )
     if winner is None:
         return {
             "available": bool(ar and isinstance(ar.get("tok_s"), (int, float))),
@@ -2238,6 +2387,10 @@ def _best_multiplier_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
             "winner": None,
             "verdict": "no_mtp_depth_beat_ar",
         }
+    raw_winner_changed = (
+        raw_winner is not None
+        and raw_winner.get("mode") != winner.get("mode")
+    )
     return {
         "available": True,
         "ar_tok_s": ar.get("tok_s") if ar else None,
@@ -2246,6 +2399,18 @@ def _best_multiplier_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
             "depth": winner.get("depth"),
             "tok_s": winner.get("tok_s"),
             "multiplier_vs_ar": winner.get("multiplier_vs_ar"),
+        },
+        "raw_winner": {
+            "mode": raw_winner.get("mode"),
+            "depth": raw_winner.get("depth"),
+            "tok_s": raw_winner.get("tok_s"),
+            "multiplier_vs_ar": raw_winner.get("multiplier_vs_ar"),
+        }
+        if raw_winner is not None
+        else None,
+        "tie_breaker": {
+            "applied": raw_winner_changed,
+            "prefer_deeper_within_pct": tie_margin_pct,
         },
         "verdict": "mtp_depth_wins",
     }
@@ -2357,6 +2522,15 @@ def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None
             f"Best for this Mac: {best.get('mode')}, "
             f"{_fmt_metric(best.get('multiplier_vs_ar'), digits=2)}x AR"
         )
+        best_multiplier = payload.get("best_multiplier") or {}
+        tie_breaker = best_multiplier.get("tie_breaker") or {}
+        raw_winner = best_multiplier.get("raw_winner") or {}
+        if tie_breaker.get("applied") and raw_winner.get("mode"):
+            print(
+                f"Tie-break: {best.get('mode')} was within "
+                f"{_fmt_metric(tie_breaker.get('prefer_deeper_within_pct'), digits=1)}% "
+                f"of raw fastest {raw_winner.get('mode')}; preferred the deeper depth."
+            )
     else:
         print("No MTP depth beat AR on this run")
     if payload.get("saved") and best:

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -6406,7 +6406,7 @@ def _quickstart_apply_tuned_depth(
     target: str,
     can_prompt: bool,
 ) -> None:
-    if target != "openwebui":
+    if target not in {"openwebui", "terminal"}:
         return
     if bool(getattr(args, "_explicit_depth", False)):
         return

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import platform
 import shlex
 import shutil
 import socket
@@ -64,7 +66,6 @@ from mtplx.profiles import (
     DEFAULT_MODEL_ID,
     DEFAULT_PROFILE_NAME,
     DEFAULT_PUBLIC_MODEL_ID,
-    QUALITY_PUBLIC_MODEL_ID,
     apply_profile_env,
     get_profile,
 )
@@ -116,6 +117,12 @@ EXTERNAL_RUNTIME_ENV_KEYS = (
 )
 LOCALHOST_BINDS = {"", "127.0.0.1", "::1", "localhost"}
 MAX_PUBLIC_SPECULATIVE_DEPTH = 3
+TUNE_DEFAULT_DEPTHS = "1,2,3"
+TUNE_DEFAULT_SUITE = "cold-long-code-192"
+TUNE_DEFAULT_MAX_TOKENS = 192
+TUNE_DEFAULT_LIMIT = 1
+TUNE_DEFAULT_SEED = 0
+TUNE_STATE_PATH = Path("~/.mtplx/tuning.json").expanduser()
 GENERATION_MODE_MTP = "mtp"
 GENERATION_MODE_AR = "ar"
 GENERATION_MODES = {GENERATION_MODE_MTP, GENERATION_MODE_AR}
@@ -137,6 +144,13 @@ def _benchmark_seed(args: Any, *, runtime_profile: str, harness: str) -> int:
         return 0
     return 42
 
+
+def _depths_for_bench_run(args: Any) -> str:
+    explicit_depths = getattr(args, "depths", None)
+    if explicit_depths:
+        return str(explicit_depths)
+    depth = int(getattr(args, "speculative_depth", 0) or 0)
+    return str(depth) if depth > 0 else "3"
 
 def _runtime_env_with_external_overrides(runtime_env: dict[str, str]) -> dict[str, str]:
     merged = dict(runtime_env)
@@ -859,12 +873,14 @@ def _depth_sweep_native60(
     *,
     model: str,
     prompt_suite: str,
+    depths: str = "3",
     max_tokens: int,
     limit: int | None,
     seed: int,
-    depth: int = 3,
     draft_lm_head: dict[str, Any] | None = None,
     draft_sampler: dict[str, Any] | None = None,
+    compare_ar: bool = False,
+    ar_only: bool = False,
 ) -> dict[str, Any]:
     from mtplx.benchmarks.runners.mtp_depth_sweep import run_mtp_depth_sweep
 
@@ -877,7 +893,7 @@ def _depth_sweep_native60(
     return run_mtp_depth_sweep(
         model,
         prompt_suite,
-        depths=str(depth),
+        depths=depths,
         temperature=0.6,
         top_p=0.95,
         top_k=20,
@@ -885,7 +901,8 @@ def _depth_sweep_native60(
         seed=seed,
         limit=limit,
         enable_thinking=False,
-        compare_ar=False,
+        compare_ar=compare_ar,
+        ar_only=ar_only,
         mtp_hidden_variant="post_norm",
         mtp_cache_policy="persistent",
         mtp_history_policy="committed",
@@ -901,7 +918,6 @@ def _depth_sweep_native60(
         draft_top_p=None if draft_sampler is None else float(draft_sampler["top_p"]),
         draft_top_k=None if draft_sampler is None else int(draft_sampler["top_k"]),
     )
-
 
 class _temporary_env:
     def __init__(self, updates: dict[str, str]) -> None:
@@ -1113,6 +1129,8 @@ def cmd_bench_public(args: Any) -> int:
         return 0
     if action in {"run", "context"}:
         return _cmd_bench_run(args)
+    if action == "tune":
+        return _cmd_bench_tune(args)
     if action == "nightly":
         return _cmd_bench_nightly(args)
     if action == "compare":
@@ -1125,6 +1143,694 @@ def cmd_bench_public(args: Any) -> int:
         return _cmd_bench_reference_vllm(args)
     raise SystemExit(f"unknown bench action: {action}")
 
+
+def cmd_tune_public(args: Any) -> int:
+    if getattr(args, "_tune_candidate", None):
+        return _cmd_tune_candidate(args)
+    return _cmd_tune(
+        args,
+        action="tune",
+        save_default=not bool(getattr(args, "no_save", False)),
+        verbose_default=bool(getattr(args, "verbose", False)),
+    )
+
+
+def _cmd_bench_tune(args: Any) -> int:
+    child = SimpleNamespace(**vars(args))
+    cli_flags = getattr(child, "_cli_flags", set()) or set()
+    if "max-tokens" not in cli_flags:
+        child.max_tokens = TUNE_DEFAULT_MAX_TOKENS
+    return _cmd_tune(
+        child,
+        action="bench tune",
+        save_default=False,
+        verbose_default=True,
+    )
+
+
+def _cmd_tune(
+    args: Any,
+    *,
+    action: str,
+    save_default: bool,
+    verbose_default: bool,
+) -> int:
+    try:
+        depths = _parse_tune_depths(getattr(args, "depths", None) or TUNE_DEFAULT_DEPTHS)
+    except ValueError as exc:
+        return _tune_error(str(exc), json_output=bool(getattr(args, "json", False)))
+
+    model = getattr(args, "model", None) or DEFAULT_CHAMPION
+    settings = _tune_settings(args, depths=depths)
+    run_id = getattr(args, "run_id", None) or f"tune-{time.strftime('%Y%m%d-%H%M%S')}"
+    output_root = Path(getattr(args, "output_dir", None) or "outputs/cli/tune") / run_id
+    output_path = Path(getattr(args, "output", None)) if getattr(args, "output", None) else output_root / "tune.json"
+    json_output = bool(getattr(args, "json", False))
+    verbose = bool(getattr(args, "verbose", verbose_default) or verbose_default)
+
+    if bool(getattr(args, "dry_run", False)):
+        payload = _tune_dry_run_payload(
+            args,
+            action=action,
+            model=model,
+            run_id=run_id,
+            output_root=output_root,
+            output_path=output_path,
+            settings=settings,
+            depths=depths,
+            save_default=save_default,
+        )
+        if json_output or action == "bench tune":
+            _print(payload)
+        else:
+            _print_tune_dry_run_human(payload)
+        return 0
+
+    runtime_model, resolve_error = _resolve_runtime_model_path(
+        model,
+        cache_dir=getattr(args, "cache_dir", None),
+    )
+    if resolve_error is not None:
+        return _tune_error(
+            resolve_error.get("error") or "model is not available locally",
+            detail=resolve_error.get("detail"),
+            json_output=json_output,
+        )
+
+    profile = get_profile("performance-cold")
+    hardware = _apple_hardware_context()
+    software = _software_context()
+    backend = _mlx_backend_context(profile)
+    state_key, key_material = _tune_state_key(
+        runtime_model,
+        settings=settings,
+        hardware=hardware,
+        software=software,
+        backend=backend,
+    )
+    cached = None if bool(getattr(args, "retune", False)) else _load_tune_record(state_key)
+    if save_default and cached is not None:
+        payload = dict(cached.get("payload") or {})
+        payload["from_cache"] = True
+        payload["state_path"] = str(_tune_state_path())
+        if json_output:
+            _print(payload)
+        else:
+            _print_tune_human(payload, verbose=verbose)
+        return 0
+
+    from mtplx.thermal import MaxSession
+
+    def _emit(line: str) -> None:
+        print(line, file=sys.stderr, flush=True)
+
+    max_session = MaxSession(log=_emit)
+    if not max_session.start():
+        verified = max_session.thermal.get("verified") or {}
+        return _tune_error(
+            "verified max-fan mode did not start; refusing to run a model tune",
+            detail=verified.get("message"),
+            actionable=verified.get("actionable"),
+            thermal=max_session.thermal,
+            json_output=json_output,
+        )
+
+    try:
+        candidate_rows = _run_tune_candidates(
+            args,
+            runtime_model=runtime_model,
+            run_id=run_id,
+            output_root=output_root,
+            depths=depths,
+            settings=settings,
+        )
+    finally:
+        max_session.stop()
+
+    payload = _tune_payload(
+        action=action,
+        run_id=run_id,
+        model=runtime_model,
+        settings=settings,
+        rows=candidate_rows,
+        output_root=output_root,
+        output_path=output_path,
+        hardware=hardware,
+        software=software,
+        backend=backend,
+        thermal=max_session.thermal,
+        state_key=state_key,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(output_path, payload)
+
+    if payload.get("best") and save_default and not bool(getattr(args, "no_save", False)):
+        payload["saved"] = True
+        payload["state_path"] = str(_tune_state_path())
+        _save_tune_record(state_key, key_material=key_material, payload=payload)
+        write_json(output_path, payload)
+    else:
+        payload["saved"] = False
+        payload["state_path"] = str(_tune_state_path())
+        if not payload.get("best"):
+            payload["save_skipped_reason"] = "no MTP depth beat AR"
+        elif bool(getattr(args, "no_save", False)) or not save_default:
+            payload["save_skipped_reason"] = "save disabled"
+        write_json(output_path, payload)
+
+    if json_output:
+        _print(payload)
+    else:
+        _print_tune_human(payload, verbose=verbose)
+    if not candidate_rows or not any(isinstance(row.get("tok_s"), (int, float)) for row in candidate_rows):
+        return 1
+    return 0
+
+
+def _cmd_tune_candidate(args: Any) -> int:
+    candidate = str(getattr(args, "_tune_candidate", "")).lower()
+    output = Path(getattr(args, "_tune_candidate_output", None) or "")
+    if candidate not in {"ar", "1", "2", "3"}:
+        return _tune_error("invalid tune candidate", json_output=True)
+    if not output:
+        return _tune_error("missing tune candidate output path", json_output=True)
+    model = getattr(args, "model", None) or DEFAULT_CHAMPION
+    runtime_model, resolve_error = _resolve_runtime_model_path(
+        model,
+        cache_dir=getattr(args, "cache_dir", None),
+    )
+    if resolve_error is not None:
+        _print(resolve_error)
+        return 1
+    inspection, gate_exit = _model_gate(
+        runtime_model,
+        unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
+        yes=True,
+    )
+    if gate_exit is not None:
+        _print({"error": "model failed MTP primary gate", "model": inspection})
+        return gate_exit
+    profile = get_profile("performance-cold")
+    draft_lm_head = _model_draft_lm_head_spec(inspection, profile)
+    draft_sampler = _model_draft_sampler_spec(inspection, profile)
+    result = _depth_sweep_native60(
+        model=runtime_model,
+        prompt_suite=prompt_suite_path(TUNE_DEFAULT_SUITE),
+        depths="1" if candidate == "ar" else candidate,
+        max_tokens=int(getattr(args, "max_tokens", TUNE_DEFAULT_MAX_TOKENS) or TUNE_DEFAULT_MAX_TOKENS),
+        limit=int(getattr(args, "limit", TUNE_DEFAULT_LIMIT) or TUNE_DEFAULT_LIMIT),
+        seed=int(getattr(args, "seed", TUNE_DEFAULT_SEED) or TUNE_DEFAULT_SEED),
+        draft_lm_head=draft_lm_head,
+        draft_sampler=draft_sampler,
+        compare_ar=candidate == "ar",
+        ar_only=candidate == "ar",
+    )
+    from mtplx.benchmarks.runners.mtp_depth_sweep import write_depth_sweep
+
+    write_depth_sweep(output, result)
+    _print({"candidate": candidate, "output": str(output)})
+    return 0
+
+
+def _parse_tune_depths(raw: Any) -> list[int]:
+    if raw is None:
+        raw = TUNE_DEFAULT_DEPTHS
+    parts = [part.strip() for part in str(raw).split(",") if part.strip()]
+    if not parts:
+        raise ValueError("tune depths must include at least one of 1,2,3")
+    depths: list[int] = []
+    for part in parts:
+        try:
+            depth = int(part)
+        except ValueError as exc:
+            raise ValueError("tune depths must be integers from 1 to 3") from exc
+        if depth < 1 or depth > MAX_PUBLIC_SPECULATIVE_DEPTH:
+            raise ValueError("tune depths must be between 1 and 3")
+        if depth not in depths:
+            depths.append(depth)
+    return depths
+
+
+def _tune_settings(args: Any, *, depths: list[int]) -> dict[str, Any]:
+    return {
+        "profile": "performance-cold",
+        "suite": TUNE_DEFAULT_SUITE,
+        "depths": ",".join(str(depth) for depth in depths),
+        "max_tokens": int(getattr(args, "max_tokens", TUNE_DEFAULT_MAX_TOKENS) or TUNE_DEFAULT_MAX_TOKENS),
+        "limit": int(getattr(args, "limit", TUNE_DEFAULT_LIMIT) or TUNE_DEFAULT_LIMIT),
+        "seed": int(getattr(args, "seed", TUNE_DEFAULT_SEED) or TUNE_DEFAULT_SEED),
+        "thinking": "disabled",
+    }
+
+
+def _tune_state_path() -> Path:
+    env = os.environ.get("MTPLX_TUNE_STATE")
+    return Path(env).expanduser() if env else TUNE_STATE_PATH
+
+
+def _load_tune_state() -> dict[str, Any]:
+    path = _tune_state_path()
+    if not path.exists():
+        return {"schema_version": 1, "records": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"schema_version": 1, "records": {}}
+    if not isinstance(data, dict):
+        return {"schema_version": 1, "records": {}}
+    records = data.get("records")
+    if not isinstance(records, dict):
+        data["records"] = {}
+    return data
+
+
+def _load_tune_record(state_key: str) -> dict[str, Any] | None:
+    record = (_load_tune_state().get("records") or {}).get(state_key)
+    if not isinstance(record, dict):
+        return None
+    payload = record.get("payload")
+    best = payload.get("best") if isinstance(payload, dict) else None
+    if not isinstance(best, dict):
+        return None
+    if not isinstance(best.get("depth"), int):
+        return None
+    return record
+
+
+def _save_tune_record(state_key: str, *, key_material: dict[str, Any], payload: dict[str, Any]) -> None:
+    state = _load_tune_state()
+    records = state.setdefault("records", {})
+    records[state_key] = {
+        "schema_version": 1,
+        "saved_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "key": state_key,
+        "key_material": key_material,
+        "payload": payload,
+    }
+    path = _tune_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(path, state)
+
+
+def _tune_state_key(
+    model: str,
+    *,
+    settings: dict[str, Any],
+    hardware: dict[str, Any],
+    software: dict[str, Any],
+    backend: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    model_identity = str(Path(model).expanduser().resolve()) if Path(model).expanduser().exists() else str(model)
+    key_material = {
+        "model": model_identity,
+        "hardware": {
+            "chip": hardware.get("chip"),
+            "chip_family": hardware.get("chip_family"),
+            "hw_model": hardware.get("hw_model"),
+            "machine": hardware.get("machine"),
+        },
+        "software": {
+            "mtplx_version": software.get("mtplx_version"),
+            "mlx_version": software.get("mlx_version"),
+            "mlx_lm_version": software.get("mlx_lm_version"),
+        },
+        "backend": {
+            "mlx_core_path": backend.get("mlx_core_path"),
+            "optional_fast_mlx_fork_active": backend.get("optional_fast_mlx_fork_active"),
+            "stock_mlx_likely": backend.get("stock_mlx_likely"),
+        },
+        "settings": settings,
+    }
+    encoded = json.dumps(key_material, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest(), key_material
+
+
+def _tune_dry_run_payload(
+    args: Any,
+    *,
+    action: str,
+    model: str,
+    run_id: str,
+    output_root: Path,
+    output_path: Path,
+    settings: dict[str, Any],
+    depths: list[int],
+    save_default: bool,
+) -> dict[str, Any]:
+    commands = []
+    for candidate in ["ar", *[str(depth) for depth in depths]]:
+        candidate_output = output_root / f"{_tune_candidate_label(candidate).lower()}.json"
+        commands.append(
+            {
+                "candidate": _tune_candidate_label(candidate),
+                "command": _tune_candidate_command(
+                    args,
+                    candidate=candidate,
+                    model=model,
+                    output=candidate_output,
+                    settings=settings,
+                ),
+                "output": str(candidate_output),
+            }
+        )
+    return {
+        "dry_run": True,
+        "action": action,
+        "run_id": run_id,
+        "model": model,
+        "settings": settings,
+        "candidates": commands,
+        "output": str(output_path),
+        "state_path": str(_tune_state_path()),
+        "save_default": save_default,
+        "fan_control": "verified max-fan required before model load",
+    }
+
+
+def _run_tune_candidates(
+    args: Any,
+    *,
+    runtime_model: str,
+    run_id: str,
+    output_root: Path,
+    depths: list[int],
+    settings: dict[str, Any],
+) -> list[dict[str, Any]]:
+    output_root.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    for candidate in ["ar", *[str(depth) for depth in depths]]:
+        label = _tune_candidate_label(candidate)
+        candidate_output = output_root / f"{label.lower()}.json"
+        stdout_path = output_root / f"{label.lower()}.log"
+        command = _tune_candidate_command(
+            args,
+            candidate=candidate,
+            model=runtime_model,
+            output=candidate_output,
+            settings=settings,
+        )
+        proc = subprocess.run(
+            command,
+            cwd=repo_root(),
+            env={**os.environ, "MTPLX_TUNE_CHILD": "1"},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+        stdout_path.write_text(proc.stdout, encoding="utf-8")
+        rows.append(
+            _tune_candidate_summary(
+                candidate,
+                candidate_output,
+                returncode=proc.returncode,
+                stdout_path=stdout_path,
+                command=command,
+            )
+        )
+    return rows
+
+
+def _tune_candidate_command(
+    args: Any,
+    *,
+    candidate: str,
+    model: str,
+    output: Path,
+    settings: dict[str, Any],
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "mtplx.cli",
+        "tune",
+        "--_candidate",
+        candidate,
+        "--_candidate-output",
+        str(output),
+        "--model",
+        str(model),
+        "--max-tokens",
+        str(int(settings["max_tokens"])),
+        "--limit",
+        str(int(settings["limit"])),
+        "--seed",
+        str(int(settings["seed"])),
+        "--depths",
+        str(settings["depths"]),
+        "--yes",
+    ]
+    cache_dir = getattr(args, "cache_dir", None)
+    if cache_dir:
+        command.extend(["--cache-dir", str(cache_dir)])
+    if bool(getattr(args, "unsafe_force_unverified", False)):
+        command.append("--unsafe-force-unverified")
+    return command
+
+
+def _tune_candidate_label(candidate: str) -> str:
+    return "AR" if candidate == "ar" else f"D{candidate}"
+
+
+def _tune_candidate_summary(
+    candidate: str,
+    path: Path,
+    *,
+    returncode: int,
+    stdout_path: Path,
+    command: list[str],
+) -> dict[str, Any]:
+    label = _tune_candidate_label(candidate)
+    base = {
+        "mode": label,
+        "depth": None if candidate == "ar" else int(candidate),
+        "candidate": candidate,
+        "returncode": returncode,
+        "artifact": str(path),
+        "stdout": str(stdout_path),
+        "command": command,
+    }
+    if not path.exists():
+        return {**base, "error": "candidate did not write an artifact"}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return {**base, "error": f"candidate artifact is not valid JSON: {exc}"}
+    if candidate == "ar":
+        ar_rows = data.get("ar_rows") or []
+        tok_values = [
+            float(row["tok_s"])
+            for row in ar_rows
+            if isinstance(row.get("tok_s"), (int, float))
+        ]
+        return {
+            **base,
+            "tok_s": (sum(tok_values) / len(tok_values)) if tok_values else None,
+            "generated_tokens": sum(int(row.get("generated_tokens") or 0) for row in ar_rows),
+            "verify_ms_per_call": None,
+            "quality_passed": True if ar_rows else None,
+        }
+    depth_rows = data.get("depths") or data.get("depth_results") or []
+    row = depth_rows[0] if depth_rows else {}
+    summary = row.get("summary") or {}
+    verify_calls = int(summary.get("verify_calls") or 0)
+    validations = [
+        validation
+        for depth_row in depth_rows
+        for result_row in depth_row.get("rows", [])
+        for validation in result_row.get("validations", [])
+    ]
+    acceptance = summary.get("acceptance_by_depth")
+    if acceptance is None:
+        acceptance = _rate_lists(
+            summary.get("accepted_by_depth") or [],
+            summary.get("drafted_by_depth") or [],
+        )
+    return {
+        **base,
+        "tok_s": summary.get("mean_tok_s"),
+        "generated_tokens": summary.get("generated_tokens"),
+        "elapsed_s": summary.get("elapsed_s"),
+        "verify_time_s": summary.get("verify_time_s"),
+        "verify_calls": verify_calls,
+        "verify_ms_per_call": _ms_per_call(summary.get("verify_time_s"), verify_calls),
+        "verify_forward_ms_per_call": _ms_per_call(summary.get("verify_forward_time_s"), verify_calls),
+        "verify_eval_ms_per_call": _ms_per_call(summary.get("verify_eval_time_s"), verify_calls),
+        "verify_hidden_eval_ms_per_call": _ms_per_call(summary.get("verify_hidden_eval_time_s"), verify_calls),
+        "accepted_by_depth": summary.get("accepted_by_depth"),
+        "drafted_by_depth": summary.get("drafted_by_depth"),
+        "acceptance_by_depth": acceptance,
+        "acceptance_percent_by_depth": [
+            (None if value is None else 100.0 * float(value)) for value in acceptance
+        ],
+        "mean_accept_probability_by_depth": summary.get("mean_accept_probability_by_depth"),
+        "quality_passed": all(bool(v.get("passed")) for v in validations) if validations else None,
+        "validations_total": len(validations),
+        "validations_passed": sum(1 for v in validations if v.get("passed")),
+    }
+
+
+def _tune_payload(
+    *,
+    action: str,
+    run_id: str,
+    model: str,
+    settings: dict[str, Any],
+    rows: list[dict[str, Any]],
+    output_root: Path,
+    output_path: Path,
+    hardware: dict[str, Any],
+    software: dict[str, Any],
+    backend: dict[str, Any],
+    thermal: dict[str, Any],
+    state_key: str,
+) -> dict[str, Any]:
+    rows = _annotate_multipliers(rows)
+    best = _best_multiplier_summary(rows)
+    return {
+        "action": action,
+        "run_id": run_id,
+        "model": model,
+        "profile": "performance-cold",
+        "suite": settings["suite"],
+        "settings": settings,
+        "results": rows,
+        "best": best.get("winner"),
+        "best_multiplier": best,
+        "hardware": hardware,
+        "software": software,
+        "backend": backend,
+        "thermal": thermal,
+        "state_key": state_key,
+        "artifacts": {
+            "root": str(output_root),
+            "summary": str(output_path),
+        },
+    }
+
+
+def _annotate_multipliers(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ar_tok_s = None
+    for row in results:
+        if row.get("mode") == "AR":
+            ar_tok_s = row.get("tok_s")
+            break
+    annotated = []
+    for row in results:
+        item = dict(row)
+        if item.get("mode") == "AR":
+            item["multiplier_vs_ar"] = 1.0 if isinstance(item.get("tok_s"), (int, float)) else None
+        else:
+            item["multiplier_vs_ar"] = item.get("speedup_vs_ar") or _safe_ratio(item.get("tok_s"), ar_tok_s)
+        annotated.append(item)
+    return annotated
+
+
+def _best_multiplier_summary(results: list[dict[str, Any]]) -> dict[str, Any]:
+    annotated = _annotate_multipliers(results)
+    ar = next((row for row in annotated if row.get("mode") == "AR"), None)
+    candidates = [
+        row
+        for row in annotated
+        if row.get("depth") is not None
+        and isinstance(row.get("multiplier_vs_ar"), (int, float))
+        and float(row["multiplier_vs_ar"]) > 1.0
+    ]
+    winner = max(candidates, key=lambda row: float(row["multiplier_vs_ar"]), default=None)
+    if winner is None:
+        return {
+            "available": bool(ar and isinstance(ar.get("tok_s"), (int, float))),
+            "ar_tok_s": ar.get("tok_s") if ar else None,
+            "winner": None,
+            "verdict": "no_mtp_depth_beat_ar",
+        }
+    return {
+        "available": True,
+        "ar_tok_s": ar.get("tok_s") if ar else None,
+        "winner": {
+            "mode": winner.get("mode"),
+            "depth": winner.get("depth"),
+            "tok_s": winner.get("tok_s"),
+            "multiplier_vs_ar": winner.get("multiplier_vs_ar"),
+        },
+        "verdict": "mtp_depth_wins",
+    }
+
+
+def _print_tune_dry_run_human(payload: dict[str, Any]) -> None:
+    print("MTPLX Tune")
+    print("dry-run: no model will be loaded")
+    print(f"model: {payload.get('model')}")
+    print(f"output: {payload.get('output')}")
+    print("candidate commands:")
+    for row in payload.get("candidates", []):
+        print(f"  {row.get('candidate')}: {shlex.join(row.get('command') or [])}")
+
+
+def _print_tune_human(payload: dict[str, Any], *, verbose: bool = False) -> None:
+    print("MTPLX Tune")
+    if payload.get("from_cache"):
+        print("Using saved tuning. Run `mtplx tune --retune` to measure again.")
+    else:
+        print("Close heavy apps for cleaner results. Fans may get loud during tuning.")
+    print()
+    best = payload.get("best") or {}
+    for row in payload.get("results", []):
+        mode = str(row.get("mode") or "?")
+        tok_s = _fmt_metric(row.get("tok_s"), digits=1)
+        multiplier = _fmt_metric(row.get("multiplier_vs_ar"), digits=2)
+        marker = "  BEST" if best.get("mode") == mode else ""
+        print(f"{mode:<4} {tok_s:>6} tok/s   {multiplier}x{marker}")
+    print()
+    if best:
+        print(
+            f"Best for this Mac: {best.get('mode')}, "
+            f"{_fmt_metric(best.get('multiplier_vs_ar'), digits=2)}x AR"
+        )
+    else:
+        print("No MTP depth beat AR on this run")
+    if payload.get("saved") and best:
+        print(f"Saved: Web UI starts will use depth {best.get('depth')} for this model.")
+    elif payload.get("save_skipped_reason"):
+        print(f"Not saved: {payload.get('save_skipped_reason')}.")
+    if verbose:
+        print()
+        for row in payload.get("results", []):
+            if row.get("depth") is None:
+                continue
+            print(
+                f"{row.get('mode')}: verify_ms={_fmt_metric(row.get('verify_ms_per_call'), digits=2)} "
+                f"acceptance={_format_depth_acceptance(row)}"
+            )
+        artifacts = payload.get("artifacts") or {}
+        if artifacts:
+            print(f"artifacts: {artifacts.get('root')}")
+
+
+def _tune_error(
+    message: str,
+    *,
+    detail: str | None = None,
+    actionable: str | None = None,
+    thermal: dict[str, Any] | None = None,
+    json_output: bool = False,
+) -> int:
+    payload: dict[str, Any] = {"error": message}
+    if detail:
+        payload["detail"] = detail
+    if actionable:
+        payload["actionable"] = actionable
+    if thermal is not None:
+        payload["thermal"] = thermal
+    if json_output:
+        _print(payload)
+    else:
+        print(f"error: {message}", file=sys.stderr)
+        if detail:
+            print(f"detail: {detail}", file=sys.stderr)
+        if actionable:
+            print(f"action: {actionable}", file=sys.stderr)
+    return 1
 
 def cmd_pull_public(args: Any) -> int:
     from mtplx.hf_loader import pull_model, repo_id_from_model_ref
@@ -1234,6 +1940,7 @@ def _cmd_bench_run(args: Any) -> int:
     if harness == "auto":
         harness = "depth-sweep" if selected_profile.name == "performance-cold" else "direct-http"
     benchmark_seed = _benchmark_seed(args, runtime_profile=runtime_profile, harness=harness)
+    depths = _depths_for_bench_run(args)
 
     if args.dry_run:
         direct_command = _direct_http_bench_command(
@@ -1257,6 +1964,10 @@ def _cmd_bench_run(args: Any) -> int:
                     "profile": _exactness_profile_kwargs(args),
                 },
                 "harness": harness,
+                "depths": depths if harness == "depth-sweep" else None,
+                "compare_ar": bool(getattr(args, "compare_ar", False))
+                if harness == "depth-sweep"
+                else None,
                 "seed": benchmark_seed,
                 "profile": selected_profile.to_dict(),
                 "runtime_profile": runtime_profile,
@@ -1332,19 +2043,13 @@ def _cmd_bench_run(args: Any) -> int:
         result = _depth_sweep_native60(
             model=runtime_model,
             prompt_suite=prompt_suite,
+            depths=depths,
             max_tokens=args.max_tokens,
             limit=args.limit,
             seed=benchmark_seed,
-            depth=(
-                int(getattr(args, "depth", 3))
-                if "depth" in (getattr(args, "_cli_flags", set()) or set())
-                else _model_contract_depth(
-                    inspection,
-                    fallback=int(getattr(args, "depth", 3)),
-                )
-            ),
             draft_lm_head=draft_lm_head,
             draft_sampler=draft_sampler,
+            compare_ar=bool(getattr(args, "compare_ar", False)),
         )
     output.parent.mkdir(parents=True, exist_ok=True)
     write_depth_sweep(output, result)
@@ -3246,6 +3951,144 @@ def _active_mlx_fork_status(*, expected_fragment: str, expected_commit: str | No
         "observed_commit": commit,
     }
 
+
+def _apple_hardware_context() -> dict[str, Any]:
+    mem_bytes = _sysctl_int("hw.memsize")
+    chip = _sysctl_text("machdep.cpu.brand_string")
+    return {
+        "system": platform.system(),
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+        "macos_version": _command_text(["sw_vers", "-productVersion"]),
+        "macos_build": _command_text(["sw_vers", "-buildVersion"]),
+        "chip": chip,
+        "chip_family": _apple_chip_family(chip),
+        "hw_model": _sysctl_text("hw.model"),
+        "memory_gib": (mem_bytes / (1024**3)) if mem_bytes else None,
+        "logical_cpu": _sysctl_int("hw.logicalcpu"),
+        "physical_cpu": _sysctl_int("hw.physicalcpu"),
+        "perf_cores": _sysctl_int("hw.perflevel0.physicalcpu"),
+        "efficiency_cores": _sysctl_int("hw.perflevel1.physicalcpu"),
+        "arm64": _sysctl_int("hw.optional.arm64"),
+    }
+
+def _software_context() -> dict[str, Any]:
+    env = collect_environment(".").to_dict()
+    return {
+        "python_executable": env.get("python_executable"),
+        "python_version": env.get("python_version"),
+        "mtplx_version": _package_version("mtplx"),
+        "mlx_version": _package_version("mlx"),
+        "mlx_lm_version": _package_version("mlx-lm"),
+        "numpy_version": _package_version("numpy"),
+        "git_branch": env.get("git_branch"),
+        "git_status": env.get("git_status"),
+    }
+
+def _mlx_backend_context(profile: Any) -> dict[str, Any]:
+    path = None
+    try:
+        spec = importlib.util.find_spec("mlx.core")
+        path = str(Path(spec.origin).resolve()) if spec and spec.origin else None
+    except Exception as exc:  # pragma: no cover - host dependent
+        path = f"ERROR: {exc}"
+    fork_status = None
+    if getattr(profile, "required_mlx_fork_fragment", None):
+        fork_status = _active_mlx_fork_status(
+            expected_fragment=profile.required_mlx_fork_fragment,
+            expected_commit=profile.required_mlx_fork_commit,
+        )
+    custom_env = {
+        key: os.environ.get(key)
+        for key in (
+            "MTPLX_GDN_OUT_QMV8",
+            "MTPLX_SOURCE_QMM_MANY",
+            "MTPLX_SOURCE_QMM_MANY_STRICT",
+            "MTPLX_NATIVE_MLP",
+            "MTPLX_VERIFY_MLP_FUSED",
+        )
+        if os.environ.get(key)
+    }
+    fork_active = bool(fork_status and fork_status.get("ok"))
+    return {
+        "mlx_core_path": path,
+        "mlx_version": _package_version("mlx"),
+        "mlx_lm_version": _package_version("mlx-lm"),
+        "optional_fast_mlx_fork_active": fork_active,
+        "optional_fast_mlx_fork": fork_status,
+        "stock_mlx_likely": not fork_active,
+        "custom_qmv_or_qmm_env": custom_env,
+    }
+
+def _ms_per_call(seconds: Any, calls: int) -> float | None:
+    if not isinstance(seconds, (int, float)) or not calls:
+        return None
+    return 1000.0 * float(seconds) / calls
+
+def _safe_ratio(numerator: Any, denominator: Any) -> float | None:
+    if not isinstance(numerator, (int, float)) or not isinstance(denominator, (int, float)):
+        return None
+    if float(denominator) == 0.0:
+        return None
+    return float(numerator) / float(denominator)
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except Exception:
+        return None
+
+def _command_text(args: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(
+            args,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2.0,
+        ).strip()
+    except Exception:
+        return None
+
+def _sysctl_text(name: str) -> str | None:
+    return _command_text(["sysctl", "-n", name])
+
+def _sysctl_int(name: str) -> int | None:
+    text = _sysctl_text(name)
+    try:
+        return int(text) if text is not None else None
+    except ValueError:
+        return None
+
+def _apple_chip_family(chip: str | None) -> str | None:
+    if not chip:
+        return None
+    words = str(chip).replace("(TM)", "").split()
+    if len(words) >= 2 and words[0] == "Apple" and words[1].startswith("M"):
+        return " ".join(words[:3]) if len(words) >= 3 else " ".join(words[:2])
+    return chip
+
+def _rate_lists(numerators: list[Any], denominators: list[Any]) -> list[float | None]:
+    rates: list[float | None] = []
+    for numerator, denominator in zip(numerators, denominators):
+        den = float(denominator or 0)
+        rates.append((float(numerator) / den) if den else None)
+    return rates
+
+def _format_depth_acceptance(row: dict[str, Any]) -> str:
+    accepted = row.get("accepted_by_depth") or []
+    drafted = row.get("drafted_by_depth") or []
+    percentages = row.get("acceptance_percent_by_depth") or []
+    parts = []
+    for index, (acc, draft) in enumerate(zip(accepted, drafted), start=1):
+        pct = percentages[index - 1] if index - 1 < len(percentages) else None
+        pct_text = _fmt_metric(pct, digits=2)
+        parts.append(f"MTP{index} {acc}/{draft} ({pct_text}%)")
+    return " | ".join(parts) if parts else "n/a"
+
+def _fmt_metric(value: Any, *, digits: int) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.{digits}f}"
+    return "n/a"
 
 def _print_serve_start_line(text: str = "") -> None:
     print(text, flush=True)
@@ -5556,6 +6399,97 @@ def _quickstart_run_terminal_chat_body(args: Any, *, runtime_model: str, inspect
         turn_index += 1
 
 
+def _quickstart_apply_tuned_depth(
+    args: Any,
+    *,
+    runtime_model: str,
+    target: str,
+    can_prompt: bool,
+) -> None:
+    if target != "openwebui":
+        return
+    if bool(getattr(args, "_explicit_depth", False)):
+        return
+    settings = {
+        "profile": "performance-cold",
+        "suite": TUNE_DEFAULT_SUITE,
+        "depths": TUNE_DEFAULT_DEPTHS,
+        "max_tokens": TUNE_DEFAULT_MAX_TOKENS,
+        "limit": TUNE_DEFAULT_LIMIT,
+        "seed": TUNE_DEFAULT_SEED,
+        "thinking": "disabled",
+    }
+    profile = get_profile("performance-cold")
+    hardware = _apple_hardware_context()
+    software = _software_context()
+    backend = _mlx_backend_context(profile)
+    state_key, _key_material = _tune_state_key(
+        runtime_model,
+        settings=settings,
+        hardware=hardware,
+        software=software,
+        backend=backend,
+    )
+    record = _load_tune_record(state_key)
+    if record is not None:
+        payload = record.get("payload") or {}
+        best = payload.get("best") or {}
+        depth = best.get("depth")
+        if isinstance(depth, int):
+            args.depth = depth
+            _quickstart_line(
+                f"tuned depth: D{depth} "
+                f"({_fmt_metric(best.get('multiplier_vs_ar'), digits=2)}x AR)"
+            )
+            return
+    if not can_prompt:
+        return
+    try:
+        from mtplx.ui.onboarding import screen_tuning_offer
+
+        should_tune = screen_tuning_offer()
+    except (KeyboardInterrupt, EOFError):
+        _quickstart_line()
+        _quickstart_line("tuning skipped")
+        return
+    if not should_tune:
+        _quickstart_line("tuning skipped; using default depth")
+        return
+    tune_args = SimpleNamespace(
+        command="tune",
+        model=runtime_model,
+        cache_dir=getattr(args, "cache_dir", None),
+        depths=TUNE_DEFAULT_DEPTHS,
+        max_tokens=TUNE_DEFAULT_MAX_TOKENS,
+        limit=TUNE_DEFAULT_LIMIT,
+        seed=TUNE_DEFAULT_SEED,
+        run_id=None,
+        output_dir=None,
+        output=None,
+        json=False,
+        verbose=False,
+        dry_run=False,
+        no_save=False,
+        retune=False,
+        unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
+        yes=True,
+    )
+    code = _cmd_tune(
+        tune_args,
+        action="tune",
+        save_default=True,
+        verbose_default=False,
+    )
+    if code != 0:
+        _quickstart_line("tuning did not finish; using default depth")
+        return
+    record = _load_tune_record(state_key)
+    payload = record.get("payload") if isinstance(record, dict) else None
+    best = payload.get("best") if isinstance(payload, dict) else None
+    depth = best.get("depth") if isinstance(best, dict) else None
+    if isinstance(depth, int):
+        args.depth = depth
+
 def cmd_quickstart_public(args: Any) -> int:
     raw_target = getattr(args, "target", None)
 
@@ -5585,6 +6519,8 @@ def cmd_quickstart_public(args: Any) -> int:
     has_explicit_model = "model" in cli_flags
     args._model_explicit = has_explicit_model
     has_explicit_profile_flag = "profile" in cli_flags
+    has_explicit_depth = "depth" in cli_flags
+    args._explicit_depth = has_explicit_depth
     has_explicit_max = "max" in cli_flags
     has_prompt = bool(getattr(args, "prompt", None))
     is_dry_run = bool(getattr(args, "dry_run", False))
@@ -5861,6 +6797,12 @@ def cmd_quickstart_public(args: Any) -> int:
                 )
                 return gate_exit
             _apply_model_contract_depth_default(args, inspection)
+            _quickstart_apply_tuned_depth(
+                args,
+                runtime_model=runtime_model,
+                target=target,
+                can_prompt=bool(getattr(args, "_onboarded", False) and is_tty and not is_yes),
+            )
             if target == "openwebui":
                 args.model = runtime_model
                 return _quickstart_run_openwebui(args, runtime_model=runtime_model, inspection=inspection)
@@ -5900,6 +6842,12 @@ def cmd_quickstart_public(args: Any) -> int:
         )
         return gate_exit
     _apply_model_contract_depth_default(args, inspection)
+    _quickstart_apply_tuned_depth(
+        args,
+        runtime_model=runtime_model,
+        target=target,
+        can_prompt=bool(getattr(args, "_onboarded", False) and is_tty and not is_yes),
+    )
     _quickstart_line(f"model ready: {runtime_model}")
     if resolution.get("downloaded"):
         _quickstart_line(f"downloaded: {resolution.get('download_ref')}")

--- a/mtplx/config.py
+++ b/mtplx/config.py
@@ -14,7 +14,7 @@ from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_MODEL_ID, DEFAULT_PROFIL
 
 
 DEFAULT_CONFIG_PATH = Path("~/.mtplx/config.toml").expanduser()
-RUNTIME_MODEL_COMMANDS = {"ask", "run", "chat", "start", "serve", "quickstart", "quick-start"}
+RUNTIME_MODEL_COMMANDS = {"ask", "run", "chat", "start", "serve", "quickstart", "quick-start", "tune"}
 CACHE_COMMANDS = {"pull", "list", "models", "remove"}
 LEGACY_DEFAULT_MODEL_REFS = {
     "models/Qwen3.6-27B-MTPLX-GDN8-Speed4",
@@ -62,7 +62,13 @@ def load_user_config(path: str | Path | None = None) -> UserConfig:
     profile = data.get("profile")
     thermal_control = data.get("thermal_control")
     if profile is not None:
-        profile = resolve_profile_name(str(profile))
+        try:
+            profile = resolve_profile_name(str(profile))
+        except ValueError:
+            # Config files can outlive profile names. Keep the raw value for
+            # diagnostics, but do not let a stale saved profile break unrelated
+            # commands before they can parse or explicitly choose a profile.
+            profile = str(profile)
     return UserConfig(
         path=resolved,
         exists=True,
@@ -84,7 +90,7 @@ def apply_user_config(args: Any, *, config_path: str | Path | None = None) -> Us
         _apply_model_default(args, config)
         _apply_cache_default(args, config)
         _apply_profile_default(args, config)
-    elif command == "bench" and getattr(args, "bench_action", None) == "run":
+    elif command == "bench" and getattr(args, "bench_action", None) in {"run", "tune"}:
         _apply_model_default(args, config)
         _apply_cache_default(args, config)
         _apply_profile_default(args, config)
@@ -131,4 +137,7 @@ def _apply_profile_default(args: Any, config: UserConfig) -> None:
         return
     current = getattr(args, "profile", None)
     if config.profile and current == DEFAULT_PROFILE_NAME:
-        args.profile = config.profile
+        try:
+            args.profile = resolve_profile_name(config.profile)
+        except ValueError:
+            return

--- a/mtplx/default_models.py
+++ b/mtplx/default_models.py
@@ -202,16 +202,29 @@ def _public_model_id_from_metadata(path: Path) -> str | None:
         inferred = _artifact_role_model_id(role)
         if inferred:
             return inferred
+    verified_on = runtime.get("verified_on")
+    if isinstance(verified_on, dict):
+        verified_model = verified_on.get("model")
+        if isinstance(verified_model, str):
+            inferred = _artifact_role_model_id(verified_model)
+            if inferred:
+                return inferred
 
     config = _read_json(path / "config.json")
     quantization = config.get("quantization") or config.get("quantization_config")
     if isinstance(quantization, dict):
-        text = json.dumps(quantization, sort_keys=True).lower()
-        if "bits\": 8" in text and "language_model" in text:
-            return QUALITY_PUBLIC_MODEL_ID
         bits = quantization.get("bits")
         if bits == 4:
+            child_bits = [
+                value.get("bits")
+                for value in quantization.values()
+                if isinstance(value, dict) and "bits" in value
+            ]
+            if child_bits and all(bit == 8 for bit in child_bits):
+                return QUALITY_PUBLIC_MODEL_ID
             return DEFAULT_PUBLIC_MODEL_ID
+        if bits == 8:
+            return QUALITY_PUBLIC_MODEL_ID
     return None
 
 

--- a/mtplx/default_models.py
+++ b/mtplx/default_models.py
@@ -24,18 +24,30 @@ from mtplx.profiles import (
 
 
 DEFAULT_MODEL_VARIANT_ENV = "MTPLX_DEFAULT_MODEL_VARIANT"
+SPEED_MODEL_ENV = "MTPLX_OPTIMIZED_SPEED_MODEL"
 QUALITY_MODEL_ENV = "MTPLX_OPTIMIZED_QUALITY_MODEL"
-DEFAULT_MODEL_VARIANTS = frozenset({"auto", "bf16", "fp16"})
+DEFAULT_MODEL_VARIANTS = frozenset({"auto", "speed", "q4", "bf16", "fp16"})
 _LEGACY_APPLE_FP16_GENERATIONS = frozenset({"m1", "m2"})
-_NEWER_APPLE_BF16_GENERATIONS = frozenset({"m3", "m4", "m5"})
+_NEWER_APPLE_SPEED_GENERATIONS = frozenset({"m3", "m4", "m5"})
+OPTIMIZED_SPEED_LABEL = "Qwen3.6 27B MTPLX Optimized Speed"
+OPTIMIZED_SPEED_DESCRIPTION = "Q4 target with Q4 MTP sidecar"
 OPTIMIZED_QUALITY_LABEL = "Qwen3.6 27B MTPLX Optimized Quality"
 OPTIMIZED_QUALITY_DESCRIPTION = "Flat8 target with INT8 MTP sidecar"
+_OPTIMIZED_SPEED_LOCAL_CANDIDATES = (
+    "~/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized",
+    "~/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized-Speed",
+    "~/.mtplx/models/Youssofal--Qwen3.6-27B-MTPLX-Optimized-Speed",
+    "~/Documents/MTPLX/hf-staging/Qwen3.6-27B-MTPLX-Optimized",
+    "~/Documents/MTPLX/hf-staging/Qwen3.6-27B-MTPLX-Optimized-Speed",
+)
 _OPTIMIZED_QUALITY_LOCAL_CANDIDATES = (
     "~/Documents/MTPLX/hf-staging/Qwen3.6-27B-MTPLX-Optimized-Quality",
     "~/.mtplx/models/Youssofal--Qwen3.6-27B-MTPLX-Optimized-Quality",
 )
 _VERIFIED_DEFAULT_LOCAL_NAMES = frozenset(
     {
+        "Qwen3.6-27B-MTPLX-Optimized",
+        "Youssofal--Qwen3.6-27B-MTPLX-Optimized",
         "Qwen3.6-27B-MTPLX-Optimized-Speed",
         "Youssofal--Qwen3.6-27B-MTPLX-Optimized-Speed",
         "Qwen3.6-27B-MTPLX-Optimized-Speed-FP16",
@@ -58,8 +70,9 @@ class DefaultModelSelection:
 
     @property
     def display_name(self) -> str:
-        suffix = "FP16" if self.variant == "fp16" else "BF16"
-        return f"Qwen3.6 27B Optimized Speed {suffix}"
+        if self.variant == "fp16":
+            return "Qwen3.6 27B Optimized Speed FP16"
+        return OPTIMIZED_SPEED_LABEL
 
     @property
     def label(self) -> str:
@@ -101,14 +114,46 @@ def _is_complete_local_model(path: Path) -> bool:
     return has_weights and has_mtp
 
 
-def optimized_quality_model_ref() -> str:
-    env_ref = str(os.environ.get(QUALITY_MODEL_ENV) or "").strip()
-    candidates = (env_ref, *_OPTIMIZED_QUALITY_LOCAL_CANDIDATES) if env_ref else _OPTIMIZED_QUALITY_LOCAL_CANDIDATES
+def _env_ref_disabled(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"0", "false", "no", "none", "off", "disabled"}
+
+
+def _complete_local_model_ref(candidates: tuple[str, ...]) -> str | None:
     for candidate in candidates:
+        if not candidate or _env_ref_disabled(candidate):
+            continue
         path = Path(candidate).expanduser()
         if _is_complete_local_model(path):
             return str(path)
-    return QUALITY_HF_MODEL_ID
+    return None
+
+
+def optimized_speed_model_ref() -> str:
+    env_ref = str(os.environ.get(SPEED_MODEL_ENV) or "").strip()
+    candidates: tuple[str, ...]
+    if env_ref:
+        if _env_ref_disabled(env_ref):
+            return DEFAULT_HF_MODEL_ID
+        else:
+            candidates = (env_ref, *_OPTIMIZED_SPEED_LOCAL_CANDIDATES)
+    else:
+        candidates = _OPTIMIZED_SPEED_LOCAL_CANDIDATES
+    repo_local = str((_repo_root() / DEFAULT_RUNTIME_MODEL_DIR).resolve())
+    local = _complete_local_model_ref((*candidates, repo_local))
+    return local or DEFAULT_HF_MODEL_ID
+
+
+def optimized_quality_model_ref() -> str:
+    env_ref = str(os.environ.get(QUALITY_MODEL_ENV) or "").strip()
+    if env_ref:
+        if _env_ref_disabled(env_ref):
+            candidates = ()
+        else:
+            candidates = (env_ref, *_OPTIMIZED_QUALITY_LOCAL_CANDIDATES)
+    else:
+        candidates = _OPTIMIZED_QUALITY_LOCAL_CANDIDATES
+    local = _complete_local_model_ref(candidates)
+    return local or QUALITY_HF_MODEL_ID
 
 
 def is_optimized_quality_model_ref(model: str | Path | None) -> bool:
@@ -233,9 +278,13 @@ def _normalize_variant(value: str | None) -> tuple[str, str | None]:
     if raw in {"", "auto"}:
         return "auto", None
     aliases = {
-        "bf16": "bf16",
-        "bfloat16": "bf16",
-        "bfloat": "bf16",
+        "speed": "speed",
+        "optimized-speed": "speed",
+        "q4": "speed",
+        "int4": "speed",
+        "bf16": "speed",
+        "bfloat16": "speed",
+        "bfloat": "speed",
         "fp16": "fp16",
         "float16": "fp16",
         "f16": "fp16",
@@ -265,7 +314,7 @@ def select_default_model(
     """Select the verified default model for this machine.
 
     Auto policy is intentionally simple and visible:
-    M1/M2 -> FP16, M3/M4/M5/unknown -> BF16.
+    M1/M2 -> FP16, M3/M4/M5/unknown -> quantized Optimized Speed.
     """
 
     env_value = variant_override if variant_override is not None else os.environ.get(DEFAULT_MODEL_VARIANT_ENV)
@@ -278,18 +327,21 @@ def select_default_model(
         variant = "fp16"
         reason = f"forced by {DEFAULT_MODEL_VARIANT_ENV}=fp16"
         auto_selected = False
-    elif requested_variant == "bf16":
-        variant = "bf16"
-        reason = f"forced by {DEFAULT_MODEL_VARIANT_ENV}=bf16"
+    elif requested_variant == "speed":
+        variant = "speed"
+        if str(env_value or "").strip().lower() in {"bf16", "bfloat16", "bfloat"}:
+            reason = f"forced by {DEFAULT_MODEL_VARIANT_ENV}={env_value} (legacy alias for optimized speed)"
+        else:
+            reason = f"forced by {DEFAULT_MODEL_VARIANT_ENV}=speed"
         auto_selected = False
     elif generation in _LEGACY_APPLE_FP16_GENERATIONS:
         variant = "fp16"
         reason = "selected for M1/M2 Apple Silicon"
         auto_selected = True
     else:
-        variant = "bf16"
+        variant = "speed"
         auto_selected = True
-        if generation in _NEWER_APPLE_BF16_GENERATIONS:
+        if generation in _NEWER_APPLE_SPEED_GENERATIONS:
             reason = "selected for newer Apple Silicon"
         elif generation == "intel":
             reason = "selected because this is not Apple Silicon"
@@ -299,10 +351,18 @@ def select_default_model(
     if invalid_override is not None and requested_variant == "auto":
         reason = f"{reason}; ignored invalid {DEFAULT_MODEL_VARIANT_ENV}={invalid_override}"
 
-    hf_model = DEFAULT_FP16_HF_MODEL_ID if variant == "fp16" else DEFAULT_HF_MODEL_ID
-    precision = "FP16" if variant == "fp16" else "BF16"
+    if variant == "fp16":
+        model = DEFAULT_FP16_HF_MODEL_ID
+        hf_model = DEFAULT_FP16_HF_MODEL_ID
+        precision = "FP16"
+    else:
+        model = optimized_speed_model_ref()
+        hf_model = DEFAULT_HF_MODEL_ID
+        precision = OPTIMIZED_SPEED_DESCRIPTION
+        if model != hf_model:
+            reason = f"{reason}; installed locally"
     return DefaultModelSelection(
-        model=hf_model,
+        model=model,
         hf_model=hf_model,
         variant=variant,
         precision=precision,
@@ -316,10 +376,12 @@ def select_default_model(
 
 def verified_default_refs() -> set[str]:
     root = _repo_root()
+    local_speed = optimized_speed_model_ref()
     refs = {
         DEFAULT_HF_MODEL_ID,
         DEFAULT_FP16_HF_MODEL_ID,
         DEFAULT_MODEL_ID,
+        local_speed,
         str(DEFAULT_RUNTIME_MODEL_DIR),
         str((root / DEFAULT_RUNTIME_MODEL_DIR).resolve()),
     }

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -198,6 +198,8 @@ def is_background_request(
 
 
 _DEFAULT_POSTCOMMIT_WAIT_TIMEOUT_S = 2.0
+_DEFAULT_NEAR_PREFIX_MAX_TOKEN_GAP = 8
+_DEFAULT_NEAR_PREFIX_MIN_MATCH_TOKENS = 64
 
 
 def _postcommit_wait_timeout_s() -> float:
@@ -216,6 +218,33 @@ def _postcommit_wait_timeout_s() -> float:
     if value < 0:
         return 0.0
     return value
+
+
+def _env_int(name: str, default: int, *, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return max(int(minimum), value)
+
+
+def _near_prefix_max_token_gap() -> int:
+    return _env_int(
+        "MTPLX_SESSION_NEAR_PREFIX_MAX_TOKEN_GAP",
+        _DEFAULT_NEAR_PREFIX_MAX_TOKEN_GAP,
+        minimum=0,
+    )
+
+
+def _near_prefix_min_match_tokens() -> int:
+    return _env_int(
+        "MTPLX_SESSION_NEAR_PREFIX_MIN_MATCH_TOKENS",
+        _DEFAULT_NEAR_PREFIX_MIN_MATCH_TOKENS,
+        minimum=1,
+    )
 
 
 @dataclass
@@ -666,7 +695,10 @@ class EngineSession:
                     self.prefix_len,
                 )
             matched = common_prefix_len(current, tokens)
-            if matched < len(current) and (len(current) - matched) > 2:
+            if (
+                matched < len(current)
+                and (len(current) - matched) > _near_prefix_max_token_gap()
+            ):
                 return EngineSessionCommit(
                     False,
                     "retokenized_prefix_not_extending_session",
@@ -881,10 +913,21 @@ class EngineSessionManager:
         self,
         token_ids: list[int] | tuple[int, ...],
         *,
-        max_token_gap: int = 2,
+        max_token_gap: int | None = None,
+        min_matched_tokens: int | None = None,
     ) -> tuple[EngineSession | None, int]:
         """Return a pending-postcommit session with a near-exact prompt prefix."""
         tokens = tuple(int(token) for token in token_ids)
+        gap_limit = (
+            _near_prefix_max_token_gap()
+            if max_token_gap is None
+            else max(0, int(max_token_gap))
+        )
+        min_match = (
+            _near_prefix_min_match_tokens()
+            if min_matched_tokens is None
+            else max(1, int(min_matched_tokens))
+        )
         best: EngineSession | None = None
         best_matched = 0
         for session in self._sessions.values():
@@ -893,11 +936,12 @@ class EngineSessionManager:
             prefix = session.committed_token_ids
             if not prefix:
                 continue
-            if len(prefix) > len(tokens) + int(max_token_gap):
+            if len(prefix) > len(tokens) + gap_limit:
                 continue
             matched = common_prefix_len(tokens, prefix)
             gap = len(prefix) - matched
-            if gap < 0 or gap > int(max_token_gap):
+            required_match = min(min_match, max(1, len(prefix) - gap_limit))
+            if gap < 0 or gap > gap_limit or matched < required_match:
                 continue
             if best is None or matched > best_matched or (
                 matched == best_matched and len(prefix) > len(best.committed_token_ids)

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -13,6 +13,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass, field, fields, is_dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable, Literal
 
 import mlx.core as mx
@@ -24,6 +25,7 @@ from .cache_state import (
     detach_array_leaf,
     detach_cache_state,
     owned_recurrent_state_stats,
+    restore_cache,
     rollback_after_verify,
     snapshot_cache,
     snapshot_untrimmable_cache,
@@ -1325,6 +1327,312 @@ class GenerationFinalState:
     mtp_history_position_base: int = 0
 
 
+def _prefill_restored_prompt_suffix(
+    rt: MTPLXRuntime,
+    restored: Any,
+    suffix: list[int],
+    *,
+    mtp_hidden_variant: str,
+    mtp_history_policy: str,
+    abort_check: Callable[[], bool] | None = None,
+) -> tuple[Any, Any, float, float]:
+    """Extend a restored SessionBank prefix without one giant suffix forward.
+
+    The old warm-prefix path sent the entire suffix through `forward_ar` with
+    hidden capture and logits enabled. In OpenCode sessions that made a stale
+    postcommit suffix behave like a full long-context prefill and, worse, it
+    could not observe abort requests until the huge Metal graph completed. This
+    mirrors the oMLX-style prefill shape: cache-only or hidden-only chunks for
+    the body, then a single final-token logits/hidden pass for decode startup.
+    """
+
+    if not suffix:
+        raise ValueError("suffix must not be empty")
+    _check_postcommit_abort(abort_check)
+    target_forward_time = 0.0
+    mtp_history_time = 0.0
+    final_logits_only = _final_logits_prefill_enabled()
+    use_committed_mtp = (
+        _mtp_history_uses_committed_cache(mtp_history_policy)
+        and restored.mtp_history_cache is not None
+    )
+
+    def append_history(hidden_states: Any, token_ids: list[int]) -> None:
+        nonlocal mtp_history_time
+        if not use_committed_mtp or not token_ids:
+            return
+        mtp_history_time += _append_mtp_history(
+            rt,
+            restored.mtp_history_cache,
+            hidden_states,
+            token_ids,
+            mtp_hidden_variant=mtp_hidden_variant,
+            force_eval=True,
+        )
+        _check_postcommit_abort(abort_check)
+
+    if use_committed_mtp and restored.hidden is not None:
+        append_history(restored.hidden, [int(suffix[0])])
+
+    if len(suffix) > 1:
+        body = suffix[:-1]
+        body_array = mx.array([body])
+        for start, end in _iter_prefill_chunk_spans(len(body)):
+            _check_postcommit_abort(abort_check)
+            chunk_array = body_array[:, start:end]
+            started = time.perf_counter()
+            with attention_phase("prefill"):
+                if use_committed_mtp:
+                    logits_chunk, hidden_chunk = rt.forward_ar(
+                        chunk_array,
+                        cache=restored.cache,
+                        return_hidden=True,
+                        hidden_variant=mtp_hidden_variant,
+                        emit_logits=False,
+                    )
+                else:
+                    hidden_chunk = None
+                    logits_chunk = _prefill_cache_only_forward(
+                        rt,
+                        chunk_array,
+                        restored.cache,
+                    )
+            if hidden_chunk is None:
+                if logits_chunk is None:
+                    _eval_cache_roots(restored.cache)
+                else:
+                    _eval(logits_chunk)
+            elif logits_chunk is None:
+                _eval(hidden_chunk)
+            else:
+                _eval(logits_chunk, hidden_chunk)
+            target_forward_time += time.perf_counter() - started
+            _runtime_count(rt, "restored_suffix_prefill_chunks")
+            _runtime_count(rt, "prefill_chunks")
+            _check_postcommit_abort(abort_check)
+
+            if hidden_chunk is not None:
+                append_history(
+                    hidden_chunk,
+                    [int(token) for token in suffix[start + 1 : end + 1]],
+                )
+            del hidden_chunk
+            del logits_chunk
+            target_forward_time += _prefill_chunk_cache_cleanup(rt)
+            _check_postcommit_abort(abort_check)
+
+    started = time.perf_counter()
+    _check_postcommit_abort(abort_check)
+    with attention_phase("prefill"):
+        suffix_logits, suffix_hidden = rt.forward_ar(
+            mx.array([[suffix[-1]]]),
+            cache=restored.cache,
+            return_hidden=True,
+            hidden_variant=mtp_hidden_variant,
+            emit_logits=True,
+            logits_keep=1 if final_logits_only else None,
+        )
+    _eval(suffix_logits, suffix_hidden)
+    target_forward_time += time.perf_counter() - started
+    _check_postcommit_abort(abort_check)
+    return (
+        suffix_logits[:, -1, :],
+        suffix_hidden[:, -1:, :],
+        target_forward_time,
+        mtp_history_time,
+    )
+
+
+def _cache_offset(cache: Any) -> int:
+    if not cache:
+        return 0
+    try:
+        return int(getattr(cache[0], "offset", 0) or 0)
+    except Exception:
+        return 0
+
+
+def _trim_cache_to_offset(cache: Any, offset: int) -> bool:
+    target = max(0, int(offset))
+    if not cache:
+        return target == 0
+    for entry in cache:
+        current = int(getattr(entry, "offset", target) or 0)
+        if current < target:
+            return False
+        delta = current - target
+        if delta <= 0:
+            continue
+        trim = getattr(entry, "trim", None)
+        if not callable(trim):
+            return False
+        trimmed = int(trim(delta))
+        if trimmed != delta:
+            return False
+    return True
+
+
+def _entry_matches_restore_lookup(
+    entry: Any,
+    rt: MTPLXRuntime,
+    *,
+    hidden_variant: str | None,
+    template_hash: str | None,
+    mtp_history_policy: str | None,
+    draft_head_identity: str | None,
+    policy_fingerprint: str | None,
+) -> bool:
+    if getattr(entry, "model_path", None) != str(rt.model_path):
+        return False
+    if hidden_variant is not None and getattr(entry, "hidden_variant", None) != hidden_variant:
+        return False
+    if template_hash is not None and getattr(entry, "template_hash", None) != template_hash:
+        return False
+    entry_policy = getattr(entry, "mtp_history_policy", None)
+    if mtp_history_policy is not None:
+        if entry_policy != mtp_history_policy:
+            committed = {"committed", "last_window"}
+            if entry_policy not in committed or mtp_history_policy not in committed:
+                return False
+    if draft_head_identity is not None and getattr(entry, "draft_head_identity", None) != draft_head_identity:
+        return False
+    if policy_fingerprint is not None and getattr(entry, "policy_fingerprint", None) != policy_fingerprint:
+        return False
+    if (
+        getattr(entry, "mtp_snapshot_epoch", None) is not None
+        and int(getattr(entry, "mtp_snapshot_epoch")) != int(getattr(entry, "snapshot_epoch", 0))
+    ):
+        return False
+    return True
+
+
+def _near_prefix_restore_enabled() -> bool:
+    return not _env_falsey("MTPLX_SESSION_NEAR_PREFIX_RESTORE")
+
+
+def _restore_near_prefix_prompt_state(
+    rt: MTPLXRuntime,
+    prompt_ids: list[int],
+    *,
+    mtp_hidden_variant: str,
+    mtp_history_policy: str,
+    session_bank: Any,
+    template_hash: str | None,
+    draft_head_identity: str | None,
+    policy_fingerprint: str | None,
+    abort_check: Callable[[], bool] | None = None,
+) -> PromptState | None:
+    if not _near_prefix_restore_enabled() or len(prompt_ids) < 2:
+        return None
+    candidates = getattr(session_bank, "near_prefix_candidates", None)
+    if not callable(candidates):
+        return None
+    max_gap = max(0, _env_int("MTPLX_SESSION_NEAR_PREFIX_MAX_TOKEN_GAP", 8))
+    min_match = max(1, _env_int("MTPLX_SESSION_NEAR_PREFIX_MIN_MATCH_TOKENS", 64))
+    for entry, matched in candidates(
+        prompt_ids,
+        max_token_gap=max_gap,
+        min_matched_tokens=min_match,
+    ):
+        _check_postcommit_abort(abort_check)
+        matched = int(matched)
+        if matched < 2 or matched >= int(getattr(entry, "prefix_len", 0) or 0):
+            continue
+        if not _entry_matches_restore_lookup(
+            entry,
+            rt,
+            hidden_variant=mtp_hidden_variant,
+            template_hash=template_hash,
+            mtp_history_policy=mtp_history_policy,
+            draft_head_identity=draft_head_identity,
+            policy_fingerprint=policy_fingerprint,
+        ):
+            continue
+        if entry.mtp_history_snapshot is None and _mtp_history_uses_committed_cache(
+            mtp_history_policy
+        ):
+            continue
+
+        cache = rt.make_cache()
+        restore_cache(cache, entry.cache_snapshot)
+        if not _trim_cache_to_offset(cache, matched - 1):
+            continue
+
+        mtp_history_cache = None
+        if entry.mtp_history_snapshot is not None:
+            mtp_history_cache = rt.make_mtp_cache()
+            restore_cache(mtp_history_cache, entry.mtp_history_snapshot)
+            if not _trim_cache_to_offset(mtp_history_cache, matched - 1):
+                continue
+
+        started = time.perf_counter()
+        _check_postcommit_abort(abort_check)
+        with attention_phase("prefill"):
+            logits, hidden = rt.forward_ar(
+                mx.array([[int(prompt_ids[matched - 1])]]),
+                cache=cache,
+                return_hidden=True,
+                hidden_variant=mtp_hidden_variant,
+                emit_logits=True,
+                logits_keep=1 if _final_logits_prefill_enabled() else None,
+            )
+        _eval(logits, hidden)
+        repair_time = time.perf_counter() - started
+        _check_postcommit_abort(abort_check)
+        restored = SimpleNamespace(
+            entry=SimpleNamespace(prefix_len=matched),
+            cache=cache,
+            logits=logits[:, -1, :],
+            hidden=hidden[:, -1:, :],
+            mtp_history_cache=mtp_history_cache,
+            restore_mode="near_prefix_clone",
+        )
+        suffix = list(prompt_ids[matched:])
+        if not suffix:
+            entry.hits += 1
+            entry.last_access_s = time.time()
+            return PromptState(
+                trunk_cache=cache,
+                logits=logits[:, -1, :],
+                hidden=hidden[:, -1:, :],
+                committed_mtp_cache=mtp_history_cache,
+                token_prefix=tuple(int(token) for token in prompt_ids),
+                prompt_eval_time_s=repair_time,
+                mtp_history_policy=mtp_history_policy,
+                cached_tokens=matched,
+                suffix_tokens=0,
+                cache_hit=True,
+                restore_mode="near_prefix_clone",
+            )
+        suffix_logits, suffix_hidden, suffix_time, mtp_history_time = (
+            _prefill_restored_prompt_suffix(
+                rt,
+                restored,
+                suffix,
+                mtp_hidden_variant=mtp_hidden_variant,
+                mtp_history_policy=mtp_history_policy,
+                abort_check=abort_check,
+            )
+        )
+        entry.hits += 1
+        entry.last_access_s = time.time()
+        return PromptState(
+            trunk_cache=cache,
+            logits=suffix_logits,
+            hidden=suffix_hidden,
+            committed_mtp_cache=mtp_history_cache,
+            token_prefix=tuple(int(token) for token in prompt_ids),
+            prompt_eval_time_s=repair_time + suffix_time + mtp_history_time,
+            prompt_mtp_history_time_s=mtp_history_time,
+            mtp_history_policy=mtp_history_policy,
+            cached_tokens=matched,
+            suffix_tokens=len(suffix),
+            cache_hit=True,
+            restore_mode="near_prefix_clone",
+        )
+    return None
+
+
 def restore_or_prefill_prompt_state(
     rt: MTPLXRuntime,
     prompt_ids: list[int],
@@ -1388,43 +1696,21 @@ def restore_or_prefill_prompt_state(
                     restore_mode=restored.restore_mode,
                 )
 
-            started = time.perf_counter()
             _check_postcommit_abort(abort_check)
-            suffix_logits, suffix_hidden = rt.forward_ar(
-                mx.array([suffix]),
-                cache=restored.cache,
-                return_hidden=True,
-                hidden_variant=mtp_hidden_variant,
-                emit_logits=True,
-                logits_keep=1 if _final_logits_prefill_enabled() else None,
+            suffix_logits, suffix_hidden, suffix_time, mtp_history_time = (
+                _prefill_restored_prompt_suffix(
+                    rt,
+                    restored,
+                    suffix,
+                    mtp_hidden_variant=mtp_hidden_variant,
+                    mtp_history_policy=mtp_history_policy,
+                    abort_check=abort_check,
+                )
             )
-            _eval(suffix_logits, suffix_hidden)
-            _check_postcommit_abort(abort_check)
-            suffix_time = time.perf_counter() - started
-            mtp_history_time = 0.0
-            if _mtp_history_uses_committed_cache(mtp_history_policy):
-                history_hidden_parts = []
-                if restored.hidden is not None:
-                    history_hidden_parts.append(restored.hidden)
-                if len(suffix) > 1:
-                    history_hidden_parts.append(suffix_hidden[:, :-1, :])
-                if history_hidden_parts:
-                    history_hidden = (
-                        history_hidden_parts[0]
-                        if len(history_hidden_parts) == 1
-                        else mx.concatenate(history_hidden_parts, axis=1)
-                    )
-                    mtp_history_time = _append_mtp_history(
-                        rt,
-                        restored.mtp_history_cache,
-                        history_hidden,
-                        suffix,
-                        mtp_hidden_variant=mtp_hidden_variant,
-                    )
             return PromptState(
                 trunk_cache=restored.cache,
-                logits=suffix_logits[:, -1, :],
-                hidden=suffix_hidden[:, -1:, :],
+                logits=suffix_logits,
+                hidden=suffix_hidden,
                 committed_mtp_cache=restored.mtp_history_cache,
                 token_prefix=tuple(int(token) for token in prompt_ids),
                 prompt_eval_time_s=suffix_time + mtp_history_time,
@@ -1436,6 +1722,20 @@ def restore_or_prefill_prompt_state(
                 cache_hit=True,
                 restore_mode=restored.restore_mode,
             )
+
+        near_prompt_state = _restore_near_prefix_prompt_state(
+            rt,
+            prompt_ids,
+            mtp_hidden_variant=mtp_hidden_variant,
+            mtp_history_policy=mtp_history_policy,
+            session_bank=session_bank,
+            template_hash=template_hash,
+            draft_head_identity=draft_head_identity,
+            policy_fingerprint=policy_fingerprint,
+            abort_check=abort_check,
+        )
+        if near_prompt_state is not None:
+            return near_prompt_state
 
     mtp_history_cache = None
     prompt_history_time = 0.0
@@ -2953,6 +3253,7 @@ def generate_mtpk(
     session_policy_fingerprint: str | None = None,
     capture_final_state: bool = False,
     commit_prompt_state_to_bank: bool = False,
+    commit_prompt_state_keep_live_ref: bool = False,
     trace_label: str | None = None,
     trace_metadata: dict[str, Any] | None = None,
 ) -> GenerationOutput:
@@ -3075,7 +3376,7 @@ def generate_mtpk(
                 logits=prompt_state.logits,
                 hidden=prompt_state.hidden,
                 hidden_variant=mtp_hidden_variant,
-                keep_live_ref=False,
+                keep_live_ref=bool(commit_prompt_state_keep_live_ref),
                 session_id=session_id,
                 template_hash=session_template_hash,
                 mtp_history_policy=prompt_state.mtp_history_policy,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -638,8 +638,10 @@ def _apply_metal_memory_caps(
     fixed budget; ``clear_cache`` periodically drops idle pool memory.
 
     Operators can override via env:
-      MTPLX_MEMORY_LIMIT_BYTES   - hard cap, default 75% of total RAM
-      MTPLX_WIRED_LIMIT_BYTES    - wired (resident) cap, default 60% of total RAM
+      MTPLX_MEMORY_LIMIT_BYTES   - hard cap, default 75% of total RAM,
+                                   capped at 192 GiB on very large Macs
+      MTPLX_WIRED_LIMIT_BYTES    - wired (resident) cap, default 60% of total
+                                   RAM, capped at 160 GiB on very large Macs
 
     Both accept plain bytes or K/M/G/T suffix.
     """
@@ -669,8 +671,20 @@ def _apply_metal_memory_caps(
         default_mem = 1
         default_wired = 1
     else:
-        default_mem = min(total_ram, max(8 * 1024**3, int(total_ram * 0.75)))
-        default_wired = min(default_mem, max(4 * 1024**3, int(total_ram * 0.60)))
+        # Percentage-only caps scale badly on 512 GiB M3 Ultra systems: 75% /
+        # 60% permits hundreds of GiB of allocator high-water before MLX is
+        # forced to release pressure. Keep the old behavior on 64-128 GiB Macs,
+        # but bound the default resident budget on large unified-memory boxes.
+        default_mem = min(
+            total_ram,
+            max(8 * 1024**3, int(total_ram * 0.75)),
+            192 * 1024**3,
+        )
+        default_wired = min(
+            default_mem,
+            max(4 * 1024**3, int(total_ram * 0.60)),
+            160 * 1024**3,
+        )
     mem_limit = _parse_metal_memory_size_bytes(mem_raw, default_mem)
     wired_limit = _parse_metal_memory_size_bytes(wired_raw, default_wired)
 
@@ -1549,6 +1563,7 @@ def _mtplx_tool_contract_text(tools: list[dict[str, Any]]) -> str:
     return (
         f"{_MTPLX_TOOL_CONTRACT_SENTINEL} declared tools and schemas: {allowed}. "
         "Call only these exact tool names and exact argument keys/case. "
+        "Include every required key shown in the signature. "
         f'Emit one tool call as <tool_call>{{"name":"{example_name}","arguments":{example_args}}}</tool_call>. '
         "Never invent Agent/task/Explore or any undeclared tool. "
         "If no declared tool applies, answer normally."
@@ -1662,10 +1677,49 @@ def _json_object_string(value: Any, *, context: str) -> str:
     return json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
 
 
-def _decode_tool_parameter_value(value: str) -> Any:
+def _schema_type_names(schema: Any) -> set[str]:
+    if not isinstance(schema, dict):
+        return set()
+    raw_type = schema.get("type")
+    if isinstance(raw_type, str):
+        return {raw_type}
+    if isinstance(raw_type, list):
+        return {str(item) for item in raw_type if isinstance(item, str)}
+    return set()
+
+
+def _tool_parameter_schema(
+    tools: list[dict[str, Any]],
+    *,
+    tool_name: str | None,
+    parameter_name: str,
+) -> dict[str, Any] | None:
+    if not tool_name:
+        return None
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(function, dict):
+            continue
+        if str(function.get("name") or "").strip() != str(tool_name).strip():
+            continue
+        parameters = function.get("parameters")
+        if not isinstance(parameters, dict):
+            return None
+        properties = parameters.get("properties")
+        if not isinstance(properties, dict):
+            return None
+        schema = properties.get(parameter_name)
+        return schema if isinstance(schema, dict) else None
+    return None
+
+
+def _decode_tool_parameter_value(value: str, schema: Any | None = None) -> Any:
     text = value.strip()
     if not text:
         return ""
+    schema_types = _schema_type_names(schema)
+    if schema_types and schema_types <= {"string", "null"}:
+        return text
     try:
         return json.loads(text)
     except json.JSONDecodeError:
@@ -1834,10 +1888,6 @@ def _stream_tool_call_deltas(
             }
 
 
-def _json_string_inner(text: str) -> str:
-    return json.dumps(text, ensure_ascii=False)[1:-1]
-
-
 def _find_casefold(haystack: str, needle: str, start: int = 0) -> int:
     return haystack.lower().find(needle.lower(), start)
 
@@ -1920,8 +1970,7 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
         self._name: str | None = None
         self._current_key: str | None = None
         self._current_value_parts: list[str] = []
-        self._params: dict[str, str] = {}
-        self._arg_open = False
+        self._params: dict[str, Any] = {}
         self._done = False
         self._tool_calls: list[dict[str, Any]] | None = None
         self._fallback_reason: str | None = None
@@ -1960,8 +2009,11 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                 )
             )
             self._name_delta_emitted = True
-        suffix = "}" if self._arg_open else "{}"
-        deltas.append(_tool_delta(self._call_index, arguments=suffix))
+        arguments = _json_object_string(
+            self._params,
+            context=f"tool_call[{self._call_index}]",
+        )
+        deltas.append(_tool_delta(self._call_index, arguments=arguments))
         self._done = True
         self._tool_calls = [
             {
@@ -1969,10 +2021,7 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                 "type": "function",
                 "function": {
                     "name": str(self._name or ""),
-                    "arguments": _json_object_string(
-                        self._params,
-                        context=f"tool_call[{self._call_index}]",
-                    ),
+                    "arguments": arguments,
                 },
             }
         ]
@@ -2042,15 +2091,6 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                         )
                     )
                     self._name_delta_emitted = True
-                prefix = "," if self._arg_open else "{"
-                self._arg_open = True
-                deltas.append(
-                    _tool_delta(
-                        self._call_index,
-                        arguments=f"{prefix}{json.dumps(key, ensure_ascii=False)}:",
-                    )
-                )
-                deltas.append(_tool_delta(self._call_index, arguments='"'))
                 self._buf = self._buf[param_end + 1 :]
                 self._stage = "in_parameter"
                 continue
@@ -2067,12 +2107,6 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                         value_piece = value_piece[1:]
                     if value_piece:
                         self._current_value_parts.append(value_piece)
-                        deltas.append(
-                            _tool_delta(
-                                self._call_index,
-                                arguments=_json_string_inner(value_piece),
-                            )
-                        )
                     return deltas
                 value_piece = self._buf[:close_start]
                 # Qwen usually formats XML parameters as newline-delimited
@@ -2085,15 +2119,15 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                     value_piece = value_piece[1:]
                 if value_piece:
                     self._current_value_parts.append(value_piece)
-                    deltas.append(
-                        _tool_delta(
-                            self._call_index,
-                            arguments=_json_string_inner(value_piece),
-                        )
-                    )
                 key = str(self._current_key or "")
-                self._params[key] = "".join(self._current_value_parts).strip()
-                deltas.append(_tool_delta(self._call_index, arguments='"'))
+                self._params[key] = _decode_tool_parameter_value(
+                    "".join(self._current_value_parts),
+                    schema=_tool_parameter_schema(
+                        self._tools,
+                        tool_name=self._name,
+                        parameter_name=key,
+                    ),
+                )
                 self._buf = self._buf[close_start + len(self._PARAM_CLOSE) :]
                 self._stage = "find_parameter"
                 continue
@@ -2880,16 +2914,33 @@ def _postcommit_next_turn_prefix_ids(
     )
     if not rendered:
         return None
+    sentinel_at = rendered.find(_POSTCOMMIT_SENTINEL_CONTENT)
     turn_start = _sentinel_next_turn_start(
         rendered,
         sentinel_role=sentinel_role,
     )
+    if turn_start is None and sentinel_role == "tool":
+        # Qwen-style templates render OpenAI tool-result messages as a user
+        # turn containing <tool_response>. The sentinel is still a tool
+        # message semantically, but the rendered boundary to cut at is user.
+        user_turn_start = _sentinel_next_turn_start(rendered, sentinel_role="user")
+        if (
+            user_turn_start is not None
+            and sentinel_at >= 0
+            and (sentinel_at - user_turn_start) <= 2048
+        ):
+            turn_start = user_turn_start
     if turn_start is None:
         return None
     prefix_text = rendered[:turn_start]
     if not prefix_text:
         return None
-    return _encode_rendered_chat_text(tokenizer, prefix_text)
+    boundaries = (
+        _tool_history_generation_boundaries(prefix_text)
+        if assistant_tool_calls
+        else []
+    )
+    return _encode_rendered_chat_text_segmented(tokenizer, prefix_text, boundaries)
 
 
 def _encode_prompt(
@@ -3330,14 +3381,195 @@ def _temporary_env(updates: dict[str, str | None]):
                 os.environ[key] = value
 
 
+def _dynamic_paged_kv_initial_new_token_budget(max_new_tokens: int) -> tuple[int, int | None]:
+    raw = (
+        os.environ.get("MTPLX_DYNAMIC_PAGED_KV_MAX_INITIAL_NEW_TOKENS")
+        or "16384"
+    ).strip().lower()
+    requested = max(0, int(max_new_tokens))
+    if raw in {"0", "off", "false", "no", "none", "unlimited"}:
+        return requested, None
+    try:
+        cap = max(1, int(raw))
+    except (TypeError, ValueError):
+        cap = 16384
+    return min(requested, cap), cap
+
+
+def _dynamic_paged_kv_reservation(
+    *,
+    prompt_tokens: int,
+    max_new_tokens: int,
+    mtp_depth: int,
+) -> dict[str, Any]:
+    requested_new = max(0, int(max_new_tokens))
+    reserved_new, cap = _dynamic_paged_kv_initial_new_token_budget(requested_new)
+    reserved_tokens = (
+        max(0, int(prompt_tokens))
+        + max(0, int(reserved_new))
+        + max(0, int(mtp_depth))
+    )
+    return {
+        "env": {"MTPLX_DYNAMIC_PAGED_KV_TOKENS": str(reserved_tokens)},
+        "requested_new_tokens": int(requested_new),
+        "reserved_new_tokens": int(reserved_new),
+        "initial_new_token_cap": cap,
+        "reservation_capped": bool(reserved_new < requested_new),
+        "reserved_total_tokens": int(reserved_tokens),
+    }
+
+
 def _dynamic_paged_kv_env(
     *,
     prompt_tokens: int,
     max_new_tokens: int,
     mtp_depth: int,
 ) -> dict[str, str]:
-    needed = max(0, int(prompt_tokens)) + max(0, int(max_new_tokens)) + max(0, int(mtp_depth))
-    return {"MTPLX_DYNAMIC_PAGED_KV_TOKENS": str(needed)}
+    return _dynamic_paged_kv_reservation(
+        prompt_tokens=prompt_tokens,
+        max_new_tokens=max_new_tokens,
+        mtp_depth=mtp_depth,
+    )["env"]
+
+
+def _session_keep_live_refs_for_request(
+    *,
+    session_source: str | None,
+    session_id: str | None,
+    tool_names: list[str] | tuple[str, ...] | None = None,
+) -> bool:
+    if (
+        os.environ.get("MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS", "")
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    ):
+        return True
+    source = str(session_source or "")
+    if source.startswith("header.") or source.startswith("metadata."):
+        return True
+    if source in {"user", "chat_id", "conversation_id"}:
+        return True
+    if _anonymous_coding_agent_tool_request(tool_names):
+        return True
+    # Anonymous auto sessions are useful as cloneable prefix snapshots, but
+    # retaining their live paged-KV containers preserves the full request
+    # capacity. A benchmark with 65k max_tokens and many one-off prompts can
+    # otherwise pin huge unused buffers for no reuse benefit.
+    return bool(
+        session_id
+        and not session_id.startswith("anon-")
+        and source == "longest_prefix"
+    )
+
+
+def _anonymous_coding_agent_tool_request(
+    tool_names: list[str] | tuple[str, ...] | None,
+) -> bool:
+    names = {str(name).strip().lower() for name in (tool_names or []) if str(name).strip()}
+    if not names:
+        return False
+    coding_agent_tools = {
+        "bash",
+        "edit",
+        "glob",
+        "grep",
+        "ls",
+        "multi_edit",
+        "patch",
+        "read",
+        "str_replace_editor",
+        "task",
+        "todowrite",
+        "webfetch",
+        "write",
+    }
+    return bool(names & coding_agent_tools)
+
+
+def _clear_mlx_cache_after_request(
+    state: Any,
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    raw = (
+        os.environ.get("MTPLX_CLEAR_CACHE_AFTER_REQUEST") or "auto"
+    ).strip().lower()
+    if raw in {"0", "false", "no", "off", "never"}:
+        return {"cleared": False, "reason": "disabled"}
+    lock = getattr(state, "lock", None)
+    acquired = False
+    if lock is not None and hasattr(lock, "acquire"):
+        acquired = bool(lock.acquire(blocking=False))
+        if not acquired:
+            return {"cleared": False, "reason": "model_lock_busy", "trigger": reason}
+    try:
+        try:
+            import mlx.core as mx
+        except Exception as exc:
+            return {
+                "cleared": False,
+                "reason": "mlx_unavailable",
+                "trigger": reason,
+                "error": repr(exc),
+            }
+        synchronize = getattr(mx, "synchronize", None)
+        if callable(synchronize):
+            synchronize()
+        clear_cache = getattr(mx, "clear_cache", None)
+        if not callable(clear_cache):
+            return {
+                "cleared": False,
+                "reason": "clear_cache_unavailable",
+                "trigger": reason,
+            }
+        clear_cache()
+        return {"cleared": True, "reason": reason}
+    except Exception as exc:
+        return {
+            "cleared": False,
+            "reason": "clear_cache_error",
+            "trigger": reason,
+            "error": repr(exc),
+        }
+    finally:
+        if acquired:
+            lock.release()
+
+
+def _attach_skipped_postcommit_cleanup(
+    state: Any,
+    snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    if (
+        snapshot.get("mode") == "async_skipped"
+        and snapshot.get("reason") == "stop_token_boundary_mismatch"
+    ):
+        snapshot["mlx_cache_cleanup"] = _clear_mlx_cache_after_request(
+            state,
+            reason="stop_token_boundary_mismatch_postcommit_skipped",
+        )
+    return snapshot
+
+
+def _mlx_allocator_public_stats() -> dict[str, int]:
+    try:
+        import mlx.core as mx
+    except Exception:
+        return {}
+    stats: dict[str, int] = {}
+    for name, attr in (
+        ("active_memory_bytes", "get_active_memory"),
+        ("peak_memory_bytes", "get_peak_memory"),
+        ("cache_memory_bytes", "get_cache_memory"),
+    ):
+        fn = getattr(mx, attr, None)
+        if callable(fn):
+            try:
+                stats[name] = int(fn())
+            except Exception:
+                pass
+    return stats
 
 
 def _generation_truth_stats(state: "ServerState", effective_mode: str) -> dict[str, Any]:
@@ -3469,7 +3701,9 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "requested_mtp_depth",
     "requested_speculative_depth",
     "long_context_mtp_depth_policy",
+    "active_memory_bytes",
     "peak_memory_bytes",
+    "cache_memory_bytes",
     "reasoning_reentries",
     "reasoning_tokens",
     "answer_tokens",
@@ -3479,7 +3713,9 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "tool_parse_fallback_kind",
     "tool_parser_dialect",
     "request_session_source",
+    "request_session_keep_live_ref",
     "request_session_prefix_diagnostic",
+    "dynamic_paged_kv",
     "session_prompt_prefix_commit",
 )
 PUBLIC_POSTCOMMIT_KEYS = (
@@ -3494,6 +3730,7 @@ PUBLIC_POSTCOMMIT_KEYS = (
     "cached_tokens",
     "suffix_tokens",
     "cache_miss_reason",
+    "mlx_cache_cleanup",
     "error",
 )
 
@@ -3730,6 +3967,7 @@ def _store_retokenized_history_snapshot(
     abort_check: Callable[[], bool] | None = None,
     abort_reason: Callable[[], str] | None = None,
     pending_record: Any | None = None,
+    keep_live_ref: bool = True,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "reason": "no_session_id"}
@@ -3846,7 +4084,7 @@ def _store_retokenized_history_snapshot(
                 logits=prompt_state.logits,
                 hidden=prompt_state.hidden,
                 hidden_variant="post_norm",
-                keep_live_ref=True,
+                keep_live_ref=bool(keep_live_ref),
                 session_id=session_id,
                 template_hash=state.template_hash,
                 mtp_history_policy="committed",
@@ -4070,6 +4308,7 @@ def _store_generation_final_history_snapshot(
     thinking_enabled: bool,
     policy_fingerprint: str,
     tool_specs: list[dict[str, Any]] | None = None,
+    keep_live_ref: bool = True,
 ) -> dict[str, Any]:
     if session_id is None:
         return {"stored": False, "mode": "unsafe", "reason": "no_session_id"}
@@ -4114,7 +4353,7 @@ def _store_generation_final_history_snapshot(
             logits=final_state.final_logits,
             hidden=final_state.final_hidden,
             hidden_variant="post_norm",
-            keep_live_ref=True,
+            keep_live_ref=bool(keep_live_ref),
             session_id=session_id,
             template_hash=state.template_hash,
             mtp_history_policy="committed",
@@ -4162,6 +4401,7 @@ def _schedule_idle_postcommit_snapshot(
     tool_specs: list[dict[str, Any]] | None = None,
     session: Any | None = None,
     expected_session_revision: int | None = None,
+    keep_live_ref: bool = True,
 ) -> dict[str, Any]:
     """Schedule a background SessionBank commit for a response the
     generation-final compatibility check rejected as unsafe (most commonly
@@ -4301,6 +4541,7 @@ def _schedule_idle_postcommit_snapshot(
                     abort_check=_postcommit_abort_check,
                     abort_reason=_postcommit_abort_reason,
                     pending_record=record,
+                    keep_live_ref=bool(keep_live_ref),
                 )
                 if postcommit.get("stored"):
                     _log(postcommit)
@@ -4351,6 +4592,42 @@ def _schedule_idle_postcommit_snapshot(
             # Telemetry plumbing must never break the request path.
             pass
     return pending
+
+
+def _skipped_idle_postcommit_snapshot(
+    *,
+    unsafe_reason: str,
+    assistant_tool_calls: list[dict[str, Any]] | None = None,
+    prompt_prefix_len: int | None = None,
+) -> dict[str, Any] | None:
+    """Return a cheap postcommit result for unsafe cases that should not prefill.
+
+    OpenCode often finishes a tool-result turn with a tiny assistant message
+    whose canonical chat-template history differs from the generated boundary
+    only because of stop-token framing. The foreground path has already
+    committed the prompt prefix, so scheduling a full retokenized postcommit
+    here burns GPU for seconds without improving the next request materially.
+
+    Tool-call turns are different: the next request sends structured
+    assistant tool-call history, so they must still use the retokenized async
+    path.
+    """
+    reason = str(unsafe_reason or "")
+    if assistant_tool_calls:
+        return None
+    if reason != "stop_token_boundary_mismatch":
+        return None
+    result: dict[str, Any] = {
+        "stored": False,
+        "mode": "async_skipped",
+        "reason": reason,
+    }
+    if prompt_prefix_len is not None:
+        try:
+            result["prefix_len"] = int(prompt_prefix_len)
+        except (TypeError, ValueError):
+            pass
+    return result
 
 
 def _generation_params(
@@ -4446,6 +4723,7 @@ def _run_generation(
     background_request: bool = False,
     commit_final_state_to_bank: bool = True,
     commit_prompt_prefix_to_bank: bool = False,
+    session_keep_live_ref: bool = True,
     request_observability: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     response_max, sampler, generation_limits = _generation_params(
@@ -4519,12 +4797,12 @@ def _run_generation(
             state.lock.acquire()
         lock_wait_time_s += time.perf_counter() - lock_started
         try:
-            dynamic_kv_env = _dynamic_paged_kv_env(
+            dynamic_kv_reservation = _dynamic_paged_kv_reservation(
                 prompt_tokens=len(prompt_ids),
                 max_new_tokens=response_max,
                 mtp_depth=effective_depth,
             )
-            with _temporary_env(dynamic_kv_env):
+            with _temporary_env(dynamic_kv_reservation["env"]):
                 if effective_mode == "ar":
                     out = generate_ar(
                         state.runtime,
@@ -4568,6 +4846,7 @@ def _run_generation(
                             and session_bank is not None
                             and session_id is not None
                         ),
+                        commit_prompt_state_keep_live_ref=session_keep_live_ref,
                         trace_label=trace_label,
                         trace_metadata=trace_metadata,
                         adaptive_policy=adaptive_policy,
@@ -4642,7 +4921,7 @@ def _run_generation(
                 logits=final_state.final_logits,
                 hidden=final_state.final_hidden,
                 hidden_variant="post_norm",
-                keep_live_ref=True,
+                keep_live_ref=bool(session_keep_live_ref),
                 session_id=session_id,
                 template_hash=session_template_hash,
                 mtp_history_policy="committed",
@@ -4685,6 +4964,12 @@ def _run_generation(
             mtp_depth=actual_mtp_depth if effective_mode == "mtp" else 0,
             generation_limits=generation_limits,
         )
+        envelope["dynamic_paged_kv"] = {
+            key: value
+            for key, value in dynamic_kv_reservation.items()
+            if key != "env"
+        }
+        envelope.update(_mlx_allocator_public_stats())
         envelope["generation_mode"] = effective_mode
         envelope["requested_mtp_depth"] = (
             requested_mtp_depth if effective_mode == "mtp" else 0
@@ -6934,7 +7219,20 @@ def create_app(state: ServerState) -> FastAPI:
 
     @app.post("/admin/cache/clear")
     def admin_clear_cache() -> dict[str, Any]:
-        return state.sessions.clear_all()
+        cleared = state.sessions.clear_all()
+        if isinstance(cleared, dict):
+            cleared["mlx_cache_cleanup"] = _clear_mlx_cache_after_request(
+                state,
+                reason="admin_cache_clear",
+            )
+            return cleared
+        return {
+            "cleared": cleared,
+            "mlx_cache_cleanup": _clear_mlx_cache_after_request(
+                state,
+                reason="admin_cache_clear",
+            ),
+        }
 
     @app.get("/v1/models")
     def list_models() -> dict[str, Any]:
@@ -7084,6 +7382,15 @@ def create_app(state: ServerState) -> FastAPI:
         prefix_diagnostic = getattr(state.sessions, "last_prefix_diagnostic", None)
         if isinstance(prefix_diagnostic, dict):
             request_observability["request_session_prefix_diagnostic"] = prefix_diagnostic
+        session_keep_live_ref = _session_keep_live_refs_for_request(
+            session_source=session_source,
+            session_id=session_id,
+            tool_names=_tool_names(tool_specs) if tools_active else None,
+        )
+        request_observability["request_session_keep_live_ref"] = bool(
+            session_keep_live_ref
+        )
+
         def run_generation_for_response() -> dict[str, Any]:
             if session is None:
                 return _run_generation(
@@ -7107,6 +7414,7 @@ def create_app(state: ServerState) -> FastAPI:
                     session_policy_fingerprint=policy_fingerprint,
                     background_request=background,
                     commit_prompt_prefix_to_bank=tools_active,
+                    session_keep_live_ref=session_keep_live_ref,
                     request_observability=request_observability,
                 )
             with session.in_flight_generation():
@@ -7128,6 +7436,7 @@ def create_app(state: ServerState) -> FastAPI:
                     session_draft_head_identity=state.draft_head_identity,
                     session_policy_fingerprint=policy_fingerprint,
                     commit_prompt_prefix_to_bank=tools_active,
+                    session_keep_live_ref=session_keep_live_ref,
                     request_observability=request_observability,
                 )
                 session.commit(
@@ -7173,6 +7482,16 @@ def create_app(state: ServerState) -> FastAPI:
             generated_mode = str(
                 generated.get("stats", {}).get("generation_mode") or ""
             )
+            skipped = _skipped_idle_postcommit_snapshot(
+                unsafe_reason=unsafe_reason,
+                assistant_tool_calls=assistant_tool_calls,
+                prompt_prefix_len=len(prompt_ids),
+            )
+            if skipped is not None:
+                generated["stats"]["session_postcommit_snapshot"] = (
+                    _attach_skipped_postcommit_cleanup(state, skipped)
+                )
+                return
             if (
                 stream_response
                 and state.args.session_postcommit_mode == "async"
@@ -7191,6 +7510,7 @@ def create_app(state: ServerState) -> FastAPI:
                         tool_specs=tool_specs if tools_active else None,
                         session=session,
                         expected_session_revision=getattr(session, "revision", None),
+                        keep_live_ref=session_keep_live_ref,
                     )
                 )
                 return
@@ -7206,6 +7526,7 @@ def create_app(state: ServerState) -> FastAPI:
                         thinking_enabled=thinking_enabled,
                         policy_fingerprint=policy_fingerprint,
                         tool_specs=tool_specs if tools_active else None,
+                        keep_live_ref=session_keep_live_ref,
                     ),
                     batch_key=f"postcommit.inline:{session_id or 'stateless'}",
                 ),
@@ -7333,6 +7654,7 @@ def create_app(state: ServerState) -> FastAPI:
                                 session_policy_fingerprint=policy_fingerprint,
                                 background_request=background,
                                 commit_prompt_prefix_to_bank=tools_active,
+                                session_keep_live_ref=session_keep_live_ref,
                                 request_observability=request_observability,
                             )
                         else:
@@ -7357,6 +7679,7 @@ def create_app(state: ServerState) -> FastAPI:
                                     session_policy_fingerprint=policy_fingerprint,
                                     commit_final_state_to_bank=False,
                                     commit_prompt_prefix_to_bank=tools_active,
+                                    session_keep_live_ref=session_keep_live_ref,
                                     request_observability=request_observability,
                                 )
                                 queue.put(("done", generated))
@@ -7386,6 +7709,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
                                             tool_specs=tool_specs if tools_active else None,
+                                            keep_live_ref=session_keep_live_ref,
                                         )
                                     else:
                                         postcommit = _store_generation_final_history_snapshot(
@@ -7399,6 +7723,7 @@ def create_app(state: ServerState) -> FastAPI:
                                             thinking_enabled=thinking_enabled,
                                             policy_fingerprint=policy_fingerprint,
                                             tool_specs=tool_specs if tools_active else None,
+                                            keep_live_ref=session_keep_live_ref,
                                         )
                                         if not postcommit.get("stored"):
                                             generated["stats"][
@@ -7645,6 +7970,7 @@ def create_app(state: ServerState) -> FastAPI:
                     )
                     return content
 
+                stream_cancelled_by_client = False
                 for field, text in splitter.start():
                     if text:
                         for chunk in stream_content_delta_chunks(field, text):
@@ -7659,9 +7985,16 @@ def create_app(state: ServerState) -> FastAPI:
                                 cancel_event.is_set()
                                 or await raw_request.is_disconnected()
                             ):
+                                stream_cancelled_by_client = True
                                 _cancel_stream_generation(
                                     cancel_event, generation_future
                                 )
+                                if session is not None and hasattr(
+                                    session, "abort_pending_postcommit"
+                                ):
+                                    session.abort_pending_postcommit(
+                                        "stream_client_disconnected"
+                                    )
                                 return
                             now_s = time.perf_counter()
                             if (
@@ -7832,28 +8165,47 @@ def create_app(state: ServerState) -> FastAPI:
                                         ),
                                         "boundary_kind": prompt_prefix_boundary_kind,
                                     }
-                                    generated["stats"][
-                                        "session_postcommit_snapshot"
-                                    ] = _schedule_idle_postcommit_snapshot(
-                                        state,
-                                        session_id=session_id,
-                                        messages=request.messages,
-                                        assistant_content=assistant_history_content,
+                                    unsafe_reason = str(
+                                        postcommit.get("reason") or "unsafe_history"
+                                    )
+                                    postcommit_snapshot = _skipped_idle_postcommit_snapshot(
+                                        unsafe_reason=unsafe_reason,
                                         assistant_tool_calls=assistant_tool_calls,
-                                        thinking_enabled=thinking_enabled,
-                                        policy_fingerprint=policy_fingerprint,
-                                        unsafe_reason=str(
-                                            postcommit.get("reason")
-                                            or "unsafe_history"
-                                        ),
-                                        tool_specs=(
-                                            tool_specs if tools_active else None
-                                        ),
-                                        session=session,
-                                        expected_session_revision=getattr(
-                                            session, "revision", None
+                                        prompt_prefix_len=(
+                                            prompt_prefix_commit.prefix_len
                                         ),
                                     )
+                                    if postcommit_snapshot is not None:
+                                        postcommit_snapshot = (
+                                            _attach_skipped_postcommit_cleanup(
+                                                state,
+                                                postcommit_snapshot,
+                                            )
+                                        )
+                                    else:
+                                        postcommit_snapshot = _schedule_idle_postcommit_snapshot(
+                                            state,
+                                            session_id=session_id,
+                                            messages=request.messages,
+                                            assistant_content=(
+                                                assistant_history_content
+                                            ),
+                                            assistant_tool_calls=assistant_tool_calls,
+                                            thinking_enabled=thinking_enabled,
+                                            policy_fingerprint=policy_fingerprint,
+                                            unsafe_reason=unsafe_reason,
+                                            tool_specs=(
+                                                tool_specs if tools_active else None
+                                            ),
+                                            session=session,
+                                            expected_session_revision=getattr(
+                                                session, "revision", None
+                                            ),
+                                            keep_live_ref=session_keep_live_ref,
+                                        )
+                                    generated["stats"][
+                                        "session_postcommit_snapshot"
+                                    ] = postcommit_snapshot
                                 else:
                                     yield mark_sse_sent(
                                         error_chunk(
@@ -7903,6 +8255,7 @@ def create_app(state: ServerState) -> FastAPI:
                             yield mark_sse_sent("data: [DONE]\n\n")
                             return
                 except asyncio.CancelledError:
+                    stream_cancelled_by_client = True
                     _cancel_stream_generation(cancel_event, generation_future)
                     raise
                 except BaseException as exc:
@@ -7911,6 +8264,12 @@ def create_app(state: ServerState) -> FastAPI:
                     return
                 finally:
                     _cancel_stream_generation(cancel_event, generation_future)
+                    if (
+                        stream_cancelled_by_client
+                        and session is not None
+                        and hasattr(session, "abort_pending_postcommit")
+                    ):
+                        session.abort_pending_postcommit("stream_cancelled")
                     if session is not None and not commit_event.is_set():
                         commit_state["commit"] = False
                         commit_event.set()

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -47,6 +47,14 @@ def token_prefix_hash(token_ids: list[int] | tuple[int, ...]) -> str:
     return h.hexdigest()
 
 
+def common_prefix_len(left: list[int] | tuple[int, ...], right: list[int] | tuple[int, ...]) -> int:
+    limit = min(len(left), len(right))
+    for index in range(limit):
+        if int(left[index]) != int(right[index]):
+            return index
+    return limit
+
+
 # Policies that share the committed-mtp-cache representation. An entry stored
 # under any of these policies can be safely reused for a lookup that requests
 # any other policy in this set, because the cache snapshot shape is identical
@@ -292,6 +300,37 @@ class SessionBank:
             if best is None or len(prefix) > len(best.token_ids):
                 best = entry
         return best
+
+    def near_prefix_candidates(
+        self,
+        token_ids: list[int] | tuple[int, ...],
+        *,
+        max_token_gap: int = 8,
+        min_matched_tokens: int = 64,
+    ) -> list[tuple[SessionBankEntry, int]]:
+        """Return entries whose divergence is only at the prompt boundary.
+
+        This is for tokenizer-boundary drift in tool-call transcripts. It does
+        not accept arbitrary shared system prompts: the common prefix must reach
+        within ``max_token_gap`` tokens of the stored entry's end.
+        """
+        tokens = tuple(int(token) for token in token_ids)
+        gap_limit = max(0, int(max_token_gap))
+        min_match = max(1, int(min_matched_tokens))
+        matches: list[tuple[SessionBankEntry, int]] = []
+        self._purge_expired()
+        for entry in self._entries.values():
+            prefix = entry.token_ids
+            if not prefix:
+                continue
+            matched = common_prefix_len(tokens, prefix)
+            gap = len(prefix) - matched
+            required_match = min(min_match, max(1, len(prefix) - gap_limit))
+            if gap < 0 or gap > gap_limit or matched < required_match:
+                continue
+            matches.append((entry, matched))
+        matches.sort(key=lambda item: (item[1], item[0].prefix_len), reverse=True)
+        return matches
 
     def restore(
         self,

--- a/mtplx/thermal.py
+++ b/mtplx/thermal.py
@@ -386,14 +386,12 @@ def _summary_indicates_auto(summary: dict[str, Any]) -> bool:
     for fan in fans:
         mode = str(fan.get("mode") or "").lower()
         target_int = _int_or_none(fan.get("target_rpm"))
-        # ThermalForge may report target_rpm as 0 or as the fan's low automatic
-        # setpoint (~min_rpm) while mode is auto. The mode is the authoritative
+        # ThermalForge may briefly keep reporting the previous max target while
+        # mode has already flipped to auto. The mode is the authoritative
         # restore signal; target only helps when a tool omits mode.
         if mode in {"auto", "automatic", "default"}:
-            if _fan_target_is_ramped(fan):
-                return False
             continue
-        if target_int is not None and target_int <= 0:
+        if target_int is not None and target_int < FAN_RAMP_FALLBACK_THRESHOLD_RPM:
             continue
         return False
     return True

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -1126,6 +1126,30 @@ def screen_interface() -> str:
     return "swival"
 
 
+def screen_tuning_offer() -> bool:
+    """Return whether the first-run Web UI flow should tune depth now."""
+
+    _step_panel(
+        step=4,
+        total=4,
+        title="Tune MTPLX for this Mac?",
+        options=[
+            (
+                "1",
+                "Run tuning [recommended]",
+                "Tests AR, D1, D2, and D3 on a short coding prompt, then saves the fastest depth for this model and Mac. This takes a few minutes; close heavy background apps for cleaner results. Fans may get loud and will be restored after tuning.",
+            ),
+            (
+                "2",
+                "Skip for now",
+                "Start the Web UI with the default depth. You can run mtplx tune later.",
+            ),
+        ],
+    )
+    choice = _prompt_choice("Select", ["1", "2"], default="1")
+    return choice == "1"
+
+
 def screen_server_surface(
     *,
     host: str = "127.0.0.1",

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -1127,7 +1127,7 @@ def screen_interface() -> str:
 
 
 def screen_tuning_offer() -> bool:
-    """Return whether the first-run Web UI flow should tune depth now."""
+    """Return whether the first-run interactive flow should tune depth now."""
 
     _step_panel(
         step=4,
@@ -1142,7 +1142,7 @@ def screen_tuning_offer() -> bool:
             (
                 "2",
                 "Skip for now",
-                "Start the Web UI with the default depth. You can run mtplx tune later.",
+                "Start MTPLX with the default depth. You can run mtplx tune later.",
             ),
         ],
     )

--- a/mtplx/version.py
+++ b/mtplx/version.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "0.3.5"
-DISPLAY_VERSION = "0.3.5"
+__version__ = "0.3.6"
+DISPLAY_VERSION = "0.3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mtplx"
-version = "0.3.5"
+version = "0.3.6"
 description = "Native MTP speculative decoding for Qwen3-Next on Apple Silicon."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -60,6 +60,7 @@ dev = [
 
 [project.scripts]
 mtplx = "mtplx.cli:main"
+mtplx-tune = "mtplx.cli:main_tune"
 
 [tool.setuptools.packages.find]
 include = ["mtplx*", "vllm_metal*"]

--- a/scripts/aime_shape_memory_bench.py
+++ b/scripts/aime_shape_memory_bench.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""AIME-shaped memory regression harness for MTPLX OpenAI serving.
+
+The failure this targets is small benchmark prompts with a huge response budget
+(`max_tokens=65536`) creating oversized paged-KV allocations. The harness uses
+the live OpenAI-compatible server so it measures the actual product path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import signal
+import statistics
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+try:
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - optional runtime dependency
+    psutil = None
+
+
+AIME_PROMPTS = [
+    "Find the sum of all positive integers n such that n^2 + 19n + 89 is a perfect square.",
+    "Let a and b be positive integers with ab=432. What is the minimum possible value of a+b?",
+    "A circle has radius 5. A chord is 6 units long. Find the distance from the center to the chord.",
+    "How many ordered pairs of integers (x,y) satisfy x^2 + y^2 = 25?",
+    "The sequence a_n is defined by a_1=2 and a_{n+1}=3a_n+1. Find a_5.",
+    "A fair six-sided die is rolled three times. What is the probability that the sum is 10?",
+    "Find the remainder when 7^2026 is divided by 13.",
+    "The roots of x^2 - kx + 36 = 0 differ by 5. Find k if k is positive.",
+    "A rectangle has integer side lengths and perimeter 50. What is the largest possible area?",
+    "How many subsets of {1,2,3,4,5,6,7,8} have an even sum?",
+]
+
+
+CODING_PROMPTS = [
+    "Write a compact Python function that validates and normalizes OpenAI chat messages for a local model server. Include edge cases.",
+    "Design a small CLI command that prints before/after benchmark summaries for decode TPS, TTFT, and memory. Show the Python code.",
+    "Given a slow FastAPI endpoint, explain how you would instrument request latency, first-token latency, and memory growth without changing behavior.",
+]
+
+
+def _json_request(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    timeout_s: float = 1200.0,
+) -> dict[str, Any]:
+    data = None
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{method} {url} failed: HTTP {exc.code}: {body}") from exc
+    return json.loads(raw) if raw else {}
+
+
+def _try_json_request(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    timeout_s: float = 1200.0,
+) -> dict[str, Any] | None:
+    try:
+        return _json_request(
+            url,
+            method=method,
+            payload=payload,
+            api_key=api_key,
+            timeout_s=timeout_s,
+        )
+    except Exception:
+        return None
+
+
+def _git_commit() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return None
+
+
+def _git_branch() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return None
+
+
+def _system_memory() -> dict[str, Any]:
+    if psutil is None:
+        return {}
+    vm = psutil.virtual_memory()
+    data = {
+        "total_bytes": int(getattr(vm, "total", 0) or 0),
+        "available_bytes": int(getattr(vm, "available", 0) or 0),
+        "used_bytes": int(getattr(vm, "used", 0) or 0),
+        "percent": float(getattr(vm, "percent", 0.0) or 0.0),
+    }
+    wired = getattr(vm, "wired", None)
+    if wired is not None:
+        data["wired_bytes"] = int(wired)
+    return data
+
+
+def _process_memory(pid: int | None) -> dict[str, Any]:
+    if pid is None or psutil is None:
+        return {}
+    try:
+        proc = psutil.Process(pid)
+        info = proc.memory_info()
+    except Exception:
+        return {}
+    data = {"pid": int(pid), "rss_bytes": int(getattr(info, "rss", 0) or 0)}
+    vms = getattr(info, "vms", None)
+    if vms is not None:
+        data["vms_bytes"] = int(vms)
+    return data
+
+
+class _MemorySampler:
+    def __init__(
+        self,
+        *,
+        pid: int | None,
+        poll_s: float,
+        abort_rss_gb: float | None,
+        abort_system_used_gb: float | None,
+    ) -> None:
+        self.pid = pid
+        self.poll_s = max(float(poll_s), 0.05)
+        self.abort_rss_bytes = (
+            int(abort_rss_gb * 1_000_000_000) if abort_rss_gb else None
+        )
+        self.abort_system_used_bytes = (
+            int(abort_system_used_gb * 1_000_000_000)
+            if abort_system_used_gb
+            else None
+        )
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.samples = 0
+        self.aborted = False
+        self.abort_reason: str | None = None
+        self.process_peak: dict[str, Any] = {}
+        self.system_peak: dict[str, Any] = {}
+
+    def __enter__(self) -> "_MemorySampler":
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(self.poll_s * 2, 0.2))
+
+    def _record_process(self, sample: dict[str, Any]) -> None:
+        if not sample:
+            return
+        current = int(sample.get("rss_bytes") or 0)
+        previous = int(self.process_peak.get("rss_bytes") or 0)
+        if current >= previous:
+            self.process_peak = sample
+        if self.abort_rss_bytes is not None and current >= self.abort_rss_bytes:
+            self._abort_server(f"process_rss_bytes>={self.abort_rss_bytes}")
+
+    def _record_system(self, sample: dict[str, Any]) -> None:
+        if not sample:
+            return
+        current = int(sample.get("used_bytes") or 0)
+        previous = int(self.system_peak.get("used_bytes") or 0)
+        if current >= previous:
+            self.system_peak = sample
+        if (
+            self.abort_system_used_bytes is not None
+            and current >= self.abort_system_used_bytes
+        ):
+            self._abort_server(f"system_used_bytes>={self.abort_system_used_bytes}")
+
+    def _abort_server(self, reason: str) -> None:
+        if self.aborted:
+            return
+        self.aborted = True
+        self.abort_reason = reason
+        if self.pid is None:
+            return
+        try:
+            os.kill(int(self.pid), signal.SIGTERM)
+        except Exception:
+            pass
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self.samples += 1
+            self._record_process(_process_memory(self.pid))
+            self._record_system(_system_memory())
+            self._stop.wait(self.poll_s)
+
+
+def _server_pid_from_arg(args: argparse.Namespace) -> int | None:
+    if args.server_pid:
+        return int(args.server_pid)
+    if args.server_pid_file:
+        try:
+            return int(Path(args.server_pid_file).read_text().strip())
+        except Exception:
+            return None
+    return None
+
+
+def _percent_delta(before: float | None, after: float | None) -> float | None:
+    if before is None or after is None or before == 0:
+        return None
+    return ((after - before) / before) * 100.0
+
+
+def _finite(values: list[Any]) -> list[float]:
+    out = []
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(number):
+            out.append(number)
+    return out
+
+
+def _mean(values: list[Any]) -> float | None:
+    numbers = _finite(values)
+    return statistics.fmean(numbers) if numbers else None
+
+
+def _max(values: list[Any]) -> float | None:
+    numbers = _finite(values)
+    return max(numbers) if numbers else None
+
+
+def _last(values: list[Any]) -> Any:
+    return values[-1] if values else None
+
+
+def _slope_per_request(values: list[Any]) -> float | None:
+    numbers = _finite(values)
+    if len(numbers) < 2:
+        return None
+    first = numbers[0]
+    last = numbers[-1]
+    return (last - first) / float(len(numbers) - 1)
+
+
+def _summarize_rows(rows: list[dict[str, Any]], *, suite: str) -> dict[str, Any]:
+    stats = [row.get("mtplx_stats") or {} for row in rows]
+    process = [
+        row.get("process_memory_peak") or row.get("process_memory") or {}
+        for row in rows
+    ]
+    system = [
+        row.get("system_memory_peak") or row.get("system_memory") or {}
+        for row in rows
+    ]
+    dynamic = [item.get("dynamic_paged_kv") or {} for item in stats]
+    return {
+        "suite": suite,
+        "count": len(rows),
+        "decode_tok_s_mean": _mean([item.get("decode_tok_s") for item in stats]),
+        "request_tok_s_mean": _mean([item.get("request_tok_s") for item in stats]),
+        "ttft_s_mean": _mean([item.get("ttft_s") for item in stats]),
+        "prompt_eval_time_s_mean": _mean(
+            [item.get("prompt_eval_time_s") for item in stats]
+        ),
+        "prefill_tok_s_mean": _mean([item.get("prefill_tok_s") for item in stats]),
+        "completion_tokens_total": int(
+            sum(int(item.get("completion_tokens") or 0) for item in stats)
+        ),
+        "prompt_tokens_mean": _mean([item.get("prompt_tokens") for item in stats]),
+        "peak_memory_bytes_max": _max([item.get("peak_memory_bytes") for item in stats]),
+        "active_memory_bytes_last": _last(
+            [item.get("active_memory_bytes") for item in stats]
+        ),
+        "active_memory_bytes_slope_per_request": _slope_per_request(
+            [item.get("active_memory_bytes") for item in stats]
+        ),
+        "cache_memory_bytes_last": _last(
+            [item.get("cache_memory_bytes") for item in stats]
+        ),
+        "cache_memory_bytes_slope_per_request": _slope_per_request(
+            [item.get("cache_memory_bytes") for item in stats]
+        ),
+        "process_rss_bytes_max": _max([item.get("rss_bytes") for item in process]),
+        "process_rss_bytes_slope_per_request": _slope_per_request(
+            [item.get("rss_bytes") for item in process]
+        ),
+        "system_used_bytes_max": _max([item.get("used_bytes") for item in system]),
+        "system_used_bytes_slope_per_request": _slope_per_request(
+            [item.get("used_bytes") for item in system]
+        ),
+        "system_wired_bytes_max": _max([item.get("wired_bytes") for item in system]),
+        "system_wired_bytes_slope_per_request": _slope_per_request(
+            [item.get("wired_bytes") for item in system]
+        ),
+        "paged_kv_capacity_tokens_max": _max(
+            [item.get("paged_kv_capacity_tokens") for item in stats]
+        ),
+        "paged_kv_num_blocks_max": _max(
+            [item.get("paged_kv_num_blocks") for item in stats]
+        ),
+        "paged_kv_grow_events_total": int(
+            sum(int(item.get("paged_kv_grow_events") or 0) for item in stats)
+        ),
+        "sessionbank_snapshot_bytes_max": _max(
+            [item.get("sessionbank_snapshot_bytes") for item in stats]
+        ),
+        "session_keep_live_ref_values": sorted(
+            {
+                str(item.get("request_session_keep_live_ref"))
+                for item in stats
+                if "request_session_keep_live_ref" in item
+            }
+        ),
+        "dynamic_requested_new_tokens_max": _max(
+            [item.get("requested_new_tokens") for item in dynamic]
+        ),
+        "dynamic_reserved_new_tokens_max": _max(
+            [item.get("reserved_new_tokens") for item in dynamic]
+        ),
+        "dynamic_reservation_capped_count": int(
+            sum(1 for item in dynamic if item.get("reservation_capped"))
+        ),
+    }
+
+
+def _prompts_for_suite(suite: str) -> list[tuple[str, str]]:
+    prompts: list[tuple[str, str]] = []
+    if suite in {"aime10", "all"}:
+        prompts.extend((f"aime_shape_{idx:02d}", prompt) for idx, prompt in enumerate(AIME_PROMPTS, 1))
+    if suite in {"coding3", "all"}:
+        prompts.extend((f"coding_control_{idx:02d}", prompt) for idx, prompt in enumerate(CODING_PROMPTS, 1))
+    return prompts
+
+
+def _expanded_prompts(args: argparse.Namespace) -> list[tuple[str, str]]:
+    base = _prompts_for_suite(args.suite)
+    repeat = max(1, int(args.repeat))
+    prompts = [
+        (f"{row_id}_r{repeat_index:02d}", prompt)
+        for repeat_index in range(1, repeat + 1)
+        for row_id, prompt in base
+    ]
+    if args.limit is not None:
+        prompts = prompts[: max(0, int(args.limit))]
+    return prompts
+
+
+def _payload(args: argparse.Namespace, prompt: str, row_id: str) -> dict[str, Any]:
+    if row_id.startswith("coding_control"):
+        content = (
+            "Complete the coding task concisely. Prefer concrete code or steps over "
+            "background explanation.\n\n"
+            f"Task: {prompt}"
+        )
+    elif args.prompt_mode == "answer-only":
+        content = (
+            "Answer with only the final answer. Do not explain or show reasoning.\n\n"
+            f"Problem: {prompt}\nFinal answer:"
+        )
+    else:
+        content = (
+            "Solve the problem. Give the final answer clearly after the reasoning.\n\n"
+            f"Problem: {prompt}"
+        )
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": int(args.max_tokens),
+        "temperature": float(args.temperature),
+        "top_p": float(args.top_p),
+        "top_k": int(args.top_k),
+        "seed": int(args.seed),
+        "enable_thinking": bool(args.enable_thinking),
+        "stream": False,
+        "metadata": {
+            "mtplx_benchmark": "aime_shape_memory",
+            "row_id": row_id,
+            "phase": args.phase,
+        },
+    }
+    if args.stop:
+        payload["stop"] = args.stop
+    return payload
+
+
+def run(args: argparse.Namespace) -> int:
+    base_url = args.base_url.rstrip("/")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows_path = output_dir / f"{args.phase}-{args.suite}-rows.jsonl"
+    summary_path = output_dir / f"{args.phase}-{args.suite}-summary.json"
+    pid = _server_pid_from_arg(args)
+    health_before = _try_json_request(f"{base_url}/health", api_key=args.api_key)
+    if args.clear_cache_first:
+        _try_json_request(
+            f"{base_url}/admin/cache/clear",
+            method="POST",
+            payload={},
+            api_key=args.api_key,
+        )
+    rows = []
+    with rows_path.open("w", encoding="utf-8") as handle:
+        for index, (row_id, prompt) in enumerate(_expanded_prompts(args), 1):
+            started = time.perf_counter()
+            payload = _payload(args, prompt, row_id)
+            monitor = _MemorySampler(
+                pid=pid,
+                poll_s=float(args.memory_poll_s),
+                abort_rss_gb=args.abort_rss_gb,
+                abort_system_used_gb=args.abort_system_used_gb,
+            )
+            try:
+                with monitor:
+                    response = _json_request(
+                        f"{base_url}/v1/chat/completions",
+                        method="POST",
+                        payload=payload,
+                        api_key=args.api_key,
+                        timeout_s=float(args.timeout_s),
+                    )
+            except Exception as exc:
+                elapsed = time.perf_counter() - started
+                row = {
+                    "index": index,
+                    "id": row_id,
+                    "phase": args.phase,
+                    "suite": args.suite,
+                    "elapsed_wall_s": elapsed,
+                    "prompt_preview": prompt[:160],
+                    "error": str(exc),
+                    "memory_sampler": {
+                        "samples": monitor.samples,
+                        "aborted": monitor.aborted,
+                        "abort_reason": monitor.abort_reason,
+                    },
+                    "process_memory_peak": monitor.process_peak,
+                    "system_memory_peak": monitor.system_peak,
+                    "process_memory": _process_memory(pid),
+                    "system_memory": _system_memory(),
+                }
+                rows.append(row)
+                handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+                handle.flush()
+                if monitor.aborted:
+                    print(
+                        json.dumps(
+                            {
+                                "id": row_id,
+                                "aborted": True,
+                                "abort_reason": monitor.abort_reason,
+                            },
+                            sort_keys=True,
+                        ),
+                        flush=True,
+                    )
+                    break
+                raise
+            elapsed = time.perf_counter() - started
+            stats = response.get("mtplx_stats") or {}
+            metrics = _try_json_request(f"{base_url}/metrics", api_key=args.api_key)
+            sessions = _try_json_request(f"{base_url}/admin/sessions", api_key=args.api_key)
+            row = {
+                "index": index,
+                "id": row_id,
+                "phase": args.phase,
+                "suite": args.suite,
+                "elapsed_wall_s": elapsed,
+                "prompt_preview": prompt[:160],
+                "request": {
+                    "max_tokens": int(args.max_tokens),
+                    "temperature": float(args.temperature),
+                    "top_p": float(args.top_p),
+                    "top_k": int(args.top_k),
+                    "seed": int(args.seed),
+                    "enable_thinking": bool(args.enable_thinking),
+                    "prompt_mode": args.prompt_mode,
+                    "stop": args.stop,
+                },
+                "response_finish_reason": (
+                    (response.get("choices") or [{}])[0].get("finish_reason")
+                    if isinstance(response.get("choices"), list)
+                    else None
+                ),
+                "usage": response.get("usage"),
+                "mtplx_stats": stats,
+                "metrics_latest": (metrics or {}).get("latest") if metrics else None,
+                "sessions": sessions,
+                "memory_sampler": {
+                    "samples": monitor.samples,
+                    "aborted": monitor.aborted,
+                    "abort_reason": monitor.abort_reason,
+                },
+                "process_memory_peak": monitor.process_peak,
+                "system_memory_peak": monitor.system_peak,
+                "process_memory": _process_memory(pid),
+                "system_memory": _system_memory(),
+            }
+            rows.append(row)
+            handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+            handle.flush()
+            print(
+                json.dumps(
+                    {
+                        "id": row_id,
+                        "decode_tok_s": stats.get("decode_tok_s"),
+                        "ttft_s": stats.get("ttft_s"),
+                        "peak_memory_gb": (
+                            (stats.get("peak_memory_bytes") or 0) / 1e9
+                            if stats.get("peak_memory_bytes") is not None
+                            else None
+                        ),
+                        "reserved_new_tokens": (
+                            (stats.get("dynamic_paged_kv") or {}).get(
+                                "reserved_new_tokens"
+                            )
+                        ),
+                        "session_keep_live_ref": stats.get(
+                            "request_session_keep_live_ref"
+                        ),
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+    summary = {
+        "phase": args.phase,
+        "suite": args.suite,
+        "created_at_unix": time.time(),
+        "git": {"commit": _git_commit(), "branch": _git_branch()},
+        "host": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "server": {
+            "base_url": base_url,
+            "pid": pid,
+            "health_before": health_before,
+        },
+        "request": {
+            "max_tokens": int(args.max_tokens),
+            "temperature": float(args.temperature),
+            "top_p": float(args.top_p),
+            "top_k": int(args.top_k),
+            "seed": int(args.seed),
+            "enable_thinking": bool(args.enable_thinking),
+            "prompt_mode": args.prompt_mode,
+            "stop": args.stop,
+            "repeat": int(args.repeat),
+            "limit": args.limit,
+        },
+        "pillars": _summarize_rows(rows, suite=args.suite),
+        "artifacts": {"rows_jsonl": str(rows_path), "summary_json": str(summary_path)},
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def _load_summary(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _gate_ok(metric: str, before: dict[str, Any], after: dict[str, Any], *, max_drop_pct: float) -> dict[str, Any]:
+    before_value = before.get(metric)
+    after_value = after.get(metric)
+    delta = _percent_delta(
+        float(before_value) if before_value is not None else None,
+        float(after_value) if after_value is not None else None,
+    )
+    ok = delta is None or delta >= -abs(max_drop_pct)
+    return {
+        "metric": metric,
+        "before": before_value,
+        "after": after_value,
+        "delta_pct": delta,
+        "ok": ok,
+        "max_allowed_drop_pct": max_drop_pct,
+    }
+
+
+def compare(args: argparse.Namespace) -> int:
+    before = _load_summary(args.before)["pillars"]
+    after = _load_summary(args.after)["pillars"]
+    gates = [
+        _gate_ok("decode_tok_s_mean", before, after, max_drop_pct=args.max_regression_pct),
+        _gate_ok("ttft_s_mean", before, after, max_drop_pct=args.max_regression_pct),
+        _gate_ok("prefill_tok_s_mean", before, after, max_drop_pct=args.max_regression_pct),
+    ]
+    memory_before = before.get("peak_memory_bytes_max")
+    memory_after = after.get("peak_memory_bytes_max")
+    memory_delta = _percent_delta(
+        float(memory_before) if memory_before is not None else None,
+        float(memory_after) if memory_after is not None else None,
+    )
+    memory_ok = memory_delta is not None and memory_delta <= -abs(args.min_memory_improvement_pct)
+    comparison = {
+        "before": args.before,
+        "after": args.after,
+        "gates": gates,
+        "memory": {
+            "metric": "peak_memory_bytes_max",
+            "before": memory_before,
+            "after": memory_after,
+            "delta_pct": memory_delta,
+            "ok": memory_ok,
+            "min_required_improvement_pct": args.min_memory_improvement_pct,
+        },
+    }
+    comparison["passed"] = bool(memory_ok and all(gate["ok"] for gate in gates))
+    if args.output:
+        Path(args.output).write_text(json.dumps(comparison, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(comparison, indent=2, sort_keys=True))
+    return 0 if comparison["passed"] else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser("run", help="Run AIME-shape or coding-control requests")
+    run_p.add_argument("--base-url", default="http://127.0.0.1:8000")
+    run_p.add_argument("--api-key", default=os.environ.get("MTPLX_API_KEY"))
+    run_p.add_argument("--model", default="mtplx-qwen36-27b-optimized-speed")
+    run_p.add_argument("--phase", choices=("before", "after", "candidate"), required=True)
+    run_p.add_argument("--suite", choices=("aime10", "coding3", "all"), default="aime10")
+    run_p.add_argument("--repeat", type=int, default=1)
+    run_p.add_argument("--limit", type=int)
+    run_p.add_argument("--output-dir", required=True)
+    run_p.add_argument("--server-pid", type=int)
+    run_p.add_argument("--server-pid-file")
+    run_p.add_argument("--max-tokens", type=int, default=65536)
+    run_p.add_argument("--temperature", type=float, default=0.0)
+    run_p.add_argument("--top-p", type=float, default=1.0)
+    run_p.add_argument("--top-k", type=int, default=0)
+    run_p.add_argument("--seed", type=int, default=42)
+    run_p.add_argument("--enable-thinking", action="store_true", default=True)
+    run_p.add_argument("--disable-thinking", dest="enable_thinking", action="store_false")
+    run_p.add_argument(
+        "--prompt-mode",
+        choices=("aime", "answer-only"),
+        default="aime",
+        help="Use answer-only for quick memory-policy runs that keep max_tokens high.",
+    )
+    run_p.add_argument(
+        "--stop",
+        action="append",
+        help="OpenAI stop sequence. Repeat for multiple sequences.",
+    )
+    run_p.add_argument("--clear-cache-first", action="store_true")
+    run_p.add_argument("--timeout-s", type=float, default=1200.0)
+    run_p.add_argument("--memory-poll-s", type=float, default=0.5)
+    run_p.add_argument(
+        "--abort-rss-gb",
+        type=float,
+        help="Terminate the benchmark server if its RSS reaches this many GB.",
+    )
+    run_p.add_argument(
+        "--abort-system-used-gb",
+        type=float,
+        help="Terminate the benchmark server if system used memory reaches this many GB.",
+    )
+    run_p.set_defaults(func=run)
+
+    compare_p = sub.add_parser("compare", help="Compare before/after summaries")
+    compare_p.add_argument("--before", required=True)
+    compare_p.add_argument("--after", required=True)
+    compare_p.add_argument("--output")
+    compare_p.add_argument("--max-regression-pct", type=float, default=2.0)
+    compare_p.add_argument("--min-memory-improvement-pct", type=float, default=10.0)
+    compare_p.set_defaults(func=compare)
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_mx_compile_buckets.py
+++ b/scripts/probe_mx_compile_buckets.py
@@ -33,7 +33,7 @@ from mtplx.generation import generate_mtpk
 from mtplx.mtp_patch import MTPContract
 from mtplx.runtime import load
 from mtplx.sampling import SamplerConfig
-from scripts.probe_draft_lm_head_requant import _install_draft_lm_head
+from mtplx.draft_lm_head import _install_draft_lm_head
 
 
 FAST_PATH_ENV = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,3 +94,50 @@ def test_apply_user_config_preserves_explicit_default_like_model(tmp_path):
     apply_user_config(args, config_path=config)
 
     assert args.model == explicit_model
+
+
+def test_apply_user_config_fills_tune_model_defaults(tmp_path):
+    config = tmp_path / "config.toml"
+    model_dir = tmp_path / "models"
+    config.write_text(
+        'model = "mtplx/example"\n'
+        f'model_dir = "{model_dir}"\n'
+        'profile = "exact"\n',
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        command="tune",
+        model=str(DEFAULT_RUNTIME_MODEL_DIR),
+        cache_dir=None,
+        profile="performance-cold",
+        _cli_flags=set(),
+    )
+
+    apply_user_config(args, config_path=config)
+
+    assert args.model == "mtplx/example"
+    assert args.cache_dir == str(model_dir)
+    assert args.profile == "performance-cold"
+
+
+def test_apply_user_config_fills_bench_tune_model_defaults(tmp_path):
+    config = tmp_path / "config.toml"
+    model_dir = tmp_path / "models"
+    config.write_text(
+        'model = "mtplx/example"\n'
+        f'model_dir = "{model_dir}"\n',
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        command="bench",
+        bench_action="tune",
+        model=str(DEFAULT_RUNTIME_MODEL_DIR),
+        cache_dir=None,
+        profile=None,
+        _cli_flags=set(),
+    )
+
+    apply_user_config(args, config_path=config)
+
+    assert args.model == "mtplx/example"
+    assert args.cache_dir == str(model_dir)

--- a/tests/test_default_models.py
+++ b/tests/test_default_models.py
@@ -240,6 +240,44 @@ def test_public_model_id_for_ref_uses_runtime_metadata_before_folder_name(tmp_pa
     assert public_model_id_for_ref(model) == QUALITY_PUBLIC_MODEL_ID
 
 
+def test_public_model_id_for_ref_maps_mixed_q4_speed_metadata_to_speed(tmp_path):
+    model = tmp_path / "Qwen3.6-27B-MTPLX-Optimized"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization": {
+                    "bits": 4,
+                    "language_model.model.layers.0.mlp.down_proj": {"bits": 4},
+                    "language_model.model.layers.0.linear_attn.in_proj_qkv": {"bits": 8},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert public_model_id_for_ref(model) == DEFAULT_PUBLIC_MODEL_ID
+
+
+def test_public_model_id_for_ref_maps_flat8_metadata_to_quality(tmp_path):
+    model = tmp_path / "Qwen3.6-27B-MTPLX-Optimized"
+    model.mkdir()
+    (model / "config.json").write_text(
+        json.dumps(
+            {
+                "quantization": {
+                    "bits": 4,
+                    "language_model.model.layers.0.mlp.down_proj": {"bits": 8},
+                    "language_model.model.layers.0.linear_attn.in_proj_qkv": {"bits": 8},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert public_model_id_for_ref(model) == QUALITY_PUBLIC_MODEL_ID
+
+
 def test_public_model_id_for_ref_maps_unknown_local_name_to_sanitized_id():
     assert (
         public_model_id_for_ref("/tmp/My Custom Local Model!")

--- a/tests/test_default_models.py
+++ b/tests/test_default_models.py
@@ -6,9 +6,12 @@ import pytest
 
 from mtplx.default_models import (
     DEFAULT_MODEL_VARIANT_ENV,
+    OPTIMIZED_SPEED_DESCRIPTION,
     QUALITY_MODEL_ENV,
+    SPEED_MODEL_ENV,
     is_verified_default_model_ref,
     optimized_quality_model_ref,
+    optimized_speed_model_ref,
     public_model_id_for_ref,
     select_default_model,
 )
@@ -22,6 +25,14 @@ from mtplx.profiles import (
     LEGACY_OPTIMIZED_PUBLIC_MODEL_ID,
     QUALITY_PUBLIC_MODEL_ID,
 )
+
+
+def _make_complete_model(path):
+    path.mkdir()
+    (path / "config.json").write_text("{}", encoding="utf-8")
+    (path / "mtp.safetensors").write_bytes(b"mtp")
+    (path / "model-00001-of-00001.safetensors").write_bytes(b"model")
+    return path
 
 
 @pytest.mark.parametrize(
@@ -84,8 +95,9 @@ def test_auto_default_uses_fp16_for_m1_m2(monkeypatch, generation):
 
 
 @pytest.mark.parametrize("generation", ["m3", "m4", "m5", "unknown", "intel"])
-def test_auto_default_uses_bf16_for_newer_unknown_and_intel(monkeypatch, generation):
+def test_auto_default_uses_q4_speed_for_newer_unknown_and_intel(monkeypatch, generation):
     monkeypatch.delenv(DEFAULT_MODEL_VARIANT_ENV, raising=False)
+    monkeypatch.setenv(SPEED_MODEL_ENV, "off")
 
     selection = select_default_model(
         hardware={
@@ -94,9 +106,10 @@ def test_auto_default_uses_bf16_for_newer_unknown_and_intel(monkeypatch, generat
         }
     )
 
-    assert selection.variant == "bf16"
-    assert selection.precision == "BF16"
+    assert selection.variant == "speed"
+    assert selection.precision == OPTIMIZED_SPEED_DESCRIPTION
     assert selection.model == DEFAULT_HF_MODEL_ID
+    assert "BF16" not in selection.label
     assert selection.auto_selected is True
 
 
@@ -115,8 +128,9 @@ def test_default_model_variant_env_override_forces_fp16(monkeypatch):
     assert selection.auto_selected is False
 
 
-def test_default_model_variant_env_override_forces_bf16(monkeypatch):
+def test_default_model_variant_env_override_legacy_bf16_alias_forces_speed(monkeypatch):
     monkeypatch.setenv(DEFAULT_MODEL_VARIANT_ENV, "bf16")
+    monkeypatch.setenv(SPEED_MODEL_ENV, "off")
 
     selection = select_default_model(
         hardware={
@@ -125,8 +139,10 @@ def test_default_model_variant_env_override_forces_bf16(monkeypatch):
         }
     )
 
-    assert selection.variant == "bf16"
+    assert selection.variant == "speed"
+    assert selection.precision == OPTIMIZED_SPEED_DESCRIPTION
     assert selection.model == DEFAULT_HF_MODEL_ID
+    assert "legacy alias" in selection.reason
     assert selection.auto_selected is False
 
 
@@ -145,9 +161,12 @@ def test_invalid_default_model_variant_env_falls_back_to_auto(monkeypatch):
     assert "ignored invalid" in selection.reason
 
 
-def test_verified_default_refs_include_bf16_and_fp16():
+def test_verified_default_refs_include_speed_and_fp16():
     assert is_verified_default_model_ref(DEFAULT_HF_MODEL_ID)
     assert is_verified_default_model_ref(DEFAULT_FP16_HF_MODEL_ID)
+    assert is_verified_default_model_ref(
+        "/Users/example/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized"
+    )
     assert is_verified_default_model_ref(
         "/Users/example/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed"
     )
@@ -158,12 +177,28 @@ def test_verified_default_refs_include_bf16_and_fp16():
     assert not is_verified_default_model_ref("/Users/example/models/custom-model")
 
 
+def test_optimized_speed_prefers_complete_local_env_model(tmp_path, monkeypatch):
+    local_speed = _make_complete_model(tmp_path / "Qwen3.6-27B-MTPLX-Optimized")
+    monkeypatch.setenv(SPEED_MODEL_ENV, str(local_speed))
+
+    selection = select_default_model(
+        hardware={
+            "chip": "Apple M5 Max",
+            "apple_silicon_generation": "m5",
+        }
+    )
+
+    assert optimized_speed_model_ref() == str(local_speed)
+    assert selection.model == str(local_speed)
+    assert selection.hf_model == DEFAULT_HF_MODEL_ID
+    assert selection.variant == "speed"
+    assert selection.precision == OPTIMIZED_SPEED_DESCRIPTION
+    assert "installed locally" in selection.reason
+    assert "BF16" not in selection.label
+
+
 def test_optimized_quality_prefers_complete_local_env_model(tmp_path, monkeypatch):
-    local_quality = tmp_path / "Qwen3.6-27B-MTPLX-Optimized-Quality"
-    local_quality.mkdir()
-    (local_quality / "config.json").write_text("{}", encoding="utf-8")
-    (local_quality / "mtp.safetensors").write_bytes(b"mtp")
-    (local_quality / "model-00001-of-00001.safetensors").write_bytes(b"model")
+    local_quality = _make_complete_model(tmp_path / "Qwen3.6-27B-MTPLX-Optimized-Quality")
     monkeypatch.setenv(QUALITY_MODEL_ENV, str(local_quality))
 
     assert optimized_quality_model_ref() == str(local_quality)

--- a/tests/test_generation_sustained.py
+++ b/tests/test_generation_sustained.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
@@ -275,6 +276,61 @@ def test_sustained_prefill_chunks_without_full_prompt_logits(monkeypatch):
     assert rt.diagnostic_counters["prefill_chunks"] == 2
     assert rt.diagnostic_counters.get("full_logits_tokens_emitted", 0) == 0
     assert rt.diagnostic_counters["final_logits_tokens_emitted"] == 1
+
+
+def test_warm_restored_suffix_prefill_is_chunked_and_typed_for_abort(monkeypatch):
+    monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_PREFILL_CHUNK_SIZE", "2")
+    monkeypatch.setenv("MTPLX_TARGET_EMIT_FULL_PREFILL_LOGITS", "0")
+    model = TinyModel()
+    rt = _runtime(model, mtp_enabled=True)
+    appended: list[list[int]] = []
+
+    class Bank:
+        last_miss_reason = None
+
+        def restore(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                entry=SimpleNamespace(prefix_len=3),
+                cache=[],
+                logits=mx.zeros((1, 4), dtype=mx.float32),
+                hidden=mx.zeros((1, 1, 2), dtype=mx.float32),
+                mtp_history_cache=[],
+                restore_mode="clone",
+            )
+
+    def append_history(
+        _rt,
+        _mtp_cache,
+        hidden_states,
+        token_ids,
+        *,
+        mtp_hidden_variant,
+        position_offset=None,
+        force_eval=False,
+    ):
+        assert hidden_states.shape[1] == len(token_ids)
+        assert force_eval is True
+        appended.append(list(token_ids))
+        return 0.0
+
+    monkeypatch.setattr("mtplx.generation._append_mtp_history", append_history)
+
+    prompt_state = restore_or_prefill_prompt_state(
+        rt,
+        [0, 1, 2, 3, 4, 5, 6],
+        mtp_history_policy="committed",
+        session_bank=Bank(),
+    )
+
+    assert prompt_state.cache_hit is True
+    assert prompt_state.cached_tokens == 3
+    assert prompt_state.suffix_tokens == 4
+    assert [call["tokens"] for call in model.calls] == [2, 1, 1]
+    assert [call["return_hidden"] for call in model.calls] == [True, True, True]
+    assert [call["emit_logits"] for call in model.calls] == [False, False, True]
+    assert appended == [[3], [4, 5], [6]]
+    assert rt.diagnostic_counters["restored_suffix_prefill_chunks"] == 2
 
 
 def test_sustained_prefill_chunk_cache_cleanup_is_explicit(monkeypatch):

--- a/tests/test_metal_memory_caps.py
+++ b/tests/test_metal_memory_caps.py
@@ -77,6 +77,38 @@ def test_apply_metal_memory_caps_uses_top_level_mlx_apis(monkeypatch):
     assert calls == [("memory", 64 * GiB), ("wired", 48 * GiB)]
 
 
+def test_apply_metal_memory_caps_caps_large_unified_memory_defaults(monkeypatch):
+    mx, calls = _fake_mx(top_level=True)
+    monkeypatch.delenv("MTPLX_MEMORY_LIMIT_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_WIRED_LIMIT_BYTES", raising=False)
+
+    result = openai._apply_metal_memory_caps(
+        mx_module=mx,
+        total_ram_bytes=512 * GiB,
+    )
+
+    assert result["applied"] is True
+    assert result["memory_limit_bytes"] == 192 * GiB
+    assert result["wired_limit_bytes"] == 160 * GiB
+    assert calls == [("memory", 192 * GiB), ("wired", 160 * GiB)]
+
+
+def test_apply_metal_memory_caps_preserves_128g_defaults(monkeypatch):
+    mx, calls = _fake_mx(top_level=True)
+    monkeypatch.delenv("MTPLX_MEMORY_LIMIT_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_WIRED_LIMIT_BYTES", raising=False)
+
+    result = openai._apply_metal_memory_caps(
+        mx_module=mx,
+        total_ram_bytes=128 * GiB,
+    )
+
+    assert result["applied"] is True
+    assert result["memory_limit_bytes"] == 96 * GiB
+    assert result["wired_limit_bytes"] == int(128 * GiB * 0.60)
+    assert calls == [("memory", 96 * GiB), ("wired", int(128 * GiB * 0.60))]
+
+
 def test_apply_metal_memory_caps_falls_back_to_deprecated_metal_apis(monkeypatch):
     mx, calls = _fake_mx(top_level=False)
     monkeypatch.setenv("MTPLX_MEMORY_LIMIT_BYTES", "32G")

--- a/tests/test_mtp_depth_sweep.py
+++ b/tests/test_mtp_depth_sweep.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mtplx.benchmarks.runners import mtp_depth_sweep
+
+
+def test_depth_sweep_uses_packaged_draft_lm_head_helper(monkeypatch, tmp_path) -> None:
+    calls = []
+    fake_runtime = SimpleNamespace(
+        model=object(),
+        tokenizer=object(),
+        contract=SimpleNamespace(
+            mtp_quant_bits=None,
+            mtp_quant_group_size=64,
+            mtp_quant_mode="affine",
+            mtp_quant_policy=None,
+        ),
+        mtp_adapter_metadata=None,
+    )
+
+    monkeypatch.setattr(mtp_depth_sweep, "load", lambda *_args, **_kwargs: fake_runtime)
+    monkeypatch.setattr(mtp_depth_sweep, "load_prompt_suite", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        "mtplx.draft_lm_head._install_draft_lm_head",
+        lambda runtime, **kwargs: calls.append((runtime, kwargs)) or {"installed": True},
+    )
+
+    result = mtp_depth_sweep.run_mtp_depth_sweep(
+        tmp_path / "model",
+        tmp_path / "suite.jsonl",
+        depths=[1],
+        draft_lm_head_bits=4,
+        draft_lm_head_group_size=64,
+        draft_lm_head_mode="affine",
+    )
+
+    assert result["draft_lm_head"] == {"installed": True}
+    assert calls == [
+        (
+            fake_runtime,
+            {"bits": 4, "group_size": 64, "mode": "affine"},
+        )
+    ]

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -911,3 +911,115 @@ def test_screen_model_local_folder_routes_through_picker(tmp_path, monkeypatch):
 
     assert chosen == str(target)
     assert invocations == [None]
+
+
+def test_screen_tuning_offer_uses_numbered_choices(monkeypatch):
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "2")
+
+    assert onboarding.screen_tuning_offer() is False
+
+
+def test_quickstart_applies_saved_tuned_depth(monkeypatch):
+    import argparse
+
+    from mtplx.commands import public
+
+    args = argparse.Namespace(depth=3, _explicit_depth=False, cache_dir=None)
+    monkeypatch.setattr(public, "_apple_hardware_context", lambda: {"chip": "Apple M5"})
+    monkeypatch.setattr(public, "_software_context", lambda: {"mtplx_version": "test", "mlx_version": "test"})
+    monkeypatch.setattr(public, "_mlx_backend_context", lambda _profile: {"stock_mlx_likely": True})
+    monkeypatch.setattr(public, "_tune_state_key", lambda *_args, **_kwargs: ("key", {}))
+    monkeypatch.setattr(
+        public,
+        "_load_tune_record",
+        lambda _key: {
+            "payload": {
+                "best": {
+                    "mode": "D2",
+                    "depth": 2,
+                    "multiplier_vs_ar": 1.8,
+                }
+            }
+        },
+    )
+
+    public._quickstart_apply_tuned_depth(
+        args,
+        runtime_model="/tmp/model",
+        target="openwebui",
+        can_prompt=False,
+    )
+
+    assert args.depth == 2
+
+
+def test_quickstart_tuning_prompt_can_save_and_apply(monkeypatch):
+    import argparse
+
+    from mtplx.commands import public
+
+    args = argparse.Namespace(
+        depth=3,
+        _explicit_depth=False,
+        cache_dir=None,
+        unsafe_force_unverified=False,
+    )
+    monkeypatch.setattr(public, "_apple_hardware_context", lambda: {"chip": "Apple M5"})
+    monkeypatch.setattr(public, "_software_context", lambda: {"mtplx_version": "test", "mlx_version": "test"})
+    monkeypatch.setattr(public, "_mlx_backend_context", lambda _profile: {"stock_mlx_likely": True})
+    monkeypatch.setattr(public, "_tune_state_key", lambda *_args, **_kwargs: ("key", {}))
+    monkeypatch.setattr("mtplx.ui.onboarding.screen_tuning_offer", lambda: True)
+    calls = []
+    records = iter(
+        [
+            None,
+            {
+                "payload": {
+                    "best": {
+                        "mode": "D1",
+                        "depth": 1,
+                        "multiplier_vs_ar": 1.4,
+                    }
+                }
+            },
+        ]
+    )
+    monkeypatch.setattr(public, "_load_tune_record", lambda _key: next(records))
+
+    def fake_tune(*_args, **_kwargs):
+        calls.append(True)
+        return 0
+
+    monkeypatch.setattr(public, "_cmd_tune", fake_tune)
+
+    public._quickstart_apply_tuned_depth(
+        args,
+        runtime_model="/tmp/model",
+        target="openwebui",
+        can_prompt=True,
+    )
+
+    assert calls == [True]
+    assert args.depth == 1
+
+
+def test_quickstart_explicit_depth_never_uses_tuning(monkeypatch):
+    import argparse
+
+    from mtplx.commands import public
+
+    args = argparse.Namespace(depth=2, _explicit_depth=True, cache_dir=None)
+    monkeypatch.setattr(
+        public,
+        "_load_tune_record",
+        lambda _key: (_ for _ in ()).throw(AssertionError("should not load tuning")),
+    )
+
+    public._quickstart_apply_tuned_depth(
+        args,
+        runtime_model="/tmp/model",
+        target="openwebui",
+        can_prompt=True,
+    )
+
+    assert args.depth == 2

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -72,8 +72,10 @@ def test_run_onboarding_screens_with_stubbed_input(monkeypatch, capsys):
     """Walk all three screens with stubbed ``input`` answers."""
     answers = iter(["1", "1", "1"])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    expected_model = onboarding._verified_default_model()
+
     state = onboarding.run_onboarding_screens()
-    assert state["model"] == onboarding.DEFAULT_HF_MODEL
+    assert state["model"] == expected_model
     assert state["profile"] == "sustained"
     assert state["max"] is False
     assert state["target"] == "openwebui"
@@ -371,7 +373,7 @@ def test_run_quickstart_flow_legacy_stable_state_is_not_reused(tmp_path, monkeyp
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     state = onboarding.run_quickstart_flow(fresh=False)
     assert state is not None
-    assert state["model"] == onboarding.DEFAULT_HF_MODEL
+    assert state["model"] == onboarding._verified_default_model()
     assert state["profile"] == "sustained"
     assert state["max"] is False
     assert state["target"] == "openwebui"
@@ -423,7 +425,7 @@ def test_run_quickstart_flow_returning_user_says_no(tmp_path, monkeypatch):
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
     state = onboarding.run_quickstart_flow(fresh=False)
     assert state is not None
-    assert state["model"] == onboarding.DEFAULT_HF_MODEL
+    assert state["model"] == onboarding._verified_default_model()
     assert state["profile"] == "sustained"
     assert state["target"] == "openwebui"
 
@@ -438,14 +440,16 @@ def test_screen_model_surfaces_configured_path_first(tmp_path, monkeypatch):
     assert chosen == configured
 
 
-def test_screen_model_picks_canonical_default_when_configured_offered(monkeypatch):
+def test_screen_model_picks_verified_default_when_configured_offered(monkeypatch):
     """With a configured path shown as option 1, option 2 still maps to the
-    canonical Hugging Face default."""
+    verified default, preferring an installed local artifact when present."""
     configured = "/Users/test/Documents/MTPLX/models/Qwen3.6-27B-MTPLX"
     answers = iter(["2"])  # explicit "verified default"
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    expected_model = onboarding._verified_default_model()
+
     chosen = onboarding.screen_model(configured=configured)
-    assert chosen == onboarding.DEFAULT_HF_MODEL
+    assert chosen == expected_model
 
 
 def test_screen_model_picks_hardware_default_when_configured_offered(monkeypatch):
@@ -463,8 +467,10 @@ def test_screen_model_no_configured_uses_default_first(monkeypatch):
     """Without a configured path, option 1 maps to the hardware default."""
     answers = iter(["1"])
     monkeypatch.setattr(builtins, "input", lambda _prompt="": next(answers))
+    expected_model = onboarding._verified_default_model()
+
     chosen = onboarding.screen_model(configured=None)
-    assert chosen == onboarding.DEFAULT_HF_MODEL
+    assert chosen == expected_model
 
 
 def test_screen_model_optimized_quality_prefers_local_model(tmp_path, monkeypatch, capsys):
@@ -685,6 +691,7 @@ def test_start_invokes_onboarding_when_no_explicit_flags(tmp_path, monkeypatch):
         "mtplx.commands.public._quickstart_run_terminal_chat",
         fake_run_terminal,
     )
+    monkeypatch.setattr("mtplx.ui.onboarding.screen_tuning_offer", lambda: False)
 
     from mtplx.commands.public import cmd_quickstart_public
 
@@ -946,7 +953,7 @@ def test_quickstart_applies_saved_tuned_depth(monkeypatch):
     public._quickstart_apply_tuned_depth(
         args,
         runtime_model="/tmp/model",
-        target="openwebui",
+        target="terminal",
         can_prompt=False,
     )
 
@@ -995,7 +1002,7 @@ def test_quickstart_tuning_prompt_can_save_and_apply(monkeypatch):
     public._quickstart_apply_tuned_depth(
         args,
         runtime_model="/tmp/model",
-        target="openwebui",
+        target="terminal",
         can_prompt=True,
     )
 

--- a/tests/test_postcommit_wait_integration.py
+++ b/tests/test_postcommit_wait_integration.py
@@ -151,6 +151,30 @@ def test_pending_near_prefix_resolves_tool_result_waiter() -> None:
     session.wait_for_pending_postcommit(timeout_s=1.0)
 
 
+def test_pending_near_prefix_tolerates_small_tool_boundary_gap() -> None:
+    manager = EngineSessionManager()
+    session = manager.get_or_create("sess-tool")
+    prompt = list(range(200))
+    session.commit_prompt_prefix(
+        prompt_ids=prompt,
+        finish_reason="tool_calls",
+        boundary_kind="tool_call_prompt_prefix",
+    )
+    future: Future = Future()
+    session.set_pending_postcommit(future)
+    tool_result_prompt = prompt[:-3] + [10_001, 10_002, 10_003, 10_004]
+
+    session_id, source = manager.resolve_session_id(prompt_ids=tool_result_prompt)
+
+    assert session_id == "sess-tool"
+    assert source == "pending_postcommit_near_prefix"
+    assert manager.last_prefix_diagnostic is not None
+    assert manager.last_prefix_diagnostic["near_prefix_gap"] == 3
+
+    future.set_result(None)
+    session.wait_for_pending_postcommit(timeout_s=1.0)
+
+
 def test_retokenized_prefix_replaces_prompt_anchor_boundary() -> None:
     session = EngineSession("sess-tool")
     session.commit_prompt_prefix(prompt_ids=[1, 2, 3, 4], finish_reason="tool_calls")
@@ -166,6 +190,24 @@ def test_retokenized_prefix_replaces_prompt_anchor_boundary() -> None:
     assert session.committed_token_ids == (1, 2, 3, 99, 100)
     assert session.prefix_len == 5
     assert session.bytes_estimate == 123
+    assert session.revision == 2
+
+
+def test_retokenized_prefix_tolerates_small_tool_boundary_gap() -> None:
+    session = EngineSession("sess-tool")
+    prompt = list(range(200))
+    session.commit_prompt_prefix(prompt_ids=prompt, finish_reason="tool_calls")
+
+    retokenized = prompt[:-3] + [10_001, 10_002, 10_003, 10_004]
+    commit = session.commit_retokenized_prefix(
+        token_ids=retokenized,
+        expected_revision=1,
+        nbytes=123,
+    )
+
+    assert commit.committed is True
+    assert commit.reason == "committed_retokenized_prefix"
+    assert session.committed_token_ids == tuple(retokenized)
     assert session.revision == 2
 
 

--- a/tests/test_prefill_chunk_defaults.py
+++ b/tests/test_prefill_chunk_defaults.py
@@ -1,10 +1,8 @@
 """Tests for sustained prefill chunk defaults.
 
-The product default is intentionally boring: 2048 for both dense and repage
-prefill. A cached 40-turn growth benchmark once favored dense=4096, but the
-OpenCode/Pi-shaped release gate regressed TTFT, prefill TPS, decode TPS, and
-memory. Keep 2048 as the default unless a future adaptive policy proves both
-workloads independently.
+OpenCode issue #63 must not move the sustained product chunk policy without a
+matched workload benchmark. The product default keeps the reverted 2048-token
+chunk shape through the dense path.
 
 The diagnostic dense/repage env knobs remain supported, and the legacy
 single-knob `MTPLX_PREFILL_CHUNK_SIZE` env still overrides BOTH paths.
@@ -26,10 +24,13 @@ from mtplx.profiles import SUSTAINED_PREFILL_ENV
 
 
 def test_sustained_profile_keeps_dense_decode_through_128k() -> None:
-    assert SUSTAINED_PREFILL_ENV["MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT"] == "131072"
+    assert (
+        SUSTAINED_PREFILL_ENV["MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT"]
+        == "131072"
+    )
 
 
-def test_sustained_profile_ships_2048_chunk_defaults() -> None:
+def test_sustained_profile_ships_split_chunk_defaults() -> None:
     assert SUSTAINED_PREFILL_ENV["MTPLX_PREFILL_CHUNK_SIZE"] == "auto"
     assert SUSTAINED_PREFILL_ENV["MTPLX_PREFILL_CHUNK_SIZE_DENSE"] == "2048"
     assert SUSTAINED_PREFILL_ENV["MTPLX_PREFILL_CHUNK_SIZE_REPAGE"] == "2048"
@@ -62,7 +63,7 @@ def test_prefill_chunk_dense_uses_2048_through_128k(
 
 
 @pytest.mark.parametrize("context_tokens", [150_000, 200_000])
-def test_prefill_chunk_repage_also_uses_2048_above_128k(
+def test_prefill_chunk_repage_uses_2048_above_128k(
     monkeypatch: pytest.MonkeyPatch, context_tokens: int
 ) -> None:
     _apply_product_env(monkeypatch)
@@ -81,7 +82,7 @@ def test_prefill_chunk_envs_honored(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL", "1")
     monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL_LAYOUT", "auto")
-    monkeypatch.setenv("MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT", "65536")
+    monkeypatch.setenv("MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT", "131072")
     monkeypatch.setenv("MTPLX_PREFILL_CHUNK_SIZE", "auto")
     monkeypatch.setenv("MTPLX_PREFILL_CHUNK_SIZE_DENSE", "1024")
     monkeypatch.setenv("MTPLX_PREFILL_CHUNK_SIZE_REPAGE", "512")
@@ -90,7 +91,7 @@ def test_prefill_chunk_envs_honored(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _sustained_prefill_layout() == "contiguous_dense_decode"
     assert _prefill_chunk_size() == 1024
 
-    monkeypatch.setenv("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", "131072")
+    monkeypatch.setenv("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", "150000")
     assert _sustained_prefill_layout() == "contiguous_then_repage"
     assert _prefill_chunk_size() == 512
 
@@ -101,7 +102,7 @@ def test_prefill_chunk_legacy_env_back_compat(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL", "1")
     monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL_LAYOUT", "auto")
-    monkeypatch.setenv("MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT", "65536")
+    monkeypatch.setenv("MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT", "131072")
     # Legacy single-knob set to a non-default value; split envs are deliberately
     # left at fresh defaults so we can confirm the legacy knob actually wins.
     monkeypatch.setenv("MTPLX_PREFILL_CHUNK_SIZE", "1536")
@@ -111,5 +112,5 @@ def test_prefill_chunk_legacy_env_back_compat(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", "32768")
     assert _prefill_chunk_size() == 1536
 
-    monkeypatch.setenv("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", "131072")
+    monkeypatch.setenv("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", "150000")
     assert _prefill_chunk_size() == 1536

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1536,7 +1536,29 @@ def test_tune_human_reports_candidate_errors_instead_of_false_no_win(capsys):
     out = capsys.readouterr().out
     assert "Tune failed for one or more candidates" in out
     assert "No MTP depth beat AR" not in out
+    assert "Close heavy apps" not in out
     assert "/tmp/ar.log" in out
+
+
+def test_tune_human_results_do_not_give_pre_run_advice_afterward(capsys):
+    payload = {
+        "results": [
+            {"mode": "AR", "depth": None, "tok_s": 20.0, "multiplier_vs_ar": 1.0},
+            {"mode": "D1", "depth": 1, "tok_s": 30.0, "multiplier_vs_ar": 1.5},
+        ],
+        "best": {"mode": "D1", "depth": 1, "tok_s": 30.0, "multiplier_vs_ar": 1.5},
+        "saved": False,
+        "save_skipped_reason": "save disabled",
+        "artifacts": {"root": "/tmp/tune"},
+    }
+
+    public._print_tune_human(payload)
+
+    out = capsys.readouterr().out
+    assert "Results written to /tmp/tune" in out
+    assert "Close heavy apps" not in out
+    assert "Fans may get loud" not in out
+    assert "Best for this Mac: D1" in out
 
 
 def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsys):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1430,6 +1430,56 @@ def test_bench_tune_dry_run_is_json_support_payload(capsys):
     assert payload["settings"]["depths"] == "1,2,3"
     assert payload["settings"]["max_tokens"] == 192
     assert [row["candidate"] for row in payload["candidates"]] == ["AR", "D1", "D2", "D3"]
+    assert "power" in payload["diagnostics"]
+
+
+def test_bench_tune_powermetrics_parser_extracts_power_frequency_and_utilization():
+    parsed = public._parse_powermetrics_text(
+        """
+M0-Cluster HW active frequency: 1600 MHz
+M0-Cluster HW active residency:  65.53%
+M1-Cluster HW active frequency: 1407 MHz
+M1-Cluster HW active residency:  18.71%
+P-Cluster HW active frequency: 3844 MHz
+P-Cluster HW active residency:  78.03%
+CPU Power: 5267 mW
+GPU Power: 128 mW
+ANE Power: 0 mW
+Combined Power (CPU + GPU + ANE): 5395 mW
+Current pressure level: Nominal
+GPU HW active frequency: 338 MHz
+GPU HW active residency:  18.41%
+GPU Power: 124 mW
+"""
+    )
+
+    assert parsed["power_w"]["package"] == pytest.approx(5.395)
+    assert parsed["power_w"]["cpu"] == pytest.approx(5.267)
+    assert parsed["power_w"]["ane"] == 0.0
+    assert parsed["power_w"]["gpu"] == pytest.approx(0.124)
+    assert parsed["frequency_ghz"]["p_cluster"] == pytest.approx(3.844)
+    assert parsed["frequency_ghz"]["m_cluster"] == pytest.approx((1.6 + 1.407) / 2)
+    assert parsed["frequency_ghz"]["gpu"] == pytest.approx(0.338)
+    assert parsed["utilization_pct"]["p_core"] == pytest.approx(78.03)
+    assert parsed["utilization_pct"]["m_core"] == pytest.approx((65.53 + 18.71) / 2)
+    assert parsed["utilization_pct"]["gpu"] == pytest.approx(18.41)
+    assert parsed["thermal_pressure"] == "Nominal"
+
+
+def test_bench_tune_thermalforge_temperature_grouping_prefers_core_sensors():
+    core, gpu = public._temperature_groups_from_thermalforge(
+        {
+            "TAOL": 36.7,
+            "TCDX": 56.1,
+            "TCMb": 65.2,
+            "TG0B": 36.6,
+            "Tp04": 56.4,
+            "Tm08": 54.4,
+        }
+    )
+
+    assert core == [56.1, 65.2, 56.4, 54.4]
+    assert gpu == [36.6]
 
 
 def test_tune_best_multiplier_selects_depth_not_ar():
@@ -1520,6 +1570,61 @@ def test_tune_candidate_outputs_are_absolute_from_non_repo_cwd(tmp_path, monkeyp
     assert any("AR finished" in line for line in progress)
 
 
+def test_bench_tune_candidate_rows_include_hardware_telemetry(tmp_path, monkeypatch):
+    progress: list[str] = []
+    telemetry = {
+        "enabled": True,
+        "sample_count": 2,
+        "power_w": {"package": {"avg": 42.0}},
+        "frequency_ghz": {"p_cluster": {"avg": 4.05}},
+        "temperature_c": {"core_avg": {"avg": 71.0}},
+        "utilization_pct": {"gpu": {"avg": 95.0}},
+        "fans_rpm": {"avg": {"avg": 7800.0}},
+    }
+
+    class FakeSampler:
+        def __init__(self, *, enabled):
+            self.enabled = enabled
+
+        def start(self):
+            assert self.enabled is True
+
+        def stop(self):
+            return telemetry
+
+    def fake_run(command, *, cwd, env, text, stdout, stderr, check):
+        output_arg = command[command.index("--_candidate-output") + 1]
+        output = Path(output_arg)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps({"ar_rows": [{"tok_s": 12.0, "generated_tokens": 2}]}),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="candidate ok")
+
+    monkeypatch.setattr(public, "_TuneTelemetrySampler", FakeSampler)
+    monkeypatch.setattr(public.subprocess, "run", fake_run)
+
+    rows = public._run_tune_candidates(
+        SimpleNamespace(cache_dir=None, unsafe_force_unverified=False),
+        runtime_model="/tmp/model",
+        run_id="run",
+        output_root=tmp_path / "run",
+        depths=[],
+        settings={
+            "max_tokens": 8,
+            "limit": 1,
+            "seed": 0,
+            "depths": "",
+        },
+        progress=progress.append,
+        collect_telemetry=True,
+    )
+
+    assert rows[0]["telemetry"]["power_w"]["package"]["avg"] == 42.0
+    assert any("telemetry: power pkg=42.0W" in line for line in progress)
+
+
 def test_tune_human_reports_candidate_errors_instead_of_false_no_win(capsys):
     payload = {
         "results": [
@@ -1559,6 +1664,54 @@ def test_tune_human_results_do_not_give_pre_run_advice_afterward(capsys):
     assert "Close heavy apps" not in out
     assert "Fans may get loud" not in out
     assert "Best for this Mac: D1" in out
+
+
+def test_bench_tune_human_verbose_prints_power_diagnostic_lines(capsys):
+    payload = {
+        "results": [
+            {
+                "mode": "AR",
+                "depth": None,
+                "tok_s": 20.0,
+                "multiplier_vs_ar": 1.0,
+                "telemetry": {
+                    "enabled": True,
+                    "sample_count": 3,
+                    "power_w": {
+                        "package": {"avg": 44.0},
+                        "cpu": {"avg": 6.0},
+                        "ane": {"avg": 0.0},
+                        "gpu": {"avg": 38.0},
+                    },
+                    "frequency_ghz": {
+                        "p_cluster": {"avg": 4.05},
+                        "m_cluster": {"avg": 1.05},
+                        "gpu": {"avg": 1.22},
+                    },
+                    "temperature_c": {
+                        "core_avg": {"avg": 71.0},
+                        "core_max": {"avg": 77.0},
+                        "gpu_avg": {"avg": 69.0},
+                    },
+                    "utilization_pct": {
+                        "p_core": {"avg": 17.0},
+                        "m_core": {"avg": 10.0},
+                        "gpu": {"avg": 99.0},
+                    },
+                },
+            }
+        ],
+        "best": None,
+        "saved": False,
+    }
+
+    public._print_tune_human(payload, verbose=True)
+
+    out = capsys.readouterr().out
+    assert "telemetry=power pkg=44.0W cpu=6.0W ane=0.0W gpu=38.0W" in out
+    assert "freq P=4.05GHz M=1.05GHz GPU=1.22GHz" in out
+    assert "temp core_avg=71.0C core_max=77.0C gpu_avg=69.0C" in out
+    assert "util P=17.0% M=10.0% GPU=99.0%" in out
 
 
 def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsys):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1479,6 +1479,66 @@ def test_tune_state_round_trip(tmp_path, monkeypatch):
     assert record["payload"]["best"]["depth"] == 2
 
 
+def test_tune_candidate_outputs_are_absolute_from_non_repo_cwd(tmp_path, monkeypatch):
+    caller = tmp_path / "caller"
+    caller.mkdir()
+    monkeypatch.chdir(caller)
+    progress: list[str] = []
+
+    def fake_run(command, *, cwd, env, text, stdout, stderr, check):
+        output_arg = command[command.index("--_candidate-output") + 1]
+        output = Path(output_arg)
+        assert output.is_absolute()
+        assert str(output).startswith(str(caller))
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps({"ar_rows": [{"tok_s": 12.0, "generated_tokens": 2}]}),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="candidate ok")
+
+    monkeypatch.setattr(public.subprocess, "run", fake_run)
+
+    rows = public._run_tune_candidates(
+        SimpleNamespace(cache_dir=None, unsafe_force_unverified=False),
+        runtime_model="/tmp/model",
+        run_id="run",
+        output_root=Path("outputs/cli/tune/run"),
+        depths=[],
+        settings={
+            "max_tokens": 8,
+            "limit": 1,
+            "seed": 0,
+            "depths": "",
+        },
+        progress=progress.append,
+    )
+
+    assert rows[0]["mode"] == "AR"
+    assert rows[0]["tok_s"] == 12.0
+    assert any("AR (1/1) starting" in line for line in progress)
+    assert any("AR finished" in line for line in progress)
+
+
+def test_tune_human_reports_candidate_errors_instead_of_false_no_win(capsys):
+    payload = {
+        "results": [
+            {"mode": "AR", "depth": None, "tok_s": None, "multiplier_vs_ar": None, "error": "candidate did not write an artifact", "stdout": "/tmp/ar.log"},
+            {"mode": "D1", "depth": 1, "tok_s": None, "multiplier_vs_ar": None, "error": "candidate did not write an artifact", "stdout": "/tmp/d1.log"},
+        ],
+        "best": None,
+        "saved": False,
+        "save_skipped_reason": "tune failed; no candidate produced usable tokens",
+    }
+
+    public._print_tune_human(payload)
+
+    out = capsys.readouterr().out
+    assert "Tune failed for one or more candidates" in out
+    assert "No MTP depth beat AR" not in out
+    assert "/tmp/ar.log" in out
+
+
 def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsys):
     monkeypatch.setenv("MTPLX_VERIFY_OUTPUT_DEPENDS", "recurrent")
     monkeypatch.setenv("MTPLX_VERIFY_OUTPUT_DEPENDS_AFTER_TOKENS", "1024")

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1758,7 +1758,85 @@ def test_bench_tune_candidate_rows_include_hardware_telemetry(tmp_path, monkeypa
     )
 
     assert rows[0]["telemetry"]["power_w"]["package"]["avg"] == 42.0
-    assert any("telemetry: power pkg=42.0W" in line for line in progress)
+    assert any("telemetry: scope=candidate | power pkg=42.0W" in line for line in progress)
+
+
+def test_bench_tune_telemetry_prefers_generation_window_samples(tmp_path, monkeypatch):
+    progress: list[str] = []
+    telemetry = {
+        "enabled": True,
+        "scope": "candidate_process",
+        "sample_count": 2,
+        "samples": [
+            {
+                "timestamp": 100.0,
+                "power_w": {"gpu": 5.0},
+                "utilization_pct": {"gpu": 10.0},
+            },
+            {
+                "timestamp": 105.0,
+                "power_w": {"gpu": 40.0},
+                "utilization_pct": {"gpu": 99.0},
+            },
+        ],
+        "power_w": {"gpu": {"avg": 22.5}},
+        "utilization_pct": {"gpu": {"avg": 54.5}},
+    }
+
+    class FakeSampler:
+        def __init__(self, *, enabled):
+            self.enabled = enabled
+
+        def start(self):
+            assert self.enabled is True
+
+        def stop(self):
+            return dict(telemetry)
+
+    def fake_run(command, *, cwd, env, text, stdout, stderr, check):
+        output_arg = command[command.index("--_candidate-output") + 1]
+        output = Path(output_arg)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(
+                {
+                    "ar_rows": [
+                        {
+                            "tok_s": 12.0,
+                            "generated_tokens": 2,
+                            "generation_started_at": 104.0,
+                            "generation_ended_at": 106.0,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="candidate ok")
+
+    monkeypatch.setattr(public, "_TuneTelemetrySampler", FakeSampler)
+    monkeypatch.setattr(public.subprocess, "run", fake_run)
+
+    rows = public._run_tune_candidates(
+        SimpleNamespace(cache_dir=None, unsafe_force_unverified=False),
+        runtime_model="/tmp/model",
+        run_id="run",
+        output_root=tmp_path / "run",
+        depths=[],
+        settings={
+            "max_tokens": 8,
+            "limit": 1,
+            "seed": 0,
+            "depths": "",
+        },
+        progress=progress.append,
+        collect_telemetry=True,
+    )
+
+    generation = rows[0]["telemetry"]["generation"]
+    assert generation["scope"] == "generation_window"
+    assert generation["utilization_pct"]["gpu"]["avg"] == 99.0
+    assert any("scope=generation" in line and "GPU=99.0%" in line for line in progress)
 
 
 def test_tune_human_reports_candidate_errors_instead_of_false_no_win(capsys):
@@ -1844,7 +1922,7 @@ def test_bench_tune_human_verbose_prints_power_diagnostic_lines(capsys):
     public._print_tune_human(payload, verbose=True)
 
     out = capsys.readouterr().out
-    assert "telemetry=power pkg=44.0W cpu=6.0W ane=0.0W gpu=38.0W" in out
+    assert "telemetry=scope=candidate | power pkg=44.0W cpu=6.0W ane=0.0W gpu=38.0W" in out
     assert "freq P=4.05GHz M=1.05GHz GPU=1.22GHz" in out
     assert "temp core_avg=71.0C core_max=77.0C gpu_avg=69.0C" in out
     assert "util P=17.0% M=10.0% GPU=99.0%" in out

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1430,7 +1430,50 @@ def test_bench_tune_dry_run_is_json_support_payload(capsys):
     assert payload["settings"]["depths"] == "1,2,3"
     assert payload["settings"]["max_tokens"] == 192
     assert [row["candidate"] for row in payload["candidates"]] == ["AR", "D1", "D2", "D3"]
-    assert "power" in payload["diagnostics"]
+    assert payload["diagnostics"]["telemetry_enabled"] is True
+    assert payload["diagnostics"]["model_source_notes"] == []
+    assert "power" in payload["diagnostics"]["description"]
+
+
+def test_bench_tune_dry_run_can_disable_telemetry(capsys):
+    code = main(
+        [
+            "bench",
+            "tune",
+            "--model",
+            "models/not-loaded-in-dry-run",
+            "--dry-run",
+            "--no-telemetry",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["diagnostics"]["telemetry_enabled"] is False
+    assert "telemetry disabled" in payload["diagnostics"]["description"]
+
+
+def test_bench_tune_dry_run_warns_when_config_model_differs_from_default(tmp_path, monkeypatch, capsys):
+    config = tmp_path / "config.toml"
+    config.write_text(
+        'model = "/Users/youssof/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MTPLX_CONFIG", str(config))
+    monkeypatch.setattr(
+        public,
+        "select_default_model",
+        lambda: SimpleNamespace(model="/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized"),
+    )
+
+    code = main(["bench", "tune", "--dry-run", "--json", "--no-telemetry"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["model"] == "/Users/youssof/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed"
+    notes = payload["diagnostics"]["model_source_notes"]
+    assert any("using configured model" in note for note in notes)
+    assert any("verified default for this Mac" in note for note in notes)
 
 
 def test_bench_tune_powermetrics_parser_extracts_power_frequency_and_utilization():
@@ -1515,6 +1558,23 @@ def test_tune_no_mtp_win_has_no_saved_recommendation():
     assert best["verdict"] == "no_mtp_depth_beat_ar"
 
 
+def test_tune_tie_breaker_prefers_deeper_depth_within_noise_band():
+    best = public._best_multiplier_summary(
+        public._annotate_multipliers(
+            [
+                {"mode": "AR", "depth": None, "tok_s": 29.57},
+                {"mode": "D1", "depth": 1, "tok_s": 49.14},
+                {"mode": "D2", "depth": 2, "tok_s": 54.67},
+                {"mode": "D3", "depth": 3, "tok_s": 54.34},
+            ]
+        )
+    )
+
+    assert best["raw_winner"]["mode"] == "D2"
+    assert best["winner"]["mode"] == "D3"
+    assert best["tie_breaker"]["applied"] is True
+
+
 def test_tune_state_round_trip(tmp_path, monkeypatch):
     monkeypatch.setenv("MTPLX_TUNE_STATE", str(tmp_path / "tuning.json"))
     payload = {
@@ -1527,6 +1587,29 @@ def test_tune_state_round_trip(tmp_path, monkeypatch):
 
     assert record is not None
     assert record["payload"]["best"]["depth"] == 2
+
+
+def test_tune_model_source_notes_warn_when_config_model_differs_from_default(monkeypatch):
+    monkeypatch.setattr(
+        public,
+        "select_default_model",
+        lambda: SimpleNamespace(model="/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized"),
+    )
+    args = SimpleNamespace(
+        _cli_flags=set(),
+        mtplx_config={
+            "path": "/Users/youssof/.mtplx/config.toml",
+            "model": "/Users/youssof/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed",
+        },
+    )
+
+    notes = public._tune_model_source_notes(
+        args,
+        runtime_model="/Users/youssof/Documents/MTPLX/models/Qwen3.6-27B-MTPLX-Optimized-Speed",
+    )
+
+    assert any("using configured model" in note for note in notes)
+    assert any("verified default for this Mac" in note for note in notes)
 
 
 def test_tune_candidate_outputs_are_absolute_from_non_repo_cwd(tmp_path, monkeypatch):
@@ -1568,6 +1651,59 @@ def test_tune_candidate_outputs_are_absolute_from_non_repo_cwd(tmp_path, monkeyp
     assert rows[0]["tok_s"] == 12.0
     assert any("AR (1/1) starting" in line for line in progress)
     assert any("AR finished" in line for line in progress)
+
+
+def test_tune_candidates_settle_between_depth_runs(tmp_path, monkeypatch):
+    sleeps: list[float] = []
+    progress: list[str] = []
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    def fake_run(command, *, cwd, env, text, stdout, stderr, check):
+        output_arg = command[command.index("--_candidate-output") + 1]
+        candidate = command[command.index("--_candidate") + 1]
+        output = Path(output_arg)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if candidate == "ar":
+            payload = {"ar_rows": [{"tok_s": 12.0, "generated_tokens": 2}]}
+        else:
+            payload = {
+                "depths": [
+                    {
+                        "summary": {
+                            "mean_tok_s": 13.0,
+                            "generated_tokens": 2,
+                            "verify_calls": 1,
+                        }
+                    }
+                ]
+            }
+        output.write_text(json.dumps(payload), encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="candidate ok")
+
+    monkeypatch.setattr(public.time, "sleep", fake_sleep)
+    monkeypatch.setattr(public.subprocess, "run", fake_run)
+
+    rows = public._run_tune_candidates(
+        SimpleNamespace(cache_dir=None, unsafe_force_unverified=False),
+        runtime_model="/tmp/model",
+        run_id="run",
+        output_root=tmp_path / "run",
+        depths=[1],
+        settings={
+            "max_tokens": 8,
+            "limit": 1,
+            "seed": 0,
+            "depths": "1",
+            "candidate_settle_s": 5.0,
+        },
+        progress=progress.append,
+    )
+
+    assert [row["mode"] for row in rows] == ["AR", "D1"]
+    assert sleeps == [5.0]
+    assert any("settling 5.0s before D1" in line for line in progress)
 
 
 def test_bench_tune_candidate_rows_include_hardware_telemetry(tmp_path, monkeypatch):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1394,6 +1394,91 @@ def test_public_bench_long_code_dash_alias_uses_sustained_direct_test(capsys):
     assert command[command.index("--tests") + 1] == "long_code"
 
 
+def test_tune_dry_run_prints_clean_candidate_commands(capsys):
+    code = main(
+        [
+            "tune",
+            "--model",
+            "models/not-loaded-in-dry-run",
+            "--dry-run",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "MTPLX Tune" in out
+    assert "dry-run: no model will be loaded" in out
+    assert "--_candidate ar" in out
+    assert "--_candidate 3" in out
+
+
+def test_bench_tune_dry_run_is_json_support_payload(capsys):
+    code = main(
+        [
+            "bench",
+            "tune",
+            "--model",
+            "models/not-loaded-in-dry-run",
+            "--dry-run",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["action"] == "bench tune"
+    assert payload["save_default"] is False
+    assert payload["settings"]["depths"] == "1,2,3"
+    assert payload["settings"]["max_tokens"] == 192
+    assert [row["candidate"] for row in payload["candidates"]] == ["AR", "D1", "D2", "D3"]
+
+
+def test_tune_best_multiplier_selects_depth_not_ar():
+    rows = public._annotate_multipliers(
+        [
+            {"mode": "AR", "depth": None, "tok_s": 30.0},
+            {"mode": "D1", "depth": 1, "tok_s": 48.0},
+            {"mode": "D2", "depth": 2, "tok_s": 54.0},
+            {"mode": "D3", "depth": 3, "tok_s": 57.0},
+        ]
+    )
+    best = public._best_multiplier_summary(rows)
+
+    assert rows[0]["multiplier_vs_ar"] == 1.0
+    assert best["winner"]["mode"] == "D3"
+    assert best["winner"]["depth"] == 3
+    assert best["winner"]["multiplier_vs_ar"] == 1.9
+
+
+def test_tune_no_mtp_win_has_no_saved_recommendation():
+    best = public._best_multiplier_summary(
+        public._annotate_multipliers(
+            [
+                {"mode": "AR", "depth": None, "tok_s": 50.0},
+                {"mode": "D1", "depth": 1, "tok_s": 49.0},
+                {"mode": "D2", "depth": 2, "tok_s": 48.0},
+                {"mode": "D3", "depth": 3, "tok_s": 47.0},
+            ]
+        )
+    )
+
+    assert best["winner"] is None
+    assert best["verdict"] == "no_mtp_depth_beat_ar"
+
+
+def test_tune_state_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("MTPLX_TUNE_STATE", str(tmp_path / "tuning.json"))
+    payload = {
+        "best": {"mode": "D2", "depth": 2, "tok_s": 54.0, "multiplier_vs_ar": 1.8},
+        "results": [],
+    }
+
+    public._save_tune_record("key", key_material={"model": "m"}, payload=payload)
+    record = public._load_tune_record("key")
+
+    assert record is not None
+    assert record["payload"]["best"]["depth"] == 2
+
+
 def test_public_bench_run_dry_run_records_external_kernel_env(monkeypatch, capsys):
     monkeypatch.setenv("MTPLX_VERIFY_OUTPUT_DEPENDS", "recurrent")
     monkeypatch.setenv("MTPLX_VERIFY_OUTPUT_DEPENDS_AFTER_TOKENS", "1024")
@@ -1762,6 +1847,7 @@ def test_product_helper_commands_parse():
     ask = parser.parse_args(["ask", "hello"])
     ask_stats = parser.parse_args(["ask", "hello", "--stats"])
     serve_start = parser.parse_args(["serve", "--port", "18012"])
+    tune = parser.parse_args(["tune", "--dry-run"])
     status = parser.parse_args(["status", "--deep"])
     doctor_opencode = parser.parse_args(["doctor", "opencode", "--json"])
     doctor_android = parser.parse_args(["doctor", "android-studio", "--port", "8008", "--json"])
@@ -1771,6 +1857,7 @@ def test_product_helper_commands_parse():
     models = parser.parse_args(["models", "--json"])
     report = parser.parse_args(["report", "--output-dir", "reports"])
     nightly = parser.parse_args(["bench", "nightly", "--out", "out.json"])
+    bench_tune = parser.parse_args(["bench", "tune", "--dry-run"])
     nightly_json = parser.parse_args(["bench", "nightly", "--json", "--dry-run"])
     debug = parser.parse_args(["debug", "bundle", "--run-id", "debug-test"])
     hotpath = parser.parse_args(["debug", "hotpath"])
@@ -1815,6 +1902,8 @@ def test_product_helper_commands_parse():
     assert serve_start.command == "serve"
     assert serve_start.port == 18012
     assert serve_start.stats_footer is True
+    assert tune.command == "tune"
+    assert tune.depths == "1,2,3"
     assert status.command == "status"
     assert status.deep is True
     assert doctor_opencode.command == "doctor"
@@ -1831,6 +1920,7 @@ def test_product_helper_commands_parse():
     assert report.bundle is True
     assert report.deep is True
     assert nightly.bench_action == "nightly"
+    assert bench_tune.bench_action == "tune"
     assert nightly.output == "out.json"
     assert nightly_json.json is True
     assert debug.debug_action == "bundle"

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -50,6 +50,108 @@ def test_startup_urls_distinguish_wildcard_bind_from_local_url():
     assert openai._startup_openai_base_url(args) == "http://127.0.0.1:8000/v1"
 
 
+def test_dynamic_paged_kv_reservation_caps_oversized_response_budget(monkeypatch):
+    monkeypatch.delenv("MTPLX_DYNAMIC_PAGED_KV_MAX_INITIAL_NEW_TOKENS", raising=False)
+
+    reservation = openai._dynamic_paged_kv_reservation(
+        prompt_tokens=181,
+        max_new_tokens=65536,
+        mtp_depth=3,
+    )
+
+    assert reservation["env"]["MTPLX_DYNAMIC_PAGED_KV_TOKENS"] == str(181 + 16384 + 3)
+    assert reservation["requested_new_tokens"] == 65536
+    assert reservation["reserved_new_tokens"] == 16384
+    assert reservation["initial_new_token_cap"] == 16384
+    assert reservation["reservation_capped"] is True
+
+
+def test_dynamic_paged_kv_reservation_can_disable_initial_cap(monkeypatch):
+    monkeypatch.setenv("MTPLX_DYNAMIC_PAGED_KV_MAX_INITIAL_NEW_TOKENS", "off")
+
+    reservation = openai._dynamic_paged_kv_reservation(
+        prompt_tokens=10,
+        max_new_tokens=65536,
+        mtp_depth=3,
+    )
+
+    assert reservation["env"]["MTPLX_DYNAMIC_PAGED_KV_TOKENS"] == str(10 + 65536 + 3)
+    assert reservation["reserved_new_tokens"] == 65536
+    assert reservation["initial_new_token_cap"] is None
+    assert reservation["reservation_capped"] is False
+
+
+def test_implicit_anonymous_sessions_do_not_keep_live_refs(monkeypatch):
+    monkeypatch.delenv(
+        "MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS",
+        raising=False,
+    )
+
+    assert (
+        openai._session_keep_live_refs_for_request(
+            session_source="implicit_hash", session_id="anon-bench"
+        )
+        is False
+    )
+
+
+def test_anonymous_coding_agent_tool_sessions_keep_live_refs(monkeypatch):
+    monkeypatch.delenv(
+        "MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS",
+        raising=False,
+    )
+
+    assert (
+        openai._session_keep_live_refs_for_request(
+            session_source="new",
+            session_id="anon-opencode",
+            tool_names=["bash", "read", "write"],
+        )
+        is True
+    )
+
+
+def test_anonymous_non_tool_benchmark_sessions_stay_cold(monkeypatch):
+    monkeypatch.delenv(
+        "MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS",
+        raising=False,
+    )
+
+    assert (
+        openai._session_keep_live_refs_for_request(
+            session_source="new",
+            session_id="anon-aime",
+            tool_names=[],
+        )
+        is False
+    )
+
+
+def test_explicit_sessions_keep_live_refs(monkeypatch):
+    monkeypatch.delenv(
+        "MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS",
+        raising=False,
+    )
+
+    assert (
+        openai._session_keep_live_refs_for_request(
+            session_source="metadata.chat_id", session_id="chat-123"
+        )
+        is True
+    )
+
+
+def test_implicit_session_live_refs_have_diagnostic_override(monkeypatch):
+    monkeypatch.setenv("MTPLX_SESSIONBANK_LIVE_REFS_FOR_IMPLICIT_SESSIONS", "1")
+
+    assert (
+        openai._session_keep_live_refs_for_request(
+            session_source="implicit_hash", session_id="anon-bench"
+        )
+        is True
+    )
+
+
 class FakeExecutor:
     def submit(self, fn, *args, **kwargs):
         future: Future = Future()
@@ -628,6 +730,72 @@ def test_streaming_unsafe_postcommit_releases_without_blocking_second_request(
     assert "already in flight" not in second.text
 
 
+def test_streaming_stop_boundary_mismatch_skips_idle_retokenized_postcommit(
+    monkeypatch,
+):
+    state = _fake_streaming_session_state()
+    cleanup_calls: list[str] = []
+
+    def fake_store_generation_final(*_args, **_kwargs):
+        return {
+            "stored": False,
+            "mode": "unsafe",
+            "reason": "stop_token_boundary_mismatch",
+        }
+
+    def fail_schedule(*_args, **_kwargs):
+        raise AssertionError("stop-token mismatches should not schedule GPU postcommit")
+
+    def fake_cleanup(_state, *, reason):
+        cleanup_calls.append(reason)
+        return {"cleared": True, "reason": reason}
+
+    def fake_run_generation(_state, prompt_ids, **kwargs):
+        token_callback = kwargs.get("token_callback")
+        tokens = [ord("O"), ord("K")]
+        if token_callback is not None:
+            token_callback(tokens)
+        return {
+            "text": "OK",
+            "tokens": tokens,
+            "stats": {
+                "generation_mode": kwargs["generation_mode"],
+                "mtp_depth": kwargs["depth"],
+                "completion_tokens": 2,
+            },
+            "prompt_tokens": len(prompt_ids),
+            "completion_tokens": 2,
+            "finish_reason": "stop",
+            "_final_state": _fake_final_state(tokens),
+        }
+
+    monkeypatch.setattr(
+        openai, "_store_generation_final_history_snapshot", fake_store_generation_final
+    )
+    monkeypatch.setattr(openai, "_schedule_idle_postcommit_snapshot", fail_schedule)
+    monkeypatch.setattr(openai, "_clear_mlx_cache_after_request", fake_cleanup)
+    monkeypatch.setattr(openai, "_run_generation", fake_run_generation)
+
+    with TestClient(create_app(state)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"x-mtplx-session-id": "stop-boundary-session"},
+            json={
+                "messages": [{"role": "user", "content": "Say OK"}],
+                "enable_thinking": False,
+                "stream": True,
+                "max_tokens": 4,
+            },
+        )
+
+    assert response.status_code == 200
+    assert '"mode": "async_skipped"' in response.text
+    assert '"reason": "stop_token_boundary_mismatch"' in response.text
+    assert '"mlx_cache_cleanup"' in response.text
+    assert '"postcommit_prompt_prefix"' in response.text
+    assert cleanup_calls == ["stop_token_boundary_mismatch_postcommit_skipped"]
+
+
 def test_streaming_ar_schedules_async_postcommit_in_default_mode(monkeypatch):
     state = _fake_streaming_session_state()
     scheduled: list[dict] = []
@@ -960,6 +1128,44 @@ def _write_tool_schema():
     }
 
 
+def _bash_tool_schema():
+    return {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "description": {"type": "string"},
+                    "timeout": {"type": "number"},
+                },
+                "required": ["command", "description"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def _question_tool_schema():
+    return {
+        "type": "function",
+        "function": {
+            "name": "question",
+            "description": "Ask the user one or more questions.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "questions": {"type": "array"},
+                },
+                "required": ["questions"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
 def _fake_generation(text: str):
     return {
         "text": text,
@@ -1065,6 +1271,7 @@ def test_tool_contract_includes_exact_schema_keys_for_opencode_write(monkeypatch
     assert '"filePath":"<string>"' in contract
     assert '"content":"<string>"' in contract
     assert "exact argument keys/case" in contract
+    assert "Include every required key" in contract
 
 
 def test_opencode_title_request_fast_path_does_not_enter_model(monkeypatch):
@@ -1150,6 +1357,52 @@ def test_tool_requests_enable_prompt_prefix_bank_commit(monkeypatch):
     )
 
     assert captured["commit_prompt_state_to_bank"] is True
+    assert captured["commit_prompt_state_keep_live_ref"] is True
+
+
+def test_run_generation_can_store_final_state_without_live_cache_ref(monkeypatch):
+    state = _fake_streaming_session_state()
+    state.draft_sampler = None
+    state.requests_completed = 0
+
+    def fake_generate_mtpk(*_args, **_kwargs):
+        tokens = [ord("O"), ord("K")]
+        return SimpleNamespace(
+            tokens=tokens,
+            text="OK",
+            stats=SimpleNamespace(
+                to_dict=lambda: {
+                    "prompt_eval_time_s": 0.0,
+                    "generated_tokens": 2,
+                    "elapsed_s": 0.1,
+                    "tok_s": 20.0,
+                }
+            ),
+            final_state=_fake_final_state(tokens),
+        )
+
+    monkeypatch.setattr(openai, "generate_mtpk", fake_generate_mtpk)
+
+    openai._run_generation(
+        state,
+        [1, 2, 3],
+        max_tokens=65536,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        seed=42,
+        generation_mode="mtp",
+        depth=3,
+        session_id="anon-bench",
+        session_bank=state.sessions.bank,
+        session_template_hash=state.template_hash,
+        session_draft_head_identity=state.draft_head_identity,
+        session_policy_fingerprint="policy",
+        session_keep_live_ref=False,
+    )
+
+    assert state.sessions.bank.puts
+    assert state.sessions.bank.puts[-1]["keep_live_ref"] is False
 
 
 def test_tool_template_schema_failure_retries_with_compact_contract(monkeypatch):
@@ -1330,6 +1583,54 @@ def test_tool_result_history_encoding_keeps_generation_prompt_prefix():
     assert "<tool_response>" in rendered
 
 
+def test_postcommit_tool_history_encoding_matches_next_tool_turn_prefix():
+    tokenizer = QwenToolHistoryBoundaryTokenizer()
+    tools = [_tool_schema()]
+    initial_messages = [
+        openai.ChatMessage(role="system", content="You are opencode."),
+        openai.ChatMessage(role="user", content="write hello.py"),
+    ]
+    tool_call = {
+        "id": "call_write",
+        "type": "function",
+        "function": {
+            "name": "session_status",
+            "arguments": "{}",
+        },
+    }
+    history_messages = [
+        *initial_messages,
+        openai.ChatMessage(role="assistant", content="", tool_calls=[tool_call]),
+    ]
+    resumed_messages = [
+        *history_messages,
+        openai.ChatMessage(
+            role="tool",
+            tool_call_id="call_write",
+            content='{"status":"ok"}',
+        ),
+    ]
+
+    postcommit_prefix = openai._postcommit_next_turn_prefix_ids(
+        tokenizer,
+        history_messages,
+        enable_thinking=True,
+        strip_assistant_reasoning_history=False,
+        tools=tools,
+        assistant_tool_calls=[tool_call],
+    )
+    resumed_prompt = openai._encode_messages(
+        tokenizer,
+        resumed_messages,
+        enable_thinking=True,
+        tools=tools,
+    )
+
+    assert postcommit_prefix is not None
+    assert resumed_prompt[: len(postcommit_prefix)] == postcommit_prefix
+    assert tokenizer.merged not in postcommit_prefix
+
+
 def test_chat_tool_xml_returns_openai_tool_calls_nonstream(monkeypatch):
     client = TestClient(create_app(_fake_state()))
     monkeypatch.setattr(openai, "_encode_messages", lambda *_args, **_kwargs: [1, 2, 3])
@@ -1469,6 +1770,89 @@ def test_chat_stream_consecutive_qwen_xml_tool_calls_emit_ordered_deltas(monkeyp
         payload["choices"][0].get("finish_reason") == "tool_calls"
         for payload in payloads
     )
+
+
+def test_chat_stream_qwen_xml_shell_arguments_are_typed(monkeypatch):
+    client = TestClient(create_app(_fake_state()))
+    monkeypatch.setattr(openai, "_encode_messages", lambda *_args, **_kwargs: [1, 2, 3])
+    generated = (
+        "<tool_call>\n<function=bash>\n"
+        "<parameter=command>\nnpm run build\n</parameter>\n"
+        "<parameter=description>\nBuild the project\n</parameter>\n"
+        "<parameter=timeout>\n60000\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    monkeypatch.setattr(openai, "_run_generation", _fake_streaming_generation(generated))
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"x-mtplx-cache-mode": "bypass"},
+        json={
+            "messages": [{"role": "user", "content": "Build."}],
+            "tools": [_bash_tool_schema()],
+            "tool_choice": "auto",
+            "stream": True,
+            "max_tokens": 256,
+        },
+    )
+
+    assert response.status_code == 200
+    payloads = _stream_payloads(response.text)
+    args_text = "".join(
+        item.get("function", {}).get("arguments", "")
+        for payload in payloads
+        for item in payload["choices"][0]["delta"].get("tool_calls", [])
+    )
+    args = json.loads(args_text)
+    assert args == {
+        "command": "npm run build",
+        "description": "Build the project",
+        "timeout": 60000,
+    }
+    assert isinstance(args["timeout"], int)
+    assert '"timeout":"60000"' not in args_text
+    assert any(
+        payload["choices"][0].get("finish_reason") == "tool_calls"
+        for payload in payloads
+    )
+
+
+def test_chat_stream_qwen_xml_questions_arguments_are_arrays(monkeypatch):
+    client = TestClient(create_app(_fake_state()))
+    monkeypatch.setattr(openai, "_encode_messages", lambda *_args, **_kwargs: [1, 2, 3])
+    questions = (
+        '[{"header":"Scope","id":"scope","question":"Pick one",'
+        '"options":[{"label":"A","description":"first"},'
+        '{"label":"B","description":"second"}]}]'
+    )
+    generated = (
+        "<tool_call>\n<function=question>\n"
+        f"<parameter=questions>\n{questions}\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    monkeypatch.setattr(openai, "_run_generation", _fake_streaming_generation(generated))
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"x-mtplx-cache-mode": "bypass"},
+        json={
+            "messages": [{"role": "user", "content": "Ask."}],
+            "tools": [_question_tool_schema()],
+            "tool_choice": "auto",
+            "stream": True,
+            "max_tokens": 256,
+        },
+    )
+
+    assert response.status_code == 200
+    args_text = "".join(
+        item.get("function", {}).get("arguments", "")
+        for payload in _stream_payloads(response.text)
+        for item in payload["choices"][0]["delta"].get("tool_calls", [])
+    )
+    args = json.loads(args_text)
+    assert isinstance(args["questions"], list)
+    assert args["questions"][0]["options"][1]["description"] == "second"
 
 
 def test_chat_stream_tool_call_preamble_is_stored_for_postcommit(monkeypatch):

--- a/tests/test_session_bank.py
+++ b/tests/test_session_bank.py
@@ -50,3 +50,37 @@ def test_session_bank_skips_dense_materializing_snapshot():
     assert len(bank) == 0
     assert bank.last_put_skipped_oversized_snapshot is True
     assert bank.eviction_log[-1]["reason"] == "skipped_dense_materializing_snapshot"
+
+
+def test_session_bank_near_prefix_candidates_only_accept_boundary_drift():
+    bank = SessionBank(max_entries=4, max_bytes=1024, per_session_max_bytes=512)
+    runtime = SimpleNamespace(model_path=Path("models/example"), mtp_enabled=True)
+    entry = bank.put(
+        runtime=runtime,
+        token_ids=list(range(200)),
+        cache=[],
+        logits=None,
+        hidden=None,
+        session_id="session-1",
+        nbytes_override=128,
+    )
+    assert entry is not None
+
+    near = list(range(197)) + [10_001, 10_002, 10_003, 10_004]
+    far = list(range(120)) + [20_001, 20_002]
+
+    candidates = bank.near_prefix_candidates(
+        near,
+        max_token_gap=8,
+        min_matched_tokens=64,
+    )
+
+    assert candidates == [(entry, 197)]
+    assert (
+        bank.near_prefix_candidates(
+            far,
+            max_token_gap=8,
+            min_matched_tokens=64,
+        )
+        == []
+    )

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -583,7 +583,7 @@ def test_restore_thermal_profile_verified_fails_when_still_manual(monkeypatch):
     thermal.detect_thermal_control.cache_clear()
 
 
-def test_restore_thermal_profile_verified_rejects_auto_with_max_target(monkeypatch):
+def test_restore_thermal_profile_verified_accepts_auto_with_transient_max_target(monkeypatch):
     thermal.detect_thermal_control.cache_clear()
     monkeypatch.setattr(thermal, "_find_thermalforge", lambda: "/usr/local/bin/thermalforge")
     suspicious_status = (
@@ -601,7 +601,8 @@ def test_restore_thermal_profile_verified_rejects_auto_with_max_target(monkeypat
 
     result = thermal.restore_thermal_profile_verified(settle_timeout_s=0)
 
-    assert result["ok"] is False
+    assert result["ok"] is True
+    assert result["message"] == "fan profile restored"
     thermal.detect_thermal_control.cache_clear()
 
 

--- a/tests/test_tool_aware_stream_translator.py
+++ b/tests/test_tool_aware_stream_translator.py
@@ -58,6 +58,38 @@ OPENCODE_WRITE_TOOL_SPECS = [
         },
     }
 ]
+OPENCODE_SHELL_TOOL_SPECS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "description": {"type": "string"},
+                    "timeout": {"type": "number"},
+                },
+                "required": ["command", "description"],
+            },
+        },
+    }
+]
+OPENCODE_QUESTIONS_TOOL_SPECS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "question",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "questions": {"type": "array"},
+                },
+                "required": ["questions"],
+            },
+        },
+    }
+]
 
 
 def _make(*, tools=TOOL_SPECS):
@@ -455,6 +487,47 @@ def test_opencode_style_long_write_arguments_stream_without_raw_xml():
     streamed_args = _argument_text(out)
     assert "\\ud83c" not in streamed_args
     assert json.loads(streamed_args) == args
+
+
+def test_opencode_shell_xml_stream_emits_complete_typed_arguments():
+    t = _make(tools=OPENCODE_SHELL_TOOL_SPECS)
+    text = (
+        "<tool_call>\n<function=bash>\n"
+        "<parameter=command>\nnpm run build\n</parameter>\n"
+        "<parameter=description>\nBuild the project\n</parameter>\n"
+        "<parameter=timeout>\n60000\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    out = _feed_in_chunks(t, text, [11, 2, 19, 5, 7, 3, 23, 1])
+
+    args_text = _argument_text(out)
+    args = json.loads(args_text)
+    assert args == {
+        "command": "npm run build",
+        "description": "Build the project",
+        "timeout": 60000,
+    }
+    assert isinstance(args["timeout"], int)
+    assert '"timeout":"60000"' not in args_text
+
+
+def test_opencode_questions_xml_stream_emits_array_not_string():
+    t = _make(tools=OPENCODE_QUESTIONS_TOOL_SPECS)
+    questions = (
+        '[{"header":"Scope","id":"scope","question":"Pick one",'
+        '"options":[{"label":"A","description":"first"},'
+        '{"label":"B","description":"second"}]}]'
+    )
+    text = (
+        "<tool_call>\n<function=question>\n"
+        f"<parameter=questions>\n{questions}\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    out = _feed_in_chunks(t, text, [4, 4, 9, 2, 17, 1, 31, 8])
+
+    args = json.loads(_argument_text(out))
+    assert isinstance(args["questions"], list)
+    assert args["questions"][0]["options"][1]["label"] == "B"
 
 
 def test_existing_json_tool_call_final_parse_still_works():

--- a/uv.lock
+++ b/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "mtplx"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Release `v0.3.6` as the production patch over `v0.3.5`.

This branch carries the bounded-memory/OpenCode fixes, ports Tune into the packaged CLI, fixes verified-default onboarding/model labeling, and hardens `mtplx bench tune` so chip diagnostics show the exact model path and generation-window telemetry when available.

## Core Pillars

- Decode TPS: protected by the existing runtime KPI and focused MTP depth tests; no release change intentionally alters draft/verify semantics after the measured memory fix.
- Prefill/TTFT: bounded KV reservation preserves prompt-context allocation and only caps huge initial new-token reserve.
- Memory: AIME-shaped `max_tokens=65536` no longer reserves the full decode window up front, and anonymous one-off sessions do not retain full-capacity live cache refs.
- CLI UX: checked through actual packaged commands, including `mtplx`, `mtplx-tune`, OpenCode, Pi, and `bench tune` dry-run paths.

## User-Facing Changes

- `mtplx tune`, `mtplx-tune`, and `mtplx bench tune` are available from the release package.
- `mtplx start` verified default now points at the installed Optimized Speed/Q4 artifact instead of prompting a bogus install.
- Tune advice is shown before measurements start, not after the benchmark has already run.
- `bench tune` prints exact model source notes, has `--no-telemetry`, waits between candidates, and scopes telemetry to generation windows when samples land inside decode.
- README now avoids claiming the speed multiplier is hardware-independent.

## Validation

- `python3 -m compileall -q mtplx tests scripts`
- `uv run --extra dev python -m ruff check`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev python -m twine check dist/*`
- `scripts/fresh_venv_smoke.sh`
- `git diff --check`
- `mtplx --version` -> `mtplx 0.3.6 (0.3.6)`
- `mtplx start opencode --dry-run --json --model models/example --yes`
- `mtplx start pi --dry-run --json --model models/example --yes`
- `mtplx-tune --model models/not-loaded-in-dry-run --dry-run --yes`
- `mtplx bench tune --model models/not-loaded-in-dry-run --dry-run --json --yes --no-telemetry`

## Real Hardware Evidence Already Run On This Branch

- `bench tune` against `/Users/youssof/.mtplx/hf-upload/Qwen3.6-27B-MTPLX-Optimized`
- D3 selected at `54.51 tok/s`, `2.22x AR`
- D3 telemetry: `scope=generation`, `gpu=72.0W`, `GPU=98.4%`, `window=3.5s`
- Fans restored to auto afterward.

## Known Non-Claims

- This PR does not claim the unrelated draft PR #62 is ready.
- Issue #64 remains a release-copy honesty topic; README claims were tightened here, but unavailable fork/patch proof is not invented.
- Issues #65, #56, and #16 are not fixed by this release unless their paths are incidentally covered by existing tests.
