### PR TITLE
Fork to a fresh session when a shared session is busy

### DIFF
--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import secrets
 import subprocess
 import sys
 import time
@@ -178,6 +179,13 @@ def token_hash_short(token_ids: list[int] | tuple[int, ...]) -> str:
 
 def hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+IMPLICIT_SESSION_SOURCES = frozenset({"longest_prefix", "pending_postcommit_near_prefix"})
+
+
+def _new_anon_session_id() -> str:
+    return f"anon-{secrets.token_hex(8)}"
 
 
 def common_prefix_len(left: list[int] | tuple[int, ...], right: list[int] | tuple[int, ...]) -> int:
@@ -666,20 +674,28 @@ class EngineSession:
         record.mark_finished(outcome)
         return outcome
 
-    @contextmanager
-    def in_flight_generation(self) -> Iterator["EngineSession"]:
+    def try_begin_generation(self) -> bool:
         if not self._lock.acquire(blocking=False):
-            raise EngineSessionBusy(f"session {self.session_id} is already in flight")
+            return False
         self.in_flight = True
         self.in_flight_started_s = time.time()
         self.touch()
+        return True
+
+    def end_generation(self) -> None:
+        self.in_flight = False
+        self.in_flight_started_s = None
+        self.touch()
+        self._lock.release()
+
+    @contextmanager
+    def in_flight_generation(self) -> Iterator["EngineSession"]:
+        if not self.try_begin_generation():
+            raise EngineSessionBusy(f"session {self.session_id} is already in flight")
         try:
             yield self
         finally:
-            self.in_flight = False
-            self.in_flight_started_s = None
-            self.touch()
-            self._lock.release()
+            self.end_generation()
 
     def commit(
         self,
@@ -980,7 +996,7 @@ class EngineSessionManager:
             self.last_prefix_diagnostic = self._prefix_diagnostic(prompt_ids)
         else:
             self.last_prefix_diagnostic = None
-        return f"anon-{hash_text(str(time.time_ns()))}", "new"
+        return _new_anon_session_id(), "new"
 
     def get_or_create(self, session_id: str) -> EngineSession:
         with self._lock:
@@ -991,10 +1007,36 @@ class EngineSessionManager:
             session.touch()
             return session
 
+    def _sessions_snapshot(self) -> list[EngineSession]:
+        with self._lock:
+            return list(self._sessions.values())
+
+    @contextmanager
+    def generation_slot(
+        self,
+        session: EngineSession,
+        *,
+        source: str | None = None,
+    ) -> Iterator[EngineSession]:
+        acquired = session
+        if not session.try_begin_generation():
+            if str(source or "") not in IMPLICIT_SESSION_SOURCES:
+                raise EngineSessionBusy(
+                    f"session {session.session_id} is already in flight"
+                )
+            while True:
+                acquired = self.get_or_create(_new_anon_session_id())
+                if acquired.try_begin_generation():
+                    break
+        try:
+            yield acquired
+        finally:
+            acquired.end_generation()
+
     def longest_prefix_session(self, token_ids: list[int] | tuple[int, ...]) -> EngineSession | None:
         tokens = tuple(int(token) for token in token_ids)
         best: EngineSession | None = None
-        for session in self._sessions.values():
+        for session in self._sessions_snapshot():
             prefix = session.committed_token_ids
             if not prefix:
                 continue
@@ -1029,7 +1071,7 @@ class EngineSessionManager:
         best_matched = 0
         block_size = _prefix_block_size()
         block_min_match = max(block_size, _block_prefix_min_match_tokens())
-        for session in self._sessions.values():
+        for session in self._sessions_snapshot():
             if not session.has_pending_postcommit():
                 continue
             prefix = session.committed_token_ids
@@ -1066,7 +1108,7 @@ class EngineSessionManager:
         tokens = tuple(int(token) for token in token_ids)
         best: EngineSession | None = None
         best_len = 0
-        for session in self._sessions.values():
+        for session in self._sessions_snapshot():
             prefix = session.committed_token_ids
             if not prefix:
                 continue
@@ -1155,7 +1197,7 @@ class EngineSessionManager:
     def list_sessions(self) -> dict[str, Any]:
         self.evict_stale()
         sessions = sorted(
-            (session.to_admin_dict() for session in self._sessions.values()),
+            (session.to_admin_dict() for session in self._sessions_snapshot()),
             key=lambda row: row["last_access_s"],
             reverse=True,
         )

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -19068,6 +19068,19 @@ def create_app(state: ServerState) -> FastAPI:
                             nonstream_stop_monitor.matched_stop or ""
                         )
 
+        def adopt_forked_session(acquired_session: Any) -> None:
+            nonlocal session, session_id, session_keep_live_ref
+            if acquired_session is session:
+                return
+            session = acquired_session
+            session_id = session.session_id
+            session_keep_live_ref = False
+            request_observability["request_session_forked_busy"] = True
+            request_observability["request_session_keep_live_ref"] = False
+            request_observability["request_session_keep_live_ref_reason"] = (
+                "forked_busy_session"
+            )
+
         def run_generation_for_response() -> dict[str, Any]:
             if session is None:
                 return attach_response_observability(
@@ -19102,7 +19115,10 @@ def create_app(state: ServerState) -> FastAPI:
                         streaming_response=False,
                     )
                 )
-            with session.in_flight_generation():
+            with state.sessions.generation_slot(
+                session, source=session_source
+            ) as acquired_session:
+                adopt_forked_session(acquired_session)
                 generated_result = _run_generation_dispatched(
                     state,
                     prompt_ids,
@@ -20138,7 +20154,10 @@ def create_app(state: ServerState) -> FastAPI:
                                 generated
                             )
                         else:
-                            with session.in_flight_generation():
+                            with state.sessions.generation_slot(
+                                session, source=session_source
+                            ) as acquired_session:
+                                adopt_forked_session(acquired_session)
                                 generated = _run_generation_dispatched(
                                     state,
                                     prompt_ids,


### PR DESCRIPTION
## Summary

Parallel requests that share a prompt prefix resolve to the same session, so while one was generating the others failed with "session is already in flight" with clients that don't send a session id.

Generation now goes through a manager-level slot: a busy session that was picked implicitly by prefix matching falls back to a fresh anonymous session.

And anonymous ids are now random rather than clock-derived to reduce the risk of a collision.

## Verification

Fixes #94
