### PR TITLE
Context-copy (prompt-lookup) drafting in the MTP decode loop: +39-74% on public code-edit suites, parity elsewhere

### DIFF
--- a/mtplx/context_copy.py
+++ b/mtplx/context_copy.py
@@ -1,6 +1,6 @@
 """Context-copy (prompt-lookup) speculative drafting for the MTP decode loop.
 
-Opt-in via MTPLX_CONTEXT_COPY=1. When the tail of (prompt + generated) tokens matches an
+Always on (kill switch: MTPLX_CONTEXT_COPY=0). When the tail of (prompt + generated) tokens matches an
 earlier n-gram, the continuation block is proposed verbatim (uncapped, K up to
 MTPLX_CONTEXT_COPY_K) and verified in one forward through the existing capture_commit
 verify path — no MTP-head compute for that round. When there is no match, the normal MTP
@@ -15,7 +15,9 @@ import os
 
 
 def context_copy_enabled() -> bool:
-    return (os.environ.get("MTPLX_CONTEXT_COPY") or "").strip() in {"1", "true", "on"}
+    """Context-copy is part of the engine (always on). MTPLX_CONTEXT_COPY=0 is an
+    emergency kill switch only; there is no opt-in flag."""
+    return (os.environ.get("MTPLX_CONTEXT_COPY") or "").strip() not in {"0", "false", "off"}
 
 
 def context_copy_block_k() -> int:
@@ -41,13 +43,23 @@ def context_copy_ng_max() -> int:
 
 def context_copy_min_ext() -> int:
     """Minimum backward match extension (beyond ng_min) required to fire a copy round.
-    Short, ng_min-only matches are common in novel generation (loops, boilerplate) and
-    have low acceptance — those rounds should stay with the MTP head. Default 2 =
-    require an (ng_min+2)-token suffix match before copying."""
+    Default 0: weak matches are allowed but propose only a SHORT block (see
+    block_for_ext), so a wrong incidental match wastes little."""
     try:
-        return max(0, int(os.environ.get("MTPLX_CONTEXT_COPY_MINEXT") or 2))
+        return max(0, int(os.environ.get("MTPLX_CONTEXT_COPY_MINEXT") or 0))
     except ValueError:
-        return 2
+        return 0
+
+
+# Confidence ladder: block length by backward match extension (0..ng_max-ng_min).
+# A longer suffix match earns a longer copy block; weak matches stay cheap.
+# Same schedule validated in the standalone prompt-lookup work (K_LADDER).
+_BLOCK_LADDER = (8, 12, 16, 24, 32)
+
+
+def block_for_ext(ext: int, k_cap: int) -> int:
+    idx = max(0, min(int(ext), len(_BLOCK_LADDER) - 1))
+    return min(_BLOCK_LADDER[idx], max(4, k_cap))
 
 
 class NgramIndex:

--- a/mtplx/context_copy.py
+++ b/mtplx/context_copy.py
@@ -1,0 +1,96 @@
+"""Context-copy (prompt-lookup) speculative drafting for the MTP decode loop.
+
+Opt-in via MTPLX_CONTEXT_COPY=1. When the tail of (prompt + generated) tokens matches an
+earlier n-gram, the continuation block is proposed verbatim (uncapped, K up to
+MTPLX_CONTEXT_COPY_K) and verified in one forward through the existing capture_commit
+verify path — no MTP-head compute for that round. When there is no match, the normal MTP
+round runs unchanged. Greedy (temperature<=0) only for now.
+
+Rationale: MTP heads draft novel tokens well (~2x ceiling at depth<=3) but cannot open a
+long verbatim window; on grounded/agentic workloads (code edits, file re-emission, RAG)
+most output already exists in context, where block-copy verification reaches 4-8x.
+The two mechanisms compose: copy when a match exists, MTP otherwise.
+"""
+import os
+
+
+def context_copy_enabled() -> bool:
+    return (os.environ.get("MTPLX_CONTEXT_COPY") or "").strip() in {"1", "true", "on"}
+
+
+def context_copy_block_k() -> int:
+    try:
+        return max(4, int(os.environ.get("MTPLX_CONTEXT_COPY_K") or 24))
+    except ValueError:
+        return 24
+
+
+def context_copy_ng_min() -> int:
+    try:
+        return max(2, int(os.environ.get("MTPLX_CONTEXT_COPY_NGMIN") or 6))
+    except ValueError:
+        return 6
+
+
+def context_copy_ng_max() -> int:
+    try:
+        return max(context_copy_ng_min(), int(os.environ.get("MTPLX_CONTEXT_COPY_NGMAX") or 10))
+    except ValueError:
+        return 10
+
+
+def context_copy_min_ext() -> int:
+    """Minimum backward match extension (beyond ng_min) required to fire a copy round.
+    Short, ng_min-only matches are common in novel generation (loops, boilerplate) and
+    have low acceptance — those rounds should stay with the MTP head. Default 2 =
+    require an (ng_min+2)-token suffix match before copying."""
+    try:
+        return max(0, int(os.environ.get("MTPLX_CONTEXT_COPY_MINEXT") or 2))
+    except ValueError:
+        return 2
+
+
+class NgramIndex:
+    """Incremental ng_min-gram index over the token history: gram -> continuation
+    positions. find() is O(candidates) instead of an O(L) backward scan, which
+    keeps the proposer off the CPU-bound path at 16-32K contexts."""
+
+    def __init__(self, ng_min: int, ng_max: int, max_candidates: int = 32):
+        self.ng_min = ng_min
+        self.ng_max = ng_max
+        self.max_candidates = max_candidates
+        self.grams: dict[tuple, list[int]] = {}
+        self.indexed = 0
+
+    def sync(self, history: list[int]) -> None:
+        """Index grams ending at positions (self.indexed, len(history)]."""
+        for e in range(max(self.indexed + 1, self.ng_min), len(history) + 1):
+            self.grams.setdefault(tuple(history[e - self.ng_min:e]), []).append(e)
+        self.indexed = len(history)
+
+    def find(self, history: list[int]):
+        """Best match: (continuation_pos, extension) or (None, -1). Extension =
+        how many tokens beyond ng_min the match runs backwards (0..ng_max-ng_min),
+        a free confidence signal (longer suffix match -> longer safe block)."""
+        L = len(history)
+        if L < self.ng_min + 1:
+            return None, -1
+        cands = self.grams.get(tuple(history[-self.ng_min:]))
+        if not cands:
+            return None, -1
+        best_pos, best_ext = None, -1
+        max_ext = self.ng_max - self.ng_min
+        for pos in reversed(cands[-self.max_candidates:]):
+            if pos >= L:                       # the trailing gram itself
+                continue
+            ext = 0                            # longest backward extension wins,
+            while (ext < max_ext               # most recent wins ties
+                   and pos - self.ng_min - 1 - ext >= 0
+                   and history[pos - self.ng_min - 1 - ext]
+                   == history[L - self.ng_min - 1 - ext]):
+                ext += 1
+            if ext > best_ext:
+                best_ext, best_pos = ext, pos
+                if ext == max_ext:
+                    break
+        return best_pos, best_ext

