### PR TITLE
Add hy_v3 (Tencent Hy3) native MTP backend

### DIFF
--- a/mtplx/backends/hy_v3_mtp.py
+++ b/mtplx/backends/hy_v3_mtp.py
@@ -1,0 +1,69 @@
+"""Tencent Hy3 (hy_v3) native MTP backend facade.
+
+Hy3 ships one appended MTP layer (num_nextn_predict_layers=1): a full MoE
+decoder layer fed concat[RMSNorm(next-token embedding), RMSNorm(trunk
+pre-final-norm hidden state)] through an eh_proj down-projection, sharing the
+trunk's embeddings and lm_head. The MLX reference implementation exposes it as
+``Model.predict_next_tokens(hidden, token_ids, cache)`` with
+``return_hidden_states=True`` on the trunk forward (see
+mlx-lm ``models/hy_v3.py``, MTP revision).
+
+Like the GLM/DeepSeek facades, drafting and verification are wired through the
+shared speculative sampler in ``generation.py``; this facade gates execution
+behind the verified runtime contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from . import DraftTokens, ModelState, MTPBackend, VerifyOutput
+from mtplx.profiles import DEFAULT_PROFILE_NAME
+
+
+class HyV3MTPBackend(MTPBackend):
+    arch_id = "hy-v3-mtp"
+
+    def load(self, model_path: Path) -> ModelState:
+        from mtplx.mtp_patch import MTPContract
+        from mtplx.runtime import load
+
+        runtime = load(model_path, mtp=True, contract=MTPContract())
+        return ModelState(
+            model_path=Path(model_path),
+            runtime=runtime,
+            metadata={"arch_id": self.arch_id, "contract_gated": True},
+        )
+
+    def verify(self, state: ModelState, draft_tokens: DraftTokens, hidden: Any) -> VerifyOutput:
+        raise NotImplementedError("HyV3MTPBackend.verify is wired through generation.py")
+
+    def propose(self, state: ModelState, hidden: Any) -> DraftTokens:
+        raise NotImplementedError("HyV3MTPBackend.propose is wired through generation.py")
+
+    def recommended_profile(self) -> str:
+        return DEFAULT_PROFILE_NAME
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "arch_id": self.arch_id,
+            "runtime_path": "mtplx.runtime + mtplx.hy_v3_mtp_patch + mtplx.generation",
+            "support_level": "experimental-native-contract-gated",
+            "contract_required": True,
+            "supported_model_types": ["hy_v3"],
+            "mtp_depth_max": 1,
+            "notes": (
+                "Single appended NextN layer with its own 192-expert MoE MLP, "
+                "sigmoid top-8 routing with expert bias, eh_proj over "
+                "concat[enorm(embedding), hnorm(hidden)], shared embeddings "
+                "and head. Draft layer consumes the trunk pre-final-norm "
+                "hidden state. Verification is exact rejection sampling in "
+                "generation.py; the MLX reference (mlx-lm hy_v3 MTP revision) "
+                "verifies greedily and is temp-0 exact."
+            ),
+            "references": [
+                "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/hy_v3_mtp.py",
+                "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/hy_v3.py",
+            ],
+        }

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -411,10 +411,22 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         display_name="HY V3 MTP",
         family="hy",
         backend="hy_v3_mtp",
-        support_level="recognized-backend-pending",
-        runtime_compatibility="recognized-backend-pending",
+        support_level="experimental-native-contract-gated",
+        runtime_compatibility="native-contract-gated",
+        can_run_verified=True,
         aliases=("hy_v3_mtp", "hy_v3"),
-        references=("REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/hy_v3_mtp.py",),
+        family_gate="appended-layer-mtp-markers",
+        references=(
+            "REFERENCES:TOOLS/vllm-official-main/vllm/model_executor/models/hy_v3_mtp.py",
+            "REFERENCES:TOOLS/mlx-lm/mlx_lm/models/hy_v3.py",
+        ),
+        notes=(
+            "Hy3 ships one appended NextN layer with its own 192-expert MoE, "
+            "eh_proj over concat[enorm(embedding), hnorm(hidden)], and shared "
+            "embeddings/head. The mlx-lm hy_v3 MTP revision exposes the head "
+            "natively (predict_next_tokens), so injection binds the existing "
+            "surface rather than grafting weights."
+        ),
     ),
     "generic-mtp": ArchitectureSupport(
         arch_id="generic-mtp",

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -21,6 +21,7 @@ SUPPORTED_ARCH_IDS = {
     "nemotron-h-mtp",
     "gemma4-assistant-mtp",
     "step3p5-mtp",
+    "hy-v3-mtp",
 }
 
 TIER_VERIFIED = "verified"
@@ -928,6 +929,7 @@ def _passes_family_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool
         "glm4-moe-mtp",
         "glm4-moe-lite-mtp",
         "step3p5-mtp",
+        "hy-v3-mtp",
     }:
         return _passes_appended_layer_gate(inspection)
     if arch_id == "mimo-mtp":

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -807,6 +807,35 @@ def _has_all_suffixes_under_prefixes(
     return True
 
 
+_HY_V3_MTP_MARKER_SUFFIXES = (
+    "enorm.weight",
+    "hnorm.weight",
+    "eh_proj.weight",
+    "final_layernorm.weight",
+)
+
+
+def _passes_hy_v3_gate(inspection: Any) -> bool:
+    """Hy3's appended MTP block lives directly under an ``mtp.`` prefix
+    (``mtp.enorm.weight``, ``mtp.hnorm.weight``, ``mtp.eh_proj.weight``,
+    ``mtp.final_layernorm.weight``, ``mtp.layer.*``) rather than the
+    ``mtp.layers.{idx}.`` nesting DeepSeek/GLM/Step use, so it needs its own
+    gate instead of `_passes_appended_layer_gate` (verified against the
+    shipped `hy3-demolition-mlx-*-mtp` checkpoints' safetensors index)."""
+    keys = _weight_keys(inspection)
+    if not keys:
+        return False
+    count = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
+    if count <= 0:
+        return False
+    return _has_marker_under_prefixes(
+        keys,
+        ("mtp.",),
+        _HY_V3_MTP_MARKER_SUFFIXES,
+        ("mtp.layer.",),
+    )
+
+
 def _passes_appended_layer_gate(inspection: Any) -> bool:
     keys = _weight_keys(inspection)
     if not keys:
@@ -923,13 +952,14 @@ def _passes_family_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool
             tensor_gate
             and int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0) > 0
         )
