### PR TITLE
fix: pin transformers<5.13 — 5.13.0 breaks mlx-lm import (model load crash on fresh installs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
   "huggingface-hub>=0.36",
   "mlx>=0.31,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "mlx-lm>=0.31,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  # transformers 5.13.0 changed AutoTokenizer.register to require a config class; mlx-lm 0.31.x
+  # still registers by name ("NewlineTokenizer") and crashes at import — pin until mlx-lm adapts.
+  "transformers<5.13; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "nanobind>=2; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy>=2",
   "pydantic>=2",


### PR DESCRIPTION
## What breaks

A fresh install of MTPLX 1.0.4 (e.g. `brew install youssofal/mtplx/mtplx`) resolves `transformers` transitively via mlx-lm at install time. As of **transformers 5.13.0** the `import mlx_lm` inside `runtime.py` crashes before any model can load:

```
Model load failed after 1.6s: AttributeError: 'str' object has no attribute '__module__'
  File ".../mtplx/runtime.py", line 325, in load
    from mlx_lm.utils import load as mlx_lm_load
  File ".../mlx_lm/tokenizer_utils.py", line 505, in <module>
    AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
  File ".../transformers/models/auto/auto_factory.py", line 680, in register
    if key.__module__.startswith("transformers."):
AttributeError: 'str' object has no attribute '__module__'. Did you mean: '__mod__'?
[server exited: 1]
```

## Root cause

transformers 5.13.0 changed `AutoTokenizer.register` to require a config **class** as the key; mlx-lm 0.31.x still registers by name (`"NewlineTokenizer"`). Any venv built before 5.13 shipped keeps working (a June install with 5.12.1 is fine), so the break only hits **new installs** — easy to miss.

## Fix

Pin `transformers<5.13` next to the existing mlx/mlx-lm pins. Bisected: **5.12.1 last good, 5.13.0 first bad**. Verified on Apple Silicon (M5 Max, macOS 26.5.1): installing 5.12.1 into a broken venv restores model load and serving with no other change; a fresh resolve under the pin works.

The pin can be dropped once mlx-lm registers the tokenizer the 5.13-compatible way.

Repro command: `mtplx serve --model Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed --download --mtp --generation-mode mtp --depth 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)