--- a/mtplx/context_copy.py
+++ b/mtplx/context_copy.py
@@ -1,22 +1,25 @@
 """Context-copy (prompt-lookup) speculative drafting for the MTP decode loop.
 
-Always on (kill switch: MTPLX_CONTEXT_COPY=0). When the tail of (prompt + generated) tokens matches an
-earlier n-gram, the continuation block is proposed verbatim (uncapped, K up to
-MTPLX_CONTEXT_COPY_K) and verified in one forward through the existing capture_commit
-verify path — no MTP-head compute for that round. When there is no match, the normal MTP
-round runs unchanged. Greedy (temperature<=0) only for now.
+Enabled by default; MTPLX_CONTEXT_COPY set to 0, false, or off disables it. When the
+tail of the generated stream matches an n-gram that occurs in the PROMPT, the prompt
+continuation is proposed verbatim as a block (up to MTPLX_CONTEXT_COPY_K tokens, with
+shorter blocks for weaker matches) and verified in one forward pass through the
+existing capture-commit verify path, so the MTP head is skipped for that cycle. When
+there is no match, the normal MTP round runs unchanged. Active only for greedy
+decoding (temperature <= 0) without repetition penalties; a temperature path via
+sample-and-match verification is a possible follow-up.
 
-Rationale: MTP heads draft novel tokens well (~2x ceiling at depth<=3) but cannot open a
-long verbatim window; on grounded/agentic workloads (code edits, file re-emission, RAG)
-most output already exists in context, where block-copy verification reaches 4-8x.
-The two mechanisms compose: copy when a match exists, MTP otherwise.
+Rationale: MTP heads draft novel tokens well but commit at most mtp_depth tokens per
+step, and they cannot open a long verbatim window. On grounded workloads (code edits,
+file re-emission, RAG) most of the output already exists in the prompt, where a copy
+block can commit far more per verify call (see the benchmarks in the pull request).
+The two mechanisms compose: copy when a prompt match exists, MTP otherwise.
 """
 import os
 
 
 def context_copy_enabled() -> bool:
-    """Context-copy is part of the engine (always on). MTPLX_CONTEXT_COPY=0 is an
-    emergency kill switch only; there is no opt-in flag."""
+    """Enabled by default. MTPLX_CONTEXT_COPY set to 0, false, or off disables it."""
     return (os.environ.get("MTPLX_CONTEXT_COPY") or "").strip() not in {"0", "false", "off"}
 
 
@@ -52,8 +55,8 @@ def context_copy_min_ext() -> int:
 
 
 # Confidence ladder: block length by backward match extension (0..ng_max-ng_min).
-# A longer suffix match earns a longer copy block; weak matches stay cheap.
-# Same schedule validated in the standalone prompt-lookup work (K_LADDER).
+# A longer suffix match earns a longer copy block, so a weak match only ever
+# risks a short, cheap verify while a strong match copies a full window.
 _BLOCK_LADDER = (8, 12, 16, 24, 32)
 
 
@@ -63,7 +66,7 @@ def block_for_ext(ext: int, k_cap: int) -> int:
 
 
 class NgramIndex:
-    """Incremental ng_min-gram index over the token history: gram -> continuation
+    """ng_min-gram index, built once over the prompt at setup: gram -> continuation
     positions. find() is O(candidates) instead of an O(L) backward scan, which
     keeps the proposer off the CPU-bound path at 16-32K contexts."""
 

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -6150,6 +6150,11 @@ def generate_mtpk(
     ccopy_min_ext = context_copy_min_ext()
     if ccopy_active:
         ccopy_index = NgramIndex(context_copy_ng_min(), context_copy_ng_max())
+        # Prompt-lookup semantics: the index covers the PROMPT only. Matches into
+        # the model's own generated text (self-repetition) have weak continuation
+        # predictiveness and sit below verify break-even (measured on math/boilerplate
+        # workloads); grounded re-emission always matches into the prompt.
+        ccopy_index.sync(prompt_ids)
     while len(tokens) < max_tokens:
         repetition_result = _trim_repeated_suffix(tokens, repetition_config)
         if repetition_result is not None:
@@ -6291,7 +6296,6 @@ def generate_mtpk(
         # ---- context-copy round: verbatim block from context, no MTP compute this cycle ----
         if ccopy_active and cycle_depth >= 1 and len(tokens) >= ccopy_suspend_until:
             _cc_hist = prompt_ids + tokens
-            ccopy_index.sync(_cc_hist)
             _cc_pos, _cc_ext = ccopy_index.find(_cc_hist)
             if _cc_pos is not None and _cc_ext >= ccopy_min_ext:
                 _cc_klen = block_for_ext(_cc_ext, ccopy_k)

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -6131,6 +6131,22 @@ def generate_mtpk(
             token_callback(new_tokens)
 
     step = 0
+    # ---- context-copy (prompt-lookup) drafting: opt-in, greedy, capture_commit only ----
+    from .context_copy import (NgramIndex, context_copy_block_k, context_copy_enabled,
+                               context_copy_min_ext, context_copy_ng_max,
+                               context_copy_ng_min)
+    ccopy_active = (
+        context_copy_enabled()
+        and sampler.temperature <= 0
+        and verify_strategy in {"capture_commit", "graphbank_capture_commit"}
+    )
+    ccopy_rounds = ccopy_drafted = ccopy_accepted = 0
+    ccopy_ema, ccopy_seen, ccopy_suspend_until = 0.5, 0, 0
+    ccopy_index = None
+    ccopy_k = context_copy_block_k()
+    ccopy_min_ext = context_copy_min_ext()
+    if ccopy_active:
+        ccopy_index = NgramIndex(context_copy_ng_min(), context_copy_ng_max())
     while len(tokens) < max_tokens:
         repetition_result = _trim_repeated_suffix(tokens, repetition_config)
         if repetition_result is not None:
@@ -6269,6 +6285,81 @@ def generate_mtpk(
         trace_current_mtp_cache = (
             mtp_cache if mtp_cache is not None else mtp_history_cache
         )
+        # ---- context-copy round: verbatim block from context, no MTP compute this cycle ----
+        if ccopy_active and cycle_depth >= 1 and len(tokens) >= ccopy_suspend_until:
+            _cc_hist = prompt_ids + tokens
+            ccopy_index.sync(_cc_hist)
+            _cc_pos, _cc_ext = ccopy_index.find(_cc_hist)
+            if _cc_pos is not None and _cc_ext >= ccopy_min_ext:
+                _cc_block = [int(t) for t in _cc_hist[_cc_pos:_cc_pos + ccopy_k]]
+                _cc_block = _cc_block[: max(1, max_tokens - len(tokens))]
+                _cc_T = 1 + len(_cc_block)
+                started_forward = time.perf_counter()
+                with attention_phase("decode_verify"):
+                    _cc_logits, _cc_hidden, _cc_captures = rt.forward_ar_capture(
+                        mx.array([[primary] + _cc_block]),
+                        cache=cache,
+                        return_hidden=True,
+                        hidden_variant=base_hidden_variant,
+                        capture_backend=verify_core_backend,
+                    )
+                _cc_g = [int(x) for x in mx.argmax(_cc_logits[0], axis=-1).tolist()]
+                elapsed_verify = time.perf_counter() - started_forward
+                verify_forward_time += elapsed_verify
+                verify_time += elapsed_verify
+                target_time += elapsed_verify
+                verify_calls += 1
+                _cc_nacc = 0
+                for _cc_d, _cc_t in zip(_cc_block, _cc_g):
+                    if _cc_d == _cc_t:
+                        _cc_nacc += 1
+                    else:
+                        break
+                _cc_m = _cc_nacc + 1
+                if _cc_nacc < len(_cc_block):
+                    from .gdn_capture import commit_captured_prefix
+                    started_commit = time.perf_counter()
+                    _cc_ok = commit_captured_prefix(
+                        cache, _cc_captures, keep_tokens=_cc_m, verified_tokens=_cc_T,
+                    )
+                    capture_commit_time += time.perf_counter() - started_commit
+                    if not _cc_ok:
+                        raise RuntimeError("context-copy: capture commit failed")
+                tokens.extend(_cc_block[:_cc_nacc])
+                ccopy_rounds += 1
+                ccopy_drafted += len(_cc_block)
+                ccopy_accepted += _cc_nacc
+                ccopy_ema = 0.7 * ccopy_ema + 0.3 * (_cc_nacc / len(_cc_block))
+                ccopy_seen += 1
+                if ccopy_seen >= 4 and ccopy_ema < 0.35:
+                    # acceptance collapsed (novel region with incidental repeats):
+                    # suspend copy rounds and let the MTP head work; retry later
+                    ccopy_suspend_until = len(tokens) + 64
+                    ccopy_ema, ccopy_seen = 0.5, 0
+                event["context_copy"] = {
+                    "block": len(_cc_block),
+                    "accepted": _cc_nacc,
+                    "extension": int(_cc_ext),
+                    "time_s": float(elapsed_verify),
+                }
+                if _mtp_history_uses_committed_cache(mtp_history_policy) and _cc_nacc > 0:
+                    _cc_committed_toks = [primary] + _cc_block[:_cc_nacc]
+                    draft_time += append_mtp_history(
+                        mtp_cache,
+                        _cc_hidden[:, : len(_cc_committed_toks) - 1, :],
+                        _cc_committed_toks[1:],
+                    )
+                logits = _cc_logits[:, _cc_m - 1, :]
+                hidden = _cc_hidden[:, _cc_m - 1:_cc_m, :]
+                events.append(event)
+                _cc_stop = next((i for i, t in enumerate(_cc_block[:_cc_nacc])
+                                 if _is_stop(int(t), stop_token_ids)), None)
+                if _cc_stop is not None:
+                    del tokens[len(tokens) - _cc_nacc + _cc_stop + 1:]
+                    break
+                emit_new_tokens()
+                step += 1
+                continue
         draft_hidden = hidden
         next_token = primary
 

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1566,6 +1566,21 @@ class GenerationStats:
     bonus_tokens: int = 0
     correction_tokens: int = 0
     verify_calls: int = 0
+    # Context-copy (prompt-lookup) drafting. Counters are cumulative per
+    # generation; the per-round detail stays in events. accepted_tokens counts
+    # verified matches (_cc_nacc), which can exceed emitted tokens when a stop
+    # token truncates the accepted block. suspended/backoff_tokens are gauges
+    # of the end-of-generation state, suspensions counts entries into backoff.
+    context_copy_active: bool = False
+    context_copy_probes: int = 0
+    context_copy_rounds: int = 0
+    context_copy_drafted_tokens: int = 0
+    context_copy_accepted_blocks: int = 0
+    context_copy_accepted_tokens: int = 0
+    context_copy_suspensions: int = 0
+    context_copy_suspended: bool = False
+    context_copy_backoff_tokens: int = 0
+    context_copy_disabled_reason: str | None = None
     graphbank: dict[str, object] = field(default_factory=dict)
     reject_path_counts: dict[str, int] = field(default_factory=dict)
     repair_time_by_reject_depth_s: dict[str, float] = field(default_factory=dict)
@@ -6144,6 +6159,8 @@ def generate_mtpk(
         and verify_strategy in {"capture_commit", "graphbank_capture_commit"}
     )
     ccopy_rounds = ccopy_drafted = ccopy_accepted = 0
+    ccopy_probes = ccopy_blocks_accepted = ccopy_suspensions = 0
+    ccopy_disabled_reason = None
     ccopy_ema, ccopy_seen, ccopy_suspend_until = 0.5, 0, 0
     ccopy_backoff = 64   # doubles on each suspension (self-repetitive novel text would
                          # otherwise re-trigger copy rounds after every backoff and pay
@@ -6299,6 +6316,7 @@ def generate_mtpk(
         # ---- context-copy round: verbatim block from context, no MTP compute this cycle ----
         if ccopy_active and cycle_depth >= 1 and len(tokens) >= ccopy_suspend_until:
             _cc_hist = prompt_ids + tokens
+            ccopy_probes += 1
             _cc_pos, _cc_ext = ccopy_index.find(_cc_hist)
             if _cc_pos is not None and _cc_ext >= ccopy_min_ext:
                 _cc_klen = block_for_ext(_cc_ext, ccopy_k)
@@ -6365,6 +6383,7 @@ def generate_mtpk(
                     logits = _cc_l2[:, -1, :]
                     hidden = _cc_h2[:, -1:, :]
                     ccopy_active = False
+                    ccopy_disabled_reason = "no_per_position_commit"
                     event["context_copy"] = {"disabled": "no_per_position_commit"}
                     append_event(event)
                     continue
@@ -6377,6 +6396,8 @@ def generate_mtpk(
                 ccopy_rounds += 1
                 ccopy_drafted += len(_cc_block)
                 ccopy_accepted += _cc_nacc
+                if _cc_nacc:
+                    ccopy_blocks_accepted += 1
                 ccopy_ema = 0.7 * ccopy_ema + 0.3 * (_cc_nacc / len(_cc_block))
                 ccopy_seen += 1
                 if _cc_nacc / len(_cc_block) >= 0.5:
@@ -6388,6 +6409,7 @@ def generate_mtpk(
                     ccopy_suspend_until = len(tokens) + ccopy_backoff
                     ccopy_backoff = min(ccopy_backoff * 2, 4096)
                     ccopy_ema, ccopy_seen = 0.5, 0
+                    ccopy_suspensions += 1
                 event["context_copy"] = {
                     "block": len(_cc_block),
                     "accepted": _cc_nacc,
@@ -7921,6 +7943,16 @@ def generate_mtpk(
         bonus_tokens=bonus_tokens,
         correction_tokens=correction_tokens,
         verify_calls=verify_calls,
+        context_copy_active=bool(ccopy_active),
+        context_copy_probes=ccopy_probes,
+        context_copy_rounds=ccopy_rounds,
+        context_copy_drafted_tokens=ccopy_drafted,
+        context_copy_accepted_blocks=ccopy_blocks_accepted,
+        context_copy_accepted_tokens=ccopy_accepted,
+        context_copy_suspensions=ccopy_suspensions,
+        context_copy_suspended=len(tokens) < ccopy_suspend_until,
+        context_copy_backoff_tokens=ccopy_backoff if ccopy_index is not None else 0,
+        context_copy_disabled_reason=ccopy_disabled_reason,
         graphbank={
             **(graphbank.to_dict() if graphbank is not None else {}),
             **(

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -6132,9 +6132,9 @@ def generate_mtpk(
 
     step = 0
     # ---- context-copy (prompt-lookup) drafting: opt-in, greedy, capture_commit only ----
-    from .context_copy import (NgramIndex, context_copy_block_k, context_copy_enabled,
-                               context_copy_min_ext, context_copy_ng_max,
-                               context_copy_ng_min)
+    from .context_copy import (NgramIndex, block_for_ext, context_copy_block_k,
+                               context_copy_enabled, context_copy_min_ext,
+                               context_copy_ng_max, context_copy_ng_min)
     ccopy_active = (
         context_copy_enabled()
         and sampler.temperature <= 0
@@ -6291,7 +6291,8 @@ def generate_mtpk(
             ccopy_index.sync(_cc_hist)
             _cc_pos, _cc_ext = ccopy_index.find(_cc_hist)
             if _cc_pos is not None and _cc_ext >= ccopy_min_ext:
-                _cc_block = [int(t) for t in _cc_hist[_cc_pos:_cc_pos + ccopy_k]]
+                _cc_klen = block_for_ext(_cc_ext, ccopy_k)
+                _cc_block = [int(t) for t in _cc_hist[_cc_pos:_cc_pos + _cc_klen]]
                 _cc_block = _cc_block[: max(1, max_tokens - len(tokens))]
                 _cc_T = 1 + len(_cc_block)
                 started_forward = time.perf_counter()

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -6131,13 +6131,16 @@ def generate_mtpk(
             token_callback(new_tokens)
 
     step = 0
-    # ---- context-copy (prompt-lookup) drafting: opt-in, greedy, capture_commit only ----
+    # ---- context-copy (prompt-lookup) drafting: always on (kill switch
+    # MTPLX_CONTEXT_COPY=0); greedy without repetition penalties, on
+    # capture-commit verify strategies ----
     from .context_copy import (NgramIndex, block_for_ext, context_copy_block_k,
                                context_copy_enabled, context_copy_min_ext,
                                context_copy_ng_max, context_copy_ng_min)
     ccopy_active = (
         context_copy_enabled()
         and sampler.temperature <= 0
+        and not _penalties_active
         and verify_strategy in {"capture_commit", "graphbank_capture_commit"}
     )
     ccopy_rounds = ccopy_drafted = ccopy_accepted = 0
@@ -6151,9 +6154,9 @@ def generate_mtpk(
     if ccopy_active:
         ccopy_index = NgramIndex(context_copy_ng_min(), context_copy_ng_max())
         # Prompt-lookup semantics: the index covers the PROMPT only. Matches into
-        # the model's own generated text (self-repetition) have weak continuation
-        # predictiveness and sit below verify break-even (measured on math/boilerplate
-        # workloads); grounded re-emission always matches into the prompt.
+        # the model's own generated text (self-repetition) tend to have weak
+        # continuation predictiveness and can cost more to verify than they commit,
+        # while grounded re-emission matches into the prompt (see the PR benchmarks).
         ccopy_index.sync(prompt_ids)
     while len(tokens) < max_tokens:
         repetition_result = _trim_repeated_suffix(tokens, repetition_config)
@@ -6302,6 +6305,11 @@ def generate_mtpk(
                 _cc_block = [int(t) for t in _cc_hist[_cc_pos:_cc_pos + _cc_klen]]
                 _cc_block = _cc_block[: max(1, max_tokens - len(tokens))]
                 _cc_T = 1 + len(_cc_block)
+                _cc_before = None
+                if not _env_truthy("MTPLX_SKIP_VERIFY_SNAPSHOT"):
+                    started = time.perf_counter()
+                    _cc_before = snapshot_untrimmable_cache(cache)
+                    snapshot_time += time.perf_counter() - started
                 started_forward = time.perf_counter()
                 with attention_phase("decode_verify"):
                     _cc_logits, _cc_hidden, _cc_captures = rt.forward_ar_capture(
@@ -6324,6 +6332,7 @@ def generate_mtpk(
                     else:
                         break
                 _cc_m = _cc_nacc + 1
+                _cc_ok = True
                 if _cc_nacc < len(_cc_block):
                     from .gdn_capture import commit_captured_prefix
                     started_commit = time.perf_counter()
@@ -6331,9 +6340,40 @@ def generate_mtpk(
                         cache, _cc_captures, keep_tokens=_cc_m, verified_tokens=_cc_T,
                     )
                     capture_commit_time += time.perf_counter() - started_commit
-                    if not _cc_ok:
-                        raise RuntimeError("context-copy: capture commit failed")
-                tokens.extend(_cc_block[:_cc_nacc])
+                if not _cc_ok:
+                    # This capture core cannot commit a per-position prefix (for
+                    # example final-state-only cores). Roll the whole block back,
+                    # restore the primary's logits, and stop proposing copies.
+                    if _cc_before is None:
+                        raise RuntimeError(
+                            "context-copy: capture commit failed and the verify "
+                            "snapshot was skipped (MTPLX_SKIP_VERIFY_SNAPSHOT=1)"
+                        )
+                    started_rollback = time.perf_counter()
+                    rollback_after_verify(cache, _cc_before, verified_tokens=_cc_T)
+                    rollback_time += time.perf_counter() - started_rollback
+                    started = time.perf_counter()
+                    with attention_phase("decode_verify"):
+                        _cc_l2, _cc_h2 = rt.forward_ar(
+                            mx.array([[primary]]),
+                            cache=cache,
+                            return_hidden=True,
+                            hidden_variant=base_hidden_variant,
+                        )
+                    _eval(_cc_l2, _cc_h2)
+                    repair_time += time.perf_counter() - started
+                    logits = _cc_l2[:, -1, :]
+                    hidden = _cc_h2[:, -1:, :]
+                    ccopy_active = False
+                    event["context_copy"] = {"disabled": "no_per_position_commit"}
+                    append_event(event)
+                    continue
+                _cc_acc = _cc_block[:_cc_nacc]
+                _cc_stop_idx = next((i for i, t in enumerate(_cc_acc)
+                                     if _is_stop(int(t), stop_token_ids)), None)
+                if _cc_stop_idx is not None:
+                    _cc_acc = _cc_acc[:_cc_stop_idx + 1]
+                tokens.extend(_cc_acc)
                 ccopy_rounds += 1
                 ccopy_drafted += len(_cc_block)
                 ccopy_accepted += _cc_nacc
@@ -6354,23 +6394,23 @@ def generate_mtpk(
                     "extension": int(_cc_ext),
                     "time_s": float(elapsed_verify),
                 }
-                if _mtp_history_uses_committed_cache(mtp_history_policy) and _cc_nacc > 0:
-                    _cc_committed_toks = [primary] + _cc_block[:_cc_nacc]
+                # Committed-history MTP caches pair every committed token with the
+                # hidden state of the token before it, including (previous hidden,
+                # primary), which the drafting path would normally have added.
+                if _mtp_history_uses_committed_cache(mtp_history_policy) and mtp_cache is not None:
+                    _cc_committed_toks = [primary] + _cc_acc
+                    _cc_hiddens = mx.concatenate(
+                        [hidden, _cc_hidden[:, : len(_cc_acc), :]], axis=1
+                    )
                     draft_time += append_mtp_history(
-                        mtp_cache,
-                        _cc_hidden[:, : len(_cc_committed_toks) - 1, :],
-                        _cc_committed_toks[1:],
+                        mtp_cache, _cc_hiddens, _cc_committed_toks
                     )
                 logits = _cc_logits[:, _cc_m - 1, :]
                 hidden = _cc_hidden[:, _cc_m - 1:_cc_m, :]
-                events.append(event)
-                _cc_stop = next((i for i, t in enumerate(_cc_block[:_cc_nacc])
-                                 if _is_stop(int(t), stop_token_ids)), None)
-                if _cc_stop is not None:
-                    del tokens[len(tokens) - _cc_nacc + _cc_stop + 1:]
-                    break
+                append_event(event)
                 emit_new_tokens()
-                step += 1
+                if _cc_stop_idx is not None:
+                    break
                 continue
         draft_hidden = hidden
         next_token = primary

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -6142,6 +6142,9 @@ def generate_mtpk(
     )
     ccopy_rounds = ccopy_drafted = ccopy_accepted = 0
     ccopy_ema, ccopy_seen, ccopy_suspend_until = 0.5, 0, 0
+    ccopy_backoff = 64   # doubles on each suspension (self-repetitive novel text would
+                         # otherwise re-trigger copy rounds after every backoff and pay
+                         # the probe cost recurrently); a paying round resets it.
     ccopy_index = None
     ccopy_k = context_copy_block_k()
     ccopy_min_ext = context_copy_min_ext()
@@ -6332,10 +6335,14 @@ def generate_mtpk(
                 ccopy_accepted += _cc_nacc
                 ccopy_ema = 0.7 * ccopy_ema + 0.3 * (_cc_nacc / len(_cc_block))
                 ccopy_seen += 1
+                if _cc_nacc / len(_cc_block) >= 0.5:
+                    ccopy_backoff = 64          # copy is paying again: full retry rate
                 if ccopy_seen >= 4 and ccopy_ema < 0.35:
                     # acceptance collapsed (novel region with incidental repeats):
-                    # suspend copy rounds and let the MTP head work; retry later
-                    ccopy_suspend_until = len(tokens) + 64
+                    # suspend copy rounds and let the MTP head work; retry with
+                    # exponential backoff so recurring probes stay cheap
+                    ccopy_suspend_until = len(tokens) + ccopy_backoff
+                    ccopy_backoff = min(ccopy_backoff * 2, 4096)
                     ccopy_ema, ccopy_seen = 0.5, 0
                 event["context_copy"] = {
                     "block": len(_cc_block),

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -12761,6 +12761,18 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "mean_accept_probability_by_depth",
     "correction_tokens",
     "bonus_tokens",
+    # Context-copy (prompt-lookup) drafting counters. Cumulative per
+    # generation; suspended/backoff_tokens are end-of-generation gauges.
+    "context_copy_active",
+    "context_copy_probes",
+    "context_copy_rounds",
+    "context_copy_drafted_tokens",
+    "context_copy_accepted_blocks",
+    "context_copy_accepted_tokens",
+    "context_copy_suspensions",
+    "context_copy_suspended",
+    "context_copy_backoff_tokens",
+    "context_copy_disabled_reason",
     "verify_time_s",
     "draft_time_s",
     "accept_time_s",

--- a/tests/test_context_copy_stats.py
+++ b/tests/test_context_copy_stats.py
@@ -1,0 +1,249 @@
+"""Context-copy GenerationStats counters: probes, rounds, accepted blocks/tokens,
+suspend/backoff state, public-envelope exposure (#151 follow-up).
+
+Deterministic next-token stub models drive generate_mtpk on CPU:
+- a mod-VOCAB cycle whose prompt continuation always agrees with the model
+  (full-accept copy rounds),
+- a non-repeating ramp whose tail never matches a prompt gram (probe misses),
+- a "trap" cycle whose prompt continuation always disagrees (zero-acceptance
+  rounds driving the EMA into suspension + exponential backoff).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+
+from mtplx.generation import GenerationStats, generate_mtpk
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+from mtplx.sampling import SamplerConfig
+
+
+class _Tokenizer:
+    def decode(self, tokens, **_kwargs):
+        return "".join(f"<{int(token)}>" for token in tokens)
+
+
+class _ScriptedModel:
+    """Deterministic automaton: after token t the model wants next_map(t)."""
+
+    def __init__(self, vocab: int, next_map):
+        self.vocab = vocab
+        self.next_map = next_map
+        self.mtp = SimpleNamespace(_mtplx_lora_targets=[])
+
+    def make_cache(self):
+        return []
+
+    def make_mtp_cache(self):
+        return []
+
+    def mtp_update_cache(self, hidden_states, next_token_ids, **_kwargs):
+        return hidden_states
+
+    def _logits_for(self, last_tokens: list[int]) -> mx.array:
+        rows = []
+        for token in last_tokens:
+            row = [0.0] * self.vocab
+            row[self.next_map(int(token)) % self.vocab] = 10.0
+            rows.append(row)
+        return mx.array([rows], dtype=mx.float32)
+
+    def __call__(
+        self,
+        input_ids,
+        *,
+        cache=None,
+        return_hidden: bool = False,
+        hidden_variant: str | None = None,
+        emit_logits: bool = True,
+        logits_keep: int | None = None,
+    ):
+        tokens = [int(token) for token in np.asarray(input_ids).reshape(-1)]
+        keep = len(tokens) if logits_keep is None else min(len(tokens), max(1, int(logits_keep)))
+        logits = self._logits_for(tokens[-keep:]) if emit_logits else None
+        hidden = mx.zeros((1, len(tokens), 2), dtype=mx.float32)
+        if not emit_logits:
+            return (None, hidden) if return_hidden else None
+        if return_hidden:
+            return logits, hidden
+        return logits
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        *,
+        mtp_cache=None,
+        concat_order=None,
+        return_hidden: bool = False,
+        mtp_hidden_variant: str | None = None,
+        position_offset=None,
+    ):
+        tokens = [int(token) for token in np.asarray(next_token_ids).reshape(-1)]
+        logits = self._logits_for(tokens)
+        hidden = mx.zeros((1, len(tokens), 2), dtype=mx.float32)
+        if return_hidden:
+            return logits, hidden
+        return logits
+
+
+def _runtime(model: _ScriptedModel) -> MTPLXRuntime:
+    return MTPLXRuntime(
+        model=model,
+        tokenizer=_Tokenizer(),
+        model_path=Path("tiny-copy"),
+        mtp_enabled=True,
+        contract=MTPContract(),
+    )
+
+
+def _mtpk(model: _ScriptedModel, prompt: list[int], max_tokens: int):
+    return generate_mtpk(
+        _runtime(model),
+        prompt,
+        max_tokens=max_tokens,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        speculative_depth=1,
+        seed=0,
+        stop_token_ids=set(),
+        verify_strategy="capture_commit",
+    )
+
+
+def _clean_env(monkeypatch) -> None:
+    for name in (
+        "MTPLX_CONTEXT_COPY",
+        "MTPLX_CONTEXT_COPY_K",
+        "MTPLX_CONTEXT_COPY_NGMIN",
+        "MTPLX_CONTEXT_COPY_NGMAX",
+        "MTPLX_CONTEXT_COPY_MINEXT",
+        "MTPLX_SKIP_VERIFY_SNAPSHOT",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- full-accept copy rounds (mod-8 cycle, prompt continuation agrees) ---
+
+
+def test_full_accept_rounds_count_probes_rounds_blocks_tokens(monkeypatch):
+    _clean_env(monkeypatch)
+    out = _mtpk(_ScriptedModel(8, lambda t: t + 1), [0, 1, 2, 3, 4, 5, 6, 7, 0], max_tokens=80)
+    stats = out.stats
+    assert stats.context_copy_active is True
+    assert stats.context_copy_disabled_reason is None
+    assert stats.context_copy_rounds >= 2
+    # Early cycles probe before the generated tail re-enters a prompt gram.
+    assert stats.context_copy_probes > stats.context_copy_rounds
+    # The prompt continuation is exactly what the model wants: every proposed
+    # block verifies in full.
+    assert stats.context_copy_accepted_blocks == stats.context_copy_rounds
+    assert stats.context_copy_drafted_tokens == stats.context_copy_accepted_tokens
+    assert stats.context_copy_accepted_tokens > 0
+    assert stats.context_copy_suspensions == 0
+    assert stats.context_copy_suspended is False
+    assert stats.context_copy_backoff_tokens == 64
+
+
+def test_kill_switch_disables_and_output_is_byte_identical(monkeypatch):
+    _clean_env(monkeypatch)
+    on = _mtpk(_ScriptedModel(8, lambda t: t + 1), [0, 1, 2, 3, 4, 5, 6, 7, 0], max_tokens=80)
+    monkeypatch.setenv("MTPLX_CONTEXT_COPY", "0")
+    off = _mtpk(_ScriptedModel(8, lambda t: t + 1), [0, 1, 2, 3, 4, 5, 6, 7, 0], max_tokens=80)
+    assert off.stats.context_copy_active is False
+    assert off.stats.context_copy_probes == 0
+    assert off.stats.context_copy_rounds == 0
+    assert off.stats.context_copy_backoff_tokens == 0
+    assert list(on.tokens) == list(off.tokens)
+
+
+# --- probe misses (non-repeating ramp, tail never matches a prompt gram) ---
+
+
+def test_probe_misses_count_probes_but_no_rounds(monkeypatch):
+    _clean_env(monkeypatch)
+    out = _mtpk(_ScriptedModel(64, lambda t: t + 1), [0, 1, 2, 3, 4, 5], max_tokens=40)
+    stats = out.stats
+    assert stats.context_copy_active is True
+    assert stats.context_copy_probes > 0
+    assert stats.context_copy_rounds == 0
+    assert stats.context_copy_drafted_tokens == 0
+    assert stats.context_copy_accepted_blocks == 0
+    assert stats.context_copy_accepted_tokens == 0
+    assert stats.context_copy_suspensions == 0
+
+
+# --- zero-acceptance rounds -> suspension with exponential backoff ---
+
+
+def _trap_next(t: int) -> int:
+    # Cycle 10..15; every token outside the cycle re-enters it at 10. The
+    # prompt continuation after the (10..15) gram is 99, which the model
+    # never produces, so every copy round verifies 0 tokens.
+    if 10 <= t < 15:
+        return t + 1
+    return 10
+
+
+def test_zero_acceptance_rounds_drive_suspension_and_backoff(monkeypatch):
+    _clean_env(monkeypatch)
+    # Every rotation of the 10..15 cycle appears in the prompt, each followed
+    # by a token the model never produces: whatever the generated tail's
+    # alignment, the probe finds a match and the copy block verifies 0 tokens.
+    cycle = [10, 11, 12, 13, 14, 15]
+    prompt = []
+    for i in range(6):
+        prompt += cycle[i:] + cycle[:i] + [99 - i]
+    out = _mtpk(_ScriptedModel(128, _trap_next), prompt, max_tokens=200)
+    stats = out.stats
+    assert stats.context_copy_active is True
+    assert stats.context_copy_rounds >= 4
+    assert stats.context_copy_drafted_tokens > 0
+    assert stats.context_copy_accepted_blocks == 0
+    assert stats.context_copy_accepted_tokens == 0
+    assert stats.context_copy_suspensions >= 1
+    # Each suspension doubles the retry backoff from its 64-token floor.
+    assert stats.context_copy_backoff_tokens >= 128
+
+
+# --- defaults + public envelope exposure ---
+
+
+def test_generation_stats_defaults_serialize_context_copy_fields():
+    stats = GenerationStats(mode="ar", generated_tokens=0, elapsed_s=0.0, tok_s=0.0)
+    payload = stats.to_dict()
+    assert payload["context_copy_active"] is False
+    assert payload["context_copy_probes"] == 0
+    assert payload["context_copy_rounds"] == 0
+    assert payload["context_copy_drafted_tokens"] == 0
+    assert payload["context_copy_accepted_blocks"] == 0
+    assert payload["context_copy_accepted_tokens"] == 0
+    assert payload["context_copy_suspensions"] == 0
+    assert payload["context_copy_suspended"] is False
+    assert payload["context_copy_backoff_tokens"] == 0
+    assert payload["context_copy_disabled_reason"] is None
+
+
+def test_public_mtplx_stats_expose_context_copy_counters():
+    from mtplx.server.openai import PUBLIC_MTPLX_STATS_KEYS, _public_mtplx_stats
+
+    keys = {
+        "context_copy_active",
+        "context_copy_probes",
+        "context_copy_rounds",
+        "context_copy_drafted_tokens",
+        "context_copy_accepted_blocks",
+        "context_copy_accepted_tokens",
+        "context_copy_suspensions",
+        "context_copy_suspended",
+        "context_copy_backoff_tokens",
+        "context_copy_disabled_reason",
+    }
+    assert keys <= set(PUBLIC_MTPLX_STATS_KEYS)
+    generated = {"stats": {key: 1 for key in keys}}
+    public = _public_mtplx_stats(generated)
+    assert keys <= set(public)


### PR DESCRIPTION
Up front, full disclosure: I am not a professional ML engineer, this was built with heavy AI assistance, and my hardware is limited (M5 Pro, 48 GB). Every number below is a real measured run on that machine, the whole thing reproduces from the included scripts, and I would genuinely welcome scrutiny, especially on better hardware.

## What this adds

Context-copy drafting inside `generate_mtpk`. When the tail of the generated stream matches an n-gram from the prompt, the continuation block (8 to 24 tokens, length scaled by match confidence) is proposed verbatim and verified in one forward pass through the existing `capture_commit` path, so the MTP head is skipped for that cycle. When there is no match, the normal MTP round runs unchanged.

The idea composes with what MTPLX already does rather than replacing it. The MTP head is strong on novel tokens, but it is capped at `mtp_depth` drafted tokens per step. On grounded work (code edits, file re-emission, RAG style answers) most of the output already exists verbatim in the prompt, and a copy window can commit far more than 3 tokens per verify. Matching is restricted to the prompt only, which is the original prompt-lookup semantics: matches into the model's own generated text (self-repeating math or boilerplate) sit below verify break-even and are exactly the cases that used to cause regressions in earlier iterations of this branch.

It is always on. There is no opt-in flag, only an emergency kill switch (`MTPLX_CONTEXT_COPY=0`). Greedy and `capture_commit`/`graphbank_capture_commit` only for now. Safety nets: an acceptance EMA that suspends probing when it stops paying, with exponential backoff, plus a confidence ladder so weak matches only ever risk a short block.

## Benchmarks, master vs this branch

Qwen3.6-27B-MTPLX-Optimized-Speed, M5 Pro 48 GB, `mtplx tune`, D3, greedy, seed 0. Arms were run interleaved per suite (master then fork, back to back) because I found that sustained runs throttle P-cores and skew Python-heavy decode paths by about 5% while leaving AR untouched, so non-paired A/B tables lie on this machine.

| suite | n | master D3 tok/s | this branch | ratio | identical output |
|---|---|---|---|---|---|
| CanItEdit (public, code edits) | 25 | 36.9 | 64.3 | 1.74x | 19/25 |
| HumanEvalFix (public, bug fixes) | 25 | 38.0 | 52.8 | 1.39x | 25/25 |
| Spec-Bench sample (public, NLP mix) | 26 | 30.6 | 30.2 | 0.99x | 23/26 |
| Aider polyglot implement (public) | 10 | 33.4 | 33.7 | 1.01x | 5/10 |
| default (yours) | 6 | 29.8 | 29.8 | 1.00x | 5/6 |
| long_code @1024 (yours) | 1 | 33.8 | 33.8 | 1.00x | 1/1 |
| long_code_uncapped @1024 (yours) | 1 | 34.3 | 34.3 | 1.00x | 1/1 |
| calibration_coding (yours) | 24 | 31.3 | 31.5 | 1.01x | 19/24 |
| python_modules_long @1024 (yours) | 1 | 34.8 | 34.5 | 0.99x | 0/1 |
| flappy @1024 (yours) | 1 | 30.3 | 30.3 | 1.00x | 1/1 |
| AIME 2026 (math reasoning) | 30 | 33.4 | 32.5 | 0.97x | 20/30 |

In short: +39% to +74% on public code-editing suites, and parity (0.97x to 1.01x) everywhere else, including every suite that ships with this repo. AR is untouched in both arms (17.4 to 17.8 tok/s). One config for the whole table, nothing tuned per suite.

## Correctness

The verify commits only the target's own argmax tokens, the same bar as your greedy gate. On the code-edit suites the output is byte-identical to master in 44 of 50 rows, and I teacher-forced every single non-identical row across the whole table: each one diverges at a verified near-tie (top1 minus top2 logit gap below the 0.8 envelope I measured for M5 GEMM vs GEMV paths, several are exact 0.000 ties). These are the same coin flips plain decode shows against itself at different prefill chunkings. Your full pytest suite is green with the feature on and off.

## What I would love from reviewers

1. Independent validation on bigger hardware and longer contexts. My M5 Pro cannot reach M5 Max or 128k territory, and these numbers deserve checking by someone who can.
2. Whether you want a proper temperature path (sample-and-match over the block) in this PR or as a follow-up.
3. Where copy stats should live. Right now they are in the per-round events; I did not touch `GenerationStats`.

While benchmarking I also ran into two things unrelated to this change: the 4B speed-test checkpoints collapse to 0 draft acceptance on M5 Pro at every depth, and `tune` under GPU contention once persisted a winning depth whose measured acceptance was 0.0, which later collapse verdicts never cleared from the saved state. I have full evidence for both and I am happy to file them as separate issues if useful.


---

Update, 18 July: rebased on 2.1.0 (clean) after the cache release, full suite
green, and a quick interleaved A/B on the 27B confirms the copy path is
undisturbed: byte-identical output with copy on and off, 31.9 to 38.6 tok/s
decode on the re-emission probe. The copy stats now live in GenerationStats
as requested in review (01534a1), so ask 3 above is settled, and the two side
observations at the bottom are filed as #176 and #177. Temperature stays a
follow-up PR as agreed. Benchmarks in the table above were measured against
the pre-2.1.0 master; the mechanism is unchanged by the rebase.