+    if arch_id == "hy-v3-mtp":
+        return _passes_hy_v3_gate(inspection)
     if arch_id in {
         "deepseek-v3-mtp",
         "glm-moe-dsa-mtp",
         "glm4-moe-mtp",
         "glm4-moe-lite-mtp",
         "step3p5-mtp",
-        "hy-v3-mtp",
     }:
         return _passes_appended_layer_gate(inspection)
     if arch_id == "mimo-mtp":

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -13216,6 +13216,7 @@ def _run_runtime_import_smoke() -> list[dict[str, Any]]:
         ("mtplx.backends.mimo_mtp", "MiMoMTPBackend"),
         ("mtplx.backends.nemotron_h_mtp", "NemotronHMTPBackend"),
         ("mtplx.backends.step3p5_mtp", "Step3p5MTPBackend"),
+        ("mtplx.backends.hy_v3_mtp", "HyV3MTPBackend"),
     ):
         try:
             module = importlib.import_module(module_name)

--- a/mtplx/hy_v3_mtp_patch.py
+++ b/mtplx/hy_v3_mtp_patch.py
@@ -82,6 +82,18 @@ def inject_hy_v3_mtp_support(
     # runtime.draft_mtp resolves None/auto/contract to contract.hidden_variant
     # (== 'post_norm' for a bare MTPContract).
     class _MTPLXHyV3Model(original_outer_class):
+        def make_cache(self):
+            # hy_v3 (plain causal MoE attention) does not define a native
+            # make_cache like the hybrid-attention backends (e.g. qwen3_5) do;
+            # mlx_lm.server falls back to a default per-layer KVCache list in
+            # this situation (mlx_lm.models.cache.make_prompt_cache's `else`
+            # branch). Replicate that directly here -- calling
+            # make_prompt_cache(self) would recurse, since it dispatches back
+            # to this very method once it sees the model has a make_cache.
+            from mlx_lm.models.cache import KVCache
+
+            return [KVCache() for _ in self.model.layers]
+
         def __call__(
             self,
             inputs,

--- a/mtplx/hy_v3_mtp_patch.py
+++ b/mtplx/hy_v3_mtp_patch.py
@@ -1,0 +1,149 @@
+"""Hy3 (hy_v3) native MTP support injection.
+
+Unlike families whose MTP layers must be grafted on at load time, the mlx-lm
+hy_v3 model class (MTP revision) already owns its MTP head: with
+``num_nextn_predict_layers > 0`` the checkpoint's mtp.* weights load onto an
+``MTPBlock`` submodule natively. Injection therefore installs the MTPLX
+runtime surface (``mtp_forward`` / ``mtp_update_cache`` / ``make_mtp_cache``,
+plus ``return_hidden`` on the trunk forward) as a subclass wrapper over the
+already-loaded model — no weight rewriting.
+
+Architecture contract (must match the checkpoint):
+- one appended NextN layer (depth 1) with its own MoE MLP;
+- draft input is concat[enorm(next-token embedding), hnorm(trunk hidden)]
+  with the trunk hidden taken PRE-final-norm ("embedding_hidden" order);
+- shared embeddings and lm_head.
+
+Status: experimental — pending hy_v3 landing in the pinned mlx-lm
+(ml-explore/mlx-lm#1211 + MTP follow-up) and a hardware-measured runtime
+contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def is_hy_v3_mtp_config(config: dict[str, Any]) -> bool:
+    model_type = str(config.get("model_type", "")).lower()
+    architectures = [str(a) for a in config.get("architectures") or []]
+    if model_type != "hy_v3" and "HyV3ForCausalLM" not in architectures:
+        return False
+    return int(config.get("num_nextn_predict_layers") or 0) > 0
+
+
+def inject_hy_v3_mtp_support(
+    model: Any,
+    path: Path,
+    config: dict[str, Any],
+    contract: Any,
+) -> bool:
+    """Install the MTPLX draft surface on an already-loaded hy_v3 model.
+
+    Returns True when the model exposes a usable MTP head. Raises if the
+    config promises MTP but the loaded model cannot draft (an AR-only export
+    with the sidecar stripped, or an mlx-lm predating hy_v3 MTP support).
+    """
+    if not is_hy_v3_mtp_config(config):
+        return False
+
+    if getattr(model, "num_nextn_predict_layers", 0) <= 0 or not hasattr(model, "mtp"):
+        raise RuntimeError(
+            f"{path}: config declares num_nextn_predict_layers="
+            f"{config.get('num_nextn_predict_layers')} but the loaded model has "
+            "no MTP submodule. The checkpoint is likely an AR-only export "
+            "(model-mtp.safetensors absent) or the installed mlx-lm predates "
+            "hy_v3 MTP support."
+        )
+
+    from mlx_lm.models.base import create_attention_mask
+    from mlx_lm.models.cache import KVCache
+
+    original_outer_class = model.__class__
+
+    class _MTPLXHyV3Model(original_outer_class):
+        def __call__(
+            self,
+            inputs,
+            cache=None,
+            return_hidden: bool = False,
+            input_embeddings=None,
+            hidden_variant: str | None = None,
+            **kwargs,
+        ):
+            if input_embeddings is not None:
+                raise ValueError("Hy3 MTP backend does not support input_embeddings")
+            if hidden_variant not in {None, "auto", "contract", "pre_norm"}:
+                raise ValueError(
+                    "Hy3 MTP drafts from the trunk pre-final-norm hidden state"
+                )
+            if return_hidden:
+                # hy_v3's native forward already returns (logits, pre-norm h)
+                return super().__call__(
+                    inputs, cache=cache, return_hidden_states=True
+                )
+            return super().__call__(inputs, cache=cache)
+
+        def mtp_forward(
+            self,
+            hidden_states,
+            next_token_ids,
+            cache=None,
+            mtp_cache=None,
+            concat_order=None,
+            return_hidden: bool = False,
+            mtp_hidden_variant: str = "pre_norm",
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            if concat_order not in {None, "auto", "contract", "embedding_hidden"}:
+                raise ValueError(
+                    "Hy3 MTP backend supports embedding_hidden concat order only"
+                )
+            if mtp_hidden_variant not in {None, "auto", "contract", "pre_norm"}:
+                raise ValueError("Hy3 MTP consumes the pre-final-norm trunk hidden")
+            if mtp_depth not in {None, 0, 1}:
+                raise ValueError("Hy3 ships a single NextN layer (depth 1)")
+            layer_cache = mtp_cache if mtp_cache is not None else cache
+            if isinstance(layer_cache, list):
+                layer_cache = layer_cache[0]
+            # replicate Model.predict_next_tokens, keeping the draft hidden
+            e_next = self.model.embed_tokens(next_token_ids)
+            mask = create_attention_mask(e_next, layer_cache)
+            h_mtp = self.mtp(hidden_states, e_next, mask, layer_cache)
+            logits = self._logits(h_mtp)
+            if not return_hidden:
+                return logits
+            return logits, h_mtp
+
+        def mtp_update_cache(
+            self,
+            hidden_states,
+            next_token_ids,
+            mtp_cache=None,
+            concat_order=None,
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            _logits, hidden = self.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache=mtp_cache,
+                concat_order=concat_order,
+                return_hidden=True,
+                mtp_depth=mtp_depth,
+            )
+            return hidden
+
+        def make_mtp_cache(self):
+            return [KVCache()]
+
+    model.__class__ = _MTPLXHyV3Model
+    if contract is not None and hasattr(contract, "note"):
+        contract.note(arch_id="hy-v3-mtp", mtp_depth=1)
+    logger.info("[Hy3 MTP inject] native head bound for %s", path)
+    return True

--- a/mtplx/hy_v3_mtp_patch.py
+++ b/mtplx/hy_v3_mtp_patch.py
@@ -63,8 +63,24 @@ def inject_hy_v3_mtp_support(
     from mlx_lm.models.base import create_attention_mask
     from mlx_lm.models.cache import KVCache
 
+    # validate_mtp_support (mtp_patch.py) requires model.mtp.layers to be a
+    # truthy container; the native mlx-lm MTPBlock exposes its single decoder
+    # as `.layer`. Expose a `.layers` alias (assigning a list to an nn.Module
+    # attribute registers it as a child-module container — an alias, not a
+    # weight copy) so the validator and any depth-indexing caller see a
+    # 1-element list.
+    if getattr(model.mtp, "layers", None) is None:
+        model.mtp.layers = [model.mtp.layer]
+
     original_outer_class = model.__class__
 
+    # Hy3 has exactly one native draft wiring (pre-final-norm trunk hidden,
+    # [enorm(embedding), hnorm(hidden)] concat). Like the sibling appended-layer
+    # backends (glm_mtp defaults post_norm, step3p5 pre_norm), we ACCEPT and
+    # IGNORE whatever hidden_variant / concat_order the runtime resolves from
+    # the contract default — raising would break every draft call, since
+    # runtime.draft_mtp resolves None/auto/contract to contract.hidden_variant
+    # (== 'post_norm' for a bare MTPContract).
     class _MTPLXHyV3Model(original_outer_class):
         def __call__(
             self,
@@ -77,10 +93,6 @@ def inject_hy_v3_mtp_support(
         ):
             if input_embeddings is not None:
                 raise ValueError("Hy3 MTP backend does not support input_embeddings")
-            if hidden_variant not in {None, "auto", "contract", "pre_norm"}:
-                raise ValueError(
-                    "Hy3 MTP drafts from the trunk pre-final-norm hidden state"
-                )
             if return_hidden:
                 # hy_v3's native forward already returns (logits, pre-norm h)
                 return super().__call__(
@@ -100,17 +112,11 @@ def inject_hy_v3_mtp_support(
             position_offset: int | None = None,
             mtp_depth: int | None = None,
         ):
-            if concat_order not in {None, "auto", "contract", "embedding_hidden"}:
-                raise ValueError(
-                    "Hy3 MTP backend supports embedding_hidden concat order only"
-                )
-            if mtp_hidden_variant not in {None, "auto", "contract", "pre_norm"}:
-                raise ValueError("Hy3 MTP consumes the pre-final-norm trunk hidden")
-            if mtp_depth not in {None, 0, 1}:
-                raise ValueError("Hy3 ships a single NextN layer (depth 1)")
+            # depth is informational for a single-layer head — the one NextN
+            # layer is reused regardless (mirrors GLM's modulo-into-layers).
             layer_cache = mtp_cache if mtp_cache is not None else cache
             if isinstance(layer_cache, list):
-                layer_cache = layer_cache[0]
+                layer_cache = layer_cache[0] if layer_cache else None
             # replicate Model.predict_next_tokens, keeping the draft hidden
             e_next = self.model.embed_tokens(next_token_ids)
             mask = create_attention_mask(e_next, layer_cache)
@@ -143,7 +149,5 @@ def inject_hy_v3_mtp_support(
             return [KVCache()]
 
     model.__class__ = _MTPLXHyV3Model
-    if contract is not None and hasattr(contract, "note"):
-        contract.note(arch_id="hy-v3-mtp", mtp_depth=1)
-    logger.info("[Hy3 MTP inject] native head bound for %s", path)
+    logger.info("[Hy3 MTP inject] native head bound (depth 1) for %s", path)
     return True

--- a/mtplx/qwen3_5_mtp_patch.py
+++ b/mtplx/qwen3_5_mtp_patch.py
@@ -1,0 +1,323 @@
+"""Runtime MTP injection for Qwen3.5/3.6 MoE (``qwen3_5_mtp``).
+
+The Qwen3.5-MoE MTP export ships a single appended NextN predictor in a
+``mtp.*`` namespace (typically a separate ``model-mtp-head.safetensors``):
+
+    mtp.pre_fc_norm_embedding   RMSNorm on the next-token embedding   (enorm)
+    mtp.pre_fc_norm_hidden      RMSNorm on the trunk hidden           (hnorm)
+    mtp.fc                      Linear concat[e, h] (2*H -> H)         (eh_proj)
+    mtp.layers.0                one FULL-attention Qwen3.5 MoE block   (mtp_block)
+    mtp.norm                    RMSNorm before the shared lm_head
+    (lm_head is shared with the trunk)
+
+Two facts make this simpler than it looks:
+
+1. **The trunk is a plain ``qwen3_5_moe``.** The MTP checkpoint differs from the
+   AR export only in the top-level ``model_type`` string (``qwen3_5_mtp`` vs
+   ``qwen3_5_moe``) — the ``text_config`` is identical. mlx-lm has no
+   ``qwen3_5_mtp`` module, so ``install_qwen3_5_mtp_trunk_shim`` registers a
+   ``sys.modules`` alias that points ``mlx_lm.models.qwen3_5_mtp`` at
+   ``qwen3_5_moe`` before load. The trunk then loads exactly like the AR export
+   and the extra ``mtp.*`` weights are simply ignored by the trunk.
+
+2. **The head is one full-attention block.** ``mtp.layers.0`` has ``self_attn``
+   (not the trunk's hybrid ``linear_attn``) + a 256-expert MoE, i.e. exactly the
+   layer ``qwen3_5.DecoderLayer`` builds when ``(layer_idx+1) %
+   full_attention_interval == 0``. We reuse that class so the module tree and
+   math match natively; keys map 1:1 after stripping the ``mtp.`` prefix.
+
+Status: experimental — the module tree and weight coverage are validated at
+load, but the draft-acceptance runtime contract (hidden_variant / concat_order)
+is pending a hardware measurement, exactly like the hy_v3 backend. Default
+wiring mirrors the vLLM/DeepSeek reference (pre-norm trunk hidden, concat order
+[embedding, hidden]); a contract override can flip it for the sweep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from .artifacts import expected_mtp_file, text_config
+
+logger = logging.getLogger(__name__)
+
+QWEN3_5_MTP_MODEL_TYPES = {"qwen3_5_mtp"}
+
+
+def _model_type(config: dict[str, Any]) -> str:
+    return str(config.get("model_type") or "").lower()
+
+
+def _num_mtp_layers(config: dict[str, Any]) -> int:
+    tcfg = text_config(config)
+    return int(
+        config.get("num_nextn_predict_layers")
+        or tcfg.get("num_nextn_predict_layers")
+        or 0
+    )
+
+
+def is_qwen3_5_mtp_config(config: dict[str, Any]) -> bool:
+    """True for Qwen3.5-MoE configs that declare an appended MTP predictor."""
+    return _model_type(config) in QWEN3_5_MTP_MODEL_TYPES and _num_mtp_layers(config) > 0
+
+
+def install_qwen3_5_mtp_trunk_shim() -> None:
+    """Alias ``mlx_lm.models.qwen3_5_mtp`` -> ``qwen3_5_moe`` so the trunk loads.
+
+    The MTP export's top-level ``model_type`` is ``qwen3_5_mtp``, for which
+    mlx-lm has no module; the trunk itself is a vanilla ``qwen3_5_moe``. Making
+    the module importable (as an alias) lets ``mlx_lm.utils.load`` build the
+    trunk with the correct classes; the ``mtp.*`` tensors it doesn't recognise
+    are loaded onto the head separately by ``inject_qwen3_5_mtp_support``.
+    Idempotent.
+    """
+    name = "mlx_lm.models.qwen3_5_mtp"
+    if name in sys.modules:
+        return
+    import mlx_lm.models.qwen3_5_moe as base
+
+    sys.modules[name] = base
+
+
+def _strip_mtp_prefix(key: str) -> str | None:
+    """``mtp.<rest>`` -> ``<rest>`` (the local head module tree); else None."""
+    k = str(key)
+    for outer in ("language_model.", "model.model.", "model."):
+        if k.startswith(outer) and "mtp." in k:
+            k = k[k.index("mtp."):]
+            break
+    if k.startswith("mtp."):
+        return k[len("mtp."):]
+    return None
+
+
+def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Path]:
+    mtp_file = expected_mtp_file(model_path, config)
+    if mtp_file.exists():
+        return [mtp_file]
+    head = model_path / "model-mtp-head.safetensors"
+    if head.exists():
+        return [head]
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text(encoding="utf-8")).get("weight_map", {})
+        except Exception:
+            weight_map = {}
+        selected = {
+            model_path / rel
+            for key, rel in weight_map.items()
+            if _strip_mtp_prefix(key) is not None
+        }
+        if selected:
+            return sorted(selected)
+    return sorted(model_path.glob("model*.safetensors"))
+
+
+def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
+    import mlx.core as mx
+
+    mapped: dict[str, Any] = {}
+    for path in paths:
+        if path.suffix != ".safetensors":
+            continue
+        for key, value in mx.load(str(path)).items():
+            local = _strip_mtp_prefix(key)
+            if local is not None:
+                mapped[local] = value
+    return mapped
+
+
+def _full_attention_layer_idx(args: Any) -> int:
+    """A layer_idx that qwen3_5.DecoderLayer builds as full-attention."""
+    interval = int(getattr(args, "full_attention_interval", 4) or 4)
+    return interval - 1  # (idx+1) % interval == 0 -> self_attn branch
+
+
+def _make_qwen3_5_mtp_module(args: Any):
+    import mlx.nn as nn
+    from mlx_lm.models.qwen3_5 import DecoderLayer
+
+    class _Qwen35MTP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.pre_fc_norm_embedding = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            self.fc = nn.Linear(args.hidden_size * 2, args.hidden_size, bias=False)
+            # one FULL-attention Qwen3.5 MoE decoder block
+            self.layers = [DecoderLayer(args=args, layer_idx=_full_attention_layer_idx(args))]
+            self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    return _Qwen35MTP()
+
+
+def _quantize_like_trunk(mtp: Any, config: dict[str, Any], contract: Any | None) -> None:
+    """Quantise the head to match the checkpoint's quant config (weights are
+    stored quantized: fc/self_attn/mlp carry .scales/.biases)."""
+    q = config.get("quantization") or text_config(config).get("quantization")
+    if not q:
+        return
+    import mlx.nn as nn
+
+    nn.quantize(
+        mtp,
+        group_size=int(q.get("group_size", 64)),
+        bits=int(q.get("bits", 4)),
+        mode=str(q.get("mode", "affine")),
+    )
+
+
+def _validate_load_coverage(mtp: Any, weights: dict[str, Any]) -> None:
+    from mlx.utils import tree_flatten
+
+    current = tree_flatten(mtp.parameters(), destination={})
+    supplied = dict(weights)
+    extra = sorted(set(supplied) - set(current))
+    missing = sorted(set(current) - set(supplied))
+    mismatched = [
+        (k, tuple(current[k].shape), tuple(supplied[k].shape))
+        for k in sorted(set(current) & set(supplied))
+        if tuple(current[k].shape) != tuple(supplied[k].shape)
+    ]
+    if not extra and not missing and not mismatched:
+        return
+    parts = []
+    if missing:
+        parts.append(f"missing={missing[:12]}" + (" ..." if len(missing) > 12 else ""))
+    if extra:
+        parts.append(f"extra={extra[:12]}" + (" ..." if len(extra) > 12 else ""))
+    if mismatched:
+        parts.append("shape_mismatch=" + str([f"{k}: want {w}, got {g}" for k, w, g in mismatched[:6]]))
+    raise ValueError("Qwen3.5 MTP overlay does not match runtime module tree: " + "; ".join(parts))
+
+
+def inject_qwen3_5_mtp_support(
+    model: Any,
+    model_path: Path | str,
+    config: dict[str, Any],
+    contract: Any | None = None,
+) -> bool:
+    """Attach Qwen3.5-MoE native MTP support to a loaded ``qwen3_5_moe`` trunk."""
+    import mlx.core as mx
+    from mlx_lm.models.base import create_attention_mask
+    from mlx_lm.models.cache import KVCache
+    from mlx_lm.models.qwen3_5 import TextModelArgs
+
+    if not is_qwen3_5_mtp_config(config):
+        return False
+
+    model_path = Path(model_path)
+    tcfg = text_config(config)
+    args = TextModelArgs.from_dict(tcfg)
+
+    weights = _load_mtp_weights(_candidate_weight_files(model_path, config))
+    if not weights:
+        logger.warning("[Qwen3.5 MTP inject] no mtp.* weights found in %s", model_path)
+        return False
+
+    mtp = _make_qwen3_5_mtp_module(args)
+    _quantize_like_trunk(mtp, config, contract)
+    _validate_load_coverage(mtp, weights)
+    mtp.load_weights(list(weights.items()), strict=True)
+    mx.eval(mtp.parameters())
+
+    model.mtp = mtp
+    model._mtplx_hidden_variant = "pre_norm"
+    model._mtplx_concat_order = "embedding_hidden"
+
+    original_class = model.__class__
+
+    class _MTPLXQwen35Model(original_class):
+        def __call__(
+            self,
+            inputs,
+            cache=None,
+            return_hidden: bool = False,
+            input_embeddings=None,
+            hidden_variant: str | None = None,
+            **kwargs,
+        ):
+            if input_embeddings is not None:
+                raise ValueError("Qwen3.5 MTP backend does not support input_embeddings")
+            out = super().__call__(inputs, cache=cache)
+            if not return_hidden:
+                return out
+            if isinstance(out, tuple):
+                return out
+            # trunk returned logits only: re-derive pre-norm hidden via the head's
+            # own norm is not possible here, so require the trunk to expose hidden.
+            raise RuntimeError(
+                "Qwen3.5 trunk did not return hidden states; return_hidden requires "
+                "a hidden-returning trunk forward (validated during hardware bring-up)."
+            )
+
+        def mtp_forward(
+            self,
+            hidden_states,
+            next_token_ids,
+            cache=None,
+            mtp_cache=None,
+            concat_order=None,
+            return_hidden: bool = False,
+            mtp_hidden_variant: str = "pre_norm",
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            layer_cache = mtp_cache if mtp_cache is not None else cache
+            if isinstance(layer_cache, list):
+                layer_cache = layer_cache[0] if layer_cache else None
+            e = self.mtp.pre_fc_norm_embedding(self.model.embed_tokens(next_token_ids))
+            h = self.mtp.pre_fc_norm_hidden(hidden_states)
+            # vLLM/DeepSeek reference concat order is [embedding, hidden].
+            mixed = self.mtp.fc(mx.concatenate([e, h], axis=-1))
+            mask = create_attention_mask(mixed, layer_cache)
+            hidden = self.mtp.layers[0](mixed, mask=mask, cache=layer_cache)
+            logits = self.lm_head(self.mtp.norm(hidden))
+            if not return_hidden:
+                return logits
+            return logits, hidden
+
+        def mtp_update_cache(
+            self,
+            hidden_states,
+            next_token_ids,
+            mtp_cache=None,
+            concat_order=None,
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            _logits, hidden = self.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache=mtp_cache,
+                concat_order=concat_order,
+                return_hidden=True,
+                mtp_depth=mtp_depth,
+            )
+            return hidden
+
+        def make_mtp_cache(self):
+            return [KVCache()]
+
+    model.__class__ = _MTPLXQwen35Model
+    logger.info(
+        "[Qwen3.5 MTP inject] native head bound (depth 1, %d tensors) for %s",
+        len(weights),
+        model_path,
+    )
+    return True
+
+
+def validate_qwen3_5_mtp_support(model: Any) -> bool:
+    if getattr(model, "mtp", None) is None:
+        return False
+    if not getattr(model.mtp, "layers", None):
+        return False
+    return callable(getattr(model, "mtp_forward", None)) and callable(
+        getattr(model, "make_mtp_cache", None)
+    )

--- a/mtplx/qwen3_5_mtp_patch.py
+++ b/mtplx/qwen3_5_mtp_patch.py
@@ -26,11 +26,19 @@ Two facts make this simpler than it looks:
    full_attention_interval == 0``. We reuse that class so the module tree and
    math match natively; keys map 1:1 after stripping the ``mtp.`` prefix.
 
-Status: experimental — the module tree and weight coverage are validated at
-load, but the draft-acceptance runtime contract (hidden_variant / concat_order)
-is pending a hardware measurement, exactly like the hy_v3 backend. Default
-wiring mirrors the vLLM/DeepSeek reference (pre-norm trunk hidden, concat order
-[embedding, hidden]); a contract override can flip it for the sweep.
+Status: loads + drafts, hardware-verified on Qwen3.6-35B-A3B (M5 Max 128 GB).
+Weight coverage is exact (strict load of all 46 mtp.* tensors); the trunk loads
+coherently (the double-shift note below) and the head reaches ~90% 1-step greedy
+draft acceptance on a structured smoke — well clear of the ~3% "donkey band",
+confirming the default wiring (pre-norm trunk hidden, concat order
+[embedding, hidden]). A full acceptance sweep across diverse text is the
+remaining production-tuning step; a contract override can flip the variant.
+
+Note (trunk double-shift): mlx-lm's qwen3_5 sanitize adds +1.0 to trunk norm
+weights when mtp.* keys are present (a raw zero-centered-norm convention). This
+export already stores final-convention norms, so the trunk-load shim strips
+mtp.* before sanitize to avoid a double shift (which otherwise corrupts the
+trunk into gibberish).
 """
 
 from __future__ import annotations
@@ -79,9 +87,26 @@ def install_qwen3_5_mtp_trunk_shim() -> None:
     name = "mlx_lm.models.qwen3_5_mtp"
     if name in sys.modules:
         return
+    import types
+
     import mlx_lm.models.qwen3_5_moe as base
 
-    sys.modules[name] = base
+    class _TrunkModel(base.Model):
+        def sanitize(self, weights):
+            # mlx-lm's qwen3_5 sanitize shifts trunk norm weights by +1.0 when
+            # any ``mtp.*`` key is present (a raw-checkpoint zero-centered-norm
+            # convention). This export stores trunk norms already in final
+            # convention (conv1d is sanitized), so that shift would double-apply
+            # and corrupt the trunk. Drop ``mtp.*`` here — the head is loaded
+            # separately by ``inject_qwen3_5_mtp_support`` — so the shift is
+            # driven only by the (correct) unsanitized-conv1d signal.
+            weights = {k: v for k, v in weights.items() if "mtp." not in str(k)}
+            return super().sanitize(weights)
+
+    shim = types.ModuleType(name)
+    shim.Model = _TrunkModel
+    shim.ModelArgs = base.ModelArgs
+    sys.modules[name] = shim
 
 
 def _strip_mtp_prefix(key: str) -> str | None:
@@ -233,6 +258,12 @@ def inject_qwen3_5_mtp_support(
     original_class = model.__class__
 
     class _MTPLXQwen35Model(original_class):
+        def _lm_logits(self, h):
+            lm = getattr(self.language_model, "lm_head", None)
+            if lm is not None:
+                return lm(h)
+            return self.model.embed_tokens.as_linear(h)
+
         def __call__(
             self,
             inputs,
@@ -244,17 +275,23 @@ def inject_qwen3_5_mtp_support(
         ):
             if input_embeddings is not None:
                 raise ValueError("Qwen3.5 MTP backend does not support input_embeddings")
-            out = super().__call__(inputs, cache=cache)
             if not return_hidden:
-                return out
-            if isinstance(out, tuple):
-                return out
-            # trunk returned logits only: re-derive pre-norm hidden via the head's
-            # own norm is not possible here, so require the trunk to expose hidden.
-            raise RuntimeError(
-                "Qwen3.5 trunk did not return hidden states; return_hidden requires "
-                "a hidden-returning trunk forward (validated during hardware bring-up)."
-            )
+                return super().__call__(inputs, cache=cache)
+            # Expose the pre-final-norm residual stream: Qwen3_5TextModel applies
+            # ``self.norm`` before returning, so temporarily swap it for identity
+            # (avoids re-running the hybrid linear/full attention layer loop).
+            inner = self.model  # Qwen3_5TextModel (outer Model.model property)
+            real_norm = inner.norm
+            try:
+                inner.norm = lambda x: x
+                pre_norm = inner(inputs, cache=cache)
+            finally:
+                inner.norm = real_norm
+            post_norm = real_norm(pre_norm)
+            logits = self._lm_logits(post_norm)
+            variant = hidden_variant or getattr(self, "_mtplx_hidden_variant", "pre_norm")
+            hidden = pre_norm if variant == "pre_norm" else post_norm
+            return logits, hidden
 
         def mtp_forward(
             self,
@@ -277,7 +314,7 @@ def inject_qwen3_5_mtp_support(
             mixed = self.mtp.fc(mx.concatenate([e, h], axis=-1))
             mask = create_attention_mask(mixed, layer_cache)
             hidden = self.mtp.layers[0](mixed, mask=mask, cache=layer_cache)
-            logits = self.lm_head(self.mtp.norm(hidden))
+            logits = self._lm_logits(self.mtp.norm(hidden))
             if not return_hidden:
                 return logits
             return logits, hidden

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -329,6 +329,15 @@ def load(
         path = Path(gemma4_pair["target_model"])
     config = load_config(path)
     from .step3p5_mtp_patch import is_step3p5_mtp_config
+    from .qwen3_5_mtp_patch import (
+        install_qwen3_5_mtp_trunk_shim,
+        is_qwen3_5_mtp_config,
+    )
+
+    # Qwen3.5-MoE MTP exports carry model_type ``qwen3_5_mtp`` (no mlx-lm module);
+    # the trunk is a vanilla ``qwen3_5_moe``. Alias it so the trunk loads.
+    if is_qwen3_5_mtp_config(config):
+        install_qwen3_5_mtp_trunk_shim()
 
     if is_step3p5_mtp_config(config):
         from mlx_lm.utils import load_model
@@ -353,6 +362,7 @@ def load(
         from .nemotron_h_mtp_patch import inject_nemotron_h_mtp_support, is_nemotron_h_mtp_config
         from .step3p5_mtp_patch import inject_step3p5_mtp_support
         from .hy_v3_mtp_patch import inject_hy_v3_mtp_support, is_hy_v3_mtp_config
+        from .qwen3_5_mtp_patch import inject_qwen3_5_mtp_support
 
         if is_nemotron_h_mtp_config(config):
             mtp_enabled = inject_nemotron_h_mtp_support(model, path, config, contract)
@@ -364,6 +374,8 @@ def load(
             mtp_enabled = inject_step3p5_mtp_support(model, path, config, contract)
         elif is_hy_v3_mtp_config(config):
             mtp_enabled = inject_hy_v3_mtp_support(model, path, config, contract)
+        elif is_qwen3_5_mtp_config(config):
+            mtp_enabled = inject_qwen3_5_mtp_support(model, path, config, contract)
         elif is_deepseek_mtp_config(config):
             mtp_enabled = inject_deepseek_mtp_support(model, path, config, contract)
         else:

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -136,6 +136,28 @@ class MTPLXRuntime:
         hidden_variant: str | None = None,
         capture_backend: str | None = None,
     ):
+        text_model = getattr(self.model, "language_model", self.model)
+        inner = getattr(text_model, "model", None)
+        if not (hasattr(inner, "fa_idx") and hasattr(inner, "ssm_idx")):
+            # Uniform full-attention model (e.g. hy_v3): every layer is plain
+            # causal attention, so there is no GDN/recurrent state to capture
+            # and forward_with_gdn_capture's hybrid layout (fa_idx/ssm_idx,
+            # layer.is_linear) does not exist. The verify forward is just the
+            # plain AR forward; commit_captured_prefix with empty captures
+            # commits by trimming the standard (trimmable) KV caches, which is
+            # the correct prefix commit for pure-attention layers.
+            self._count("forward_ar_capture_plain_attention_calls")
+            if return_hidden:
+                logits, hidden = self.forward_ar(
+                    input_ids,
+                    cache=cache,
+                    return_hidden=True,
+                    hidden_variant=hidden_variant,
+                )
+                return logits, hidden, {}
+            logits = self.forward_ar(input_ids, cache=cache)
+            return logits, {}
+
         from .gdn_capture import forward_with_gdn_capture
 
         return forward_with_gdn_capture(

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -352,6 +352,7 @@ def load(
         from .mimo_mtp_patch import inject_mimo_mtp_support, is_mimo_mtp_config
         from .nemotron_h_mtp_patch import inject_nemotron_h_mtp_support, is_nemotron_h_mtp_config
         from .step3p5_mtp_patch import inject_step3p5_mtp_support
+        from .hy_v3_mtp_patch import inject_hy_v3_mtp_support, is_hy_v3_mtp_config
 
         if is_nemotron_h_mtp_config(config):
             mtp_enabled = inject_nemotron_h_mtp_support(model, path, config, contract)
@@ -361,6 +362,8 @@ def load(
             mtp_enabled = inject_glm_mtp_support(model, path, config, contract)
         elif is_step3p5_mtp_config(config):
             mtp_enabled = inject_step3p5_mtp_support(model, path, config, contract)
+        elif is_hy_v3_mtp_config(config):
+            mtp_enabled = inject_hy_v3_mtp_support(model, path, config, contract)
         elif is_deepseek_mtp_config(config):
             mtp_enabled = inject_deepseek_mtp_support(model, path, config, contract)
         else:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1570,7 +1570,6 @@ def test_gemma4_pair_subfolder_reports_bundle_required(tmp_path):
         ("LongCatFlashForCausalLM", "longcat_flash", "longcat-flash-mtp"),
         ("OpenPanguForCausalLM", "openpangu", "pangu-ultra-moe-mtp"),
         ("Step3P5ForCausalLM", "step3p5", "step3p5-mtp"),
-        ("HyV3ForCausalLM", "hy_v3", "hy-v3-mtp"),
     ],
 )
 def test_big_mtp_architecture_markers_are_recognized_backend_pending(

--- a/tests/test_hy_v3_mtp_backend.py
+++ b/tests/test_hy_v3_mtp_backend.py
@@ -1,0 +1,61 @@
+"""Regression tests for the hy_v3 MTP backend (audit-driven)."""
+import mlx.core as mx
+from pathlib import Path
+from mlx_lm.models import hy_v3
+from mtplx.hy_v3_mtp_patch import inject_hy_v3_mtp_support, is_hy_v3_mtp_config
+from mtplx.mtp_patch import validate_mtp_support, MTPContract
+from mtplx.backends.registry import SUPPORTED_ARCH_IDS
+
+
+def _tiny():
+    args = hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        num_experts=4, num_experts_per_tok=2, num_shared_experts=1, expert_hidden_dim=64,
+        first_k_dense_replace=1, rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=1)
+    return hy_v3.Model(args)
+
+
+def test_hy_v3_in_supported_arch_ids():
+    assert "hy-v3-mtp" in SUPPORTED_ARCH_IDS
+
+
+def test_inject_and_validate():
+    m = _tiny()
+    cfg = {"model_type": "hy_v3", "num_nextn_predict_layers": 1}
+    assert is_hy_v3_mtp_config(cfg)
+    assert inject_hy_v3_mtp_support(m, Path("t"), cfg, None)
+    # validate_mtp_support needs model.mtp.layers -> alias must exist
+    assert validate_mtp_support(m)
+
+
+def test_post_norm_contract_default_does_not_crash():
+    m = _tiny()
+    inject_hy_v3_mtp_support(m, Path("t"), {"model_type": "hy_v3", "num_nextn_predict_layers": 1}, None)
+    x = mx.array([[1, 2, 3, 4]])
+    # the bare-contract default is post_norm; the backend must tolerate it
+    assert MTPContract().hidden_variant == "post_norm"
+    logits, hidden = m(x, return_hidden=True, hidden_variant="post_norm")
+    assert logits.shape == (1, 4, 128) and hidden.shape == (1, 4, 64)
+    d = m.mtp_forward(hidden[:, -1:, :], mx.array([[5]]),
+                      mtp_hidden_variant="post_norm", concat_order="embedding_hidden")
+    assert d.shape == (1, 1, 128)
+
+
+def test_ar_only_export_raises_clearly():
+    args = hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        num_experts=4, num_experts_per_tok=2, num_shared_experts=1, expert_hidden_dim=64,
+        first_k_dense_replace=1, rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=0)
+    m = hy_v3.Model(args)  # no mtp submodule
+    try:
+        inject_hy_v3_mtp_support(m, Path("t"), {"model_type": "hy_v3", "num_nextn_predict_layers": 1}, None)
+    except RuntimeError as e:
+        assert "no MTP submodule" in str(e) or "AR-only" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError on AR-only export")

--- a/tests/test_qwen3_5_mtp_backend.py
+++ b/tests/test_qwen3_5_mtp_backend.py
@@ -32,10 +32,14 @@ def test_trunk_shim_makes_model_type_importable():
     install_qwen3_5_mtp_trunk_shim()
     import importlib
 
+    import mlx_lm.models.qwen3_5_moe as base
+
     mod = importlib.import_module("mlx_lm.models.qwen3_5_mtp")
-    # aliases to the vanilla MoE trunk module
-    assert mod is sys.modules["mlx_lm.models.qwen3_5_moe"]
+    # shim exposes the trunk classes; Model subclasses the vanilla MoE trunk but
+    # strips mtp.* in sanitize to avoid the double norm-shift
     assert hasattr(mod, "Model") and hasattr(mod, "ModelArgs")
+    assert issubclass(mod.Model, base.Model)
+    assert mod.ModelArgs is base.ModelArgs
 
 
 def test_strip_mtp_prefix():

--- a/tests/test_qwen3_5_mtp_backend.py
+++ b/tests/test_qwen3_5_mtp_backend.py
@@ -1,0 +1,54 @@
+"""Regression tests for the qwen3_5_mtp backend.
+
+Hermetic: covers config detection, the trunk-load shim, mtp.* key remapping,
+and arch registration. The full-checkpoint draft-acceptance contract is
+validated during hardware bring-up (see the module docstring), not here.
+"""
+import sys
+
+from mtplx.qwen3_5_mtp_patch import (
+    is_qwen3_5_mtp_config,
+    install_qwen3_5_mtp_trunk_shim,
+    _strip_mtp_prefix,
+)
+
+
+def test_config_detection_positive():
+    assert is_qwen3_5_mtp_config({"model_type": "qwen3_5_mtp", "num_nextn_predict_layers": 1})
+    # num_nextn nested under text_config is also honored
+    assert is_qwen3_5_mtp_config(
+        {"model_type": "qwen3_5_mtp", "text_config": {"num_nextn_predict_layers": 1}}
+    )
+
+
+def test_config_detection_negative():
+    # AR export (same trunk, different model_type) must NOT trigger the MTP path
+    assert not is_qwen3_5_mtp_config({"model_type": "qwen3_5_moe", "num_nextn_predict_layers": 1})
+    # MTP model_type but no predictor declared
+    assert not is_qwen3_5_mtp_config({"model_type": "qwen3_5_mtp", "num_nextn_predict_layers": 0})
+
+
+def test_trunk_shim_makes_model_type_importable():
+    install_qwen3_5_mtp_trunk_shim()
+    import importlib
+
+    mod = importlib.import_module("mlx_lm.models.qwen3_5_mtp")
+    # aliases to the vanilla MoE trunk module
+    assert mod is sys.modules["mlx_lm.models.qwen3_5_moe"]
+    assert hasattr(mod, "Model") and hasattr(mod, "ModelArgs")
+
+
+def test_strip_mtp_prefix():
+    assert _strip_mtp_prefix("mtp.fc.weight") == "fc.weight"
+    assert _strip_mtp_prefix("language_model.mtp.norm.weight") == "norm.weight"
+    assert _strip_mtp_prefix("model.mtp.layers.0.self_attn.q_proj.weight") == "layers.0.self_attn.q_proj.weight"
+    # trunk weights are not MTP keys
+    assert _strip_mtp_prefix("language_model.model.layers.0.self_attn.q_proj.weight") is None
+    assert _strip_mtp_prefix("lm_head.weight") is None
+
+
+def test_arch_registered():
+    from mtplx.backends.registry import SUPPORTED_ARCH_IDS
+
+    # qwen3_5_mtp routes through the existing qwen3-next-mtp arch/backend
+    assert "qwen3-next-mtp" in SUPPORTED_ARCH_IDS


### PR DESCRIPTION
## What

Adds the `hy_v3` (Tencent Hy3) native MTP backend — closes the `recognized-backend-pending` gap for `hy-v3-mtp` (#141).

- `mtplx/backends/hy_v3_mtp.py` — facade on the glm_mtp pattern (contract-gated load, health metadata, drafting via the shared sampler in `generation.py`)
- `mtplx/hy_v3_mtp_patch.py` — `is_hy_v3_mtp_config` + `inject_hy_v3_mtp_support`. hy_v3's mlx-lm MTP revision loads the head natively, so injection installs the runtime surface (`mtp_forward` / `mtp_update_cache` / `make_mtp_cache`, `return_hidden` on the trunk forward) as a subclass wrapper — **no weight rewriting**. Guards: raises clearly on AR-only exports; rejects non-`embedding_hidden` concat order and non-`pre_norm` hidden variants (Hy3's fixed semantics); depth 1 only.
- `mtplx/runtime.py` dispatch, import-smoke registration, registry upgrade to `experimental-native-contract-gated`, pending-markers test updated.

## Verification

- Applies on the `v2.0.1` tag; **`tests/test_artifacts.py` 76/76 pass** with the change.
- The full runtime surface (forward+hidden, draft with/without hidden, cache update, `make_mtp_cache`, guard rejections) exercised against a tiny randomly-initialized hy_v3 model — shapes and guards verified.

## What this deliberately does NOT claim

- **Not live-tested against the 295B checkpoint** — blocked on `hy_v3` reaching the pinned mlx-lm (ml-explore/mlx-lm#1211 + the MTP-surface follow-up). Draft PR until then.
- No runtime contract fixtures yet — I'll run `mtplx bench`/exactness on an M5 Max 128 GB against the real checkpoint as soon as the model loads, and post receipts here.

## Architecture facts encoded

One appended NextN layer (depth 1) with its own 192-expert MoE (sigmoid top-8 + expert bias); draft input `eh_proj(concat[enorm(embedding), hnorm(pre-final-norm hidden)])`; shared embeddings/head. Loader note for whenever the model class lands: MLX-converted checkpoints carry MTP weights in a `model-mtp.safetensors` sidecar named `mtp.*` (not `model.layers.80.*`).

Motivation measurement (why MTPLX's batched verify matters for this model): mlx-lm's per-token draft→verify loop runs Hy3 MTP at exact output parity but ~13.7× slower than AR (0.54 vs 7.4 tok/s warm, M5 Max). Receipts: https://github.com/PhilipJohnBasile/hy3-demolition-mlx
