### PR TITLE
Stop _StartupHeartbeat orphaning into init when the parent dies

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1198,10 +1198,17 @@ def _server_console_enabled(state: Any) -> bool:
 
 class _StartupHeartbeat:
     def __init__(self, label: str, *, interval_s: float = 10.0) -> None:
+        # The heartbeat runs as a detached child so it can keep printing while
+        # the parent is busy loading the model. It must therefore stop on BOTH
+        # a clean SIGTERM (via set()) AND when the parent dies without sending
+        # one (kill -9, crash, closed terminal) — otherwise it is reparented to
+        # init and prints "<label>... Ns elapsed" forever. We detect the latter
+        # with an os.getppid() guard, mirroring the heartbeat in mtplx/ui/progress.py.
         script = (
-            "import signal,sys,time\n"
+            "import os,signal,sys,time\n"
             "label=sys.argv[1]\n"
             "interval=float(sys.argv[2])\n"
+            "parent=int(sys.argv[3])\n"
             "running=True\n"
             "def stop(_signum,_frame):\n"
             "    global running\n"
@@ -1212,11 +1219,13 @@ class _StartupHeartbeat:
             "    time.sleep(interval)\n"
             "    if not running:\n"
             "        break\n"
+            "    if os.getppid() != parent:\n"
+            "        break\n"
             "    elapsed += interval\n"
             "    print(f'      {label}... {elapsed:.0f}s elapsed', flush=True)\n"
         )
         self.proc = subprocess.Popen(
-            [sys.executable, "-c", script, label, str(float(interval_s))],
+            [sys.executable, "-c", script, label, str(float(interval_s)), str(os.getpid())],
             stdout=None,
             stderr=subprocess.DEVNULL,
             close_fds=True,


### PR DESCRIPTION
## Problem

`_StartupHeartbeat` (in `mtplx/server/openai.py`) spawns a detached `python -c` subprocess that prints `      <label>... Ns elapsed` every interval while the model loads. It only stops when `set()` sends it a clean `SIGTERM`.

If the parent server process instead dies **without** calling `set()` — `kill -9`, a crash, or a closed terminal during model load — the heartbeat is reparented to `init` (PID 1) and **keeps printing forever**.

I hit this in a setup where the server's stdout is redirected to a shared log file that's reused across runs. A heartbeat orphaned from a killed run kept appending `Model still loading... Ns elapsed` to that log; a later, completely healthy run tailing the same log looked permanently stuck. The orphan I found had been printing for ~66h (parent long gone, `PPID 1`).

## Fix

Pass the parent PID into the heartbeat subprocess and break the loop when `os.getppid()` no longer matches it (i.e. it has been reparented).

This mirrors the guard already present in the sibling heartbeat at [`mtplx/ui/progress.py:103`](https://github.com/youssofal/mtplx/blob/main/mtplx/ui/progress.py#L103):

```python
if parent and os.getppid() != parent:
    break
```

so the two heartbeat implementations now behave consistently. The clean-`SIGTERM`-via-`set()` path is unchanged; this only adds a second, independent stop condition.

## Verification

Standalone test of the patched embedded script (interval shortened to 1s): spawn the heartbeat as a child, then kill the parent **without** sending SIGTERM. 

- **Before:** child runs indefinitely (reproduced; matches the 66h orphan).
- **After:** child detects the reparent and exits within one interval (~1s).

`python -m py_compile mtplx/server/openai.py` passes.