### PR TITLE
Bound the batch scheduler's finished-request tracking

### DIFF
--- a/mtplx/batching/scheduler.py
+++ b/mtplx/batching/scheduler.py
@@ -21,6 +21,12 @@ from .state import (
     preset_config,
 )
 
+# Upper bound on how many finished RequestState objects the scheduler keeps
+# around for deduplication. The monotonic ``finished_total`` counter tracks the
+# true count, so a long-running server does not accumulate every finished
+# request forever.
+_DEFAULT_MAX_FINISHED_RETAINED = 4096
+
 
 @dataclass(frozen=True)
 class BatchSchedulerConfig:
@@ -151,7 +157,11 @@ class MTPContinuousScheduler:
         self.prefill: deque[RequestState] = deque()
         self.decode_ready: deque[RequestState] = deque()
         self.postcommit: deque[RequestState] = deque()
-        self.finished: list[RequestState] = []
+        # Keyed by request_id so deduplication is O(1) and retention is bounded
+        # (see ``_record_finished``). ``finished_total`` keeps the true count.
+        self.finished: dict[str, RequestState] = {}
+        self.finished_total = 0
+        self.max_finished_retained = _DEFAULT_MAX_FINISHED_RETAINED
         self.stats = BatchSchedulerStats()
 
     def submit(self, request: RequestState) -> None:
@@ -208,7 +218,8 @@ class MTPContinuousScheduler:
             "prefill": len(self.prefill),
             "decode_ready": len(self.decode_ready),
             "postcommit": len(self.postcommit),
-            "finished": len(self.finished),
+            "finished": self.finished_total,
+            "finished_retained": len(self.finished),
             "requests": [request.to_dict() for request in self.active.values()],
         }
 
@@ -227,7 +238,7 @@ class MTPContinuousScheduler:
             request = self.waiting.popleft()
             if request.cancel_event.is_set():
                 request.cancel()
-                self.finished.append(request)
+                self._record_finished(request)
                 continue
             decision = self.admission.decide(
                 request,
@@ -318,8 +329,26 @@ class MTPContinuousScheduler:
             self.stats.failed += 1
         else:
             self.stats.completed += 1
-        if not any(existing is request for existing in self.finished):
-            self.finished.append(request)
+        self._record_finished(request)
+
+    def _record_finished(self, request: RequestState) -> None:
+        """Record a request as finished, exactly once.
+
+        A request can reach a terminal state through either the normal finish
+        path or cancellation draining, so this must be idempotent. Keying the
+        finished set by ``request_id`` makes the dedup check O(1) instead of the
+        former O(n) identity scan over every previously finished request (which
+        made a long-running session O(n**2) in the number of requests). The set
+        is bounded so retained state does not grow without limit; the monotonic
+        ``finished_total`` counter still reflects the true count.
+        """
+        if request.request_id in self.finished:
+            return
+        self.finished_total += 1
+        self.finished[request.request_id] = request
+        while len(self.finished) > self.max_finished_retained:
+            oldest_id = next(iter(self.finished))
+            del self.finished[oldest_id]
 
     def _purge_terminal_queues(self) -> None:
         self.prefill = deque(request for request in self.prefill if not request.is_terminal)

--- a/tests/test_batching_foundation.py
+++ b/tests/test_batching_foundation.py
@@ -171,3 +171,43 @@ def test_cooperative_scheduler_cancellation_finishes_once():
     assert request.phase == RequestPhase.CANCELLED
     assert len(scheduler.finished) == 1
     assert scheduler.snapshot()["stats"]["cancelled"] == 1
+
+
+def test_finished_tracking_is_bounded_but_total_is_exact():
+    hooks = FakeHooks()
+    config = BatchSchedulerConfig(
+        mode=SchedulerMode.AR_BATCH,
+        preset=SchedulerPreset.AGENT,
+        max_active_requests=4,
+        decode_batch_max=4,
+        prefill_chunk_tokens=8,
+    )
+    scheduler = MTPContinuousScheduler(config=config, hooks=hooks)
+    scheduler.max_finished_retained = 8
+
+    total = 50
+    for i in range(total):
+        scheduler.submit(RequestState(f"r{i}", prompt_ids=[i, i + 1], max_tokens=1))
+    scheduler.run_until_idle()
+
+    # Retained finished state stays bounded instead of growing with every
+    # request, but the reported total remains exact.
+    assert len(scheduler.finished) <= 8
+    assert scheduler.finished_total == total
+    snapshot = scheduler.snapshot()
+    assert snapshot["finished"] == total
+    assert snapshot["finished_retained"] <= 8
+
+
+def test_record_finished_is_idempotent_per_request():
+    hooks = FakeHooks()
+    config = BatchSchedulerConfig(mode=SchedulerMode.SERIAL, preset=SchedulerPreset.LATENCY)
+    scheduler = MTPContinuousScheduler(config=config, hooks=hooks)
+    request = RequestState("r1", prompt_ids=[1, 2], max_tokens=1)
+
+    scheduler._record_finished(request)
+    scheduler._record_finished(request)
+
+    assert scheduler.finished_total == 1
+    assert len(scheduler.finished) == 1
+    assert scheduler.snapshot()["finished"] == 1


### PR DESCRIPTION
## What

`MTPContinuousScheduler` accumulates every finished request in an unbounded `self.finished` list and deduplicates each finish with an `any(existing is request for existing in self.finished)` identity scan. For a long-running server this has two costs:

- **Unbounded memory** — the list holds a `RequestState` for every request the scheduler has ever completed; it is never trimmed (`_purge_terminal_queues` only prunes the prefill/decode/postcommit queues).
- **O(n²) dedup** — the linear identity scan runs on *every* terminal transition, so the aggregate cost over a session is quadratic in the number of requests.

`self.finished` is only ever observed through `len()` (the `snapshot()["finished"]` gauge), so nothing depends on it being a list of live objects.

## Change

- Key the finished set by `request_id` → dedup is now O(1).
- Cap the retained `RequestState` objects (`max_finished_retained`, default 4096) so live memory stays bounded on long sessions.
- Track the true cumulative count in a new monotonic `finished_total`.
- `snapshot()["finished"]` keeps its previous meaning (cumulative distinct finishes = `finished_total`); a new `finished_retained` field reports the bounded live size.

No public behaviour changes for callers that read the `finished` gauge, and the single-owner-thread invariant is unchanged (no new locking).

## Tests

Added to `tests/test_batching_foundation.py`:

- `test_finished_tracking_is_bounded_but_total_is_exact` — with retention capped at 8, finishing 50 requests keeps `len(scheduler.finished) <= 8` while `finished_total == 50`. This is **red on `main`**, where `len(scheduler.finished)` reaches 50 (the list is unbounded).
- `test_record_finished_is_idempotent_per_request` — recording the same request twice counts once.

Existing scheduler tests (`test_batching_foundation.py`, `test_model_scheduler.py`) still pass, along with the full CI suite; `ruff check`, `compileall`, and `scripts/hygiene_scan.sh` are clean locally.