### PR TITLE
fix(ui): export pretty_path so `mtplx start` dashboard handoff works

### DIFF
--- a/mtplx/ui/__init__.py
+++ b/mtplx/ui/__init__.py
@@ -21,4 +21,17 @@ __all__ = [
     "render_startup_panel",
     "ChatPrinter",
     "ModelLoadProgress",
+    "pretty_path",
 ]
+
+
+def __getattr__(name: str):
+    # ``pretty_path`` lives in ``onboarding`` as ``_pretty_path``. Re-export it
+    # lazily so command handlers can ``from mtplx.ui import pretty_path``
+    # without eagerly importing the onboarding dependency chain on every
+    # ``mtplx.ui`` import (this package must stay import-cheap for fresh venvs).
+    if name == "pretty_path":
+        from .onboarding import _pretty_path
+
+        return _pretty_path
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -6886,3 +6886,31 @@ def test_model_gate_error_lines_render_for_every_tier():
         lines = _model_gate_error_lines(inspection)
         assert lines, tier
         assert any("try:" in line for line in lines), (tier, lines)
+
+
+def test_ui_pretty_path_is_importable():
+    # Regression: ``mtplx.ui`` must export ``pretty_path``. The dashboard
+    # handoff does ``from mtplx.ui import pretty_path``, but the symbol lived
+    # in ``onboarding`` as ``_pretty_path`` and was never re-exported, so the
+    # import raised ImportError.
+    from mtplx import ui
+    from mtplx.ui import pretty_path
+
+    assert "pretty_path" in ui.__all__
+    assert pretty_path is ui.onboarding._pretty_path
+    # Behaves like the underlying helper: collapse $HOME, pass HF refs through.
+    assert pretty_path("Youssofal/Qwen3.6-27B") == "Youssofal/Qwen3.6-27B"
+    assert pretty_path(str(Path.home() / "models" / "x")) == "~/models/x"
+
+
+def test_quickstart_dashboard_handoff_does_not_crash(capsys):
+    # Regression: ``mtplx start`` reached the dashboard handoff and crashed on
+    # ``from mtplx.ui import pretty_path``. Drive the handoff directly and
+    # assert it prints the loading line with the model path instead of raising.
+    args = SimpleNamespace(host="127.0.0.1", port=8000)
+    public._quickstart_print_dashboard_handoff(
+        args, runtime_model=str(Path.home() / ".mtplx" / "models" / "demo")
+    )
+    out = capsys.readouterr().out
+    assert "Loading model: ~/.mtplx/models/demo" in out
+    assert "Dashboard URL:" in out


### PR DESCRIPTION
## Summary

Running `mtplx start` and selecting the live-dashboard interface crashes right after the model check, on the `[2/3] Starting local MTPLX server for the live dashboard...` step:

```
File ".../mtplx/commands/public.py", line 11308, in _quickstart_print_dashboard_handoff
    from mtplx.ui import pretty_path
ImportError: cannot import name 'pretty_path' from 'mtplx.ui'
```

`_quickstart_print_dashboard_handoff()` does `from mtplx.ui import pretty_path`, but `mtplx.ui` never exported that name — the helper lives in `mtplx/ui/onboarding.py` as the private `_pretty_path`. So the dashboard handoff path is unreachable in `1.0.4`.

This re-exports `pretty_path` from `mtplx.ui` via a lazy module `__getattr__`, so command handlers can import it without eagerly pulling the `onboarding` dependency chain into every `mtplx.ui` import (the package is intentionally kept import-cheap for fresh venvs, per its module docstring). The lone caller (`public.py`) is unchanged.

## Verification

- `from mtplx.ui import pretty_path` now succeeds; `pretty_path is mtplx.ui.onboarding._pretty_path`.
- Reproduced the original crash on `main`, then confirmed it's gone after the fix.
- Added two regression tests in `tests/test_public_cli.py` (CI-covered):
  - `test_ui_pretty_path_is_importable` — the export exists, is identity-equal to the underlying helper, and behaves (collapses `$HOME` to `~`, passes HF refs through).
  - `test_quickstart_dashboard_handoff_does_not_crash` — drives `_quickstart_print_dashboard_handoff` end-to-end and asserts it prints its lines instead of raising.
- `python -m pytest tests/test_public_cli.py` → **203 passed**. (4 unrelated cache/quality-alias tests fail identically on pristine `main` on my machine due to local `~/.mtplx` state; they are untouched by this change.)
- `ruff check` clean on both changed files; `python -m compileall mtplx tests` clean.

## Benchmark Evidence

N/A — import/packaging fix, no runtime-performance impact.