### PR TITLE
Implement bounded SSD-streamed MoE runtime for Hy3 and GLM-5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,35 @@ This is not enabled by default and has not yet earned a full-checkpoint performa
 DEBUG=0 uv pip install -e native_extensions/expert_io
 
 # Build and verify an exact manifest; an aligned sidecar is optional
-python scripts/build_expert_manifest.py /path/to/model --model hy3-q4
-python scripts/verify_expert_manifest.py /path/to/model /path/to/model/expert-manifest.json
+uv run python scripts/build_expert_manifest.py /path/to/model --model hy3-q4
+uv run python scripts/verify_expert_manifest.py /path/to/model /path/to/model/expert-manifest.json
 
 # The total threshold includes resident weights, KV reservation, slots, and reserve.
 mtplx serve --model /path/to/model \
   --expert-streaming \
   --expert-manifest /path/to/model/expert-manifest.json \
   --expert-memory-limit 96GiB \
+  --expert-max-live-kv-tokens 32768
+```
+
+For a 128 GB Mac, this is the conservative starting profile for the pinned
+GLM-5.2 affine-Q4 checkpoint. The 104 GiB ceiling leaves system headroom while
+reserving 16 GiB inside the runtime plan; MTP is disabled automatically because
+the checkpoint does not contain its declared MTP layer.
+
+```bash
+MODEL=/path/to/mlx-community/GLM-5.2-4bit
+
+uv run python scripts/build_expert_manifest.py "$MODEL" --model glm52-q4
+uv run python scripts/verify_expert_manifest.py \
+  "$MODEL" "$MODEL/expert-manifest.json" --records
+
+uv run mtplx serve --model "$MODEL" \
+  --expert-streaming \
+  --expert-model-key glm52-q4 \
+  --expert-manifest "$MODEL/expert-manifest.json" \
+  --expert-memory-limit 104GiB \
+  --expert-runtime-reserve 16GiB \
   --expert-max-live-kv-tokens 32768
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ Forge takes a Hugging Face repo and turns it into an MTPLX-ready MTP model: conv
 
 The official catalog lives on Hugging Face under [Youssofal](https://huggingface.co/Youssofal): Qwen 3.5 (4B, 9B), Qwen 3.6 (27B, 35B MoE) in speed, balance, and quality builds, plus Gemma 4. The app recommends from these based on your hardware.
 
+## Experimental SSD-streamed MoE
+
+The `codex/moe-ssd-hy3-glm52` branch contains an opt-in autoregressive path for the pinned `pipenetwork/Hy3-4bit` and `mlx-community/GLM-5.2-4bit` artifacts. It keeps attention, shared experts, and each router resident; the router runs first at every sparse layer, and only its selected Q4 experts are read into a user-bounded hot slot bank. Fixed MLX/Metal byte banks are filled in place with positional reads, so routed expert tensors are never instantiated as a full parameter tree.
+
+This is not enabled by default and has not yet earned a full-checkpoint performance claim. Tiny end-to-end model fixtures, failure injection, exact artifact-layout audits, GLM FP32 near-tie routing, and IndexShare tests pass. The 166 GB Hy3 and 418 GB GLM Q4 checkpoints still require hardware parity and sustained benchmark runs using the included gates.
+
+```bash
+# Optional native GIL-free positional reader
+DEBUG=0 uv pip install -e native_extensions/expert_io
+
+# Build and verify an exact manifest; an aligned sidecar is optional
+python scripts/build_expert_manifest.py /path/to/model --model hy3-q4
+python scripts/verify_expert_manifest.py /path/to/model /path/to/model/expert-manifest.json
+
+# The total threshold includes resident weights, KV reservation, slots, and reserve.
+mtplx serve --model /path/to/model \
+  --expert-streaming \
+  --expert-manifest /path/to/model/expert-manifest.json \
+  --expert-memory-limit 96GiB \
+  --expert-max-live-kv-tokens 32768
+```
+
+These two community Q4 artifacts omit their declared MTP layers, so streamed loading intentionally selects target-only AR and rejects MTP adapters. See [the implementation and validation guide](docs/MOE_SSD_STREAMING_PLAN.md) for pinned revisions, GLM IndexShare details, sidecar packaging, memory planning, parity, and benchmark commands.
+
 ## The server
 
 `mtplx start` (or the app's play button) serves an OpenAI-compatible API on `127.0.0.1:8000`: `/v1/chat/completions`, `/v1/completions`, `/v1/models`, plus an Anthropic-compatible `/v1/messages` with streaming, tool calls in both styles, `/health`, and `/metrics`. Claude Code, Cline, Continue, Open WebUI, curl, the openai and anthropic Python clients: if it speaks the API, it works. The app and CLI share one server, so `mtplx start` attaches to the app's running model instead of loading a second copy.

--- a/docs/GLM52_Q4_SSD_EXPERT_STREAMING.md
+++ b/docs/GLM52_Q4_SSD_EXPERT_STREAMING.md
@@ -1,0 +1,319 @@
+# GLM-5.2 Q4 SSD expert streaming
+
+Status: pinned layout and implementation design. Native selective loading and
+slot-backed MLX/Metal execution are not implemented in this branch.
+
+This document specializes the shared design in
+[`MOE_SSD_STREAMING_PLAN.md`](MOE_SSD_STREAMING_PLAN.md) for
+`mlx-community/GLM-5.2-4bit`.
+
+## Target and artifact contract
+
+Pinned sources used for the design:
+
+- Official model: `zai-org/GLM-5.2`, revision
+  `b4734de4facf877f85769a911abafc5283eab3d9`.
+- Official GLM implementation/documentation: `zai-org/GLM-5`, revision
+  `431634c155dab6cc2e30535c6eaa26c01caac675`.
+- Q4 target: `mlx-community/GLM-5.2-4bit`, revision
+  `6b347a6472d46bf55de65ee34032136a3929d778`.
+
+The Q4 artifact contains 91 safetensors shards, 3,481 tensors, and
+418,320,895,488 tensor bytes (389.5917 GiB). Its index ends at transformer
+layer 77. Although the config declares one next-token-prediction layer, the Q4
+artifact contains no layer-78 MTP tensors; it is an autoregressive target.
+
+Do not let an absent layer 78 trigger a generic all-shard fallback. The loader
+must identify this artifact as AR-only and either continue in explicit AR mode
+or fail an explicit MTP request before loading routed tensors.
+
+## Exact sparse layout
+
+GLM-5.2 has 78 target layers:
+
+- Layers 0-2 use dense MLPs.
+- Layers 3-77 are 75 sparse MoE layers.
+- Hidden size is 6,144.
+- Expert intermediate size is 2,048.
+- Every sparse layer has 256 routed experts and selects exactly eight.
+- Every sparse layer also has one shared expert, which remains resident.
+
+One affine Q4/group-64 routed expert consists of gate, up, and down
+projections. The inspected MLX tensor layouts are:
+
+```text
+gate/up packed weights: [256, 2048, 768] uint32
+gate/up scales+biases:  [256, 2048,  96] bfloat16
+down packed weights:    [256, 6144, 256] uint32
+down scales+biases:     [256, 6144,  32] bfloat16
+```
+
+For one expert, each projection represents `6144 * 2048` source parameters.
+Packed weights plus BF16 scale and affine-bias metadata give:
+
+```text
+one projection =  7,077,888 bytes =  6.75 MiB
+one expert     = 21,233,664 bytes = 20.25 MiB
+```
+
+The record is exactly 1,296 blocks of 16 KiB, which is convenient for an
+aligned expert-major sidecar. Alignment does not remove the requirement to
+validate each component's offset, length, shape, dtype, and hash.
+
+Across `75 * 256` experts, routed records occupy:
+
+```text
+407,686,348,800 bytes = 379.6875 GiB
+```
+
+All non-routed Q4 artifact tensors total:
+
+```text
+10,634,546,688 bytes = 9.904193 GiB
+```
+
+That resident figure includes attention, shared experts, embeddings, dense
+layers, routers, norms, and output tensors. It does not include growing KV
+state, runtime/OS headroom, or expert slot buffers.
+
+## Router-first execution
+
+At sparse layer `n`, the resident attention path produces the hidden state,
+then the resident MoE gate selects experts. Only after those ids are known does
+the runtime resolve or load the selected records and execute their MLPs.
+
+```text
+hidden_n
+  -> resident attention/DSA
+  -> resident MoE router -> ids[8], weights[8]
+  -> lookup (n, id) in fixed expert bank
+  -> pread missing records into bounded slots
+  -> gate/up -> activation -> down
+  -> weighted sum + resident shared expert + residual
+  -> hidden_(n+1)
+```
+
+It is not possible to run all 75 MoE routers at token start. Router `n + 1`
+needs `hidden_(n+1)`, which includes the result of the experts selected at
+layer `n`. Safe overlap begins only after the current layer's ids are known:
+reads for multiple misses, execution of hot hits, and shared-expert compute can
+overlap if their final weighted combine preserves reference semantics.
+
+## Routing must be FP32-exact
+
+The official GLM-5.2 configuration requires FP32 router math. The behavioral
+oracle is the official/merged `modeling_glm_moe_dsa.py` implementation. For
+each sparse layer, the adapter must preserve this ordering:
+
+1. Project the hidden state with the router in FP32.
+2. Apply sigmoid to produce unbiased expert scores.
+3. Add the FP32 expert correction bias for selection only.
+4. Select top eight using the corrected scores.
+5. Gather the original, unbiased sigmoid scores at those ids.
+6. Normalize the eight gathered weights.
+7. Multiply by the routed scaling factor (`2.5`).
+
+The Q4 conversion stores each gate weight as BF16 `[256, 6144]` and its
+correction bias as FP32 `[256]`. The 75 gates and correction biases total
+236,006,400 bytes (225.073 MiB), so keeping them resident is inexpensive
+relative to the 379.6875 GiB expert corpus.
+
+The inspected Q4 config predates the explicit `moe_router_dtype` field, and a
+BF16 matmul followed by an FP32 sigmoid is not equivalent to an FP32 router
+projection. The GLM adapter must force the official behavior and prove exact
+top-8 parity before streamed expert execution. A one-id difference is a model
+execution difference, not a tolerable numeric approximation.
+
+## DSA IndexShare is a separate selector
+
+GLM-5.2 also uses a DSA attention indexer to select historical token positions.
+It must not be confused with the MoE expert router:
+
+| Selector | Selects | Cache effect |
+| --- | --- | --- |
+| DSA indexer | Historical KV/token positions | Controls sparse attention; remains resident |
+| MoE router | Eight feed-forward experts | Drives SSD expert record lookup |
+
+The correct IndexShare schedule has 21 full indexer layers:
+
+```text
+0, 1, 2, 6, 10, 14, 18, 22, 26, 30, 34,
+38, 42, 46, 50, 54, 58, 62, 66, 70, 74
+```
+
+The remaining 57 layers reuse indices from the preceding full layer. The
+streaming branch must first vendor or land an IndexShare-correct GLM-5.2 model
+adapter; stock model construction that creates a new indexer at every layer
+will request nonexistent parameters and cannot serve as the reference.
+
+Exact BF16 MLA+DSA cache storage is about 95,232 bytes per token across the
+target model. Planning examples are:
+
+| Context | KV/DSA cache |
+| ---: | ---: |
+| 32K | about 2.906 GiB |
+| 64K | about 5.813 GiB |
+| 128K | about 11.625 GiB |
+| 256K | about 23.25 GiB |
+| 1M | about 93 GiB |
+
+These bytes must be reserved before allocating persistent experts. Correctness
+tests must cross the 2K and 4K regions; short prompts do not exercise the
+failure modes reported around incomplete DSA/IndexShare implementations.
+
+## Memory-budget examples
+
+One fully cold token selects `75 * 8 = 600` expert records:
+
+```text
+600 * 20.25 MiB = 12,150 MiB = 11.865234 GiB/token
+```
+
+At an effective 5.5 GiB/s SSD-to-slot rate, the cold I/O ceiling is only about
+0.46 token/s before compute. A 90% record hit rate reduces reads to about
+1.1865 GiB/token and gives a theoretical I/O ceiling near 4.6 tokens/s. These
+are ceilings, not throughput claims.
+
+Equal persistent capacity across all 75 sparse layers costs:
+
+| Slots/layer | Persistent expert bytes | Capacity fraction/layer |
+| ---: | ---: | ---: |
+| 8 | 11.8652 GiB | 3.125% |
+| 16 | 23.7305 GiB | 6.25% |
+| 32 | 47.4609 GiB | 12.5% |
+| 48 | 71.1914 GiB | 18.75% |
+| 64 | 94.9219 GiB | 25% |
+| 96 | 142.3828 GiB | 37.5% |
+| 128 | 189.8438 GiB | 50% |
+
+Top-8 single-token transient scratch needs only eight records globally:
+
+```text
+8 * 20.25 MiB = 162 MiB
+```
+
+It is global because layers execute sequentially. The persistent allocation is
+per layer because expert 17 in layer 12 is unrelated to expert 17 in layer 13.
+
+The user-facing planner accepts:
+
+- A total memory limit.
+- Context-token budget.
+- Runtime/macOS reserve.
+- Optional expert-cache limit.
+- Transient slot count, defaulting to top-8 for single-token decode.
+- Explicit I/O staging and execution-workspace bytes when they are not aliased
+  to fixed expert slots.
+
+It subtracts the 9.9042 GiB resident model, KV/DSA bytes, reserve, and transient
+scratch before deriving an integer slot count per sparse layer. Startup fails
+if fixed costs do not fit. Native allocation must use that fixed result and
+must not create a full expert tensor or grow the bank on a miss.
+
+The context value is the aggregate maximum live KV-token count across admitted
+sequences; zero is load-only. The runtime must apply MTPLX's MLX memory cap
+before loading, reject a conflicting `MTPLX_MEMORY_LIMIT_BYTES`, and prevent
+context or batch admission from growing beyond the resolved plan.
+
+## GLM-specific implementation seams
+
+### Resident-only loader
+
+The load path must intercept before generic `mlx_lm.load`, which otherwise
+materializes the full 389.6 GiB artifact. It should:
+
+1. Validate the pinned model and quantization fingerprints.
+2. Instantiate the IndexShare-correct target model.
+3. Load only the resident allowlist.
+4. Bind each routed `(layer, expert)` to a manifest record without loading it.
+5. Reject unexpected or missing resident tensors.
+6. Treat omitted layer 78 as explicit AR-only metadata.
+
+### Routed MLP seam
+
+Keep the gate and shared expert resident. Replace the stacked resident
+`switch_mlp(x, ids)` operation with a slot-backed equivalent that consumes the
+same selected ids and weights. The first native kernel should preserve the
+existing quantized gate/up activation/down sequence exactly; cache policy must
+not be visible to model math.
+
+For prefill or continuous batches, selected ids may have a union much larger
+than eight. Group rows by expert, run the union in bounded waves, and accumulate
+each row with its original router weight. Never size scratch to an unbounded
+batch union.
+
+### Slot lifetime
+
+A slot is not reusable when an MLX call returns; it is reusable only after the
+last Metal command reading it has completed. Associate every fill and dispatch
+with a generation, validate the expected `(layer, expert, generation)` at
+dispatch, and fence before overwrite. Use a full synchronization for the first
+correctness baseline if necessary, then replace it with narrower command-buffer
+or shared-event fencing.
+
+## Build order and gates
+
+1. **Land the exact layout descriptor and planner.** Reproduce all byte totals
+   above and prove every plan remains under its user limit.
+2. **Implement the checked manifest.** Sampled original-shard reads and
+   optional sidecar reads must be byte-identical.
+3. **Land IndexShare-correct resident loading.** Load no routed payload and
+   match the fully resident model before 2K and beyond 4K context.
+4. **Prove FP32 router parity.** Exact ids and tolerance-matching weights at all
+   75 sparse layers are a hard gate.
+5. **Add fixed native slots and checked `pread`.** Corruption, short-read, and
+   stale-generation tests must fail closed.
+6. **Bind slot-backed Q4 kernels.** Projection, layer, logits, and greedy-token
+   comparisons must pass for forced hits and forced misses.
+7. **Add bounded batching and telemetry.** Measure prompt and decode
+   independently; report bytes/read latency/hit rate/kernel time/tokens per
+   second.
+8. **Tune cache policy.** Compare OS page cache alone against explicit hot
+   banks at multiple slot counts before selecting a default.
+9. **Evaluate MTP separately.** Only after AR correctness and sustained
+   throughput are established.
+
+## Benchmark matrix
+
+| Dimension | Required points | What it answers |
+| --- | --- | --- |
+| Context | <2K, 4K, 32K, 64K, hardware-permitting longer | IndexShare correctness and KV pressure |
+| Persistent slots/layer | 0, 8, 16, 32, 48, 64, 96, hardware-permitting 128 | Hit curve and memory/throughput tradeoff |
+| Cache state | Cold filesystem cache, warm, steady decode | Separates SSD, OS cache, and expert-bank effects |
+| Phase | Prefill and decode | Prevents prompt throughput from hiding decode stalls |
+| Workload | Single stream, continuous batch, forced high expert union | Tests scratch-wave scheduling |
+| Admission | Transient-only prefill, shared admission, decode-only hot admission | Measures cache pollution |
+| Router | Official FP32 vs candidate adapter | Proves exact ids before performance work |
+| Slot path | Resident reference, streamed hit, streamed miss | Proves cache-invariant math and isolates I/O |
+| Lifetime stress | Forced read delay, rapid eviction, repeated generations | Detects stale Metal reads |
+| Quality | Fixed greedy suite and long generations | Detects drift, gibberish, or repetition |
+
+Every result must state the immutable artifact revision, hardware and SSD,
+macOS, memory and reserve limits, context, batch/prompt shape, record alignment,
+slot count, admission mode, and warm/cold state. Report peak memory, bytes read
+and written, router/read/kernel time, hit rate, time to first token, prefill
+tokens/s, and decode tokens/s.
+
+## MTP boundary
+
+The official BF16 model has an additional layer 78, but the selected community
+Q4 artifact omits it. MTP also shares top-level embeddings and output head and
+has its own router/expert bank; constructing an independent random output head
+is incorrect. A separate community MTP conversion is not assumed trustworthy
+or layout-compatible with this target. Generate a Q4 MTP artifact from the
+pinned official source, validate router dtype/correction bias, and add it as a
+separate manifest and memory reservation.
+
+MTP verification selects experts for several speculative positions, so its
+record union and I/O behavior differ from one-token AR decode. It is enabled
+only if it matches the resident reference, passes repetition tests, stays under
+the same user memory limit, and improves end-to-end throughput.
+
+## References
+
+- <https://huggingface.co/zai-org/GLM-5.2/tree/b4734de4facf877f85769a911abafc5283eab3d9>
+- <https://github.com/zai-org/GLM-5/tree/431634c155dab6cc2e30535c6eaa26c01caac675>
+- <https://huggingface.co/mlx-community/GLM-5.2-4bit/tree/6b347a6472d46bf55de65ee34032136a3929d778>
+- <https://github.com/huggingface/transformers/blob/bca7eee6650f22fbfcb124c4642f343a3afd21f1/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py>
+- <https://github.com/ml-explore/mlx-lm/pull/1410>
+- <https://github.com/ml-explore/mlx-lm/pull/1463>

--- a/docs/GLM52_Q4_SSD_EXPERT_STREAMING.md
+++ b/docs/GLM52_Q4_SSD_EXPERT_STREAMING.md
@@ -1,7 +1,9 @@
 # GLM-5.2 Q4 SSD expert streaming
 
-Status: pinned layout and implementation design. Native selective loading and
-slot-backed MLX/Metal execution are not implemented in this branch.
+Status: AR implementation complete on the experimental branch, including FP32
+routing, IndexShare, resident-only loading, native positional I/O, and direct
+MLX/Metal slot-bank execution. Full-checkpoint parity and hardware benchmarks
+remain release gates.
 
 This document specializes the shared design in
 [`MOE_SSD_STREAMING_PLAN.md`](MOE_SSD_STREAMING_PLAN.md) for

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -101,10 +101,9 @@ Trace event format:
 Example simulation:
 
 ```bash
-python scripts/simulate_expert_cache.py routes.jsonl \
+python3 scripts/simulate_expert_cache.py routes.jsonl \
+  --model hy3-q4 \
   --persistent-slots-per-layer 64 \
-  --transient-slots 8 \
-  --expert-record-bytes 10000000 \
   --ssd-gib-per-second 5.5
 ```
 

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -100,7 +100,7 @@ python scripts/simulate_expert_cache.py routes.jsonl \
   --ssd-gib-per-second 5.5
 ```
 
-`expert-record-bytes` must come from the actual sidecar manifest. Do not infer
+`expert-record-bytes` must come from the validated layout manifest. Do not infer
 it from the repository's total byte size once dense/shared tensors have been
 split out.
 
@@ -140,6 +140,12 @@ though their config still declares one NextN predictor. They are AR-only in
 practice. Initial streaming work must prove AR first; MTP requires separately
 packaging and validating the official BF16 layer-80 weights (or a new Q4
 conversion) and adding its own expert bank.
+
+Routing is a discrete, precision-sensitive boundary. The parity baseline must
+retain the Q4 artifact's resident 8-bit gate and run router math/selection in
+FP32. A future conversion should A/B resident BF16 gate weights as well: all 79
+gates are only about 124 MiB in BF16, so improving routing fidelity costs about
+61 MiB over the inspected Q8 layout, negligible beside the expert bank.
 
 Context length materially changes the cache budget: BF16 KV for the 80 target
 layers is about 0.3125 MiB per token, or 10/20/40/80 GiB at roughly

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -1,0 +1,212 @@
+# Hy3 SSD expert streaming — fork design
+
+Status: Phase 0 cache policy and trace simulator implemented; native I/O and
+Metal execution are not implemented yet.
+
+## Goal
+
+Run final Tencent Hy3 4-bit on an Apple Silicon machine whose unified memory is
+smaller than the full checkpoint. Keep the MoE routers (the "deciders"),
+attention, norms, embeddings, output head, shared experts, and KV state
+resident. Keep a learned hot set of routed experts resident per layer and load
+cold experts from an expert-major SSD sidecar only after the router selects
+them.
+
+This belongs in MTPLX's MLX/Metal execution layer. It is not a patch to Apple's
+kernel Metal driver.
+
+## Why the cache is per layer
+
+Expert 17 in layer 12 is a different tensor from expert 17 in layer 13. A
+whole-model "path" is also too combinatorial to cache as a unit: Hy3 selects
+multiple experts at every routed layer. The stable cache key is therefore:
+
+```text
+(model fingerprint, quantization fingerprint, layer, expert)
+```
+
+The full router path remains useful telemetry, but admission and eviction are
+per-layer decisions.
+
+## Proposed execution flow
+
+```text
+resident attention/shared path
+        |
+resident router -> top-k expert ids -> slot-bank lookup
+                                      | hit
+                                      +------> fixed Metal expert slot
+                                      | miss
+                                      +------> aligned pread from sidecar
+                                               into persistent or transient slot
+        |
+quantized gate/up -> SwiGLU -> down -> weighted combine -> residual
+```
+
+The slot bank has two tiers:
+
+1. Persistent decode-hot slots. Admission uses decayed frequency plus recency.
+2. Transient service slots, at least as large as router top-k. Prefill misses
+   and decode misses that are not hot enough use these slots without evicting
+   the hot set.
+
+The persistent allocation is per layer, but the physical transient Metal
+scratch bank should be global and reused as layers execute sequentially. Eight
+top-k scratch records are needed in memory once, not once per layer.
+
+Prefill and decode must not share one blind LRU policy. Prompt tokens touch a
+wide one-off expert set and can erase the decode hot set immediately before it
+becomes valuable.
+
+The explicit hot tier is a hypothesis, not a foregone conclusion. Flash-MoE's
+48 GB measurements found that a second Metal LRU duplicated the macOS page
+cache, increased memory pressure, and lost to plain `pread`. Phase 1 must keep
+two first-class modes: `persistent_slots=0` (transient buffers plus the OS page
+cache) and the learned persistent bank proposed here. If the explicit bank
+wins, cold reads should be tested with `F_NOCACHE` so the same expert record is
+not retained twice. The winning policy is selected from route traces and
+hardware measurements, not assumed from cache capacity alone.
+
+## Phase 0 in this branch
+
+- `mtplx/expert_streaming.py` implements the per-layer admission/eviction plan
+  without importing MLX.
+- `scripts/simulate_expert_cache.py` replays JSONL route traces and reports hit
+  rate, bytes read, and an I/O-time floor for a cache size.
+- `tests/test_expert_streaming.py` covers hot-set persistence, prefill
+  isolation, transient service, admission, and I/O accounting.
+
+Trace event format:
+
+```json
+{"phase":"decode","layer":12,"experts":[7,19,31,44,58,90,121,180]}
+```
+
+Example simulation:
+
+```bash
+python scripts/simulate_expert_cache.py routes.jsonl \
+  --persistent-slots-per-layer 64 \
+  --transient-slots 8 \
+  --expert-record-bytes 10000000 \
+  --ssd-gib-per-second 5.5
+```
+
+`expert-record-bytes` must come from the actual sidecar manifest. Do not infer
+it from the repository's total byte size once dense/shared tensors have been
+split out.
+
+## Hy3 Q4 sizing hypothesis
+
+The final Hy3 config and the pinned `pipenetwork/Hy3-4bit` community conversion
+agree on 80 target layers,
+layer 0 dense, 192 routed experts, top-8 routing, hidden size 4096, expert hidden
+size 1536, affine 4-bit groups of 64, and 8-bit routers. For one routed expert,
+gate/up/down each contain `4096 * 1536` values. Including packed Q4 weights and
+fp16 scales+biases gives this provisional record size:
+
+```text
+3 * (4096 * 1536 * 4/8 bytes
+     + (4096 * 1536 / 64) * 2 bytes scales
+     + (4096 * 1536 / 64) * 2 bytes biases)
+= 10,616,832 bytes
+= 10.125 MiB per (layer, expert)
+```
+
+The pinned community conversion contains 149.98 GiB of routed experts and 4.612
+GiB of non-routed base tensors. Its 79 resident 8-bit routers, including scales,
+affine biases, and fp32 correction biases, total only about 63 MiB. A cold
+top-8 token needs about 6.25 GiB of expert records before cache hits. At an
+effective 5.5 GiB/s random-read rate, cold I/O alone caps decode below 0.9
+tokens/s.
+
+On the 128 GB reference Mac, 96 persistent slots per routed layer consume about
+74.99 GiB. Under uniform routing that is a 50% capacity hit rate and a 1.76
+tokens/s I/O-only ceiling; useful expert skew can improve it, while compute and
+cache-management overhead reduce it. These are planning numbers, not benchmark
+claims. The sidecar exporter must replace them with sizes measured from its
+manifest.
+
+The examined final-model community Q4 indexes omit checkpoint layer 80 even
+though their config still declares one NextN predictor. They are AR-only in
+practice. Initial streaming work must prove AR first; MTP requires separately
+packaging and validating the official BF16 layer-80 weights (or a new Q4
+conversion) and adding its own expert bank.
+
+Context length materially changes the cache budget: BF16 KV for the 80 target
+layers is about 0.3125 MiB per token, or 10/20/40/80 GiB at roughly
+32K/64K/128K/256K. Cache sizing must reserve KV and macOS/runtime headroom
+before assigning persistent expert slots.
+
+Primary configuration references:
+
+- <https://huggingface.co/tencent/Hy3/blob/main/config.json>
+- <https://huggingface.co/XavierLocalAI/Hy3-4bit/blob/main/config.json>
+- <https://huggingface.co/pipenetwork/Hy3-4bit/blob/main/config.json>
+
+## Phase 1: route telemetry and sidecar format
+
+1. Land or vendor a pinned Hy3 MLX model implementation; upstream mlx-lm Hy3
+   work is not yet a released dependency.
+2. Wrap each Hy3 MoE router to record selected expert ids by phase and layer.
+3. Export expert-major records. Each record contains gate/up/down packed Q4
+   weights plus scales/biases, with fixed alignment and checksums.
+4. Export a dense checkpoint without routed expert payloads.
+5. Validate that dense + one loaded expert record reproduces the resident
+   module's output on deterministic vectors before optimizing I/O.
+
+The manifest must pin the source model revision, tensor names/shapes/dtypes,
+quantization mode and group size, byte offsets/lengths, alignment, and hashes.
+
+## Phase 2: native slot bank
+
+Add a nanobind MLX extension beside `native_extensions/verify_mlp`:
+
+- Allocate fixed shared Metal buffers once; never allocate a new model-sized
+  array on a cache miss.
+- Read with positional, aligned `pread` into the selected slot. Start with the
+  normal OS page cache baseline; measure it against explicit hot slots, with
+  and without `F_NOCACHE` on misses.
+- Expose slot generations so compiled/indirect command buffers cannot replay a
+  stale expert after eviction.
+- Run Q4 gate/up/SwiGLU/down from slot buffers and return the weighted expert
+  contribution as an MLX array.
+- Export counters: hits, misses, bytes, read latency, per-layer occupancy,
+  evictions, and time in router/I/O/Metal.
+
+Cold-record `mmap` page faults are not the baseline. Existing Apple Silicon
+Flash-MoE measurements report a large cold-`mmap` regression versus explicit
+reads. The fork should reproduce that comparison on this machine rather than
+assuming virtual memory is an expert cache.
+
+## MTP sequencing
+
+Start with AR correctness and throughput. Hy3's MTP head has its own routed MoE
+layer and therefore needs a separate slot bank. A verify batch can request the
+union of experts for several speculative positions, increasing SSD traffic.
+MTP is promoted only if it beats AR while passing exactness and repetition
+gates under the same cache budget.
+
+## Validation gates
+
+1. Sidecar record hashes and bounds validate before any inference.
+2. Router ids and scores match the resident implementation.
+3. Each streamed expert projection matches resident Q4 output within the
+   quantized kernel tolerance.
+4. Layer output, logits, and greedy tokens match on fixed vectors.
+5. Cache hit/miss behavior cannot affect numerical output.
+6. Corrupt/short reads fail closed; stale slot generations cannot execute.
+7. Benchmarks report prefill and decode separately and include cold, warm, and
+   steady-state runs.
+
+## Go/no-go measurements
+
+- Real expert record bytes and dense resident footprint.
+- Decode expert-frequency distribution and hit-rate curves at 8/16/32/64/96
+  persistent slots per layer.
+- Effective random-read bandwidth into the chosen Metal-buffer path.
+- OS-page-cache-only versus explicit-hot-bank throughput and memory pressure.
+- I/O bytes/token after cache hits.
+- AR tokens/s and MTP tokens/s with identical quality gates.
+- Memory pressure, thermals, and SSD writes. Expert streaming should be
+  read-only; large write counts indicate a packaging/cache bug.

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -54,6 +54,14 @@ The persistent allocation is per layer, but the physical transient Metal
 scratch bank should be global and reused as layers execute sequentially. Eight
 top-k scratch records are needed in memory once, not once per layer.
 
+For the M1 correctness baseline, each layer must complete this lifetime:
+fill scratch under a fresh epoch, build and execute the routed MLP, materialize
+the complete layer output, then wait for the last scratch-reading Metal command
+before the next `pread`. A command-buffer/shared-event fence is the production
+mechanism; a full MLX/GPU synchronization is the conservative first proof. This
+hard-serializes layers, so it is a low-memory baseline rather than the final
+throughput path.
+
 Eight scratch records describe the first single-stream, one-token decode path.
 A prefill chunk, continuous decode batch, or MTP verify batch can have a much
 larger union of expert ids. It must group tokens by expert and execute misses in

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -54,6 +54,14 @@ The persistent allocation is per layer, but the physical transient Metal
 scratch bank should be global and reused as layers execute sequentially. Eight
 top-k scratch records are needed in memory once, not once per layer.
 
+Eight scratch records describe the first single-stream, one-token decode path.
+A prefill chunk, continuous decode batch, or MTP verify batch can have a much
+larger union of expert ids. It must group tokens by expert and execute misses in
+bounded waves, accumulating each token's weighted result; it must not require
+the whole union to be resident at once. Phase 0 trace events are deliberately
+one token at one layer, so a wider event is rejected instead of silently
+under-sizing the native scratch bank.
+
 Prefill and decode must not share one blind LRU policy. Prompt tokens touch a
 wide one-off expert set and can erase the decode hot set immediately before it
 becomes valuable.
@@ -149,6 +157,8 @@ Primary configuration references:
 1. Land or vendor a pinned Hy3 MLX model implementation; upstream mlx-lm Hy3
    work is not yet a released dependency.
 2. Wrap each Hy3 MoE router to record selected expert ids by phase and layer.
+   Decode traces must include batch/session identity so cross-request locality
+   is not mistaken for within-sequence locality.
 3. Export expert-major records. Each record contains gate/up/down packed Q4
    weights plus scales/biases, with fixed alignment and checksums.
 4. Export a dense checkpoint without routed expert payloads.
@@ -171,6 +181,8 @@ Add a nanobind MLX extension beside `native_extensions/verify_mlp`:
   stale expert after eviction.
 - Run Q4 gate/up/SwiGLU/down from slot buffers and return the weighted expert
   contribution as an MLX array.
+- For multi-token calls, group rows by expert and dispatch bounded expert waves;
+  preserve the original token/router-weight mapping during accumulation.
 - Export counters: hits, misses, bytes, read latency, per-layer occupancy,
   evictions, and time in router/I/O/Metal.
 

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -1,7 +1,8 @@
 # Hy3 SSD expert streaming — fork design
 
-Status: Phase 0 cache policy and trace simulator implemented; native I/O and
-Metal execution are not implemented yet.
+Status: AR implementation complete on the experimental branch, including the
+resident Hy3 overlay, native positional I/O, and direct MLX/Metal slot-bank
+execution. Full-checkpoint parity and hardware benchmarks remain release gates.
 
 ## Goal
 

--- a/docs/HY3_SSD_EXPERT_STREAMING.md
+++ b/docs/HY3_SSD_EXPERT_STREAMING.md
@@ -148,25 +148,42 @@ before assigning persistent expert slots.
 
 Primary configuration references:
 
-- <https://huggingface.co/tencent/Hy3/blob/main/config.json>
-- <https://huggingface.co/XavierLocalAI/Hy3-4bit/blob/main/config.json>
-- <https://huggingface.co/pipenetwork/Hy3-4bit/blob/main/config.json>
+- <https://huggingface.co/tencent/Hy3/blob/716aa7241bd6d95896be4ebfc761162a9c4d49ef/config.json>
+- <https://huggingface.co/XavierLocalAI/Hy3-4bit/blob/c4f3e2d53d0de330dd3750cc352fbe3a62fef956/config.json>
+- <https://huggingface.co/pipenetwork/Hy3-4bit/blob/160619d3f96c8470350b6dac0ef033a8381551e3/config.json>
 
-## Phase 1: route telemetry and sidecar format
+## Phase 1: route telemetry and expert layout
 
 1. Land or vendor a pinned Hy3 MLX model implementation; upstream mlx-lm Hy3
    work is not yet a released dependency.
 2. Wrap each Hy3 MoE router to record selected expert ids by phase and layer.
    Decode traces must include batch/session identity so cross-request locality
    is not mistaken for within-sequence locality.
-3. Export expert-major records. Each record contains gate/up/down packed Q4
-   weights plus scales/biases, with fixed alignment and checksums.
-4. Export a dense checkpoint without routed expert payloads.
-5. Validate that dense + one loaded expert record reproduces the resident
+3. Generate and hash a manifest of the original safetensors expert-slab file
+   offsets first. The expert dimension is contiguous, so this proves selective
+   loading without writing a second 150 GiB artifact.
+4. Benchmark those component reads against an optional expert-major sidecar.
+   The derived format combines gate/up/down packed Q4 weights plus
+   scales/biases into aligned records and is kept only if fewer, larger reads
+   justify its disk cost.
+5. Export a dense checkpoint without routed expert payloads.
+6. Validate that dense + one loaded expert record reproduces the resident
    module's output on deterministic vectors before optimizing I/O.
 
 The manifest must pin the source model revision, tensor names/shapes/dtypes,
 quantization mode and group size, byte offsets/lengths, alignment, and hashes.
+
+The closest public MLX implementation seam is SharpAI's MIT-licensed
+`mlx-swift`/`mlx-swift-lm` fork: it writes an expert slab from safetensors
+directly into an already-evaluated MLX array at a slot byte offset, then uses a
+stacked `gatherQuantizedMM`. This demonstrates that the buffer path is possible,
+but its current code relies on caller-side global GPU synchronization and lacks
+the manifest, expert-index, epoch, and source-integrity checks required here.
+Port the narrow mechanism with attribution; do not copy its lifetime assumptions
+unchanged.
+
+- <https://github.com/SharpAI/mlx-swift/blob/133864c733c8d4178547f8fe92897da6a788368f/Source/Cmlx/mlx-c/mlx/c/fast.cpp#L865-L1188>
+- <https://github.com/SharpAI/mlx-swift-lm/blob/b9bf50bdafef02fffd5b83598a61bbf7d47434f9/Libraries/MLXLMCommon/SwitchLayers.swift#L48-L421>
 
 ## Phase 2: native slot bank
 

--- a/docs/MOE_SSD_STREAMING_PLAN.md
+++ b/docs/MOE_SSD_STREAMING_PLAN.md
@@ -1,0 +1,326 @@
+# SSD-streamed MoE plan: Hy3 Q4 and GLM-5.2 Q4
+
+Status: design, model descriptors, cache policy, and memory-planning scaffold.
+This branch does **not** yet selectively load checkpoint records into MLX arrays
+or execute streamed experts with native Metal kernels.
+
+Target branch: `codex/moe-ssd-hy3-glm52`
+
+## Decision
+
+Yes: expert selection can be separated from expert execution at each MoE
+layer. The router is small enough to remain resident. It runs first, returns
+the selected expert ids and weights, and the runtime resolves those ids against
+a bounded in-memory expert bank. Missing records are read from SSD into either
+a persistent hot slot or a global transient slot before the routed MLP runs.
+
+The separation is layer-local, not whole-model lookahead. Router input at layer
+`n` depends on the hidden state produced by layer `n - 1`, so the runtime cannot
+select every layer's expert path at the start of a token. The legal ordering is:
+
+```text
+layer n hidden state
+    -> resident attention (and resident shared expert where applicable)
+    -> resident MoE router
+    -> selected (layer, expert) ids and weights
+    -> slot lookup
+         hit  -> existing persistent slot
+         miss -> checked SSD read into persistent or transient slot
+    -> quantized expert gate/up/down
+    -> weighted combine + residual
+    -> layer n + 1 hidden state
+```
+
+Once the router has produced ids, the implementation may overlap independent
+record reads, run already-resident experts, and compute a shared expert. It
+must not advance past the layer's combine until every selected contribution is
+complete.
+
+This is an MLX/Metal runtime change. It does not require modifying Apple's
+Metal driver or macOS virtual-memory implementation.
+
+## Model scope
+
+The first implementation targets autoregressive, single-token decode for two
+affine Q4/group-64 checkpoints:
+
+| Property | Hy3 Q4 | GLM-5.2 Q4 |
+| --- | ---: | ---: |
+| Target transformer layers | 80 | 78 |
+| Sparse MoE layers | 79 (layers 1-79) | 75 (layers 3-77) |
+| Routed experts per sparse layer | 192 | 256 |
+| Experts selected per token/layer | 8 | 8 |
+| One routed expert record | 10.125 MiB | 20.25 MiB |
+| Routed expert corpus | about 149.984 GiB | 379.6875 GiB |
+| Fully cold expert reads/token | about 6.249 GiB | 11.8652 GiB |
+| Non-routed resident checkpoint data | about 4.612 GiB | 9.9042 GiB |
+| Resident router data | about 63 MiB | about 225 MiB |
+| Q4 community artifact includes MTP | No (layer 80 omitted) | No (layer 78 omitted) |
+
+The resident footprint includes embeddings, norms, attention, routers, shared
+experts, dense MLPs, and the output head. KV state, MLX allocator headroom,
+command buffers, and application memory are separate reservations.
+
+These are pinned-artifact planning figures. The exporter must derive byte
+offsets, lengths, shapes, dtypes, and hashes from each exact safetensors
+revision; the native reader must trust the validated manifest rather than the
+table above.
+
+## Resident selector boundary
+
+The runtime keeps all routing dependencies resident:
+
+- The current hidden state and attention path.
+- Every sparse-layer MoE router, including selection correction bias.
+- Dense and shared experts.
+- GLM-5.2's DSA attention indexer and IndexShare state.
+- KV state for the configured context budget.
+
+GLM-5.2 contains two selectors with different jobs. The DSA indexer selects
+historical tokens for attention; the MoE router selects feed-forward experts.
+Both remain resident, and the expert cache keys only on MoE selections. The
+IndexShare schedule has 21 full indexer layers (`0`, `1`, `2`, then `6` through
+`74` in steps of four); the other 57 layers reuse the preceding full layer's
+indices.
+
+Router behavior is a correctness boundary, not an approximate cache hint. For
+GLM-5.2, the adapter must reproduce the official FP32 routing sequence: FP32
+router projection, sigmoid scores, FP32 correction bias used only for
+selection, gather the corresponding unbiased sigmoid scores, normalize the
+selected top-8 weights, and apply the routing scale. A different top-8 set
+executes different parameters and invalidates every downstream comparison.
+
+## Memory threshold contract
+
+The user supplies a total memory ceiling and may optionally supply a tighter
+expert-cache ceiling. The planner subtracts fixed and context-dependent costs
+before assigning persistent expert slots:
+
+```text
+fixed = resident_model
+      + kv_bytes_per_token * context_tokens
+      + global_transient_slots * expert_record_bytes
+      + explicit_io_staging
+      + explicit_execution_workspace
+      + runtime_and_os_reserve
+
+available_for_persistent = max(0, total_memory_limit - fixed)
+persistent_budget = min(available_for_persistent, optional_expert_cache_limit)
+slots_per_layer = floor(
+    persistent_budget / (sparse_layer_count * expert_record_bytes)
+)
+```
+
+`slots_per_layer` is capped at the model's experts per layer. The initial
+planner uses an equal per-layer allocation because every token visits every
+sparse layer and a slot can only hold an expert from its own layer. Telemetry
+may later justify an explicitly bounded non-uniform allocation.
+
+`context_tokens` is the maximum aggregate live KV-token count admitted by the
+runtime, not merely one request's advertised window. Zero is an explicit
+load-only plan. Known staging and workspace allocations are charged separately;
+the reserve covers remaining MLX, Metal, MTPLX, and OS headroom.
+
+The limit is strict at the slot-bank boundary:
+
+- Persistent slot buffers are allocated once and never grow after startup.
+- A global transient bank is reused across sequential layers. Top-8
+  single-token decode needs eight records globally, not eight per layer.
+- A miss cannot allocate an untracked temporary expert array.
+- If fixed reservations do not fit, startup fails with a memory-plan report.
+- Multi-token unions larger than the transient bank run in bounded waves.
+- Cache admission may replace a persistent slot, but cannot increase capacity.
+
+The process can still be terminated by macOS if the user reserves too little
+headroom for unrelated applications or opaque framework allocations. Tests
+therefore track both the configured slot-bank bytes and observed process/unified
+memory high-water marks.
+
+This planner is fixed-buffer accounting, not an independent macOS memory
+controller. Runtime integration must reconcile it with MTPLX's existing
+`MTPLX_MEMORY_LIMIT_BYTES`/`mx.set_memory_limit` path, reject conflicting caps,
+set the MLX limit before allocation, reject KV growth beyond the plan, and
+compare `mx.get_active_memory()` peak telemetry with the accounted budget.
+
+## Cache policy
+
+Each persistent cache key is:
+
+```text
+(model revision, quantization revision, layer, expert)
+```
+
+The proposed bank has two tiers:
+
+1. **Persistent hot slots.** Decode admission uses a frequency-and-recency
+   estimate so repeated experts displace colder residents.
+2. **Global transient scratch.** Cold, one-off, or prefill records execute
+   without polluting the decode hot set.
+
+Prefill and decode are accounted separately. A prompt can touch a broad expert
+set immediately before decode, so blindly admitting every prefill miss would
+destroy the useful decode working set. `persistent_slots=0` remains a supported
+baseline: transient reads plus the macOS page cache may beat a second explicit
+cache on some machines.
+
+Every slot carries a generation/epoch. The native implementation must prove
+that the final Metal command reading generation `g` has completed before an SSD
+read overwrites that slot with generation `g + 1`. The first correctness build
+may fully synchronize at each streamed layer; later builds can replace that
+barrier with command-buffer or shared-event fences.
+
+## Artifact layout
+
+Phase 1 should first prove selective reads from original safetensors offsets.
+An optional expert-major sidecar is accepted only if it materially improves
+read amplification or alignment. Each record contains one expert's Q4
+gate/up/down weights plus scales and affine biases.
+
+The manifest must pin:
+
+- Source repository and immutable revision.
+- Every source shard name, size, and digest.
+- Model, quantization mode, group size, tensor dtype, and tensor shape.
+- `(layer, expert)` to file/offset/length mappings.
+- Record alignment, component offsets, and record digest.
+- Resident tensor allowlist and proof that routed payloads were not loaded.
+
+Malformed bounds, unexpected shapes, short reads, checksum failures, and
+revision mismatches fail closed before a buffer is exposed to a kernel.
+
+## Staged implementation plan
+
+### Stage 0 — model-independent policy and planning
+
+- Encode pinned Hy3 Q4 and GLM-5.2 Q4 layout descriptors.
+- Calculate persistent capacity from the user's memory and context limits.
+- Keep cache simulation free of MLX imports for fast deterministic tests.
+- Report planned resident, KV, transient, persistent, reserve, and unallocated
+  bytes before model load.
+
+Gate: sizing formulas reproduce the artifact inventories and never exceed the
+configured limit.
+
+### Stage 1 — manifests and resident-only loading
+
+- Build a safetensors inventory tool with immutable revision and digest checks.
+- Export a validated offset manifest and optional aligned sidecar.
+- Add an MTPLX load path that instantiates resident tensors without generic
+  `mlx_lm.load` materializing the entire checkpoint.
+- Fail early when a config advertises an MTP layer absent from the artifact;
+  never fall back to scanning or loading every shard.
+
+Gate: process high-water memory stays near resident plan, and arbitrary sampled
+records read through the manifest match the original tensor bytes.
+
+### Stage 2 — exact resident routers and model adapters
+
+- Preserve Hy3's artifact-specific router quantization and FP32 selection.
+- Port GLM-5.2 IndexShare before attempting streamed execution.
+- Match the official GLM-5.2 FP32 top-8 ids, weights, and correction-bias
+  semantics at every sparse layer.
+- Keep attention-token selection and MoE-expert selection as separate APIs.
+
+Gate: router ids are exact and weights match tolerance on fixed vectors,
+prefill, decode, and long-context cases beyond 2K/4K tokens.
+
+### Stage 3 — native checked record fill
+
+- Allocate fixed shared Metal slot buffers from the approved plan.
+- Add positional, aligned `pread` into slot component ranges.
+- Associate each read, cache entry, and dispatch with a slot generation.
+- Add completion fences before slot reuse and failure injection for short or
+  corrupt reads.
+- Export per-layer hit/miss, bytes, latency, occupancy, eviction, and stall
+  counters.
+
+Gate: stress tests cannot execute a stale generation, leak slot capacity, or
+produce a different result for hit versus miss.
+
+### Stage 4 — routed Q4 execution
+
+- Bind slot-backed gate/up/down data to MLX/Metal quantized matmul kernels.
+- Group batch rows by selected expert and accumulate original router weights.
+- Execute expert unions larger than scratch capacity in bounded waves.
+- Materialize the layer result before reusing global scratch.
+
+Gate: expert projections, layer outputs, logits, and greedy tokens match a
+fully resident Q4 reference within declared kernel tolerances.
+
+### Stage 5 — scheduling and cache-policy tuning
+
+- Overlap independent reads, resident hits, and shared-expert compute after
+  routing.
+- Compare OS-page-cache-only, explicit persistent cache, and explicit cache
+  with cold-read cache bypass where supported.
+- Tune admission independently for prompt, single-stream decode, and
+  continuous batching.
+- Consider non-uniform layer capacity only from trace-backed evidence.
+
+Gate: a selected mode improves end-to-end tokens/s without exceeding memory,
+changing output, or increasing SSD writes beyond packaging activity.
+
+### Stage 6 — optional MTP
+
+Prove autoregressive inference first. The inspected Hy3 and GLM-5.2 community
+Q4 artifacts omit their declared MTP layers (80 and 78 respectively). A later
+MTP release needs a separately generated, validated Q4 artifact, correct
+embedding/output-head sharing, and an independent expert bank. Verification
+batches also need bounded-wave execution for the union of proposed positions.
+
+Gate: MTP passes AR-equivalent correctness and repetition tests and improves
+end-to-end throughput under the same total memory ceiling.
+
+## Acceptance gates
+
+The feature is not considered implemented until all of these hold:
+
+1. **Artifact:** every offset is bounds-checked and source/record hashes pass.
+2. **Routing:** selected ids are exact; selected weights match the resident
+   oracle within the declared precision tolerance.
+3. **Kernel:** streamed and resident expert projections agree on deterministic
+   vectors for every component shape.
+4. **Model:** layer outputs, logits, and greedy tokens agree on fixed prompts.
+5. **Cache invariance:** hit, persistent miss, and transient miss produce the
+   same numerical result.
+6. **Lifetime:** slot-generation stress and forced I/O delay never expose stale
+   or partially filled data.
+7. **Memory:** configured slot bytes never grow; observed high-water memory
+   stays within the total ceiling plus a documented measurement tolerance.
+8. **Failure:** short reads, corruption, missing MTP tensors, and incompatible
+   manifests fail closed with actionable errors.
+9. **Quality:** long decode does not introduce repetition, gibberish, or
+   router drift versus the resident reference.
+10. **Performance:** cold, warm, and steady-state results report I/O bytes,
+    router time, read time, kernel time, hit rate, and tokens/s separately.
+
+## Risk and benchmark matrix
+
+| Risk or question | Required comparison | Pass condition |
+| --- | --- | --- |
+| Router precision changes expert ids | Streamed adapter vs official/resident router on fixed hidden states | Exact top-8 ids; weights within tolerance |
+| GLM IndexShare is implemented incorrectly | Contexts below 2K and beyond 2K/4K; inspect all 78 layers | Correct 21 full-layer schedule and matching logits/tokens |
+| Generic loading materializes routed tensors | Startup/high-water trace with resident-only loader vs ordinary load | No routed corpus allocation; high-water near declared plan |
+| SSD reads cannot feed decode fast enough | Cold/warm random aligned reads at 1/8/batched records | Report effective GiB/s and I/O-only tokens/s ceiling |
+| Explicit cache duplicates macOS page cache | `persistent_slots=0` vs 8/16/32/64/96+ slots per layer | Choose by end-to-end tokens/s and memory pressure |
+| Prefill destroys decode locality | Unified admission vs prefill-bypass/transient-only admission | Decode hit rate and tokens/s do not regress after prompt |
+| Slot overwritten while GPU still reads it | Delayed reads/dispatches with rapid eviction and generation checks | Zero stale-generation executions across stress run |
+| Batch expert union exceeds scratch | Batch sizes and prompt chunks with unions above eight | Bounded memory and resident-equivalent output |
+| Memory threshold is not truly bounded | Sweep context and cache ceilings under pressure | Planned buffers fixed; high-water stays within tolerance |
+| Streaming harms quality | Fixed prompt suite, long generation, AR reference diff | Matching greedy tokens or documented sampling parity |
+| MTP increases I/O more than speed | AR vs MTP under identical memory/context/quality settings | MTP promoted only with net tokens/s gain |
+| Thermal or SSD behavior hides regressions | Cold/warm/steady runs with thermals, pressure, bytes read/written | Stable sustained result; streaming path remains read-only |
+
+Minimum benchmark reports must identify model and artifact revisions, hardware,
+macOS version, memory limit, runtime reserve, context length, batch/prefill
+shape, cache policy, slot count, record alignment, SSD, and whether filesystem
+cache was warm.
+
+## What this branch proves today
+
+This branch establishes the reusable cache decision model, memory-threshold
+contract, layout facts, simulator, and testable boundaries for both models. It
+is deliberately not presented as an SSD inference implementation. Native
+manifest reads, fixed Metal slot buffers, router adapters, IndexShare support,
+and slot-backed Q4 kernels remain required before either checkpoint can run
+with its routed parameters absent from unified memory.

--- a/docs/MOE_SSD_STREAMING_PLAN.md
+++ b/docs/MOE_SSD_STREAMING_PLAN.md
@@ -1,8 +1,9 @@
 # SSD-streamed MoE plan: Hy3 Q4 and GLM-5.2 Q4
 
-Status: design, model descriptors, cache policy, and memory-planning scaffold.
-This branch does **not** yet selectively load checkpoint records into MLX arrays
-or execute streamed experts with native Metal kernels.
+Status: implementation complete on the experimental branch; tiny end-to-end
+Hy3/GLM fixtures, failure injection, and full pinned artifact metadata audits
+pass. Full 166/418 GB checkpoint parity and performance measurements remain a
+release gate, so this document makes no full-model speed claim.
 
 Target branch: `codex/moe-ssd-hy3-glm52`
 
@@ -318,9 +319,39 @@ cache was warm.
 
 ## What this branch proves today
 
-This branch establishes the reusable cache decision model, memory-threshold
-contract, layout facts, simulator, and testable boundaries for both models. It
-is deliberately not presented as an SSD inference implementation. Native
-manifest reads, fixed Metal slot buffers, router adapters, IndexShare support,
-and slot-backed Q4 kernels remain required before either checkpoint can run
-with its routed parameters absent from unified memory.
+The branch now implements the complete AR data path:
+
+- Strict revision-pinned manifests and optional resumable 16 KiB-aligned
+  expert-major sidecars, with shape/dtype/range/hash validation.
+- Resident-only startup loading that never constructs routed parameter trees.
+- Hy3 and GLM-5.2 MLX overlays, including GLM FP32 MoE routing and the exact
+  21-full-layer IndexShare schedule.
+- Decode-aware hot admission, transient-only prefill misses, fixed slot
+  generations/pins, bounded descriptors and in-flight I/O, cancellation, and
+  corruption/short-read failure handling.
+- Optional native GIL-free `pread`, directly into stable MLX/Metal slot-bank
+  buffers. Q4 component arrays are shared-buffer views; evaluated expert work
+  is synchronized before a slot generation can be replaced.
+- Runtime/CLI/server integration, aggregate live-KV admission, MLX allocator
+  cap reconciliation, and `/health` cache/I/O/memory telemetry.
+
+The full pinned checkpoint indexes were audited without downloading payloads:
+Hy3 has 2,323 resident keys and 711 routed leaves; GLM-5.2 has 2,806 resident
+keys and 675 routed leaves. Tiny artifacts execute complete model forwards
+through the streamed path. What is not yet proven is full-checkpoint numerical
+parity, high-water memory, thermals, and sustained SSD throughput on target
+hardware. Use these gates before publishing a result:
+
+```bash
+python scripts/audit_streamed_model_layout.py --model hy3-q4
+python scripts/benchmark_expert_io.py MODEL MANIFEST \
+  --operations 256 --queue-depth 8 --cache-state steady --ssd-label "internal NVMe"
+python scripts/verify_streamed_parity.py MODEL MANIFEST probes.jsonl \
+  --model-key hy3-q4 --memory-limit 96GiB --max-live-kv-tokens 32768
+python scripts/benchmark_streamed_generation.py MODEL MANIFEST \
+  --model-key hy3-q4 --memory-limit 96GiB --max-live-kv-tokens 32768
+```
+
+`--cache-state` is provenance, not cache manipulation: the I/O benchmark never
+claims to purge macOS's filesystem cache. Every output includes immutable model
+and manifest identity plus raw cache/I/O/MLX measurements.

--- a/docs/issues/epic_moe_ssd_streaming.md
+++ b/docs/issues/epic_moe_ssd_streaming.md
@@ -57,6 +57,15 @@ causes expert records to be loaded.
 - **Parity, benchmarks, and MTP gates:** prove routing/output correctness before
   reporting throughput; add MTP only from explicit, validated weights.
 
+## Tracked implementation issues
+
+- [ ] #4 — Router-first execution and user memory budgeting.
+- [ ] #1 — Versioned expert manifest and aligned sidecar generator.
+- [ ] #3 — Native SSD-to-MLX slot loader with generations and fences.
+- [ ] #2 — GLM-5.2 Q4 adapter with FP32 router and IndexShare.
+- [ ] #6 — Runtime cache policy, batching, configuration, and telemetry.
+- [ ] #5 — AR parity, benchmarks, and explicit MTP artifacts.
+
 ## Proposed top-level API
 
 ```python

--- a/docs/issues/epic_moe_ssd_streaming.md
+++ b/docs/issues/epic_moe_ssd_streaming.md
@@ -1,8 +1,10 @@
 > **Repository scope:** Issues are repository-wide in `davidtai/MTPLX`.
 > **Target implementation branch:** `codex/moe-ssd-hy3-glm52`.
-> **Current state:** the branch has a pure-Python expert-cache policy scaffold and
-> simulator. It does **not** yet have a native SSD-to-MLX loader or a working
-> streamed model adapter.
+> **Current state:** the branch implements manifest/sidecar tooling, fixed
+> MLX/Metal slot banks, native positional I/O, resident-only Hy3/GLM adapters,
+> runtime/server integration, and benchmark gates. Tiny end-to-end fixtures and
+> full artifact metadata audits pass; full-checkpoint hardware validation is
+> still open before the epic can be closed.
 
 ## Goal
 

--- a/docs/issues/epic_moe_ssd_streaming.md
+++ b/docs/issues/epic_moe_ssd_streaming.md
@@ -1,0 +1,136 @@
+> **Repository scope:** Issues are repository-wide in `davidtai/MTPLX`.
+> **Target implementation branch:** `codex/moe-ssd-hy3-glm52`.
+> **Current state:** the branch has a pure-Python expert-cache policy scaffold and
+> simulator. It does **not** yet have a native SSD-to-MLX loader or a working
+> streamed model adapter.
+
+## Goal
+
+Run Hy3 Q4 and GLM-5.2 Q4 on Apple Silicon without materializing every routed
+expert in unified memory. Keep attention, embeddings, normalization, shared
+experts, and every MoE router resident. At each MoE layer, run that layer's
+router first, resolve its top-k experts against a bounded slot bank, load only
+the missing expert records, and then execute the routed MLP.
+
+Routing cannot be done for all layers at the beginning of a token. The router
+at layer `n` consumes the hidden state produced by layer `n - 1`; therefore the
+correct execution order is sequential and layer-local:
+
+1. Execute the resident attention/residual path for layer `n`.
+2. Evaluate the resident router for layer `n`.
+3. Produce top-k expert IDs and unbiased routing weights.
+4. Map IDs to persistent hot slots or shared transient slots.
+5. Load missing expert records from SSD and wait for their slot generations.
+6. Execute the expert GLU and resident shared expert, then continue to `n + 1`.
+
+The user controls a total-memory threshold and may also set a narrower expert
+cache cap. The planner must subtract the fixed resident model, context-dependent
+KV/DSA state, runtime reserve, and one reusable transient top-k bank before it
+allocates persistent expert slots. No code path may exceed that plan or silently
+fall back to loading every checkpoint shard.
+
+## Pinned model targets
+
+| Target | Sparse layers | Experts/layer | Top-k | Q4 expert record | Cold routed bytes/token | Fixed non-routed artifact |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Hy3 Q4 | 79 | 192 | 8 | 10.125 MiB | 6.249 GiB | 4.612 GiB |
+| GLM-5.2 Q4 | 75 (layers 3-77) | 256 | 8 | 20.25 MiB | 11.865 GiB | 9.904 GiB |
+
+For GLM-5.2, the 75 resident routers plus correction biases occupy about
+0.2198 GiB and are included in the fixed non-routed footprint. The Q4 artifact
+is about 389.59 GiB in total. GLM-5.2's DSA token indexer is distinct from the
+MoE expert router; both selectors stay resident, but only the MoE selection
+causes expert records to be loaded.
+
+## Proposed work breakdown
+
+- **Router-first execution and memory budgeting:** define model descriptors,
+  exact slot sizing, public configuration, and the layer-local state machine.
+- **Validated manifest and optional aligned sidecar:** turn safetensors tensor
+  slices into deterministic expert records without trusting guessed offsets.
+- **Native slot loader:** copy records into preallocated MLX/Metal buffers with
+  explicit slot generations, fences, cancellation, and bounded I/O.
+- **GLM-5.2 adapter:** preserve official FP32 routing and IndexShare semantics
+  while loading only the resident subset at startup.
+- **Runtime cache policy:** connect the existing policy scaffold to prefill,
+  decode, batching, admission, telemetry, and server/CLI configuration.
+- **Parity, benchmarks, and MTP gates:** prove routing/output correctness before
+  reporting throughput; add MTP only from explicit, validated weights.
+
+## Proposed top-level API
+
+```python
+runtime = load_runtime(
+    model_path,
+    expert_streaming=True,
+    memory_limit_bytes=96 * 2**30,
+    expert_cache_limit_bytes=None,
+    runtime_reserve_bytes=16 * 2**30,
+    max_live_kv_tokens=32768,
+    io_staging_bytes=512 * 2**20,
+)
+```
+
+Suggested CLI equivalents:
+
+```text
+--expert-streaming
+--memory-limit-gib 96
+--expert-cache-limit-gib 64       # optional hard sub-cap
+--expert-runtime-reserve-gib 16
+--expert-max-live-kv-tokens 32768
+--expert-io-staging-gib 0.5
+--expert-manifest /path/to/expert-manifest.json
+--expert-sidecar /path/to/experts.bin  # optional
+```
+
+The resolved plan must be printed before allocation and exposed through runtime
+metadata: fixed bytes, KV/DSA bytes at the requested context, transient bytes,
+persistent slots per layer, known I/O/workspace bytes, persistent bytes, and
+unallocated safety margin. Runtime integration must reconcile this ceiling
+with `MTPLX_MEMORY_LIMIT_BYTES` and apply the MLX cap before allocation.
+
+## Failure handling
+
+- Reject an unknown model revision, manifest version, quantization layout, file
+  size, tensor shape/dtype, or record checksum before allocating GPU buffers.
+- Fail before model load when the total threshold cannot fit the fixed resident
+  subset, requested context state, runtime reserve, and transient bank.
+- Treat short reads, checksum failures, slot-generation mismatches, and Metal
+  command failures as fatal for the affected request; never execute a partially
+  populated or stale slot.
+- Never use the current GLM MTP fallback that scans/loads all shards when the
+  expected MTP layer is absent. Autoregressive mode must work without MTP.
+- Do not silently change router dtype, top-k, routing weights, IndexShare reuse,
+  or quantization parameters to make a checkpoint load.
+
+## Epic acceptance criteria
+
+- [ ] Hy3 Q4 autoregressive generation runs through the streamed path with 79
+      resident routers, top-8 expert selection, and bounded expert buffers.
+- [ ] GLM-5.2 Q4 autoregressive generation runs through the streamed path with
+      layers 3-77 routed, official FP32 router semantics, and correct IndexShare.
+- [ ] Measured peak allocated model/cache memory remains at or below the user's
+      total-memory threshold in cold, warm, prefill, decode, cancellation, and
+      concurrent-request tests.
+- [ ] A zero-persistent-slot plan remains correct by serving every miss from the
+      reusable transient bank; an undersized fixed-footprint plan fails early.
+- [ ] Route IDs, route weights, logits, and generated tokens pass the parity
+      gates defined in the validation issue before performance claims are made.
+- [ ] Corrupt/truncated manifests, sidecars, and checkpoint shards fail closed;
+      tests prove there is no whole-checkpoint fallback.
+- [ ] Benchmarks report time-to-first-token, decode tokens/s, cache hit rate,
+      bytes read/token, I/O wait, eviction count, and peak unified memory for
+      cold and warmed workloads.
+- [ ] Documentation includes a reproducible artifact revision, manifest build
+      command, memory plan, launch command, and current limitations.
+
+## Dependency order
+
+1. Router/memory-budget contract and manifest format can proceed in parallel.
+2. Native loading depends on the manifest format and slot-buffer contract.
+3. Hy3 and GLM adapters depend on the router contract; end-to-end streaming
+   additionally depends on the native loader.
+4. Runtime policy integration depends on the model adapter and slot loader.
+5. Parity/benchmark gates consume all prior work. MTP remains a separate final
+   gate and is not required for the first autoregressive milestone.

--- a/docs/issues/glm52_adapter.md
+++ b/docs/issues/glm52_adapter.md
@@ -1,8 +1,8 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** MTPLX recognizes `glm_moe_dsa` experimentally, but
-> no GLM-5.2 streamed-Q4 adapter exists. The policy scaffold alone is not a
-> runnable model implementation.
+> **Implementation status:** the resident-only GLM-5.2 overlay, FP32 router,
+> IndexShare schedule, streamed Q4 switch, strict loader, and tiny end-to-end
+> forward are implemented. Full-checkpoint parity and memory benchmarks remain.
 
 ## Objective
 
@@ -87,13 +87,13 @@ not an acceptable precursor to swapping in streamed modules.
 - [ ] For fixed hidden-state fixtures, all 75 sparse layers match official
       top-8 IDs and normalized/scaled route weights, including near-tie cases
       where BF16 and FP32 selection would differ.
-- [ ] Tests prove correction bias changes selection only and does not contaminate
+- [x] Tests prove correction bias changes selection only and does not contaminate
       the gathered routing weight.
 - [ ] IndexShare tests assert exactly 21 full indexer executions and 57 reuses;
       sequences longer than 2,048 and 4,096 tokens exercise reuse behavior.
 - [ ] Full-resident test slots and streamed slots produce equivalent layer
       outputs within a documented Q4 numerical tolerance.
-- [ ] Autoregressive generation works without layer 78 and a requested MTP mode
+- [x] Autoregressive model execution works without layer 78 and requested MTP mode
       fails early with a clear missing-weight error.
 - [ ] Peak memory is governed by the resolved plan and not the 389.59 GiB total
       Q4 artifact size.

--- a/docs/issues/glm52_adapter.md
+++ b/docs/issues/glm52_adapter.md
@@ -1,0 +1,106 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** MTPLX recognizes `glm_moe_dsa` experimentally, but
+> no GLM-5.2 streamed-Q4 adapter exists. The policy scaffold alone is not a
+> runnable model implementation.
+
+## Objective
+
+Add a GLM-5.2 Q4 adapter that loads only resident tensors at startup, preserves
+official router and DSA/IndexShare behavior, and replaces routed expert storage
+with fixed streamed slots for layers 3-77.
+
+The pinned target is `mlx-community/GLM-5.2-4bit` revision
+`6b347a6472d46bf55de65ee34032136a3929d778` (91 shards,
+418,320,895,488 tensor bytes). The behavioral oracle is the official GLM-5.2
+Transformers implementation, not a guessed interpretation of the older Q4
+config.
+
+## Required architecture semantics
+
+- 78 target layers indexed 0-77; layers 0-2 are dense and layers 3-77 are MoE.
+- 256 routed experts/layer, exact top-8, plus one resident shared expert.
+- Hidden size 6144; routed expert intermediate size 2048.
+- The resident router projection must execute in FP32. Apply sigmoid, add the
+  FP32 correction bias for **selection only**, gather the original unbiased
+  sigmoid scores, normalize selected scores, and multiply by routing scale 2.5.
+- The Q4 router weight tensors are stored as BF16 and correction biases as F32;
+  explicitly cast the router matmul rather than inheriting a BF16 MLX default.
+- DSA token selection and MoE expert routing are independent resident selectors.
+  DSA selection must not trigger expert loads or share cache-policy state.
+- IndexShare has 21 full indexer layers: `0, 1, 2, 6, 10, ..., 74`. The other
+  57 layers reuse the previous full layer's selected token indices.
+- The 4-bit artifact omits MTP layer 78 despite config metadata. Autoregressive
+  loading must accept that omission and must not search/load every shard.
+
+## Proposed files and integration seam
+
+- `mtplx/models/glm52_streaming.py`
+  - resident GLM-5.2 module wrapper, FP32 router, IndexShare schedule, resident
+    shared expert, and streamed `HotExpertSwitchGLU`.
+- `mtplx/models/hot_expert_switch_glu.py`
+  - model-neutral Q4 slot-backed gate/up/down execution consuming resolved slot
+    IDs while preserving route weights and token aggregation.
+- `mtplx/resident_loader.py`
+  - allowlisted resident-tensor load that never invokes generic full-model
+    `mlx_lm.load` before expert tensors are intercepted.
+- `mtplx/runtime.py`
+  - branch to the streamed loader before the current generic load seam.
+- `tests/test_glm52_streaming.py`
+  - tensor allowlist, router math, IndexShare, shape, and end-to-end parity.
+
+Base IndexShare support on the relevant upstream `mlx-lm` GLM-5.2 work (PR
+#1410 and its test follow-up), but pin/vendor the minimum reviewed behavior until
+an official released `mlx-lm` dependency contains it. Do not depend on current
+main behavior that instantiates an indexer on every layer.
+
+## Resident-load contract
+
+The startup loader must enumerate an exact allowlist and validate all expected
+keys. It should load approximately 10,634,546,688 bytes of non-routed tensors,
+including about 236,006,400 bytes of routers/correction biases, attention/DSA,
+shared experts, dense MLP layers 0-2, embeddings, norms, and output head. Routed
+expert records remain represented only by the manifest plus fixed slot buffers.
+
+Generic `mlx_lm.load` currently materializes the whole model and is therefore
+not an acceptable precursor to swapping in streamed modules.
+
+## Failure handling
+
+- Fail on missing/extra resident keys, unexpected tensor shapes/dtypes, wrong
+  layer schedule, artifact revision, quantization group, or router metadata.
+- Fail if route IDs/weights differ from the official FP32 oracle; never silently
+  use BF16 router matmul for speed.
+- Fail if a shared IndexShare layer has no valid full-layer indices in the same
+  forward pass. Do not instantiate random/missing indexer parameters.
+- Reject attempts to enter MTP mode when explicit validated layer-78 weights are
+  unavailable. Do not create a random separate shared output head.
+- Missing expert records propagate a typed streaming error; no whole-shard or
+  whole-checkpoint fallback is allowed.
+
+## Acceptance criteria
+
+- [ ] A load-spy test proves startup opens/loads the exact resident allowlist and
+      does not read routed expert payloads before the first route miss.
+- [ ] Resident tensor bytes and router bytes match 10,634,546,688 and
+      236,006,400 respectively for the pinned artifact.
+- [ ] For fixed hidden-state fixtures, all 75 sparse layers match official
+      top-8 IDs and normalized/scaled route weights, including near-tie cases
+      where BF16 and FP32 selection would differ.
+- [ ] Tests prove correction bias changes selection only and does not contaminate
+      the gathered routing weight.
+- [ ] IndexShare tests assert exactly 21 full indexer executions and 57 reuses;
+      sequences longer than 2,048 and 4,096 tokens exercise reuse behavior.
+- [ ] Full-resident test slots and streamed slots produce equivalent layer
+      outputs within a documented Q4 numerical tolerance.
+- [ ] Autoregressive generation works without layer 78 and a requested MTP mode
+      fails early with a clear missing-weight error.
+- [ ] Peak memory is governed by the resolved plan and not the 389.59 GiB total
+      Q4 artifact size.
+
+## Dependencies
+
+- Depends on router/memory descriptors and GLM-5.2 manifest support.
+- End-to-end streamed execution depends on the native slot loader.
+- Parity/benchmark work supplies the official oracle fixtures and release gate.
+- MTP support is intentionally deferred to the separate validation/MTP gate.

--- a/docs/issues/manifest_sidecar.md
+++ b/docs/issues/manifest_sidecar.md
@@ -1,0 +1,127 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** this proposes a new artifact contract; no trusted
+> expert manifest or aligned sidecar generator is implemented yet.
+
+## Objective
+
+Create a versioned, validated mapping from each `(layer, expert)` to the exact
+Q4 tensor segments required by the streamed GLU. Support direct reads from the
+original safetensors shards and an optional locally generated, contiguous,
+aligned sidecar optimized for `pread`.
+
+The loader must not infer offsets from filenames, assume every model has the
+same packing order, or scan/materialize all checkpoint shards when a tensor is
+missing. Artifact identity and layout are part of the correctness boundary.
+
+## Proposed files and commands
+
+- `mtplx/expert_manifest.py`
+  - frozen schema types, strict JSON parsing, artifact verification, and
+    `(layer, expert) -> ExpertRecord` lookup.
+- `scripts/build_expert_manifest.py`
+  - read safetensors headers only, validate the selected model descriptor, and
+    emit a deterministic manifest.
+- `scripts/build_expert_sidecar.py`
+  - copy validated segments to one or more local sidecar files with 16 KiB
+    record alignment; never publish or upload artifacts automatically.
+- `docs/expert-manifest-v1.schema.json`
+  - machine-readable schema with `additionalProperties: false` at signed
+    boundaries.
+- `tests/test_expert_manifest.py`
+  - fixtures for cross-shard records, corruption, truncation, duplicate keys,
+    integer overflow, symlink/path escape, and revision mismatch.
+
+Example logical schema:
+
+```json
+{
+  "format": "mtplx-expert-manifest-v1",
+  "model_key": "glm52-q4",
+  "source_repo": "mlx-community/GLM-5.2-4bit",
+  "source_revision": "6b347a6472d46bf55de65ee34032136a3929d778",
+  "quantization": {"bits": 4, "group_size": 64, "mode": "affine"},
+  "artifact": {"tensor_bytes": 418320895488, "shard_count": 91},
+  "records": [
+    {
+      "layer": 3,
+      "expert": 0,
+      "logical_bytes": 21233664,
+      "segments": [
+        {
+          "tensor": "...gate_proj.weight",
+          "shard": "model-00001-of-00091.safetensors",
+          "offset": 0,
+          "length": 0,
+          "dtype": "U32",
+          "shape": [256, 2048, 768],
+          "expert_axis": 0,
+          "expert_index": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+The example's offsets are placeholders; generation must derive and validate
+real absolute payload offsets from safetensors headers. Each logical record
+contains the selected expert's gate/up/down packed weights plus their scales
+and biases. A sidecar form replaces the segment list with file, aligned offset,
+length, and checksum while retaining source provenance.
+
+## Validation rules
+
+- Pin source repository and immutable revision; record shard relative paths,
+  exact file sizes, safetensors header hashes, and a whole-manifest digest.
+- Reject absolute paths, `..`, symlink escapes from the artifact root, overlap,
+  out-of-file ranges, duplicate `(layer, expert)` keys, unsupported endianness,
+  unexpected dtype/shape, and non-integer offsets.
+- Validate per-projection quantized weights, scales, and biases rather than
+  checking only aggregate bytes.
+- Require a complete rectangular routed set:
+  - Hy3: `79 * 192` records of 10.125 MiB.
+  - GLM-5.2: `75 * 256` records of 20.25 MiB.
+- Verify aggregate routed bytes exactly:
+  - Hy3: 161,036,107,776 bytes.
+  - GLM-5.2: 407,686,348,800 bytes.
+- Keep resident routers, shared experts, and dense layers out of the expert
+  records and verify their expected keys separately.
+- Sidecar generation must use bounded buffers and streaming copies; it may not
+  mmap or materialize the entire 150-380 GiB routed corpus in RAM.
+
+## Failure handling
+
+- Fail closed before model allocation on any provenance, schema, file-size,
+  layout, or checksum mismatch.
+- A short read or changed source file invalidates the record and sidecar build;
+  never pad with zeros or continue to another shard.
+- Write sidecars to a temporary filename, `fsync`, validate all record hashes,
+  then atomically rename. Clean incomplete temporaries on the next invocation.
+- Do not redistribute third-party weights. Sidecars are generated locally and
+  retain source license/provenance metadata.
+- Never fall back to broad shard loading if a requested key or MTP layer is
+  absent; return a typed missing-record error.
+
+## Acceptance criteria
+
+- [ ] Manifest generation from each pinned Q4 artifact is deterministic and a
+      second run is byte-for-byte identical.
+- [ ] The record count, logical record size, aggregate routed bytes, layer
+      range, expert range, and quantization tensor shapes match the invariants
+      above for Hy3 and GLM-5.2.
+- [ ] Randomly sampled records reconstruct the same nine Q4 tensor slices as the
+      source safetensors reader, byte-for-byte.
+- [ ] Every sidecar record begins at a 16 KiB-aligned offset and a full audit
+      verifies hashes and source provenance after generation.
+- [ ] Tests corrupt a header, payload byte, size, path, offset, shape, revision,
+      and checksum and assert an early typed failure.
+- [ ] A memory-usage test proves manifest/sidecar generation remains bounded by
+      the configured copy buffer rather than artifact size.
+- [ ] The native loader can query a record without opening unrelated shards.
+
+## Dependencies
+
+- Consumes exact tensor/layout values from `ExpertStreamingModelSpec`.
+- Blocks the native slot-loader end-to-end path.
+- Can be developed and unit-tested in parallel with router/memory planning.

--- a/docs/issues/manifest_sidecar.md
+++ b/docs/issues/manifest_sidecar.md
@@ -1,7 +1,8 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** this proposes a new artifact contract; no trusted
-> expert manifest or aligned sidecar generator is implemented yet.
+> **Implementation status:** implemented on the target branch with strict JSON,
+> safetensors header/index cross-validation, path containment, record/shard
+> hashes, source reads, and resumable aligned sidecar generation/verification.
 
 ## Objective
 

--- a/docs/issues/native_slot_loader.md
+++ b/docs/issues/native_slot_loader.md
@@ -1,7 +1,8 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** the current policy produces planned `SlotLoad`
-> operations only; no native SSD-to-MLX/Metal transfer path exists yet.
+> **Implementation status:** implemented on the target branch. The optional
+> nanobind reader performs GIL-free bounded `pread` into stable MLX/Metal slot
+> banks; generation pins and explicit synchronization prevent stale reuse.
 
 ## Objective
 
@@ -91,22 +92,22 @@ dispatch completes; a persistent slot remains ready until policy eviction.
 
 ## Acceptance criteria
 
-- [ ] Mock-backend tests exercise every state transition, concurrent dedupe,
+- [x] Mock-backend tests exercise every state transition, concurrent dedupe,
       cancellation, timeout, eviction during load, and generation ABA hazard.
-- [ ] Native tests fill a slot from known bytes, run an MLX operation against
+- [x] Native/direct-buffer tests fill a slot from known bytes, run an MLX operation against
       it, replace the record in the same slot, and observe the new result while
       preserving planned allocation size.
-- [ ] Fault-injection tests for short reads and payload corruption fail before
+- [x] Fault-injection tests for short reads and payload corruption fail before
       expert dispatch and leave no slot falsely marked ready.
-- [ ] Repeated cold/warm routes never allocate beyond fixed slot buffers plus
+- [x] Repeated cold/warm routes never allocate beyond fixed slot buffers plus
       configured bounded staging/in-flight I/O memory.
 - [ ] Hy3 can load one 10.125 MiB record and GLM-5.2 one 20.25 MiB record with
       all packed weights/scales/biases matching source bytes.
 - [ ] One top-8 transient bank is safely reused across sequential layers: 81
       MiB for Hy3 and 162 MiB for GLM-5.2.
-- [ ] Metrics expose requested/read bytes, read latency, queue latency, deduped
+- [x] Metrics expose requested/read bytes, read latency, deduped
       loads, failures, cancellations, and wait time per layer.
-- [ ] A no-fallback test verifies a missing expert record does not cause all
+- [x] A no-fallback test verifies a missing expert record does not cause all
       safetensors shards to be opened.
 
 ## Dependencies

--- a/docs/issues/native_slot_loader.md
+++ b/docs/issues/native_slot_loader.md
@@ -1,0 +1,116 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** the current policy produces planned `SlotLoad`
+> operations only; no native SSD-to-MLX/Metal transfer path exists yet.
+
+## Objective
+
+Implement a bounded native loader that fills preallocated quantized expert
+slots from manifest-described records. The loader must preserve buffer identity
+used by compiled MLX graphs, prevent stale-slot execution, and expose explicit
+completion rather than relying on incidental Python or MLX synchronization.
+
+At each sparse layer, the resident router runs first. Its top-k IDs are passed
+to `LayerExpertSlotBank.plan(...)`; only the returned misses issue reads. All
+loads for that layer must reach the requested generation before the expert GLU
+dispatch. Routers for later layers cannot run early because their hidden states
+do not exist yet.
+
+## Proposed files and API
+
+- `mtplx/expert_io.py`
+  - Python ownership, manifest lookup, queue selection, cancellation, metrics,
+    and a portable/mock backend for tests.
+- `native_extensions/expert_io/`
+  - nanobind C++/Objective-C++ extension using `pread`/`preadv` into bounded
+    staging memory and explicit Metal/MLX buffer copies.
+- `mtplx/expert_slots.py`
+  - fixed per-layer slot tensors, slot-generation table, state transitions,
+    and `ensure_route(...)` orchestration.
+- `tests/test_expert_io.py` and `tests/test_expert_slots.py`
+  - short reads, cancellation, races, reuse, eviction, and stale generation.
+
+Proposed boundary:
+
+```python
+class ExpertSlotLoader:
+    def ensure_route(
+        self,
+        *,
+        layer: int,
+        plan: RoutePlan,
+        deadline_ns: int | None = None,
+    ) -> ReadyRoute: ...
+
+class ReadyRoute:
+    slots: tuple[int, ...]
+    generations: tuple[int, ...]
+    completion: CompletionEvent
+```
+
+Each physical slot has a state machine:
+
+```text
+EMPTY -> LOADING(expert, generation) -> READY(expert, generation)
+                |                           |
+                +-> FAILED ----------------+
+READY -> LOADING(next_expert, generation + 1)
+```
+
+Expert compute receives both slot IDs and generations. Dispatch is allowed only
+after the completion event and only if the slot table still maps every pair to
+the routed expert. A transient slot is reusable after that layer's expert
+dispatch completes; a persistent slot remains ready until policy eviction.
+
+## Buffer and I/O contract
+
+- Allocate all slot tensors once from the resolved memory plan. Their addresses
+  and shapes must remain stable across record replacement.
+- Preserve the source Q4 affine layout (packed weights plus BF16 scales/biases)
+  and never dequantize whole experts into resident buffers.
+- Start with a correctness path that performs aligned bounded reads and explicit
+  copies/fences. Add direct-storage optimizations only after proving MLX buffer
+  lifetime and coherence on supported macOS/Apple Silicon versions.
+- Coalesce segments for a record when the manifest/sidecar permits it. Do not
+  open or page unrelated checkpoint shards.
+- Bound file descriptors, in-flight bytes, staging buffers, and queue depth.
+  These bytes must be included in the runtime reserve or an explicit I/O budget.
+- Deduplicate concurrent requests for the same `(layer, expert, generation)`.
+
+## Failure handling
+
+- Treat `EINTR` as retryable; treat EOF/short read, checksum mismatch, closed
+  file, invalid range, deadline expiry, or Metal copy failure as a failed slot.
+- A failed or cancelled read never transitions to `READY` and never overwrites
+  a newer generation. Wake all waiters with the same typed error.
+- Keep the prior resident record valid until replacement is fully loaded when
+  buffer topology permits; otherwise mark the slot unavailable before writing.
+- On device loss or unrecoverable extension error, fail affected requests and
+  require runtime reconstruction. Do not continue with stale data.
+- Never substitute zeros, a different expert, or a broad checkpoint load.
+
+## Acceptance criteria
+
+- [ ] Mock-backend tests exercise every state transition, concurrent dedupe,
+      cancellation, timeout, eviction during load, and generation ABA hazard.
+- [ ] Native tests fill a slot from known bytes, run an MLX operation against
+      it, replace the record in the same slot, and observe the new result while
+      preserving planned allocation size.
+- [ ] Fault-injection tests for short reads and payload corruption fail before
+      expert dispatch and leave no slot falsely marked ready.
+- [ ] Repeated cold/warm routes never allocate beyond fixed slot buffers plus
+      configured bounded staging/in-flight I/O memory.
+- [ ] Hy3 can load one 10.125 MiB record and GLM-5.2 one 20.25 MiB record with
+      all packed weights/scales/biases matching source bytes.
+- [ ] One top-8 transient bank is safely reused across sequential layers: 81
+      MiB for Hy3 and 162 MiB for GLM-5.2.
+- [ ] Metrics expose requested/read bytes, read latency, queue latency, deduped
+      loads, failures, cancellations, and wait time per layer.
+- [ ] A no-fallback test verifies a missing expert record does not cause all
+      safetensors shards to be opened.
+
+## Dependencies
+
+- Blocked by the validated manifest/sidecar schema.
+- Consumes `RoutePlan` and fixed slot counts from router/memory planning.
+- Blocks end-to-end model adapters and runtime cache-policy integration.

--- a/docs/issues/parity_bench_mtp.md
+++ b/docs/issues/parity_bench_mtp.md
@@ -1,0 +1,135 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** this defines release gates. It does not imply that
+> streamed execution, benchmark results, or MTP support currently exist.
+
+## Objective
+
+Build a reproducible correctness and performance gate for Hy3 Q4 and GLM-5.2
+Q4 expert streaming. Ship autoregressive (AR) streaming first. Treat MTP as a
+separate artifact and correctness milestone, because both community Q4 targets
+omit the official next-token prediction layer.
+
+Performance is meaningful only after proving the layer-local order and routing
+math:
+
+```text
+resident router[n] -> top-k -> bounded load of misses -> expert compute[n]
+```
+
+It is invalid to route all layers up front, because later routers depend on
+earlier hidden states.
+
+## Proposed files and fixtures
+
+- `tests/parity/test_hy3_streaming_parity.py`
+- `tests/parity/test_glm52_streaming_parity.py`
+- `tests/parity/test_router_oracles.py`
+- `tests/integration/test_streaming_failures.py`
+- `benchmarks/benchmark_expert_streaming.py`
+- `benchmarks/prompts/moe-streaming.jsonl`
+- `benchmarks/results/moe-streaming/<hardware>/<revision>.json`
+- `docs/benchmarks/moe-ssd-streaming.md`
+
+Every result JSON should include code commit, immutable model revision, manifest
+digest, sidecar digest if used, macOS/MLX/`mlx-lm` versions, machine/SSD, memory
+plan, context length, batch size, prompt hash, cache start state, and raw sample
+measurements. Report medians and distributions, not one best run.
+
+## Correctness ladder
+
+1. **Manifest parity:** selected source tensor slices equal manifest/sidecar
+   records byte-for-byte.
+2. **Router parity:** official/reference top-k IDs and routing weights equal the
+   MTPLX resident-router path for fixed hidden states and near-tie fixtures.
+3. **Expert parity:** one expert loaded into a slot matches the existing
+   full-resident Q4 expert output within a documented tolerance.
+4. **Layer parity:** full sparse layer output matches with hits, transient misses,
+   persistent admission, and eviction.
+5. **Model parity:** fixed-prompt logits and generated tokens match an equivalent
+   full-resident/reference path for a tractable model slice or sufficiently
+   provisioned host.
+6. **Failure parity:** corruption, missing records, cancellation, and low-memory
+   plans fail deterministically without changing to a fallback execution path.
+
+For GLM-5.2, compare FP32 router behavior against the official Transformers
+implementation, including correction-bias selection and unbiased selected
+weights. Test IndexShare at sequences longer than 2,048 and 4,096 tokens and
+assert 21 full indexer layers plus 57 reuses. DSA token-index selection is not
+an MoE cache hit and must be evaluated separately.
+
+## Benchmark matrix
+
+- Cold cache, warmed cache, and hot-repeat prompt sets.
+- Prefill then single-stream decode; concurrent requests; bounded microbatches.
+- At least three persistent-cache sizes, including zero slots and a realistic
+  user threshold, plus a full-resident/simulator reference where feasible.
+- Context lengths that expose KV/DSA tradeoffs. GLM-5.2 cache is exactly 95,232
+  bytes/token (about 2.906 GiB at 32K and 11.625 GiB at 128K); Hy3 is 327,680
+  bytes/token.
+- Direct safetensors segments versus aligned sidecar.
+- Effective SSD bandwidth reported from actual expert bytes and wait time.
+
+Required measurements: time-to-first-token, prefill tokens/s, decode tokens/s,
+p50/p95 token latency, route/cache hit rate, bytes read/token, I/O queue/read/wait
+time, router/expert compute time, evictions, errors, and observed peak unified
+memory. Include cold theoretical context, not as a measured claim: Hy3 needs
+6.249 GiB and GLM-5.2 needs 11.865234 GiB of expert data for a completely cold
+token.
+
+## MTP scope and gates
+
+- Hy3's community final Q4 omits MTP layer 80.
+- GLM-5.2's community Q4 omits MTP layer 78 despite
+  `num_nextn_predict_layers=1` metadata.
+- AR model loading and generation must not depend on either MTP artifact.
+- Generate any supported MTP Q4 artifact from pinned official weights with the
+  same quantization/manifest validation pipeline; do not accept ambiguous
+  community conversion metadata as the default.
+- MTP has its own router/expert bank and shares only architecture-defined
+  embeddings/output head. Never create a randomly initialized replacement head.
+- Add MTP only after AR route/logit/token parity and memory-bound tests pass.
+
+Proposed mode contract:
+
+```text
+--mode ar              # works with target Q4 artifact alone
+--mode mtp             # requires explicit validated MTP manifest/artifact
+--mtp-manifest PATH
+```
+
+## Failure handling
+
+- Mark a run invalid if the artifact/manifest/code revision, cache start state,
+  memory plan, or raw samples are absent.
+- Stop benchmark collection on route/logit parity failure, checksum failure,
+  unplanned allocation, thermal throttling outside a declared band, or runtime
+  fallback. Preserve diagnostics and label the result failed.
+- Reject MTP mode before target model allocation if required explicit MTP keys,
+  shared-weight aliases, shapes, dtypes, or manifest provenance are missing.
+- Do not publish performance claims extrapolated from other quantization levels,
+  hardware, or third-party implementations as MTPLX measurements.
+
+## Acceptance criteria
+
+- [ ] The six-step correctness ladder passes for both Hy3 and GLM-5.2 AR paths.
+- [ ] GLM FP32 router near-tie and IndexShare long-context fixtures pass against
+      the official oracle.
+- [ ] Fault injection proves no corrupt/stale/partial slot reaches expert
+      compute and no missing MTP key triggers broad shard loading.
+- [ ] Peak memory remains within the user plan for every benchmark cell,
+      including cancellation and concurrent-request cases.
+- [ ] Result files contain full provenance and raw measurements and can be
+      regenerated from a documented command.
+- [ ] Cold/warm/cache-size comparisons report all required latency, throughput,
+      I/O, cache, and memory metrics.
+- [ ] AR is documented as supported independently; MTP remains disabled unless
+      its separate parity suite passes with an explicit validated artifact.
+
+## Dependencies
+
+- Depends on both model adapters, manifest, native loader, memory planner, and
+  runtime cache integration.
+- AR validation blocks any MTP implementation or performance claim.
+- Benchmark evidence is the final epic/release gate, not an implementation
+  shortcut.

--- a/docs/issues/parity_bench_mtp.md
+++ b/docs/issues/parity_bench_mtp.md
@@ -1,7 +1,9 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** this defines release gates. It does not imply that
-> streamed execution, benchmark results, or MTP support currently exist.
+> **Implementation status:** AR streaming and reproducible I/O, generation, and
+> golden-logit harnesses now exist. Tiny parity/failure tests pass. Full artifact
+> results remain deliberately unpublished, and MTP remains disabled because the
+> pinned Q4 artifacts omit its weights.
 
 ## Objective
 

--- a/docs/issues/router_memory_budget.md
+++ b/docs/issues/router_memory_budget.md
@@ -1,0 +1,160 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** only the pure cache-policy scaffold exists today;
+> the runtime and model execution path described below are proposed work.
+
+## Objective
+
+Define the model-independent contract for resident-router-first MoE execution
+and convert a user-defined total-memory threshold into fixed, transient, and
+persistent allocations with no hidden overcommit.
+
+This is a layer-local state machine. We cannot route every layer up front,
+because layer `n`'s router input does not exist until layer `n - 1` completes.
+
+```text
+hidden[n]
+  -> resident router[n]
+  -> (top-k ids, unbiased route weights)
+  -> LayerExpertSlotBank.plan(ids, phase)
+  -> await loads for missing ids
+  -> expert compute using resolved slot ids
+  -> hidden[n + 1]
+```
+
+## Proposed files and API
+
+- `mtplx/expert_streaming_models.py`
+  - `ExpertStreamingModelSpec`: exact layer ranges, expert dimensions, Q4
+    layout, router requirements, fixed bytes, KV bytes/token, and artifact pins.
+  - `ExpertMemoryPlan`: immutable resolved allocation and safety margin.
+  - `plan_expert_memory(...)`: pure integer sizing function.
+  - built-in `hy3-q4` and `glm52-q4` descriptors.
+- `mtplx/expert_streaming.py`
+  - retain `LayerExpertSlotBank`, `RoutePlan`, `SlotLoad`, and `SlotEviction` as
+    the policy boundary; add no disk or MLX dependency here.
+- `scripts/plan_expert_memory.py`
+  - print a machine-readable JSON plan before the full model is opened.
+- `tests/test_expert_streaming_models.py`
+  - exact layout arithmetic, boundary behavior, and invalid-plan tests.
+
+Proposed planner signature:
+
+```python
+def plan_expert_memory(
+    spec: ExpertStreamingModelSpec,
+    *,
+    total_limit_bytes: int,
+    context_tokens: int,
+    runtime_reserve_bytes: int = 0,
+    expert_cache_limit_bytes: int | None = None,
+    transient_slots: int | None = None,
+    io_staging_bytes: int = 0,
+    execution_workspace_bytes: int = 0,
+) -> ExpertMemoryPlan: ...
+```
+
+Use this accounting, with integer bytes throughout:
+
+```text
+fixed = resident_model_bytes
+      + context_tokens * kv_bytes_per_token
+      + runtime_reserve_bytes
+      + transient_slots * expert_record_bytes
+      + io_staging_bytes
+      + execution_workspace_bytes
+
+persistent_budget = min(
+    max(total_limit_bytes - fixed, 0),
+    expert_cache_limit_bytes if set else infinity,
+)
+
+slots_per_layer = floor(
+    persistent_budget / (routed_layer_count * expert_record_bytes)
+)
+slots_per_layer = min(slots_per_layer, expert_count)
+```
+
+The initial allocator should use the same persistent slot count for every
+sparse layer. Uneven per-layer allocation can be added later from traces, but
+must not complicate the first correctness path. One transient top-k scratch
+bank is reused across sequential layers, so it is not multiplied by layer
+count. Batched execution may require a larger explicit transient slot count or
+microbatching; it may not allocate an unplanned overflow buffer.
+
+## Exact descriptor invariants
+
+### Hy3 Q4
+
+- 79 routed layers, 192 experts/layer, top-8.
+- Hidden size 4096; routed expert hidden size 1536.
+- One affine Q4/group-64 expert record: 10.125 MiB.
+- Routed corpus: 149.98 GiB; cold top-8 reads: 6.249 GiB/token.
+- Fixed non-routed checkpoint bytes: 4,952,354,048 (4.612 GiB).
+- Exact BF16 KV cache: 327,680 bytes/token.
+- Reusable top-8 transient bank: 81 MiB.
+
+### GLM-5.2 Q4
+
+- 78 target layers; layers 0-2 dense and layers 3-77 routed (75 layers).
+- 256 experts/layer, top-8; hidden size 6144; expert hidden size 2048.
+- One affine Q4/group-64 expert record: 20.25 MiB.
+- Routed corpus: 379.6875 GiB; cold top-8 reads: 11.865234 GiB/token.
+- Fixed non-routed checkpoint bytes: 10,634,546,688 (9.904193 GiB).
+- MLA+DSA cache: 95,232 bytes/token.
+- Reusable top-8 transient bank: 162 MiB.
+
+## Configuration semantics
+
+- `memory_limit_bytes` is a hard ceiling for fixed model buffers, planned
+  context state, runtime reserve, transient expert buffers, and persistent
+  expert buffers owned by this runtime. It is not by itself a hard cap on
+  macOS file cache or unrelated processes.
+- `context_tokens` is required and means aggregate live KV tokens across all
+  admitted sequences. Zero is an explicit load-only plan.
+- Known staging/in-flight I/O and execution workspaces are explicit fixed
+  costs; do not conceal them inside an optimistic zero-byte reserve.
+- `expert_cache_limit_bytes` is an optional hard sub-cap, never a request to
+  consume more than the total limit permits.
+- Runtime reserve covers temporary compute allocations and external MLX use;
+  expose a documented default, but always report it explicitly.
+- Persistent slots may resolve to zero. This is slow but valid: misses use the
+  transient bank and correctness is unchanged.
+- A request for longer context than planned must be rejected or trigger an
+  explicit re-plan/reload; it must not silently consume the cache margin.
+- Reconcile this setting with `MTPLX_MEMORY_LIMIT_BYTES`; reject conflicting
+  limits, call `mx.set_memory_limit` before allocation, and compare observed
+  `mx.get_active_memory()` high-water telemetry against the plan.
+
+## Failure handling
+
+- Raise a typed configuration error if fixed bytes exceed the total limit,
+  any byte/count input is negative, top-k exceeds transient slots, or a model
+  descriptor is internally inconsistent.
+- Refuse fractional/float byte accounting and guard integer multiplication.
+- If actual allocations exceed the resolved plan, stop the load and report
+  planned versus observed bytes; do not shrink buffers behind active requests.
+- If a route references an expert or layer outside the descriptor range, fail
+  before issuing I/O.
+
+## Acceptance criteria
+
+- [ ] Unit tests reproduce every exact record, corpus, cold-read, fixed, KV,
+      and transient value listed above for both descriptors.
+- [ ] Planner tests cover caps below fixed footprint, exactly fixed footprint,
+      zero persistent slots, one slot/layer, full expert residency, explicit
+      cache sub-caps, context growth, and leftover bytes.
+- [ ] The JSON CLI output is deterministic and includes all inputs, derived
+      components, slots/layer, persistent bytes, and safety margin.
+- [ ] A runtime integration test proves the router executes before any expert
+      read at every sparse layer and that the next layer is not routed early.
+- [ ] A mocked batched route whose unique expert count exceeds transient slots
+      is microbatched or rejected without allocating extra memory.
+- [ ] No-MLX unit tests can import and exercise descriptors and policy on Linux.
+
+## Dependencies
+
+- No native-I/O dependency for the pure planner and policy tests.
+- Model adapters consume this descriptor/state-machine contract.
+- The native slot loader consumes `SlotLoad` plans and fixed slot shapes.
+- Runtime cache-policy integration owns phase selection and telemetry.

--- a/docs/issues/router_memory_budget.md
+++ b/docs/issues/router_memory_budget.md
@@ -1,7 +1,8 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** only the pure cache-policy scaffold exists today;
-> the runtime and model execution path described below are proposed work.
+> **Implementation status:** implemented on the target branch: pinned model
+> descriptors, total-memory planning, MLX cap reconciliation, layer-local
+> router-first execution, and aggregate live-KV admission are connected.
 
 ## Objective
 

--- a/docs/issues/runtime_cache_policy.md
+++ b/docs/issues/runtime_cache_policy.md
@@ -1,7 +1,8 @@
 > **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
 > **Target branch:** `codex/moe-ssd-hy3-glm52`.
-> **Implementation status:** `LayerExpertSlotBank` and simulation counters exist
-> as a pure policy scaffold. They are not connected to MTPLX runtime execution.
+> **Implementation status:** connected to MTPLX runtime, CLI, one-shot, and
+> server execution. Decode admission, transient prefill, bounded waves,
+> rollback, KV limits, reset/close, and health telemetry are implemented.
 
 ## Objective
 

--- a/docs/issues/runtime_cache_policy.md
+++ b/docs/issues/runtime_cache_policy.md
@@ -1,0 +1,137 @@
+> **Repository scope:** This is a repository-wide `davidtai/MTPLX` issue.
+> **Target branch:** `codex/moe-ssd-hy3-glm52`.
+> **Implementation status:** `LayerExpertSlotBank` and simulation counters exist
+> as a pure policy scaffold. They are not connected to MTPLX runtime execution.
+
+## Objective
+
+Integrate the expert slot policy into prefill, decode, batching, CLI/server
+configuration, and telemetry without changing model routing semantics or
+exceeding the resolved memory plan.
+
+The policy acts only after the current layer's resident router produces top-k
+IDs. It cannot pre-route future layers. Correct execution remains:
+
+```text
+router(layer n) -> cache plan -> load/await misses -> expert compute(layer n)
+```
+
+Prediction/prefetch may later use history as an optimization, but prefetched
+data cannot determine route IDs and cannot be required for correctness.
+
+## Proposed files and API
+
+- `mtplx/expert_streaming.py`
+  - retain decode-frequency admission, per-layer persistent banks, reusable
+    transient slots, and aggregate counters.
+- `mtplx/expert_runtime.py`
+  - connect `RoutePlan` to slot loader and model adapter; own request phase,
+    batching, completion, and cache lifetime.
+- `mtplx/runtime.py`, `mtplx/cli.py`, and server profile/config models
+  - expose explicit streaming and memory-limit fields.
+- `mtplx/metrics.py` or existing metrics surface
+  - export per-model/per-layer cache and I/O measurements with bounded label
+    cardinality.
+- `scripts/simulate_expert_cache.py`
+  - consume both built-in model descriptors and recorded route traces.
+
+Proposed configuration:
+
+```python
+ExpertStreamingConfig(
+    enabled=True,
+    memory_limit_bytes=96 * 2**30,
+    max_live_kv_tokens=32768,
+    expert_cache_limit_bytes=None,
+    runtime_reserve_bytes=16 * 2**30,
+    io_staging_bytes=512 * 2**20,
+    execution_workspace_bytes=0,
+    policy="decode-tinylfu",
+    frequency_decay=0.995,
+    prefill_admission=False,
+    max_inflight_io_bytes=512 * 2**20,
+)
+```
+
+## Policy semantics
+
+- Maintain a persistent slot bank per sparse layer and one transient scratch
+  bank reused across sequential layers.
+- Count decode routes in decayed-frequency admission. Decode misses enter an
+  empty persistent slot or replace an unpinned colder resident; otherwise use a
+  transient slot.
+- Prefill misses use transient service and do not evict a useful decode hot set.
+- Pin every expert used by the current dispatch until its Metal completion.
+- Preserve duplicate top-k IDs/order if the model emits them, while deduplicating
+  physical reads for a route.
+- For a batch, plan the union of selected experts for that layer. If its unique
+  count exceeds planned transient capacity, split into bounded microbatches or
+  use already-persistent slots; never allocate an overflow bank.
+- Keep policy state runtime-local and model-specific. Multiple requests may
+  share ready experts, but cancellation must release only that request's pins.
+- Report cache warmness explicitly; never compare warm throughput to a cold
+  baseline without labeling it.
+
+## Runtime integration
+
+- Resolve and print the memory plan before loading resident weights.
+- Reconcile `memory_limit_bytes` with `MTPLX_MEMORY_LIMIT_BYTES`, reject
+  conflicting caps, and invoke the existing `_apply_metal_memory_caps` path
+  before resident or slot allocation.
+- Validate requested context against planned KV/DSA bytes at request admission.
+- Pass `prefill` or `decode` explicitly; do not infer the phase from tensor shape
+  inside the policy.
+- Await each layer's `ReadyRoute` before slot-backed expert dispatch, and retain
+  the ready-generation token until compute completes.
+- Provide an administrative cache reset that waits for active pins and clears
+  policy metadata without rebuilding fixed buffers.
+- On graceful shutdown, stop admissions, cancel queued reads, wait for active
+  device work, then close files and buffers in that order.
+
+## Failure handling
+
+- Reject unsupported policy names, invalid decay/caps, or transient capacity
+  below the maximum route/microbatch requirement before serving.
+- Propagate native read/device errors to affected requests and increment failure
+  counters; do not mark misses as hits after a failed load.
+- Detect observed model/cache/I/O allocations beyond plan and stop admissions
+  with planned-versus-observed diagnostics.
+- A request exceeding planned context or batch capacity gets a clear admission
+  error or documented microbatching, never an implicit allocation.
+- Keep a hard maximum for trace/metric buffers so observability cannot defeat
+  the memory limit.
+
+## Required telemetry
+
+- Routes, expert requests, hits, misses, hit rate, persistent/transient loads,
+  evictions, resident occupancy, and cache reset count.
+- Requested/read bytes, bytes/token, SSD read/queue/wait latency, concurrent
+  reads, and short-read/checksum/device errors.
+- Router time, load-wait time, expert compute time, time-to-first-token, decode
+  tokens/s, and prefill tokens/s.
+- Planned fixed/KV/transient/persistent/reserve bytes and observed peak unified
+  memory from `mx.get_active_memory()`/peak counters, tagged by model and phase
+  (not expert ID).
+
+## Acceptance criteria
+
+- [ ] Deterministic trace tests reproduce policy decisions across runs for Hy3
+      and GLM-5.2 descriptors.
+- [ ] Prefill-only traces do not change the persistent decode hot set; decode
+      hot experts are admitted and cold one-offs use transient slots.
+- [ ] Concurrent same-expert requests share one load and hold independent pins;
+      cancelling one request does not corrupt the other.
+- [ ] Batch-union overflow follows bounded microbatching/rejection and peak
+      allocation stays within the plan.
+- [ ] Zero persistent slots, full persistent residency, reset, shutdown, native
+      error, and request cancellation paths are covered end-to-end.
+- [ ] CLI and server APIs return the resolved plan and expose all required
+      telemetry without unbounded expert-ID labels.
+- [ ] Integration assertions prove each layer's router precedes its reads and
+      expert dispatch, with no all-layer upfront routing.
+
+## Dependencies
+
+- Depends on router/memory plan, model adapter hooks, and native loader.
+- Uses manifest identity in telemetry and diagnostics.
+- Provides the measurements consumed by parity/benchmark release gates.

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -614,6 +614,12 @@ def _add_mtp_toggle_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_expert_streaming_args(parser: argparse.ArgumentParser) -> None:
+    from .expert_cli import add_expert_streaming_args
+
+    add_expert_streaming_args(parser)
+
+
 SCHEDULER_MODE_CHOICES = (
     "serial",
     "cooperative",
@@ -2451,6 +2457,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_p.add_argument("--top-k", type=int, default=20)
     run_p.add_argument("--depth", type=int, default=3)
     _add_mtp_toggle_args(run_p)
+    _add_expert_streaming_args(run_p)
     run_p.add_argument("--seed", type=int, default=0)
     _add_reasoning_arg(run_p)
     run_p.add_argument("--quiet", action="store_true", help="Hide the stats footer")
@@ -2480,6 +2487,7 @@ def build_parser() -> argparse.ArgumentParser:
     chat_p.add_argument("--top-k", type=int, default=20)
     chat_p.add_argument("--depth", type=int, default=3)
     _add_mtp_toggle_args(chat_p)
+    _add_expert_streaming_args(chat_p)
     chat_p.add_argument("--seed", type=int, default=0)
     _add_reasoning_arg(chat_p)
     chat_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
@@ -2514,6 +2522,7 @@ def build_parser() -> argparse.ArgumentParser:
     serve_p.add_argument("--port", type=int, default=8000)
     serve_p.add_argument("--depth", type=int, default=3)
     _add_mtp_toggle_args(serve_p)
+    _add_expert_streaming_args(serve_p)
     serve_p.add_argument(
         "--generation-mode",
         choices=["mtp", "ar", "auto"],

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -23,6 +23,7 @@ import importlib.metadata
 import importlib.util
 import re
 import webbrowser
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
@@ -654,6 +655,11 @@ def _generation_mode_from_args(args: Any) -> str:
         if bool(getattr(args, "no_mtp", False))
         else GENERATION_MODE_MTP
     )
+
+
+def _runtime_kv_admission(runtime: Any, tokens: int):
+    admit = getattr(runtime, "admit_kv_tokens", None)
+    return admit(tokens) if callable(admit) else nullcontext()
 
 
 def _fan_mode_from_args(args: Any) -> str:
@@ -7724,6 +7730,9 @@ def _resolve_runtime_options_on_args(
 
 
 def cmd_serve_public(args: Any) -> int:
+    from mtplx.expert_cli import expert_streaming_requested
+
+    streaming_requested = expert_streaming_requested(args)
     dry_run = bool(getattr(args, "dry_run", False))
     quiet_json = dry_run and bool(getattr(args, "json", False))
     runtime_options_error = _resolve_runtime_options_on_args(
@@ -7793,6 +7802,10 @@ def cmd_serve_public(args: Any) -> int:
     depth_error = _validate_public_depth(args, printer=_print_serve_start_line)
     if depth_error is not None:
         return depth_error
+    if streaming_requested:
+        args.no_mtp = True
+        args.load_mtp = False
+        args.generation_mode = GENERATION_MODE_AR
     generation_mode = _generation_mode_from_args(args)
     fan_mode = _fan_mode_from_args(args)
     if generation_mode == GENERATION_MODE_MTP and getattr(args, "load_mtp", True) is False:
@@ -8021,6 +8034,8 @@ def cmd_serve_public(args: Any) -> int:
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
         yes=bool(getattr(args, "yes", False)),
     )
+    if streaming_requested:
+        gate_exit = None
     if gate_exit is not None:
         _print_model_gate_error(inspection, printer=_print_serve_start_line)
         return gate_exit
@@ -8094,6 +8109,9 @@ def cmd_serve_public(args: Any) -> int:
         "--fan-mode",
         fan_mode,
     ]
+    from mtplx.expert_cli import append_expert_streaming_child_args
+
+    append_expert_streaming_child_args(cmd, args)
     for attr, flag in (
         ("max_active_requests", "--max-active-requests"),
         ("decode_batch_max", "--decode-batch-max"),
@@ -8643,17 +8661,26 @@ def _generate_one_shot_public(
     )
     if resolve_error is not None:
         return EXIT_TELEMETRY, resolve_error, []
+    from mtplx.expert_cli import expert_streaming_requested
+
+    streaming_requested = expert_streaming_requested(args)
     inspection, gate_exit = _model_gate(
         runtime_model,
         unsafe_force_unverified=bool(getattr(args, "unsafe_force_unverified", False)),
         yes=bool(getattr(args, "yes", False)),
     )
+    if streaming_requested:
+        gate_exit = None
     if gate_exit is not None:
         return (
             gate_exit,
             {"error": "model failed MTP primary gate", "model": inspection},
             [],
         )
+    if streaming_requested:
+        args.no_mtp = True
+        args.load_mtp = False
+        args.generation_mode = GENERATION_MODE_AR
     profile = get_profile(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
     apply_profile_env(profile.name)
     generation_mode = _generation_mode_from_args(args)
@@ -8694,8 +8721,12 @@ def _generate_one_shot_public(
     from mtplx.runtime import load
     from mtplx.sampling import SamplerConfig
 
+    rt = None
     try:
-        rt = load(runtime_model, mtp=True)
+        from mtplx.expert_cli import expert_streaming_load_kwargs
+
+        load_kwargs = expert_streaming_load_kwargs(args, runtime_model)
+        rt = load(runtime_model, **(load_kwargs or {"mtp": True}))
         draft_report = None
         if (
             draft_lm_head is not None
@@ -8755,33 +8786,39 @@ def _generate_one_shot_public(
             smart_request_id = f"cli-{command}-{int(time.time() * 1000)}"
             smart_fans.begin_request(smart_request_id)
         try:
-            if generation_mode == GENERATION_MODE_AR:
-                out = generate_ar(
-                    rt,
-                    prompt_ids,
-                    max_tokens=max_tokens_value,
-                    sampler=sampler,
-                    seed=args.seed,
-                )
-            else:
-                out = generate_mtpk(
-                    rt,
-                    prompt_ids,
-                    max_tokens=max_tokens_value,
-                    sampler=sampler,
-                    draft_sampler=_draft_sampler_from_spec(draft_sampler),
-                    speculative_depth=args.depth,
-                    seed=args.seed,
-                    mtp_hidden_variant="post_norm",
-                    mtp_cache_policy="persistent",
-                    mtp_history_policy="committed",
-                    verify_strategy="capture_commit",
-                    verify_core="linear-gdn-from-conv-tape",
-                )
+            with _runtime_kv_admission(
+                rt, len(prompt_ids) + max_tokens_value
+            ):
+                if generation_mode == GENERATION_MODE_AR:
+                    out = generate_ar(
+                        rt,
+                        prompt_ids,
+                        max_tokens=max_tokens_value,
+                        sampler=sampler,
+                        seed=args.seed,
+                    )
+                else:
+                    out = generate_mtpk(
+                        rt,
+                        prompt_ids,
+                        max_tokens=max_tokens_value,
+                        sampler=sampler,
+                        draft_sampler=_draft_sampler_from_spec(draft_sampler),
+                        speculative_depth=args.depth,
+                        seed=args.seed,
+                        mtp_hidden_variant="post_norm",
+                        mtp_cache_policy="persistent",
+                        mtp_history_policy="committed",
+                        verify_strategy="capture_commit",
+                        verify_core="linear-gdn-from-conv-tape",
+                    )
         finally:
             if smart_fans is not None and smart_request_id is not None:
                 smart_fans.end_request(smart_request_id, wait_for_restore=True)
     finally:
+        close_runtime = getattr(rt, "close", None)
+        if callable(close_runtime):
+            close_runtime(timeout=5.0)
         if max_session is not None:
             max_session.stop()
             thermal = max_session.thermal
@@ -9541,31 +9578,32 @@ def _quickstart_generate(
             smart_fans = SmartFanController(log=_quickstart_line)
             smart_request_id = f"terminal-{turn_index}-{int(time.time() * 1000)}"
             smart_fans.begin_request(smart_request_id)
-        if generation_mode == GENERATION_MODE_AR:
-            out = generate_ar(
-                rt,
-                prompt_ids,
-                max_tokens=max_tokens_value,
-                sampler=sampler,
-                seed=seed,
-                token_callback=record_tokens,
-            )
-        else:
-            out = generate_mtpk(
-                rt,
-                prompt_ids,
-                max_tokens=max_tokens_value,
-                sampler=sampler,
-                draft_sampler=_draft_sampler_from_spec(draft_sampler),
-                speculative_depth=int(getattr(args, "depth", 3)),
-                seed=seed,
-                mtp_hidden_variant="post_norm",
-                mtp_cache_policy="persistent",
-                mtp_history_policy="committed",
-                verify_strategy="capture_commit",
-                verify_core="linear-gdn-from-conv-tape",
-                token_callback=record_tokens,
-            )
+        with _runtime_kv_admission(rt, len(prompt_ids) + max_tokens_value):
+            if generation_mode == GENERATION_MODE_AR:
+                out = generate_ar(
+                    rt,
+                    prompt_ids,
+                    max_tokens=max_tokens_value,
+                    sampler=sampler,
+                    seed=seed,
+                    token_callback=record_tokens,
+                )
+            else:
+                out = generate_mtpk(
+                    rt,
+                    prompt_ids,
+                    max_tokens=max_tokens_value,
+                    sampler=sampler,
+                    draft_sampler=_draft_sampler_from_spec(draft_sampler),
+                    speculative_depth=int(getattr(args, "depth", 3)),
+                    seed=seed,
+                    mtp_hidden_variant="post_norm",
+                    mtp_cache_policy="persistent",
+                    mtp_history_policy="committed",
+                    verify_strategy="capture_commit",
+                    verify_core="linear-gdn-from-conv-tape",
+                    token_callback=record_tokens,
+                )
     finally:
         if smart_fans is not None and smart_request_id is not None:
             smart_fans.end_request(smart_request_id, wait_for_restore=False)
@@ -11663,7 +11701,10 @@ def _quickstart_run_terminal_chat_body(
     quiet_progress = not sys.stdout.isatty()
     with ModelLoadProgress("Loading model", quiet=quiet_progress) as progress:
         progress.set_subtitle(f"profile {profile.name}")
-        rt = load(runtime_model, mtp=True)
+        from mtplx.expert_cli import expert_streaming_load_kwargs
+
+        load_kwargs = expert_streaming_load_kwargs(args, runtime_model)
+        rt = load(runtime_model, **(load_kwargs or {"mtp": True}))
         progress.set_subtitle("ready")
     _quickstart_line(f"Model ready in {time.perf_counter() - started:.1f}s")
     _quickstart_line(f"Generation mode: {_generation_mode_label(generation_mode)}")

--- a/mtplx/expert_cli.py
+++ b/mtplx/expert_cli.py
@@ -1,0 +1,228 @@
+"""Shared CLI plumbing for opt-in SSD expert streaming."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .expert_runtime import ExpertStreamingConfig, parse_memory_bytes
+
+
+_BYTE_FIELDS = {
+    "memory_limit_bytes",
+    "runtime_reserve_bytes",
+    "expert_cache_limit_bytes",
+    "io_staging_bytes",
+    "execution_workspace_bytes",
+    "max_inflight_io_bytes",
+    "max_read_chunk_bytes",
+}
+
+
+def add_expert_streaming_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("SSD expert streaming")
+    group.add_argument(
+        "--expert-streaming",
+        action="store_true",
+        help=(
+            "Load only resident weights and stream routed Q4 experts from SSD. "
+            "This selects target-only AR for the pinned Hy3/GLM artifacts."
+        ),
+    )
+    group.add_argument(
+        "--expert-streaming-config",
+        help="JSON ExpertStreamingConfig; explicit flags below override its values.",
+    )
+    group.add_argument(
+        "--expert-manifest",
+        help="Manifest path (default: MODEL/expert-manifest.json).",
+    )
+    group.add_argument(
+        "--expert-model-key",
+        choices=["hy3-q4", "glm52-q4"],
+        help="Pinned streamed model descriptor; inferred from config.json by default.",
+    )
+    group.add_argument(
+        "--expert-memory-limit",
+        help="Total process memory ceiling, for example 96GiB or 320GiB.",
+    )
+    group.add_argument(
+        "--expert-max-live-kv-tokens",
+        type=int,
+        help="Aggregate live KV-token admission ceiling reserved in the memory plan.",
+    )
+    group.add_argument("--expert-runtime-reserve", help="Runtime/OS headroom (default 16GiB).")
+    group.add_argument("--expert-cache-limit", help="Optional persistent expert-cache cap.")
+    group.add_argument("--expert-transient-slots", type=int)
+    group.add_argument("--expert-io-staging", help="Host I/O staging reserve.")
+    group.add_argument("--expert-execution-workspace", help="Execution workspace reserve.")
+    group.add_argument("--expert-max-inflight-io", help="Bound concurrent expert-read bytes.")
+    group.add_argument("--expert-max-open-files", type=int)
+    group.add_argument("--expert-read-chunk", help="Maximum positional read chunk.")
+    group.add_argument("--expert-frequency-decay", type=float)
+    group.add_argument(
+        "--expert-prefer-sidecar",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+    )
+    group.add_argument(
+        "--expert-verify-record-hashes",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+    )
+    group.add_argument(
+        "--expert-verify-headers",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+    )
+
+
+def expert_streaming_requested(args: Any) -> bool:
+    return bool(
+        getattr(args, "expert_streaming", False)
+        or getattr(args, "expert_streaming_config", None)
+        or getattr(args, "expert_manifest", None)
+    )
+
+
+def _read_model_key(model_path: Path) -> str:
+    config_path = model_path / "config.json"
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(
+            "--expert-model-key is required when config.json cannot be read"
+        ) from exc
+    model_type = str(data.get("model_type") or "")
+    try:
+        return {"hy_v3": "hy3-q4", "glm_moe_dsa": "glm52-q4"}[model_type]
+    except KeyError as exc:
+        raise ValueError(
+            f"cannot infer streamed model key from model_type={model_type!r}"
+        ) from exc
+
+
+def _load_config_object(path: str | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"could not read expert streaming config {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("expert streaming config must contain one JSON object")
+    return dict(value)
+
+
+def _normalize_byte_fields(values: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(values)
+    for field in _BYTE_FIELDS:
+        value = normalized.get(field)
+        if isinstance(value, str):
+            normalized[field] = parse_memory_bytes(value)
+    return normalized
+
+
+def expert_streaming_load_kwargs(
+    args: Any,
+    model_path: Path | str,
+) -> dict[str, Any]:
+    """Build validated ``runtime.load`` kwargs or return an empty mapping."""
+
+    if not expert_streaming_requested(args):
+        return {}
+    root = Path(model_path).resolve()
+    values = _load_config_object(getattr(args, "expert_streaming_config", None))
+    overrides = {
+        "model_key": getattr(args, "expert_model_key", None),
+        "memory_limit_bytes": getattr(args, "expert_memory_limit", None),
+        "max_live_kv_tokens": getattr(args, "expert_max_live_kv_tokens", None),
+        "runtime_reserve_bytes": getattr(args, "expert_runtime_reserve", None),
+        "expert_cache_limit_bytes": getattr(args, "expert_cache_limit", None),
+        "transient_slots": getattr(args, "expert_transient_slots", None),
+        "io_staging_bytes": getattr(args, "expert_io_staging", None),
+        "execution_workspace_bytes": getattr(args, "expert_execution_workspace", None),
+        "max_inflight_io_bytes": getattr(args, "expert_max_inflight_io", None),
+        "max_open_files": getattr(args, "expert_max_open_files", None),
+        "max_read_chunk_bytes": getattr(args, "expert_read_chunk", None),
+        "frequency_decay": getattr(args, "expert_frequency_decay", None),
+        "prefer_sidecar": getattr(args, "expert_prefer_sidecar", None),
+        "verify_record_hashes": getattr(args, "expert_verify_record_hashes", None),
+        "verify_artifact_headers": getattr(args, "expert_verify_headers", None),
+    }
+    values.update({key: value for key, value in overrides.items() if value is not None})
+    if "model_key" not in values:
+        values["model_key"] = _read_model_key(root)
+    values.setdefault("runtime_reserve_bytes", 16 * 1024**3)
+    values.setdefault("io_staging_bytes", 0)
+    values.setdefault("execution_workspace_bytes", 0)
+    missing = [
+        name
+        for name in ("memory_limit_bytes", "max_live_kv_tokens")
+        if name not in values
+    ]
+    if missing:
+        flags = ", ".join(name.replace("_", "-") for name in missing)
+        raise ValueError(
+            "expert streaming requires explicit memory/KV admission limits; "
+            f"missing {flags}"
+        )
+    values = _normalize_byte_fields(values)
+    try:
+        config = ExpertStreamingConfig(**values)
+    except TypeError as exc:
+        raise ValueError(f"invalid expert streaming config: {exc}") from exc
+    manifest = Path(
+        getattr(args, "expert_manifest", None) or root / "expert-manifest.json"
+    ).resolve()
+    if not manifest.is_file():
+        raise ValueError(f"expert manifest does not exist: {manifest}")
+    return {
+        "mtp": False,
+        "expert_streaming_config": config,
+        "expert_manifest": manifest,
+    }
+
+
+def append_expert_streaming_child_args(command: list[str], args: Any) -> None:
+    """Forward public ``mtplx serve`` expert flags to the daemon child."""
+
+    if not expert_streaming_requested(args):
+        return
+    command.append("--expert-streaming")
+    mappings = (
+        ("expert_streaming_config", "--expert-streaming-config"),
+        ("expert_manifest", "--expert-manifest"),
+        ("expert_model_key", "--expert-model-key"),
+        ("expert_memory_limit", "--expert-memory-limit"),
+        ("expert_max_live_kv_tokens", "--expert-max-live-kv-tokens"),
+        ("expert_runtime_reserve", "--expert-runtime-reserve"),
+        ("expert_cache_limit", "--expert-cache-limit"),
+        ("expert_transient_slots", "--expert-transient-slots"),
+        ("expert_io_staging", "--expert-io-staging"),
+        ("expert_execution_workspace", "--expert-execution-workspace"),
+        ("expert_max_inflight_io", "--expert-max-inflight-io"),
+        ("expert_max_open_files", "--expert-max-open-files"),
+        ("expert_read_chunk", "--expert-read-chunk"),
+        ("expert_frequency_decay", "--expert-frequency-decay"),
+    )
+    for attribute, flag in mappings:
+        value = getattr(args, attribute, None)
+        if value is not None:
+            if attribute in {"expert_streaming_config", "expert_manifest"}:
+                value = Path(value).expanduser().resolve()
+            command.extend([flag, str(value)])
+    for attribute, positive, negative in (
+        ("expert_prefer_sidecar", "--expert-prefer-sidecar", "--no-expert-prefer-sidecar"),
+        (
+            "expert_verify_record_hashes",
+            "--expert-verify-record-hashes",
+            "--no-expert-verify-record-hashes",
+        ),
+        ("expert_verify_headers", "--expert-verify-headers", "--no-expert-verify-headers"),
+    ):
+        value = getattr(args, attribute, None)
+        if value is not None:
+            command.append(positive if value else negative)

--- a/mtplx/expert_io.py
+++ b/mtplx/expert_io.py
@@ -1,0 +1,370 @@
+"""Bounded positional I/O for manifest-described expert records."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+import time
+from collections import OrderedDict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+from .expert_manifest import (
+    ExpertManifest,
+    ExpertManifestError,
+    ExpertRecord,
+    resolve_artifact_member,
+)
+
+
+class ExpertIOError(RuntimeError):
+    """Base error for a record that did not reach a complete verified state."""
+
+
+class ExpertIOCancelled(ExpertIOError):
+    pass
+
+
+class ExpertIODeadlineExceeded(ExpertIOError):
+    pass
+
+
+class ExpertIOShortRead(ExpertIOError):
+    pass
+
+
+class ExpertIOIntegrityError(ExpertIOError):
+    pass
+
+
+@dataclass
+class ExpertIOMetrics:
+    record_requests: int = 0
+    source_record_requests: int = 0
+    sidecar_record_requests: int = 0
+    read_operations: int = 0
+    requested_bytes: int = 0
+    read_bytes: int = 0
+    read_ns: int = 0
+    open_files_peak: int = 0
+    short_reads: int = 0
+    integrity_errors: int = 0
+    cancellations: int = 0
+    deadline_errors: int = 0
+    io_errors: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def update(self, **values: int) -> None:
+        with self._lock:
+            for name, value in values.items():
+                setattr(self, name, int(getattr(self, name)) + int(value))
+
+    def observe_open_count(self, count: int) -> None:
+        with self._lock:
+            self.open_files_peak = max(self.open_files_peak, int(count))
+
+    def as_dict(self) -> dict[str, int | float]:
+        with self._lock:
+            result = {
+                name: int(getattr(self, name))
+                for name in (
+                    "record_requests",
+                    "source_record_requests",
+                    "sidecar_record_requests",
+                    "read_operations",
+                    "requested_bytes",
+                    "read_bytes",
+                    "read_ns",
+                    "open_files_peak",
+                    "short_reads",
+                    "integrity_errors",
+                    "cancellations",
+                    "deadline_errors",
+                    "io_errors",
+                )
+            }
+        result["read_mib_per_second"] = (
+            result["read_bytes"] / 1024**2 / (result["read_ns"] / 1e9)
+            if result["read_ns"]
+            else 0.0
+        )
+        return result
+
+
+@dataclass
+class _FDEntry:
+    fd: int
+    users: int = 0
+
+
+class PositionalExpertReader:
+    """Thread-safe bounded descriptor cache with exact positional reads.
+
+    Reads go directly into a caller-owned fixed slot buffer.  No record-sized
+    temporary allocation is made by this class.  The optional native backend
+    has the same contract and is loaded lazily when available.
+    """
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        max_open_files: int = 16,
+        max_read_chunk_bytes: int = 8 * 1024 * 1024,
+        use_native: bool = True,
+    ) -> None:
+        if isinstance(max_open_files, bool) or not isinstance(max_open_files, int):
+            raise TypeError("max_open_files must be an integer")
+        if max_open_files <= 0:
+            raise ValueError("max_open_files must be positive")
+        if isinstance(max_read_chunk_bytes, bool) or not isinstance(
+            max_read_chunk_bytes, int
+        ):
+            raise TypeError("max_read_chunk_bytes must be an integer")
+        if max_read_chunk_bytes <= 0:
+            raise ValueError("max_read_chunk_bytes must be positive")
+        self.root = Path(root).resolve()
+        if not self.root.is_dir():
+            raise ValueError(f"expert artifact root is not a directory: {self.root}")
+        self.max_open_files = max_open_files
+        self.max_read_chunk_bytes = max_read_chunk_bytes
+        self.metrics = ExpertIOMetrics()
+        self._condition = threading.Condition()
+        self._entries: OrderedDict[str, _FDEntry] = OrderedDict()
+        self._closed = False
+        self._native_read_into = self._load_native_reader() if use_native else None
+
+    @staticmethod
+    def _load_native_reader() -> Any | None:
+        try:
+            from mtplx_native_expert_io import pread_exact_into
+
+            return pread_exact_into
+        except Exception:
+            return None
+
+    @property
+    def backend(self) -> str:
+        return "native" if self._native_read_into is not None else "python-preadv"
+
+    def _evict_idle_locked(self) -> bool:
+        for key, entry in list(self._entries.items()):
+            if entry.users:
+                continue
+            del self._entries[key]
+            try:
+                os.close(entry.fd)
+            except OSError:
+                pass
+            return True
+        return False
+
+    @contextmanager
+    def _lease(self, relative_name: str) -> Iterator[int]:
+        resolved = resolve_artifact_member(self.root, relative_name)
+        key = str(resolved)
+        with self._condition:
+            while True:
+                if self._closed:
+                    raise ExpertIOError("expert reader is closed")
+                entry = self._entries.get(key)
+                if entry is not None:
+                    entry.users += 1
+                    self._entries.move_to_end(key)
+                    break
+                if (
+                    len(self._entries) < self.max_open_files
+                    or self._evict_idle_locked()
+                ):
+                    flags = os.O_RDONLY
+                    flags |= getattr(os, "O_CLOEXEC", 0)
+                    flags |= getattr(os, "O_NOFOLLOW", 0)
+                    try:
+                        fd = os.open(resolved, flags)
+                    except OSError as exc:
+                        raise ExpertIOError(
+                            f"could not open {relative_name}: {exc}"
+                        ) from exc
+                    entry = _FDEntry(fd=fd, users=1)
+                    self._entries[key] = entry
+                    self.metrics.observe_open_count(len(self._entries))
+                    break
+                self._condition.wait()
+        try:
+            yield entry.fd
+        finally:
+            with self._condition:
+                entry.users -= 1
+                self._entries.move_to_end(key)
+                self._condition.notify_all()
+
+    @staticmethod
+    def _check_cancelled(
+        cancel_event: threading.Event | None,
+        deadline_ns: int | None,
+    ) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise ExpertIOCancelled("expert read was cancelled")
+        if deadline_ns is not None and time.monotonic_ns() >= deadline_ns:
+            raise ExpertIODeadlineExceeded("expert read deadline exceeded")
+
+    @staticmethod
+    def _writable_bytes(destination: Any) -> memoryview:
+        try:
+            view = memoryview(destination)
+        except TypeError as exc:
+            raise TypeError(
+                "destination must support the writable buffer protocol"
+            ) from exc
+        if view.readonly:
+            raise TypeError("destination must be writable")
+        if not view.c_contiguous:
+            raise TypeError("destination must be C-contiguous")
+        try:
+            return view.cast("B")
+        except TypeError as exc:
+            raise TypeError("destination must be byte-addressable") from exc
+
+    def _read_range_into(
+        self,
+        relative_name: str,
+        source_offset: int,
+        destination: memoryview,
+        *,
+        cancel_event: threading.Event | None,
+        deadline_ns: int | None,
+    ) -> None:
+        self._check_cancelled(cancel_event, deadline_ns)
+        requested = len(destination)
+        started = time.monotonic_ns()
+        read_total = 0
+        try:
+            with self._lease(relative_name) as fd:
+                while read_total < requested:
+                    self._check_cancelled(cancel_event, deadline_ns)
+                    count = min(self.max_read_chunk_bytes, requested - read_total)
+                    target = destination[read_total : read_total + count]
+                    try:
+                        if self._native_read_into is not None:
+                            read_now = int(
+                                self._native_read_into(
+                                    fd,
+                                    source_offset + read_total,
+                                    target,
+                                )
+                            )
+                        else:
+                            read_now = int(
+                                os.preadv(fd, [target], source_offset + read_total)
+                            )
+                    except InterruptedError:
+                        continue
+                    if read_now <= 0:
+                        self.metrics.update(short_reads=1)
+                        raise ExpertIOShortRead(
+                            f"short read from {relative_name} at "
+                            f"{source_offset + read_total}; wanted {requested - read_total} bytes"
+                        )
+                    read_total += read_now
+        except ExpertIOCancelled:
+            self.metrics.update(cancellations=1)
+            raise
+        except ExpertIODeadlineExceeded:
+            self.metrics.update(deadline_errors=1)
+            raise
+        except ExpertIOError:
+            raise
+        except OSError as exc:
+            self.metrics.update(io_errors=1)
+            raise ExpertIOError(f"positional read failed: {exc}") from exc
+        finally:
+            self.metrics.update(
+                read_operations=1,
+                requested_bytes=requested,
+                read_bytes=read_total,
+                read_ns=time.monotonic_ns() - started,
+            )
+
+    def read_record_into(
+        self,
+        manifest: ExpertManifest,
+        record: ExpertRecord,
+        destination: Any,
+        *,
+        prefer_sidecar: bool = True,
+        verify_hash: bool = True,
+        cancel_event: threading.Event | None = None,
+        deadline_ns: int | None = None,
+    ) -> str:
+        """Fill a fixed record buffer and return its SHA-256 digest."""
+
+        view = self._writable_bytes(destination)
+        if len(view) != record.logical_bytes:
+            raise ValueError(
+                f"slot buffer has {len(view)} bytes; record needs {record.logical_bytes}"
+            )
+        self.metrics.update(record_requests=1)
+        if prefer_sidecar and manifest.sidecar is not None:
+            if record.sidecar_offset is None or record.sidecar_length is None:
+                raise ExpertIOError("manifest sidecar record is incomplete")
+            self.metrics.update(sidecar_record_requests=1)
+            self._read_range_into(
+                manifest.sidecar.file,
+                record.sidecar_offset,
+                view,
+                cancel_event=cancel_event,
+                deadline_ns=deadline_ns,
+            )
+        else:
+            self.metrics.update(source_record_requests=1)
+            cursor = 0
+            for segment in record.segments:
+                end = cursor + segment.length
+                self._read_range_into(
+                    segment.shard,
+                    segment.offset,
+                    view[cursor:end],
+                    cancel_event=cancel_event,
+                    deadline_ns=deadline_ns,
+                )
+                cursor = end
+            if cursor != record.logical_bytes:
+                raise ExpertIOShortRead("expert source segments did not fill the slot")
+        digest = hashlib.sha256(view).hexdigest()
+        if verify_hash:
+            if record.sha256 is None:
+                self.metrics.update(integrity_errors=1)
+                raise ExpertIOIntegrityError("expert record has no trusted hash")
+            if digest != record.sha256:
+                self.metrics.update(integrity_errors=1)
+                raise ExpertIOIntegrityError(
+                    f"expert record hash mismatch: ({record.layer}, {record.expert})"
+                )
+        return digest
+
+    def close(self) -> None:
+        with self._condition:
+            self._closed = True
+            while any(entry.users for entry in self._entries.values()):
+                self._condition.wait()
+            entries = tuple(self._entries.values())
+            self._entries.clear()
+            self._condition.notify_all()
+        for entry in entries:
+            try:
+                os.close(entry.fd)
+            except OSError:
+                pass
+
+    def __enter__(self) -> PositionalExpertReader:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def manifest_error_as_io_error(exc: ExpertManifestError) -> ExpertIOError:
+    return ExpertIOError(str(exc))

--- a/mtplx/expert_manifest.py
+++ b/mtplx/expert_manifest.py
@@ -1,0 +1,1371 @@
+"""Strict safetensors manifests for SSD-streamed MoE experts.
+
+The manifest is the trust boundary between a revision-pinned checkpoint and
+the native slot loader.  It maps every ``(layer, expert)`` to the nine affine
+Q4 leaves used by gate/up/down projections without materializing tensors.
+
+Only Python's standard library is used here so manifests can be inspected and
+verified on machines without MLX.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Iterator
+
+from .expert_streaming_models import ExpertStreamingModelSpec, get_model_spec
+
+
+MANIFEST_FORMAT = "mtplx-expert-manifest-v1"
+DEFAULT_ALIGNMENT = 16 * 1024
+MAX_SAFETENSORS_HEADER_BYTES = 128 * 1024 * 1024
+
+_PROJECTIONS = ("gate_proj", "up_proj", "down_proj")
+_LEAVES = ("weight", "scales", "biases")
+_COMPONENTS = tuple(
+    f"{projection}.{leaf}" for projection in _PROJECTIONS for leaf in _LEAVES
+)
+_LAYER_RE = re.compile(
+    r"(?:^|\.)layers\.(?P<layer>\d+)\.mlp\."
+    r"(?P<container>switch_mlp|experts)\.(?P<tail>.+)$"
+)
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "I8": 1,
+    "U8": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F64": 8,
+}
+
+
+class ExpertManifestError(ValueError):
+    """Raised when artifact provenance or layout fails closed validation."""
+
+
+def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ExpertManifestError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_json_bytes(payload: bytes, *, source: str) -> Any:
+    try:
+        return json.loads(payload, object_pairs_hook=_strict_pairs)
+    except ExpertManifestError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExpertManifestError(f"invalid JSON in {source}: {exc}") from exc
+
+
+def _load_json_file(path: Path) -> Any:
+    try:
+        payload = _read_file_nofollow(path)
+    except OSError as exc:
+        raise ExpertManifestError(f"could not read {path}: {exc}") from exc
+    return _load_json_bytes(payload, source=str(path))
+
+
+def _expect_object(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ExpertManifestError(f"{label} must be an object")
+    return value
+
+
+def _expect_keys(
+    value: dict[str, Any],
+    *,
+    label: str,
+    required: Iterable[str],
+    optional: Iterable[str] = (),
+) -> None:
+    required_set = set(required)
+    allowed = required_set | set(optional)
+    missing = required_set - set(value)
+    unknown = set(value) - allowed
+    if missing:
+        raise ExpertManifestError(f"{label} is missing keys: {sorted(missing)}")
+    if unknown:
+        raise ExpertManifestError(f"{label} has unknown keys: {sorted(unknown)}")
+
+
+def _integer(value: Any, *, label: str, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ExpertManifestError(f"{label} must be an exact integer")
+    if value < minimum:
+        raise ExpertManifestError(f"{label} must be at least {minimum}")
+    return value
+
+
+def _string(value: Any, *, label: str, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise ExpertManifestError(f"{label} must be a non-empty string")
+    return value
+
+
+def _shape(value: Any, *, label: str) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ExpertManifestError(f"{label} must be an integer array")
+    return tuple(_integer(item, label=f"{label}[]", minimum=1) for item in value)
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _readonly_flags() -> int:
+    return os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+def _read_file_nofollow(path: Path, *, chunk_bytes: int = 8 * 1024 * 1024) -> bytes:
+    chunks: list[bytes] = []
+    fd = os.open(path, _readonly_flags())
+    try:
+        while True:
+            try:
+                chunk = os.read(fd, chunk_bytes)
+            except InterruptedError:
+                continue
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+    return b"".join(chunks)
+
+
+def _hash_file(path: Path, *, chunk_bytes: int = 8 * 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    fd: int | None = None
+    try:
+        fd = os.open(path, _readonly_flags())
+        while True:
+            try:
+                chunk = os.read(fd, chunk_bytes)
+            except InterruptedError:
+                continue
+            if not chunk:
+                break
+            digest.update(chunk)
+    except OSError as exc:
+        raise ExpertManifestError(f"could not hash {path}: {exc}") from exc
+    finally:
+        if fd is not None:
+            os.close(fd)
+    return digest.hexdigest()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _safe_relative_name(name: str, *, label: str) -> str:
+    value = _string(name, label=label)
+    if "\\" in value:
+        raise ExpertManifestError(f"{label} must use POSIX separators")
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or ".." in pure.parts or "." in pure.parts:
+        raise ExpertManifestError(f"unsafe {label}: {value!r}")
+    normalized = pure.as_posix()
+    if normalized in {"", "."}:
+        raise ExpertManifestError(f"unsafe {label}: {value!r}")
+    return normalized
+
+
+def _resolve_member(root: Path, name: str, *, must_exist: bool = True) -> Path:
+    relative = _safe_relative_name(name, label="artifact path")
+    base = root.resolve()
+    candidate = base.joinpath(*PurePosixPath(relative).parts)
+    try:
+        resolved = candidate.resolve(strict=must_exist)
+    except OSError as exc:
+        raise ExpertManifestError(
+            f"could not resolve artifact member {relative}: {exc}"
+        ) from exc
+    if resolved != base and base not in resolved.parents:
+        raise ExpertManifestError(f"artifact member escapes root: {relative}")
+    if must_exist and not resolved.is_file():
+        raise ExpertManifestError(f"artifact member is not a file: {relative}")
+    return resolved
+
+
+def resolve_artifact_member(
+    root: Path | str,
+    name: str,
+    *,
+    must_exist: bool = True,
+) -> Path:
+    """Resolve a manifest member without permitting path or symlink escape."""
+
+    return _resolve_member(Path(root), name, must_exist=must_exist)
+
+
+@dataclass(frozen=True)
+class ShardInfo:
+    name: str
+    size: int
+    header_bytes: int
+    header_sha256: str
+    sha256: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "name": self.name,
+            "size": self.size,
+            "header_bytes": self.header_bytes,
+            "header_sha256": self.header_sha256,
+        }
+        if self.sha256 is not None:
+            result["sha256"] = self.sha256
+        return result
+
+    @classmethod
+    def from_dict(cls, value: Any) -> ShardInfo:
+        obj = _expect_object(value, label="shard")
+        _expect_keys(
+            obj,
+            label="shard",
+            required=("name", "size", "header_bytes", "header_sha256"),
+            optional=("sha256",),
+        )
+        digest = obj.get("sha256")
+        return cls(
+            name=_safe_relative_name(obj["name"], label="shard name"),
+            size=_integer(obj["size"], label="shard size", minimum=1),
+            header_bytes=_integer(
+                obj["header_bytes"], label="shard header_bytes", minimum=1
+            ),
+            header_sha256=_string(obj["header_sha256"], label="shard header_sha256"),
+            sha256=None if digest is None else _string(digest, label="shard sha256"),
+        )
+
+
+@dataclass(frozen=True)
+class TensorSegment:
+    component: str
+    tensor: str
+    shard: str
+    offset: int
+    length: int
+    dtype: str
+    shape: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "component": self.component,
+            "tensor": self.tensor,
+            "shard": self.shard,
+            "offset": self.offset,
+            "length": self.length,
+            "dtype": self.dtype,
+            "shape": list(self.shape),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> TensorSegment:
+        obj = _expect_object(value, label="segment")
+        _expect_keys(
+            obj,
+            label="segment",
+            required=(
+                "component",
+                "tensor",
+                "shard",
+                "offset",
+                "length",
+                "dtype",
+                "shape",
+            ),
+        )
+        component = _string(obj["component"], label="segment component")
+        if component not in _COMPONENTS:
+            raise ExpertManifestError(f"unsupported expert component {component!r}")
+        dtype = _string(obj["dtype"], label="segment dtype")
+        if dtype not in _DTYPE_BYTES:
+            raise ExpertManifestError(f"unsupported safetensors dtype {dtype!r}")
+        return cls(
+            component=component,
+            tensor=_string(obj["tensor"], label="segment tensor"),
+            shard=_safe_relative_name(obj["shard"], label="segment shard"),
+            offset=_integer(obj["offset"], label="segment offset"),
+            length=_integer(obj["length"], label="segment length", minimum=1),
+            dtype=dtype,
+            shape=_shape(obj["shape"], label="segment shape"),
+        )
+
+
+@dataclass(frozen=True)
+class ResidentTensor:
+    tensor: str
+    shard: str
+    offset: int
+    length: int
+    dtype: str
+    shape: tuple[int, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tensor": self.tensor,
+            "shard": self.shard,
+            "offset": self.offset,
+            "length": self.length,
+            "dtype": self.dtype,
+            "shape": list(self.shape),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> ResidentTensor:
+        obj = _expect_object(value, label="resident tensor")
+        _expect_keys(
+            obj,
+            label="resident tensor",
+            required=("tensor", "shard", "offset", "length", "dtype", "shape"),
+        )
+        dtype = _string(obj["dtype"], label="resident dtype")
+        if dtype not in _DTYPE_BYTES:
+            raise ExpertManifestError(f"unsupported safetensors dtype {dtype!r}")
+        return cls(
+            tensor=_string(obj["tensor"], label="resident tensor name"),
+            shard=_safe_relative_name(obj["shard"], label="resident shard"),
+            offset=_integer(obj["offset"], label="resident offset"),
+            length=_integer(obj["length"], label="resident length", minimum=1),
+            dtype=dtype,
+            shape=_shape(obj["shape"], label="resident shape"),
+        )
+
+
+@dataclass(frozen=True)
+class ExpertRecord:
+    layer: int
+    expert: int
+    logical_bytes: int
+    segments: tuple[TensorSegment, ...]
+    sha256: str | None = None
+    sidecar_offset: int | None = None
+    sidecar_length: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "layer": self.layer,
+            "expert": self.expert,
+            "logical_bytes": self.logical_bytes,
+            "segments": [segment.to_dict() for segment in self.segments],
+        }
+        if self.sha256 is not None:
+            result["sha256"] = self.sha256
+        if self.sidecar_offset is not None:
+            result["sidecar_offset"] = self.sidecar_offset
+            result["sidecar_length"] = self.sidecar_length
+        return result
+
+    @classmethod
+    def from_dict(cls, value: Any) -> ExpertRecord:
+        obj = _expect_object(value, label="expert record")
+        _expect_keys(
+            obj,
+            label="expert record",
+            required=("layer", "expert", "logical_bytes", "segments"),
+            optional=("sha256", "sidecar_offset", "sidecar_length"),
+        )
+        raw_segments = obj["segments"]
+        if not isinstance(raw_segments, list):
+            raise ExpertManifestError("expert record segments must be an array")
+        segments = tuple(TensorSegment.from_dict(item) for item in raw_segments)
+        if tuple(segment.component for segment in segments) != _COMPONENTS:
+            raise ExpertManifestError(
+                "expert record must contain the nine ordered Q4 components"
+            )
+        digest = obj.get("sha256")
+        sidecar_offset = obj.get("sidecar_offset")
+        sidecar_length = obj.get("sidecar_length")
+        if (sidecar_offset is None) != (sidecar_length is None):
+            raise ExpertManifestError(
+                "sidecar_offset and sidecar_length must appear together"
+            )
+        return cls(
+            layer=_integer(obj["layer"], label="record layer"),
+            expert=_integer(obj["expert"], label="record expert"),
+            logical_bytes=_integer(
+                obj["logical_bytes"], label="record logical_bytes", minimum=1
+            ),
+            segments=segments,
+            sha256=None if digest is None else _string(digest, label="record sha256"),
+            sidecar_offset=(
+                None
+                if sidecar_offset is None
+                else _integer(sidecar_offset, label="record sidecar_offset")
+            ),
+            sidecar_length=(
+                None
+                if sidecar_length is None
+                else _integer(sidecar_length, label="record sidecar_length", minimum=1)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class SidecarInfo:
+    file: str
+    alignment: int
+    size: int
+    sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "alignment": self.alignment,
+            "size": self.size,
+            "sha256": self.sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SidecarInfo:
+        obj = _expect_object(value, label="sidecar")
+        _expect_keys(
+            obj, label="sidecar", required=("file", "alignment", "size", "sha256")
+        )
+        alignment = _integer(obj["alignment"], label="sidecar alignment", minimum=1)
+        if alignment & (alignment - 1):
+            raise ExpertManifestError("sidecar alignment must be a power of two")
+        return cls(
+            file=_safe_relative_name(obj["file"], label="sidecar file"),
+            alignment=alignment,
+            size=_integer(obj["size"], label="sidecar size", minimum=1),
+            sha256=_string(obj["sha256"], label="sidecar sha256"),
+        )
+
+
+@dataclass(frozen=True)
+class ExpertManifest:
+    model_key: str
+    source_repo: str
+    source_revision: str
+    quant_bits: int
+    quant_group_size: int
+    quant_mode: str
+    artifact_tensor_bytes: int
+    resident_tensor_bytes: int
+    routed_expert_bytes: int
+    shards: tuple[ShardInfo, ...]
+    resident_tensors: tuple[ResidentTensor, ...]
+    records: tuple[ExpertRecord, ...]
+    sidecar: SidecarInfo | None = None
+    manifest_sha256: str | None = None
+    format: str = MANIFEST_FORMAT
+
+    def to_dict(self, *, include_digest: bool = True) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "format": self.format,
+            "model_key": self.model_key,
+            "source_repo": self.source_repo,
+            "source_revision": self.source_revision,
+            "quantization": {
+                "bits": self.quant_bits,
+                "group_size": self.quant_group_size,
+                "mode": self.quant_mode,
+            },
+            "artifact": {
+                "tensor_bytes": self.artifact_tensor_bytes,
+                "resident_tensor_bytes": self.resident_tensor_bytes,
+                "routed_expert_bytes": self.routed_expert_bytes,
+                "shard_count": len(self.shards),
+                "record_count": len(self.records),
+            },
+            "shards": [shard.to_dict() for shard in self.shards],
+            "resident_tensors": [tensor.to_dict() for tensor in self.resident_tensors],
+            "records": [record.to_dict() for record in self.records],
+        }
+        if self.sidecar is not None:
+            result["sidecar"] = self.sidecar.to_dict()
+        if include_digest and self.manifest_sha256 is not None:
+            result["manifest_sha256"] = self.manifest_sha256
+        return result
+
+    def with_digest(self) -> ExpertManifest:
+        digest = _sha256_bytes(_canonical_json(self.to_dict(include_digest=False)))
+        return replace(self, manifest_sha256=digest)
+
+    def record(self, layer: int, expert: int) -> ExpertRecord:
+        for record in self.records:
+            if record.layer == layer and record.expert == expert:
+                return record
+        raise ExpertManifestError(f"manifest has no expert record ({layer}, {expert})")
+
+    @classmethod
+    def from_dict(cls, value: Any, *, verify_digest: bool = True) -> ExpertManifest:
+        obj = _expect_object(value, label="manifest")
+        _expect_keys(
+            obj,
+            label="manifest",
+            required=(
+                "format",
+                "model_key",
+                "source_repo",
+                "source_revision",
+                "quantization",
+                "artifact",
+                "shards",
+                "resident_tensors",
+                "records",
+            ),
+            optional=("sidecar", "manifest_sha256"),
+        )
+        if obj["format"] != MANIFEST_FORMAT:
+            raise ExpertManifestError(f"unsupported manifest format {obj['format']!r}")
+        quant = _expect_object(obj["quantization"], label="quantization")
+        _expect_keys(
+            quant, label="quantization", required=("bits", "group_size", "mode")
+        )
+        artifact = _expect_object(obj["artifact"], label="artifact")
+        _expect_keys(
+            artifact,
+            label="artifact",
+            required=(
+                "tensor_bytes",
+                "resident_tensor_bytes",
+                "routed_expert_bytes",
+                "shard_count",
+                "record_count",
+            ),
+        )
+        raw_shards = obj["shards"]
+        raw_resident = obj["resident_tensors"]
+        raw_records = obj["records"]
+        if not all(
+            isinstance(value, list) for value in (raw_shards, raw_resident, raw_records)
+        ):
+            raise ExpertManifestError(
+                "shards, resident_tensors, and records must be arrays"
+            )
+        shards = tuple(ShardInfo.from_dict(item) for item in raw_shards)
+        resident_tensors = tuple(
+            ResidentTensor.from_dict(item) for item in raw_resident
+        )
+        records = tuple(ExpertRecord.from_dict(item) for item in raw_records)
+        if artifact["shard_count"] != len(shards) or artifact["record_count"] != len(
+            records
+        ):
+            raise ExpertManifestError("artifact counts do not match manifest arrays")
+        digest = obj.get("manifest_sha256")
+        manifest = cls(
+            format=MANIFEST_FORMAT,
+            model_key=_string(obj["model_key"], label="model_key"),
+            source_repo=_string(obj["source_repo"], label="source_repo"),
+            source_revision=_string(obj["source_revision"], label="source_revision"),
+            quant_bits=_integer(quant["bits"], label="quantization bits", minimum=1),
+            quant_group_size=_integer(
+                quant["group_size"], label="quantization group_size", minimum=1
+            ),
+            quant_mode=_string(quant["mode"], label="quantization mode"),
+            artifact_tensor_bytes=_integer(
+                artifact["tensor_bytes"], label="artifact tensor_bytes", minimum=1
+            ),
+            resident_tensor_bytes=_integer(
+                artifact["resident_tensor_bytes"],
+                label="resident_tensor_bytes",
+                minimum=0,
+            ),
+            routed_expert_bytes=_integer(
+                artifact["routed_expert_bytes"], label="routed_expert_bytes", minimum=1
+            ),
+            shards=shards,
+            resident_tensors=resident_tensors,
+            records=records,
+            sidecar=None
+            if obj.get("sidecar") is None
+            else SidecarInfo.from_dict(obj["sidecar"]),
+            manifest_sha256=None
+            if digest is None
+            else _string(digest, label="manifest_sha256"),
+        )
+        manifest.validate_structure()
+        if verify_digest:
+            if manifest.manifest_sha256 is None:
+                raise ExpertManifestError("manifest_sha256 is required")
+            expected = manifest.with_digest().manifest_sha256
+            if manifest.manifest_sha256 != expected:
+                raise ExpertManifestError("manifest digest mismatch")
+        return manifest
+
+    def validate_structure(self) -> None:
+        if self.quant_bits != 4 or self.quant_mode != "affine":
+            raise ExpertManifestError("only affine Q4 expert manifests are supported")
+        if len({shard.name for shard in self.shards}) != len(self.shards):
+            raise ExpertManifestError("duplicate shard names")
+        if (
+            self.artifact_tensor_bytes
+            != self.resident_tensor_bytes + self.routed_expert_bytes
+        ):
+            raise ExpertManifestError(
+                "resident plus routed bytes do not equal artifact bytes"
+            )
+        keys = [(record.layer, record.expert) for record in self.records]
+        if keys != sorted(keys) or len(keys) != len(set(keys)):
+            raise ExpertManifestError("expert records must be sorted and unique")
+        resident_names = [tensor.tensor for tensor in self.resident_tensors]
+        if resident_names != sorted(resident_names) or len(resident_names) != len(
+            set(resident_names)
+        ):
+            raise ExpertManifestError("resident tensor names must be sorted and unique")
+        shard_sizes = {shard.name: shard.size for shard in self.shards}
+        routed_bytes = 0
+        for record in self.records:
+            if (
+                sum(segment.length for segment in record.segments)
+                != record.logical_bytes
+            ):
+                raise ExpertManifestError(
+                    f"record ({record.layer}, {record.expert}) length mismatch"
+                )
+            if (
+                record.sidecar_length is not None
+                and record.sidecar_length != record.logical_bytes
+            ):
+                raise ExpertManifestError(
+                    "sidecar record length must equal logical_bytes"
+                )
+            routed_bytes += record.logical_bytes
+            for segment in record.segments:
+                size = shard_sizes.get(segment.shard)
+                if size is None or segment.offset + segment.length > size:
+                    raise ExpertManifestError(
+                        f"segment for {segment.tensor} exceeds its shard"
+                    )
+        if routed_bytes != self.routed_expert_bytes:
+            raise ExpertManifestError("record bytes do not equal routed_expert_bytes")
+        if (
+            sum(tensor.length for tensor in self.resident_tensors)
+            != self.resident_tensor_bytes
+        ):
+            raise ExpertManifestError(
+                "resident tensor bytes do not match artifact metadata"
+            )
+        if self.sidecar is None and any(
+            record.sidecar_offset is not None for record in self.records
+        ):
+            raise ExpertManifestError("record sidecar offsets require sidecar metadata")
+        if self.sidecar is not None:
+            ranges: list[tuple[int, int]] = []
+            for record in self.records:
+                if record.sidecar_offset is None or record.sidecar_length is None:
+                    raise ExpertManifestError("every record requires a sidecar offset")
+                if record.sidecar_offset % self.sidecar.alignment:
+                    raise ExpertManifestError("sidecar record is not aligned")
+                end = record.sidecar_offset + record.sidecar_length
+                if end > self.sidecar.size:
+                    raise ExpertManifestError("sidecar record exceeds file size")
+                ranges.append((record.sidecar_offset, end))
+            if ranges != sorted(ranges) or any(
+                a[1] > b[0] for a, b in zip(ranges, ranges[1:])
+            ):
+                raise ExpertManifestError("sidecar records overlap or are unsorted")
+
+
+@dataclass(frozen=True)
+class _TensorInfo:
+    name: str
+    shard: str
+    offset: int
+    length: int
+    dtype: str
+    shape: tuple[int, ...]
+
+
+def load_expert_manifest(
+    path: Path | str, *, verify_digest: bool = True
+) -> ExpertManifest:
+    value = _load_json_file(Path(path))
+    return ExpertManifest.from_dict(value, verify_digest=verify_digest)
+
+
+def save_expert_manifest(manifest: ExpertManifest, path: Path | str) -> ExpertManifest:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    finalized = manifest.with_digest()
+    payload = json.dumps(finalized.to_dict(), indent=2, sort_keys=True) + "\n"
+    temporary: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+        )
+        temporary = Path(temporary_name)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    except OSError as exc:
+        try:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise ExpertManifestError(f"could not save manifest {target}: {exc}") from exc
+    return finalized
+
+
+def _read_safetensors_header(
+    path: Path, *, relative_name: str
+) -> tuple[ShardInfo, tuple[_TensorInfo, ...]]:
+    try:
+        fd = os.open(path, _readonly_flags())
+        try:
+            size = os.fstat(fd).st_size
+            length_raw = _pread_exact(fd, 0, 8)
+            header_length = int.from_bytes(length_raw, "little")
+            if not 1 <= header_length <= MAX_SAFETENSORS_HEADER_BYTES:
+                raise ExpertManifestError(
+                    f"{relative_name} has an invalid header length"
+                )
+            header_raw = _pread_exact(fd, 8, header_length)
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        raise ExpertManifestError(f"could not inspect {relative_name}: {exc}") from exc
+    header = _expect_object(
+        _load_json_bytes(header_raw, source=relative_name),
+        label=f"safetensors header {relative_name}",
+    )
+    data_start = 8 + header_length
+    tensors: list[_TensorInfo] = []
+    ranges: list[tuple[int, int, str]] = []
+    for name, raw in header.items():
+        if name == "__metadata__":
+            continue
+        info = _expect_object(raw, label=f"tensor {name}")
+        _expect_keys(
+            info, label=f"tensor {name}", required=("dtype", "shape", "data_offsets")
+        )
+        dtype = _string(info["dtype"], label=f"tensor {name} dtype")
+        if dtype not in _DTYPE_BYTES:
+            raise ExpertManifestError(f"tensor {name} has unsupported dtype {dtype!r}")
+        shape = _shape(info["shape"], label=f"tensor {name} shape")
+        offsets = info["data_offsets"]
+        if not isinstance(offsets, list) or len(offsets) != 2:
+            raise ExpertManifestError(f"tensor {name} has invalid data_offsets")
+        start = _integer(offsets[0], label=f"tensor {name} start")
+        end = _integer(offsets[1], label=f"tensor {name} end")
+        if end <= start:
+            raise ExpertManifestError(f"tensor {name} has an empty or reversed range")
+        length = end - start
+        expected = _DTYPE_BYTES[dtype]
+        for dimension in shape:
+            expected *= dimension
+        if length != expected:
+            raise ExpertManifestError(
+                f"tensor {name} byte length {length} does not match dtype/shape {expected}"
+            )
+        absolute_start = data_start + start
+        absolute_end = data_start + end
+        if absolute_end > size:
+            raise ExpertManifestError(f"tensor {name} exceeds {relative_name}")
+        tensors.append(
+            _TensorInfo(
+                name=name,
+                shard=relative_name,
+                offset=absolute_start,
+                length=length,
+                dtype=dtype,
+                shape=shape,
+            )
+        )
+        ranges.append((absolute_start, absolute_end, name))
+    if not tensors:
+        raise ExpertManifestError(f"{relative_name} contains no tensors")
+    ranges.sort()
+    for previous, current in zip(ranges, ranges[1:]):
+        if previous[1] > current[0]:
+            raise ExpertManifestError(
+                f"overlapping tensors in {relative_name}: {previous[2]} and {current[2]}"
+            )
+    if max(end for _start, end, _name in ranges) != size:
+        raise ExpertManifestError(
+            f"{relative_name} has trailing or unindexed payload bytes"
+        )
+    shard = ShardInfo(
+        name=relative_name,
+        size=size,
+        header_bytes=data_start,
+        header_sha256=_sha256_bytes(length_raw + header_raw),
+    )
+    return shard, tuple(tensors)
+
+
+def _checkpoint_inventory(
+    root: Path,
+    *,
+    hash_shards: bool,
+) -> tuple[tuple[ShardInfo, ...], dict[str, _TensorInfo]]:
+    index_path = root / "model.safetensors.index.json"
+    weight_map: dict[str, str] | None = None
+    if index_path.is_file():
+        index = _expect_object(_load_json_file(index_path), label="safetensors index")
+        _expect_keys(
+            index,
+            label="safetensors index",
+            required=("weight_map",),
+            optional=("metadata",),
+        )
+        raw_map = _expect_object(index["weight_map"], label="safetensors weight_map")
+        weight_map = {}
+        for tensor, shard in raw_map.items():
+            tensor_name = _string(tensor, label="weight_map tensor")
+            shard_name = _safe_relative_name(shard, label="weight_map shard")
+            weight_map[tensor_name] = shard_name
+        shard_names = sorted(set(weight_map.values()))
+    else:
+        shard_names = sorted(
+            path.name for path in root.glob("model*.safetensors") if path.is_file()
+        )
+    if not shard_names:
+        raise ExpertManifestError(f"no model safetensors found under {root}")
+
+    shards: list[ShardInfo] = []
+    tensors: dict[str, _TensorInfo] = {}
+    for name in shard_names:
+        path = _resolve_member(root, name)
+        shard, shard_tensors = _read_safetensors_header(path, relative_name=name)
+        if hash_shards:
+            shard = replace(shard, sha256=_hash_file(path))
+        shards.append(shard)
+        for tensor in shard_tensors:
+            if tensor.name in tensors:
+                raise ExpertManifestError(
+                    f"tensor {tensor.name!r} appears in multiple shards"
+                )
+            if weight_map is not None and weight_map.get(tensor.name) != name:
+                raise ExpertManifestError(
+                    f"index maps tensor {tensor.name!r} to the wrong shard"
+                )
+            tensors[tensor.name] = tensor
+    if weight_map is not None and set(weight_map) != set(tensors):
+        missing = sorted(set(weight_map) - set(tensors))
+        extra = sorted(set(tensors) - set(weight_map))
+        raise ExpertManifestError(
+            f"index/header tensor mismatch; missing={missing[:4]}, extra={extra[:4]}"
+        )
+    return tuple(shards), tensors
+
+
+def _expected_component_shape(
+    spec: ExpertStreamingModelSpec,
+    component: str,
+) -> tuple[str, tuple[int, ...], int]:
+    projection, leaf = component.split(".", 1)
+    output = (
+        spec.expert_hidden_size
+        if projection in {"gate_proj", "up_proj"}
+        else spec.hidden_size
+    )
+    input_size = (
+        spec.hidden_size
+        if projection in {"gate_proj", "up_proj"}
+        else spec.expert_hidden_size
+    )
+    if leaf == "weight":
+        dtype = "U32"
+        shape = (output, input_size * spec.quant_bits // 32)
+    else:
+        dtype = "BF16"
+        shape = (output, input_size // spec.quant_group_size)
+    length = _DTYPE_BYTES[dtype]
+    for dimension in shape:
+        length *= dimension
+    return dtype, shape, length
+
+
+def _classify_expert_tensor(
+    tensor: _TensorInfo,
+    spec: ExpertStreamingModelSpec,
+) -> tuple[int, int | None, str] | None:
+    match = _LAYER_RE.search(tensor.name)
+    if match is None:
+        return None
+    layer = int(match.group("layer"))
+    if layer not in spec.routed_layer_indices:
+        return None
+    parts = match.group("tail").split(".")
+    expert: int | None = None
+    if len(parts) == 2 and parts[0] in _PROJECTIONS and parts[1] in _LEAVES:
+        projection, leaf = parts
+    elif (
+        len(parts) == 3
+        and parts[0].isdigit()
+        and parts[1] in _PROJECTIONS
+        and parts[2] in _LEAVES
+    ):
+        expert = int(parts[0])
+        projection, leaf = parts[1:]
+    else:
+        return None
+    return layer, expert, f"{projection}.{leaf}"
+
+
+def _expert_segments(
+    tensors: dict[str, _TensorInfo],
+    spec: ExpertStreamingModelSpec,
+) -> tuple[tuple[ExpertRecord, ...], set[str]]:
+    if spec.quant_bits != 4 or spec.quant_parameter_bytes != 2:
+        raise ExpertManifestError(
+            "manifest builder currently supports affine Q4/BF16 metadata"
+        )
+    grouped: dict[tuple[int, int, str], TensorSegment] = {}
+    expert_tensor_names: set[str] = set()
+    for tensor in tensors.values():
+        classified = _classify_expert_tensor(tensor, spec)
+        if classified is None:
+            continue
+        layer, numbered_expert, component = classified
+        expected_dtype, per_expert_shape, per_expert_length = _expected_component_shape(
+            spec, component
+        )
+        if tensor.dtype != expected_dtype:
+            raise ExpertManifestError(
+                f"{tensor.name} dtype {tensor.dtype} does not match {expected_dtype}"
+            )
+        if numbered_expert is None:
+            expected_shape = (spec.expert_count, *per_expert_shape)
+            if (
+                tensor.shape != expected_shape
+                or tensor.length != per_expert_length * spec.expert_count
+            ):
+                raise ExpertManifestError(
+                    f"{tensor.name} shape/length does not match stacked {expected_shape}"
+                )
+            experts = range(spec.expert_count)
+        else:
+            if not 0 <= numbered_expert < spec.expert_count:
+                raise ExpertManifestError(
+                    f"{tensor.name} expert index is outside the model"
+                )
+            if tensor.shape != per_expert_shape or tensor.length != per_expert_length:
+                raise ExpertManifestError(
+                    f"{tensor.name} shape/length does not match {per_expert_shape}"
+                )
+            experts = (numbered_expert,)
+        expert_tensor_names.add(tensor.name)
+        for expert in experts:
+            key = (layer, expert, component)
+            if key in grouped:
+                raise ExpertManifestError(f"duplicate expert component {key}")
+            relative_index = expert if numbered_expert is None else 0
+            grouped[key] = TensorSegment(
+                component=component,
+                tensor=tensor.name,
+                shard=tensor.shard,
+                offset=tensor.offset + relative_index * per_expert_length,
+                length=per_expert_length,
+                dtype=tensor.dtype,
+                shape=per_expert_shape,
+            )
+
+    records: list[ExpertRecord] = []
+    missing: list[tuple[int, int, str]] = []
+    for layer in spec.routed_layer_indices:
+        for expert in range(spec.expert_count):
+            segments: list[TensorSegment] = []
+            for component in _COMPONENTS:
+                segment = grouped.get((layer, expert, component))
+                if segment is None:
+                    missing.append((layer, expert, component))
+                else:
+                    segments.append(segment)
+            if len(segments) == len(_COMPONENTS):
+                logical_bytes = sum(segment.length for segment in segments)
+                if logical_bytes != spec.expert_record_bytes:
+                    raise ExpertManifestError(
+                        f"record ({layer}, {expert}) has {logical_bytes} bytes, expected "
+                        f"{spec.expert_record_bytes}"
+                    )
+                records.append(
+                    ExpertRecord(
+                        layer=layer,
+                        expert=expert,
+                        logical_bytes=logical_bytes,
+                        segments=tuple(segments),
+                    )
+                )
+    if missing:
+        preview = ", ".join(str(item) for item in missing[:8])
+        raise ExpertManifestError(
+            f"checkpoint is missing {len(missing)} expert components: {preview}"
+        )
+    return tuple(records), expert_tensor_names
+
+
+def _pread_exact(fd: int, offset: int, length: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = length
+    position = offset
+    while remaining:
+        try:
+            chunk = os.pread(fd, remaining, position)
+        except InterruptedError:
+            continue
+        if not chunk:
+            raise ExpertManifestError(
+                f"short positional read at offset {position}; wanted {remaining} more bytes"
+            )
+        chunks.append(chunk)
+        position += len(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _read_source_record(root: Path, record: ExpertRecord) -> bytes:
+    descriptors: dict[str, int] = {}
+    chunks: list[bytes] = []
+    try:
+        for segment in record.segments:
+            fd = descriptors.get(segment.shard)
+            if fd is None:
+                path = _resolve_member(root, segment.shard)
+                flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+                flags |= getattr(os, "O_NOFOLLOW", 0)
+                fd = os.open(path, flags)
+                descriptors[segment.shard] = fd
+            chunks.append(_pread_exact(fd, segment.offset, segment.length))
+    except OSError as exc:
+        raise ExpertManifestError(
+            f"could not read record ({record.layer}, {record.expert}): {exc}"
+        ) from exc
+    finally:
+        for fd in descriptors.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    return b"".join(chunks)
+
+
+def build_expert_manifest(
+    root: Path | str,
+    spec: ExpertStreamingModelSpec | str,
+    *,
+    source_repo: str | None = None,
+    source_revision: str | None = None,
+    hash_records: bool = True,
+    hash_shards: bool = False,
+    require_pinned_tensor_bytes: bool = True,
+) -> ExpertManifest:
+    """Inspect a checkpoint and build a strict deterministic expert manifest."""
+
+    artifact_root = Path(root).resolve()
+    if not artifact_root.is_dir():
+        raise ExpertManifestError(f"artifact root is not a directory: {artifact_root}")
+    model_spec = get_model_spec(spec) if isinstance(spec, str) else spec
+    if not isinstance(model_spec, ExpertStreamingModelSpec):
+        raise TypeError("spec must be a model key or ExpertStreamingModelSpec")
+    shards, tensors = _checkpoint_inventory(artifact_root, hash_shards=hash_shards)
+    records, expert_tensor_names = _expert_segments(tensors, model_spec)
+    tensor_bytes = sum(tensor.length for tensor in tensors.values())
+    if require_pinned_tensor_bytes and tensor_bytes != model_spec.total_tensor_bytes:
+        raise ExpertManifestError(
+            f"artifact tensor bytes {tensor_bytes} do not match pinned "
+            f"{model_spec.total_tensor_bytes}"
+        )
+    routed_bytes = sum(record.logical_bytes for record in records)
+    if routed_bytes != model_spec.routed_expert_bytes:
+        raise ExpertManifestError(
+            f"routed bytes {routed_bytes} do not match pinned {model_spec.routed_expert_bytes}"
+        )
+    resident_tensors = tuple(
+        ResidentTensor(
+            tensor=tensor.name,
+            shard=tensor.shard,
+            offset=tensor.offset,
+            length=tensor.length,
+            dtype=tensor.dtype,
+            shape=tensor.shape,
+        )
+        for tensor in sorted(tensors.values(), key=lambda item: item.name)
+        if tensor.name not in expert_tensor_names
+    )
+    resident_bytes = sum(tensor.length for tensor in resident_tensors)
+    if resident_bytes + routed_bytes != tensor_bytes:
+        raise ExpertManifestError(
+            "expert/resident classification does not cover the artifact"
+        )
+    if require_pinned_tensor_bytes and resident_bytes != model_spec.resident_bytes:
+        raise ExpertManifestError(
+            f"resident bytes {resident_bytes} do not match pinned {model_spec.resident_bytes}"
+        )
+    if hash_records:
+        hashed: list[ExpertRecord] = []
+        for record in records:
+            payload = _read_source_record(artifact_root, record)
+            hashed.append(replace(record, sha256=_sha256_bytes(payload)))
+        records = tuple(hashed)
+    manifest = ExpertManifest(
+        model_key=model_spec.key,
+        source_repo=source_repo or model_spec.quant_model,
+        source_revision=source_revision or model_spec.quant_revision,
+        quant_bits=model_spec.quant_bits,
+        quant_group_size=model_spec.quant_group_size,
+        quant_mode="affine",
+        artifact_tensor_bytes=tensor_bytes,
+        resident_tensor_bytes=resident_bytes,
+        routed_expert_bytes=routed_bytes,
+        shards=shards,
+        resident_tensors=resident_tensors,
+        records=records,
+    ).with_digest()
+    manifest.validate_structure()
+    return manifest
+
+
+def verify_expert_manifest(
+    manifest: ExpertManifest,
+    root: Path | str,
+    *,
+    verify_records: bool = False,
+    verify_shard_hashes: bool = False,
+    verify_sidecar_hash: bool = False,
+) -> dict[str, int | bool | str]:
+    """Verify provenance, bounds, optional payload hashes, and sidecar state."""
+
+    artifact_root = Path(root).resolve()
+    manifest.validate_structure()
+    if manifest.manifest_sha256 != manifest.with_digest().manifest_sha256:
+        raise ExpertManifestError("manifest digest mismatch")
+    checked_shards = 0
+    for shard in manifest.shards:
+        path = _resolve_member(artifact_root, shard.name)
+        current, _tensors = _read_safetensors_header(path, relative_name=shard.name)
+        if (
+            current.size != shard.size
+            or current.header_bytes != shard.header_bytes
+            or current.header_sha256 != shard.header_sha256
+        ):
+            raise ExpertManifestError(f"shard provenance mismatch: {shard.name}")
+        if verify_shard_hashes:
+            if shard.sha256 is None:
+                raise ExpertManifestError(f"shard {shard.name} has no full-file hash")
+            if _hash_file(path) != shard.sha256:
+                raise ExpertManifestError(f"shard hash mismatch: {shard.name}")
+        checked_shards += 1
+    checked_records = 0
+    if verify_records:
+        for record in manifest.records:
+            if record.sha256 is None:
+                raise ExpertManifestError(
+                    f"record ({record.layer}, {record.expert}) has no hash"
+                )
+            if (
+                _sha256_bytes(_read_source_record(artifact_root, record))
+                != record.sha256
+            ):
+                raise ExpertManifestError(
+                    f"record hash mismatch: ({record.layer}, {record.expert})"
+                )
+            checked_records += 1
+    sidecar_verified = False
+    if manifest.sidecar is not None:
+        sidecar_path = _resolve_member(artifact_root, manifest.sidecar.file)
+        if sidecar_path.stat().st_size != manifest.sidecar.size:
+            raise ExpertManifestError("sidecar size mismatch")
+        if verify_sidecar_hash:
+            if _hash_file(sidecar_path) != manifest.sidecar.sha256:
+                raise ExpertManifestError("sidecar hash mismatch")
+            sidecar_verified = True
+    return {
+        "valid": True,
+        "model_key": manifest.model_key,
+        "checked_shards": checked_shards,
+        "checked_records": checked_records,
+        "sidecar_verified": sidecar_verified,
+    }
+
+
+def read_expert_record(
+    manifest: ExpertManifest,
+    root: Path | str,
+    layer: int,
+    expert: int,
+    *,
+    prefer_sidecar: bool = True,
+    verify_hash: bool = True,
+) -> bytes:
+    """Read one complete expert record from sidecar or source segments."""
+
+    record = manifest.record(layer, expert)
+    artifact_root = Path(root).resolve()
+    if prefer_sidecar and manifest.sidecar is not None:
+        if record.sidecar_offset is None or record.sidecar_length is None:
+            raise ExpertManifestError("manifest sidecar record is incomplete")
+        path = _resolve_member(artifact_root, manifest.sidecar.file)
+        try:
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(path, flags)
+            try:
+                payload = _pread_exact(fd, record.sidecar_offset, record.sidecar_length)
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            raise ExpertManifestError(f"could not read sidecar record: {exc}") from exc
+    else:
+        payload = _read_source_record(artifact_root, record)
+    if len(payload) != record.logical_bytes:
+        raise ExpertManifestError("expert record length mismatch")
+    if verify_hash:
+        if record.sha256 is None:
+            raise ExpertManifestError("record has no payload hash")
+        if _sha256_bytes(payload) != record.sha256:
+            raise ExpertManifestError(
+                f"record hash mismatch: ({record.layer}, {record.expert})"
+            )
+    return payload
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) & -alignment
+
+
+def _relative_output(root: Path, output: Path) -> tuple[str, Path]:
+    base = root.resolve()
+    parent = output.parent.resolve()
+    try:
+        relative_parent = parent.relative_to(base)
+    except ValueError as exc:
+        raise ExpertManifestError(
+            "sidecar must be created inside the artifact root"
+        ) from exc
+    relative = (relative_parent / output.name).as_posix()
+    return _safe_relative_name(relative, label="sidecar output"), parent / output.name
+
+
+def build_expert_sidecar(
+    manifest: ExpertManifest,
+    root: Path | str,
+    output: Path | str,
+    *,
+    alignment: int = DEFAULT_ALIGNMENT,
+    resume: bool = True,
+    overwrite: bool = False,
+) -> ExpertManifest:
+    """Build a resumable expert-major sidecar and return an updated manifest."""
+
+    if isinstance(alignment, bool) or not isinstance(alignment, int) or alignment <= 0:
+        raise ExpertManifestError("alignment must be a positive integer")
+    if alignment & (alignment - 1):
+        raise ExpertManifestError("alignment must be a power of two")
+    artifact_root = Path(root).resolve()
+    relative_output, final_path = _relative_output(artifact_root, Path(output))
+    if final_path.exists() and not overwrite:
+        raise ExpertManifestError(f"sidecar already exists: {final_path}")
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    partial = final_path.with_name(f".{final_path.name}.partial")
+    if partial.exists() and not resume:
+        partial.unlink()
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(partial, flags, 0o644)
+    except OSError as exc:
+        raise ExpertManifestError(
+            f"could not open sidecar partial file: {exc}"
+        ) from exc
+
+    updated_records: list[ExpertRecord] = []
+    cursor = 0
+    try:
+        for record in manifest.records:
+            offset = _align_up(cursor, alignment)
+            payload = read_expert_record(
+                manifest,
+                artifact_root,
+                record.layer,
+                record.expert,
+                prefer_sidecar=False,
+                verify_hash=record.sha256 is not None,
+            )
+            digest = _sha256_bytes(payload)
+            current_size = os.fstat(fd).st_size
+            reusable = False
+            if resume and current_size >= offset + len(payload):
+                reusable = (
+                    _sha256_bytes(_pread_exact(fd, offset, len(payload))) == digest
+                )
+            if not reusable:
+                os.ftruncate(fd, offset)
+                if offset > os.fstat(fd).st_size:
+                    os.ftruncate(fd, offset)
+                position = offset
+                view = memoryview(payload)
+                while view:
+                    try:
+                        written = os.pwrite(fd, view, position)
+                    except InterruptedError:
+                        continue
+                    if written <= 0:
+                        raise ExpertManifestError("short positional sidecar write")
+                    position += written
+                    view = view[written:]
+            updated_records.append(
+                replace(
+                    record,
+                    sha256=digest,
+                    sidecar_offset=offset,
+                    sidecar_length=len(payload),
+                )
+            )
+            cursor = offset + len(payload)
+        os.ftruncate(fd, cursor)
+        os.fsync(fd)
+    except (OSError, ExpertManifestError) as exc:
+        if isinstance(exc, ExpertManifestError):
+            raise
+        raise ExpertManifestError(f"sidecar build failed: {exc}") from exc
+    finally:
+        os.close(fd)
+
+    sidecar_sha256 = _hash_file(partial)
+    try:
+        os.replace(partial, final_path)
+        directory_fd = os.open(final_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError as exc:
+        raise ExpertManifestError(f"could not publish sidecar: {exc}") from exc
+    updated = replace(
+        manifest,
+        records=tuple(updated_records),
+        sidecar=SidecarInfo(
+            file=relative_output,
+            alignment=alignment,
+            size=cursor,
+            sha256=sidecar_sha256,
+        ),
+        manifest_sha256=None,
+    ).with_digest()
+    updated.validate_structure()
+    return updated
+
+
+def iter_record_keys(manifest: ExpertManifest) -> Iterator[tuple[int, int]]:
+    for record in manifest.records:
+        yield record.layer, record.expert

--- a/mtplx/expert_runtime.py
+++ b/mtplx/expert_runtime.py
@@ -1,0 +1,554 @@
+"""Model-independent orchestration for bounded SSD expert streaming."""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from .expert_io import PositionalExpertReader
+from .expert_manifest import (
+    ExpertManifest,
+    ExpertManifestError,
+    load_expert_manifest,
+    verify_expert_manifest,
+)
+from .expert_slots import ExpertSlotError, ExpertSlotPool, ReadyRoute
+from .expert_streaming import (
+    CacheCounters,
+    LayerExpertSlotBank,
+    RoutingPhase,
+)
+from .expert_streaming_models import (
+    ExpertMemoryPlan,
+    ExpertStreamingModelSpec,
+    get_model_spec,
+    plan_expert_memory,
+)
+
+
+_MEMORY_RE = re.compile(r"^([0-9]+)([kmgt]i?b?|b)?$", re.IGNORECASE)
+
+
+class ExpertStreamingConfigurationError(ValueError):
+    pass
+
+
+def _integer(name: str, value: object, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an exact integer")
+    if value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return value
+
+
+def parse_memory_bytes(value: str | int) -> int:
+    if isinstance(value, bool):
+        raise ExpertStreamingConfigurationError("memory size must not be bool")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ExpertStreamingConfigurationError("memory size must be positive")
+        return value
+    if not isinstance(value, str):
+        raise ExpertStreamingConfigurationError(
+            "memory size must be bytes or a suffixed string"
+        )
+    normalized = value.strip().lower()
+    match = _MEMORY_RE.fullmatch(normalized)
+    if match is None:
+        raise ExpertStreamingConfigurationError(f"invalid memory size {value!r}")
+    number = int(match.group(1))
+    suffix = (match.group(2) or "b").lower()
+    multipliers = {
+        "b": 1,
+        "k": 1024,
+        "kb": 1024,
+        "kib": 1024,
+        "m": 1024**2,
+        "mb": 1024**2,
+        "mib": 1024**2,
+        "g": 1024**3,
+        "gb": 1024**3,
+        "gib": 1024**3,
+        "t": 1024**4,
+        "tb": 1024**4,
+        "tib": 1024**4,
+    }
+    result = number * multipliers[suffix]
+    if result <= 0:
+        raise ExpertStreamingConfigurationError("memory size must be positive")
+    return result
+
+
+@dataclass(frozen=True)
+class ExpertStreamingConfig:
+    model_key: str
+    memory_limit_bytes: int
+    max_live_kv_tokens: int
+    runtime_reserve_bytes: int = 16 * 1024**3
+    expert_cache_limit_bytes: int | None = None
+    transient_slots: int | None = None
+    io_staging_bytes: int = 0
+    execution_workspace_bytes: int = 0
+    max_inflight_io_bytes: int | None = None
+    max_open_files: int = 16
+    max_read_chunk_bytes: int = 8 * 1024 * 1024
+    frequency_decay: float = 0.995
+    prefer_sidecar: bool = True
+    verify_record_hashes: bool = True
+    verify_artifact_headers: bool = True
+    prefill_admission: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model_key, str) or not self.model_key:
+            raise TypeError("model_key must be a non-empty string")
+        for name, minimum in (
+            ("memory_limit_bytes", 1),
+            ("max_live_kv_tokens", 0),
+            ("runtime_reserve_bytes", 0),
+            ("io_staging_bytes", 0),
+            ("execution_workspace_bytes", 0),
+            ("max_open_files", 1),
+            ("max_read_chunk_bytes", 1),
+        ):
+            object.__setattr__(
+                self, name, _integer(name, getattr(self, name), minimum=minimum)
+            )
+        for name in (
+            "expert_cache_limit_bytes",
+            "transient_slots",
+            "max_inflight_io_bytes",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(self, name, _integer(name, value, minimum=0))
+        if self.max_inflight_io_bytes == 0:
+            raise ValueError("max_inflight_io_bytes must be positive when supplied")
+        if isinstance(self.frequency_decay, bool):
+            raise TypeError("frequency_decay must be numeric")
+        decay = float(self.frequency_decay)
+        if not 0.0 < decay <= 1.0:
+            raise ValueError("frequency_decay must be in (0, 1]")
+        object.__setattr__(self, "frequency_decay", decay)
+        for name in (
+            "prefer_sidecar",
+            "verify_record_hashes",
+            "verify_artifact_headers",
+            "prefill_admission",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be bool")
+        if self.prefill_admission:
+            raise ValueError(
+                "prefill admission is not implemented; prefill must use transient slots"
+            )
+
+    def memory_plan(self, spec: ExpertStreamingModelSpec) -> ExpertMemoryPlan:
+        return plan_expert_memory(
+            spec,
+            total_limit_bytes=self.memory_limit_bytes,
+            context_tokens=self.max_live_kv_tokens,
+            runtime_reserve_bytes=self.runtime_reserve_bytes,
+            expert_cache_limit_bytes=self.expert_cache_limit_bytes,
+            transient_slots=self.transient_slots,
+            io_staging_bytes=self.io_staging_bytes,
+            execution_workspace_bytes=self.execution_workspace_bytes,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {name: getattr(self, name) for name in self.__dataclass_fields__}
+
+
+@dataclass(frozen=True)
+class RouteWave:
+    positions: tuple[int, ...]
+    experts: tuple[int, ...]
+
+
+def partition_route_waves(
+    expert_ids: Iterable[int],
+    *,
+    max_unique_experts: int,
+) -> tuple[RouteWave, ...]:
+    """Greedily partition flattened assignments into bounded expert unions."""
+
+    capacity = _integer("max_unique_experts", max_unique_experts, minimum=1)
+    experts = tuple(expert_ids)
+    ordered_unique: list[int] = []
+    seen: set[int] = set()
+    for expert in experts:
+        if isinstance(expert, bool) or not isinstance(expert, int):
+            raise TypeError("expert ids must be exact integers")
+        if expert not in seen:
+            seen.add(expert)
+            ordered_unique.append(expert)
+    waves: list[RouteWave] = []
+    for start in range(0, len(ordered_unique), capacity):
+        selected = set(ordered_unique[start : start + capacity])
+        positions = tuple(
+            position for position, expert in enumerate(experts) if expert in selected
+        )
+        waves.append(
+            RouteWave(
+                positions=positions,
+                experts=tuple(experts[position] for position in positions),
+            )
+        )
+    return tuple(waves)
+
+
+@dataclass
+class KVAdmission:
+    runtime: ExpertStreamingRuntime
+    tokens: int
+    released: bool = False
+
+    def release(self) -> None:
+        if self.released:
+            return
+        self.runtime.release_kv_tokens(self.tokens)
+        self.released = True
+
+    def __enter__(self) -> KVAdmission:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+
+def reconcile_mlx_memory_cap(
+    plan: ExpertMemoryPlan,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> int:
+    """Resolve the MLX-owned portion and reject a conflicting env cap."""
+
+    mlx_limit = (
+        plan.total_limit_bytes - plan.runtime_reserve_bytes - plan.io_staging_bytes
+    )
+    if mlx_limit <= 0:
+        raise ExpertStreamingConfigurationError(
+            "memory plan leaves no MLX allocation budget"
+        )
+    source = os.environ if env is None else env
+    existing = source.get("MTPLX_MEMORY_LIMIT_BYTES")
+    if existing:
+        parsed = parse_memory_bytes(existing)
+        if parsed != mlx_limit:
+            raise ExpertStreamingConfigurationError(
+                "MTPLX_MEMORY_LIMIT_BYTES conflicts with expert streaming plan: "
+                f"env={parsed}, planned={mlx_limit}"
+            )
+    return mlx_limit
+
+
+def apply_mlx_memory_cap(
+    plan: ExpertMemoryPlan,
+    *,
+    mx_module: Any | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Apply the reconciled cap before resident or expert-slot allocation."""
+
+    target_env = os.environ if env is None else env
+    limit = reconcile_mlx_memory_cap(plan, env=target_env)
+    target_env["MTPLX_MEMORY_LIMIT_BYTES"] = str(limit)
+    if mx_module is None:
+        try:
+            import mlx.core as mx
+        except Exception as exc:
+            return {
+                "applied": False,
+                "reason": "mlx_unavailable",
+                "error": repr(exc),
+                "limit": limit,
+            }
+    else:
+        mx = mx_module
+    setter = getattr(mx, "set_memory_limit", None)
+    if not callable(setter):
+        metal = getattr(mx, "metal", None)
+        setter = getattr(metal, "set_memory_limit", None)
+    if not callable(setter):
+        raise ExpertStreamingConfigurationError("MLX memory limit API is unavailable")
+    setter(limit)
+    return {"applied": True, "limit": limit}
+
+
+def mlx_memory_telemetry(mx_module: Any | None = None) -> dict[str, int | str]:
+    if mx_module is None:
+        try:
+            import mlx.core as mx
+        except Exception as exc:
+            return {"error": repr(exc)}
+    else:
+        mx = mx_module
+    report: dict[str, int | str] = {}
+    for name in ("get_active_memory", "get_peak_memory", "get_cache_memory"):
+        getter = getattr(mx, name, None)
+        if not callable(getter):
+            getter = getattr(getattr(mx, "metal", None), name, None)
+        if callable(getter):
+            try:
+                report[name.removeprefix("get_") + "_bytes"] = int(getter())
+            except Exception as exc:
+                report[name + "_error"] = repr(exc)
+    return report
+
+
+class ExpertStreamingRuntime:
+    """Connect cache policy, checked I/O, fixed slots, and KV admission."""
+
+    def __init__(
+        self,
+        root: Path,
+        spec: ExpertStreamingModelSpec,
+        config: ExpertStreamingConfig,
+        manifest: ExpertManifest,
+        plan: ExpertMemoryPlan,
+        reader: PositionalExpertReader,
+        slots: ExpertSlotPool,
+        *,
+        memory_cap_report: dict[str, Any] | None = None,
+    ) -> None:
+        self.root = root
+        self.spec = spec
+        self.config = config
+        self.manifest = manifest
+        self.plan = plan
+        self.reader = reader
+        self.slots = slots
+        self.memory_cap_report = memory_cap_report
+        self.counters = CacheCounters()
+        self._banks = {
+            layer: LayerExpertSlotBank(
+                expert_count=spec.expert_count,
+                persistent_slots=plan.slots_per_layer,
+                transient_slots=plan.transient_slots,
+                frequency_decay=config.frequency_decay,
+            )
+            for layer in spec.routed_layer_indices
+        }
+        self._layer_locks = {
+            layer: threading.Lock() for layer in spec.routed_layer_indices
+        }
+        self._kv_lock = threading.Lock()
+        self._live_kv_tokens = 0
+        self._live_kv_peak = 0
+        self._closed = False
+
+    @classmethod
+    def open(
+        cls,
+        root: Path | str,
+        manifest_path: Path | str,
+        config: ExpertStreamingConfig,
+        *,
+        spec: ExpertStreamingModelSpec | None = None,
+        buffer_allocator: Callable[[int, str], Any] | None = None,
+        device_synchronize: Callable[[], None] | None = None,
+        apply_memory_cap: bool = True,
+        mx_module: Any | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ExpertStreamingRuntime:
+        artifact_root = Path(root).resolve()
+        model_spec = get_model_spec(config.model_key) if spec is None else spec
+        if model_spec.key != config.model_key:
+            raise ExpertStreamingConfigurationError("config and spec model keys differ")
+        manifest = load_expert_manifest(manifest_path)
+        cls._validate_manifest_identity(manifest, model_spec)
+        if config.verify_artifact_headers:
+            verify_expert_manifest(manifest, artifact_root)
+        plan = config.memory_plan(model_spec)
+        if not plan.fits_fixed:
+            raise ExpertStreamingConfigurationError(
+                f"fixed expert-streaming footprint exceeds limit by {-plan.unallocated_bytes} bytes"
+            )
+        cap_report = (
+            apply_mlx_memory_cap(plan, mx_module=mx_module, env=env)
+            if apply_memory_cap
+            else None
+        )
+        reader = PositionalExpertReader(
+            artifact_root,
+            max_open_files=config.max_open_files,
+            max_read_chunk_bytes=config.max_read_chunk_bytes,
+        )
+        try:
+            slots = ExpertSlotPool(
+                model_spec,
+                plan,
+                manifest,
+                reader,
+                buffer_allocator=buffer_allocator,
+                max_inflight_io_bytes=config.max_inflight_io_bytes,
+                prefer_sidecar=config.prefer_sidecar,
+                verify_hashes=config.verify_record_hashes,
+                device_synchronize=device_synchronize,
+            )
+        except Exception:
+            reader.close()
+            raise
+        return cls(
+            artifact_root,
+            model_spec,
+            config,
+            manifest,
+            plan,
+            reader,
+            slots,
+            memory_cap_report=cap_report,
+        )
+
+    @staticmethod
+    def _validate_manifest_identity(
+        manifest: ExpertManifest,
+        spec: ExpertStreamingModelSpec,
+    ) -> None:
+        errors: list[str] = []
+        if manifest.model_key != spec.key:
+            errors.append("model key")
+        if manifest.source_repo != spec.quant_model:
+            errors.append("source repository")
+        if manifest.source_revision != spec.quant_revision:
+            errors.append("source revision")
+        if manifest.quant_bits != spec.quant_bits:
+            errors.append("quantization bits")
+        if manifest.quant_group_size != spec.quant_group_size:
+            errors.append("quantization group size")
+        if manifest.artifact_tensor_bytes != spec.total_tensor_bytes:
+            errors.append("artifact tensor bytes")
+        if errors:
+            raise ExpertStreamingConfigurationError(
+                "manifest does not match pinned model descriptor: " + ", ".join(errors)
+            )
+
+    def admit_kv_tokens(self, tokens: int) -> KVAdmission:
+        count = _integer("tokens", tokens, minimum=1)
+        with self._kv_lock:
+            requested = self._live_kv_tokens + count
+            if requested > self.config.max_live_kv_tokens:
+                raise ExpertStreamingConfigurationError(
+                    f"live KV admission {requested} exceeds planned "
+                    f"{self.config.max_live_kv_tokens} tokens"
+                )
+            self._live_kv_tokens = requested
+            self._live_kv_peak = max(self._live_kv_peak, requested)
+        return KVAdmission(self, count)
+
+    def release_kv_tokens(self, tokens: int) -> None:
+        count = _integer("tokens", tokens, minimum=1)
+        with self._kv_lock:
+            if count > self._live_kv_tokens:
+                raise RuntimeError("KV admission accounting underflow")
+            self._live_kv_tokens -= count
+
+    def ensure_route(
+        self,
+        layer: int,
+        expert_ids: Iterable[int],
+        *,
+        phase: RoutingPhase | str,
+        cancel_event: threading.Event | None = None,
+        deadline_ns: int | None = None,
+    ) -> ReadyRoute:
+        if self._closed:
+            raise ExpertSlotError("expert streaming runtime is closed")
+        try:
+            bank = self._banks[layer]
+            lock = self._layer_locks[layer]
+        except KeyError as exc:
+            raise ValueError(
+                f"layer {layer} is not routed for {self.spec.key}"
+            ) from exc
+        with lock:
+            route_plan = bank.plan(expert_ids, phase=phase)
+            try:
+                ready = self.slots.ensure_route(
+                    layer,
+                    route_plan,
+                    cancel_event=cancel_event,
+                    deadline_ns=deadline_ns,
+                )
+            except BaseException:
+                for load in route_plan.loads:
+                    if load.persistent:
+                        bank.invalidate_expert(load.expert)
+                    try:
+                        self.slots.invalidate(layer, load.slot)
+                    except ExpertSlotError:
+                        pass
+                raise
+            self.counters.observe(
+                route_plan,
+                expert_record_bytes=self.spec.expert_record_bytes,
+            )
+            return ready
+
+    def route_waves(self, expert_ids: Iterable[int]) -> tuple[RouteWave, ...]:
+        return partition_route_waves(
+            expert_ids,
+            max_unique_experts=self.plan.transient_slots,
+        )
+
+    def reset(self) -> None:
+        for lock in self._layer_locks.values():
+            lock.acquire()
+        try:
+            self.slots.reset()
+            for bank in self._banks.values():
+                bank.reset()
+        finally:
+            for lock in reversed(tuple(self._layer_locks.values())):
+                lock.release()
+
+    def snapshot(self, *, mx_module: Any | None = None) -> dict[str, Any]:
+        with self._kv_lock:
+            live_kv = self._live_kv_tokens
+            peak_kv = self._live_kv_peak
+        return {
+            "model_key": self.spec.key,
+            "manifest_sha256": self.manifest.manifest_sha256,
+            "memory_plan": {
+                "total_limit_bytes": self.plan.total_limit_bytes,
+                "fixed_bytes": self.plan.fixed_bytes,
+                "persistent_cache_bytes": self.plan.persistent_cache_bytes,
+                "slots_per_layer": self.plan.slots_per_layer,
+                "transient_slots": self.plan.transient_slots,
+                "allocated_bytes": self.plan.allocated_bytes,
+                "unallocated_bytes": self.plan.unallocated_bytes,
+            },
+            "memory_cap": self.memory_cap_report,
+            "mlx_memory": mlx_memory_telemetry(mx_module),
+            "live_kv_tokens": live_kv,
+            "live_kv_tokens_peak": peak_kv,
+            "cache": self.counters.as_dict(),
+            "slots": self.slots.snapshot(),
+        }
+
+    def close(self, *, timeout: float | None = None) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.slots.close(timeout=timeout)
+
+    def __enter__(self) -> ExpertStreamingRuntime:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def load_configured_expert_runtime(
+    root: Path | str,
+    manifest_path: Path | str,
+    config: ExpertStreamingConfig,
+    **kwargs: Any,
+) -> ExpertStreamingRuntime:
+    try:
+        return ExpertStreamingRuntime.open(root, manifest_path, config, **kwargs)
+    except ExpertManifestError as exc:
+        raise ExpertStreamingConfigurationError(str(exc)) from exc

--- a/mtplx/expert_slots.py
+++ b/mtplx/expert_slots.py
@@ -1,0 +1,660 @@
+"""Fixed expert slot buffers with generation-safe load and pin lifetimes."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Iterable
+
+from .expert_io import ExpertIOError, PositionalExpertReader
+from .expert_manifest import ExpertManifest, ExpertManifestError, ExpertRecord
+from .expert_streaming import RoutePlan, SlotLoad
+from .expert_streaming_models import (
+    ExpertMemoryPlan,
+    ExpertStreamingModelSpec,
+)
+
+
+class ExpertSlotError(RuntimeError):
+    pass
+
+
+class ExpertSlotState(str, Enum):
+    EMPTY = "empty"
+    LOADING = "loading"
+    READY = "ready"
+    FAILED = "failed"
+    CLOSED = "closed"
+
+
+@dataclass
+class ExpertSlotMetrics:
+    ensure_calls: int = 0
+    load_requests: int = 0
+    owned_loads: int = 0
+    deduplicated_loads: int = 0
+    ready_hits: int = 0
+    load_failures: int = 0
+    generation_replacements: int = 0
+    pin_waits: int = 0
+    load_waits: int = 0
+    active_routes: int = 0
+    active_routes_peak: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def update(self, **values: int) -> None:
+        with self._lock:
+            for name, value in values.items():
+                setattr(self, name, int(getattr(self, name)) + int(value))
+            self.active_routes_peak = max(self.active_routes_peak, self.active_routes)
+
+    def as_dict(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                name: int(getattr(self, name))
+                for name in (
+                    "ensure_calls",
+                    "load_requests",
+                    "owned_loads",
+                    "deduplicated_loads",
+                    "ready_hits",
+                    "load_failures",
+                    "generation_replacements",
+                    "pin_waits",
+                    "load_waits",
+                    "active_routes",
+                    "active_routes_peak",
+                )
+            }
+
+
+@dataclass
+class _PhysicalSlot:
+    label: str
+    buffer: Any
+    state: ExpertSlotState = ExpertSlotState.EMPTY
+    layer: int | None = None
+    expert: int | None = None
+    generation: int = 0
+    pins: int = 0
+    digest: str | None = None
+    error: BaseException | None = None
+    condition: threading.Condition = field(default_factory=threading.Condition)
+
+
+@dataclass(frozen=True)
+class ExpertSlotBinding:
+    layer: int
+    expert: int
+    logical_slot: int
+    generation: int
+    record: ExpertRecord
+    buffer: Any
+
+    def component_view(self, component: str) -> memoryview:
+        view = memoryview(self.buffer)
+        if view.readonly or not view.c_contiguous:
+            raise ExpertSlotError("slot buffer is not a writable contiguous buffer")
+        raw = view.cast("B")
+        cursor = 0
+        for segment in self.record.segments:
+            end = cursor + segment.length
+            if segment.component == component:
+                return raw[cursor:end]
+            cursor = end
+        raise KeyError(component)
+
+
+class ReadyRoute:
+    """Pinned slot bindings that remain valid until explicit release."""
+
+    def __init__(
+        self,
+        pool: ExpertSlotPool,
+        plan: RoutePlan,
+        bindings: tuple[ExpertSlotBinding, ...],
+        pinned: tuple[_PhysicalSlot, ...],
+    ) -> None:
+        self.pool = pool
+        self.plan = plan
+        self.bindings = bindings
+        self._pinned = pinned
+        self._released = False
+
+    @property
+    def slots(self) -> tuple[int, ...]:
+        return self.plan.slots
+
+    @property
+    def generations(self) -> tuple[int, ...]:
+        return tuple(binding.generation for binding in self.bindings)
+
+    def validate(self) -> None:
+        if self._released:
+            raise ExpertSlotError("ready route has already been released")
+        for binding, slot in zip(self.bindings, self._binding_slots(), strict=True):
+            with slot.condition:
+                if (
+                    slot.state is not ExpertSlotState.READY
+                    or slot.layer != binding.layer
+                    or slot.expert != binding.expert
+                    or slot.generation != binding.generation
+                ):
+                    raise ExpertSlotError(
+                        "ready route references a stale slot generation"
+                    )
+
+    def _binding_slots(self) -> tuple[_PhysicalSlot, ...]:
+        return tuple(
+            self.pool._physical(binding.layer, binding.logical_slot)
+            for binding in self.bindings
+        )
+
+    def release(self, *, synchronize: bool = True) -> None:
+        if self._released:
+            return
+        if synchronize and self.pool.device_synchronize is not None:
+            self.pool.device_synchronize()
+        for slot in self._pinned:
+            with slot.condition:
+                if slot.pins <= 0:
+                    raise ExpertSlotError("slot pin accounting underflow")
+                slot.pins -= 1
+                slot.condition.notify_all()
+        self._released = True
+        self.pool._route_released()
+
+    def __enter__(self) -> ReadyRoute:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+
+class _CombinedCancel:
+    def __init__(
+        self, external: threading.Event | None, internal: threading.Event
+    ) -> None:
+        self.external = external
+        self.internal = internal
+
+    def is_set(self) -> bool:
+        return self.internal.is_set() or (
+            self.external is not None and self.external.is_set()
+        )
+
+
+class ExpertSlotPool:
+    """Own all persistent and transient record buffers for one model."""
+
+    def __init__(
+        self,
+        spec: ExpertStreamingModelSpec,
+        plan: ExpertMemoryPlan,
+        manifest: ExpertManifest,
+        reader: PositionalExpertReader,
+        *,
+        buffer_allocator: Callable[[int, str], Any] | None = None,
+        max_inflight_io_bytes: int | None = None,
+        prefer_sidecar: bool = True,
+        verify_hashes: bool = True,
+        device_synchronize: Callable[[], None] | None = None,
+    ) -> None:
+        if plan.model_key != spec.key or manifest.model_key != spec.key:
+            raise ValueError("spec, memory plan, and manifest model keys must match")
+        if (
+            manifest.quant_bits != spec.quant_bits
+            or manifest.quant_group_size != spec.quant_group_size
+        ):
+            raise ValueError("manifest quantization does not match model descriptor")
+        if manifest.routed_expert_bytes != spec.routed_expert_bytes:
+            raise ValueError("manifest routed bytes do not match model descriptor")
+        if plan.transient_slots < spec.top_k:
+            raise ValueError("memory plan transient slots do not cover model top-k")
+        if max_inflight_io_bytes is None:
+            max_inflight_io_bytes = max(plan.transient_bytes, spec.expert_record_bytes)
+        if (
+            isinstance(max_inflight_io_bytes, bool)
+            or not isinstance(max_inflight_io_bytes, int)
+            or max_inflight_io_bytes < spec.expert_record_bytes
+        ):
+            raise ValueError(
+                "max_inflight_io_bytes must cover at least one expert record"
+            )
+        self.spec = spec
+        self.plan = plan
+        self.manifest = manifest
+        self.reader = reader
+        self.prefer_sidecar = prefer_sidecar
+        self.verify_hashes = verify_hashes
+        self.device_synchronize = device_synchronize
+        self.metrics = ExpertSlotMetrics()
+        self._allocator = buffer_allocator or (lambda size, _label: bytearray(size))
+        self.buffer_backend = str(
+            getattr(self._allocator, "backend", "python-bytearray")
+        )
+        self._persistent: dict[tuple[int, int], _PhysicalSlot] = {}
+        self._transient: tuple[_PhysicalSlot, ...]
+        self._record_map = {
+            (record.layer, record.expert): record for record in manifest.records
+        }
+        self._ensure_locks = {
+            layer: threading.Lock() for layer in spec.routed_layer_indices
+        }
+        self._lifecycle = threading.Condition()
+        self._closed = False
+
+        allocated = 0
+        try:
+            for layer in spec.routed_layer_indices:
+                for slot_index in range(plan.slots_per_layer):
+                    label = f"layer-{layer}-persistent-{slot_index}"
+                    buffer = self._allocate_buffer(label)
+                    self._persistent[(layer, slot_index)] = _PhysicalSlot(label, buffer)
+                    allocated += spec.expert_record_bytes
+            transient: list[_PhysicalSlot] = []
+            for slot_index in range(plan.transient_slots):
+                label = f"global-transient-{slot_index}"
+                buffer = self._allocate_buffer(label)
+                transient.append(_PhysicalSlot(label, buffer))
+                allocated += spec.expert_record_bytes
+            self._transient = tuple(transient)
+        except Exception:
+            self._persistent.clear()
+            self._transient = ()
+            raise
+        expected = plan.persistent_cache_bytes + plan.transient_bytes
+        if allocated != expected:
+            raise ExpertSlotError(
+                f"allocated slot bytes {allocated} do not match memory plan {expected}"
+            )
+        self.allocated_bytes = allocated
+        workers = max(1, max_inflight_io_bytes // spec.expert_record_bytes)
+        workers = min(workers, plan.transient_slots)
+        self.max_inflight_io_bytes = workers * spec.expert_record_bytes
+        self._executor = ThreadPoolExecutor(
+            max_workers=workers,
+            thread_name_prefix="mtplx-expert-io",
+        )
+
+    def _allocate_buffer(self, label: str) -> Any:
+        buffer = self._allocator(self.spec.expert_record_bytes, label)
+        try:
+            view = memoryview(buffer)
+        except TypeError as exc:
+            raise ExpertSlotError(
+                f"allocator returned a non-buffer for {label}"
+            ) from exc
+        if (
+            view.readonly
+            or not view.c_contiguous
+            or view.nbytes != self.spec.expert_record_bytes
+        ):
+            raise ExpertSlotError(
+                f"allocator returned invalid buffer for {label}: "
+                f"readonly={view.readonly}, contiguous={view.c_contiguous}, bytes={view.nbytes}"
+            )
+        return buffer
+
+    def _physical(self, layer: int, logical_slot: int) -> _PhysicalSlot:
+        if layer not in self.spec.routed_layer_indices:
+            raise ExpertSlotError(f"layer {layer} is not a routed model layer")
+        if logical_slot < self.plan.slots_per_layer:
+            try:
+                return self._persistent[(layer, logical_slot)]
+            except KeyError as exc:
+                raise ExpertSlotError(
+                    "persistent slot is outside the memory plan"
+                ) from exc
+        transient_index = logical_slot - self.plan.slots_per_layer
+        if not 0 <= transient_index < len(self._transient):
+            raise ExpertSlotError("transient slot is outside the memory plan")
+        return self._transient[transient_index]
+
+    @staticmethod
+    def _remaining(deadline_ns: int | None) -> float | None:
+        if deadline_ns is None:
+            return None
+        remaining_ns = deadline_ns - time.monotonic_ns()
+        if remaining_ns <= 0:
+            raise TimeoutError("expert slot deadline exceeded")
+        return remaining_ns / 1e9
+
+    def _prepare_load(
+        self,
+        layer: int,
+        load: SlotLoad,
+        *,
+        deadline_ns: int | None,
+    ) -> tuple[_PhysicalSlot, int, bool]:
+        slot = self._physical(layer, load.slot)
+        with slot.condition:
+            while True:
+                if self._closed or slot.state is ExpertSlotState.CLOSED:
+                    raise ExpertSlotError("expert slot pool is closed")
+                if (
+                    slot.layer == layer
+                    and slot.expert == load.expert
+                    and slot.state in {ExpertSlotState.LOADING, ExpertSlotState.READY}
+                ):
+                    if slot.state is ExpertSlotState.LOADING:
+                        self.metrics.update(deduplicated_loads=1)
+                    else:
+                        self.metrics.update(ready_hits=1)
+                    return slot, slot.generation, False
+                if slot.state is ExpertSlotState.LOADING:
+                    self.metrics.update(load_waits=1)
+                    slot.condition.wait(self._remaining(deadline_ns))
+                    continue
+                if slot.pins:
+                    self.metrics.update(pin_waits=1)
+                    slot.condition.wait(self._remaining(deadline_ns))
+                    continue
+                replacing = slot.state is ExpertSlotState.READY
+                slot.generation += 1
+                slot.layer = layer
+                slot.expert = load.expert
+                slot.state = ExpertSlotState.LOADING
+                slot.digest = None
+                slot.error = None
+                if replacing:
+                    self.metrics.update(generation_replacements=1)
+                self.metrics.update(owned_loads=1)
+                return slot, slot.generation, True
+
+    def _fill(
+        self,
+        slot: _PhysicalSlot,
+        generation: int,
+        record: ExpertRecord,
+        *,
+        cancel_event: Any,
+        deadline_ns: int | None,
+    ) -> None:
+        try:
+            digest = self.reader.read_record_into(
+                self.manifest,
+                record,
+                slot.buffer,
+                prefer_sidecar=self.prefer_sidecar,
+                verify_hash=self.verify_hashes,
+                cancel_event=cancel_event,
+                deadline_ns=deadline_ns,
+            )
+        except BaseException as exc:
+            with slot.condition:
+                if (
+                    slot.generation == generation
+                    and slot.state is ExpertSlotState.LOADING
+                ):
+                    slot.state = ExpertSlotState.FAILED
+                    slot.error = exc
+                    slot.condition.notify_all()
+            self.metrics.update(load_failures=1)
+            raise
+        with slot.condition:
+            if (
+                slot.generation != generation
+                or slot.state is not ExpertSlotState.LOADING
+            ):
+                raise ExpertSlotError("slot generation changed during an expert read")
+            slot.digest = digest
+            slot.state = ExpertSlotState.READY
+            slot.error = None
+            slot.condition.notify_all()
+
+    def _wait_ready(
+        self,
+        slot: _PhysicalSlot,
+        *,
+        layer: int,
+        expert: int,
+        generation: int,
+        deadline_ns: int | None,
+    ) -> None:
+        with slot.condition:
+            while slot.state is ExpertSlotState.LOADING:
+                self.metrics.update(load_waits=1)
+                slot.condition.wait(self._remaining(deadline_ns))
+            if (
+                slot.state is not ExpertSlotState.READY
+                or slot.layer != layer
+                or slot.expert != expert
+                or slot.generation != generation
+            ):
+                if slot.error is not None:
+                    raise ExpertSlotError(
+                        f"expert load failed for ({layer}, {expert}): {slot.error}"
+                    ) from slot.error
+                raise ExpertSlotError(
+                    "expert slot did not reach the requested generation"
+                )
+
+    def ensure_route(
+        self,
+        layer: int,
+        plan: RoutePlan,
+        *,
+        cancel_event: threading.Event | None = None,
+        deadline_ns: int | None = None,
+    ) -> ReadyRoute:
+        """Load all misses, validate mappings, and pin the route's slots."""
+
+        try:
+            layer_lock = self._ensure_locks[layer]
+        except KeyError as exc:
+            raise ExpertSlotError(f"layer {layer} is not a routed model layer") from exc
+        with layer_lock:
+            return self._ensure_route_locked(
+                layer,
+                plan,
+                cancel_event=cancel_event,
+                deadline_ns=deadline_ns,
+            )
+
+    def _ensure_route_locked(
+        self,
+        layer: int,
+        plan: RoutePlan,
+        *,
+        cancel_event: threading.Event | None,
+        deadline_ns: int | None,
+    ) -> ReadyRoute:
+
+        if len(plan.experts) != len(plan.slots):
+            raise ExpertSlotError("route experts and slots differ in length")
+        with self._lifecycle:
+            if self._closed:
+                raise ExpertSlotError("expert slot pool is closed")
+            self.metrics.update(active_routes=1)
+        self.metrics.update(ensure_calls=1, load_requests=len(plan.loads))
+        internal_cancel = threading.Event()
+        combined_cancel = _CombinedCancel(cancel_event, internal_cancel)
+        prepared: dict[tuple[int, int], tuple[_PhysicalSlot, int]] = {}
+        futures: list[Future[None]] = []
+        try:
+            for load in plan.loads:
+                try:
+                    record = self._record_map[(layer, load.expert)]
+                except KeyError as exc:
+                    raise ExpertSlotError(
+                        f"manifest has no expert record ({layer}, {load.expert})"
+                    ) from exc
+                slot, generation, owner = self._prepare_load(
+                    layer,
+                    load,
+                    deadline_ns=deadline_ns,
+                )
+                prepared[(load.expert, load.slot)] = (slot, generation)
+                if owner:
+                    futures.append(
+                        self._executor.submit(
+                            self._fill,
+                            slot,
+                            generation,
+                            record,
+                            cancel_event=combined_cancel,
+                            deadline_ns=deadline_ns,
+                        )
+                    )
+            future_error: BaseException | None = None
+            for future in futures:
+                try:
+                    future.result(timeout=self._remaining(deadline_ns))
+                except BaseException as exc:
+                    internal_cancel.set()
+                    if future_error is None:
+                        future_error = exc
+            if future_error is not None:
+                for future in futures:
+                    if not future.done():
+                        try:
+                            future.result()
+                        except BaseException:
+                            pass
+                raise future_error
+
+            bindings: list[ExpertSlotBinding] = []
+            unique_pins: dict[int, _PhysicalSlot] = {}
+            try:
+                for expert, logical_slot in zip(plan.experts, plan.slots, strict=True):
+                    slot = self._physical(layer, logical_slot)
+                    with slot.condition:
+                        current_generation = slot.generation
+                    generation = prepared.get(
+                        (expert, logical_slot), (slot, current_generation)
+                    )[1]
+                    self._wait_ready(
+                        slot,
+                        layer=layer,
+                        expert=expert,
+                        generation=generation,
+                        deadline_ns=deadline_ns,
+                    )
+                    try:
+                        record = self._record_map[(layer, expert)]
+                    except KeyError as exc:
+                        raise ExpertSlotError(
+                            f"manifest has no expert record ({layer}, {expert})"
+                        ) from exc
+                    with slot.condition:
+                        if id(slot) not in unique_pins:
+                            slot.pins += 1
+                            unique_pins[id(slot)] = slot
+                        bindings.append(
+                            ExpertSlotBinding(
+                                layer=layer,
+                                expert=expert,
+                                logical_slot=logical_slot,
+                                generation=generation,
+                                record=record,
+                                buffer=slot.buffer,
+                            )
+                        )
+            except BaseException:
+                for slot in unique_pins.values():
+                    with slot.condition:
+                        slot.pins -= 1
+                        slot.condition.notify_all()
+                raise
+        except (ExpertManifestError, ExpertIOError) as exc:
+            internal_cancel.set()
+            self._route_released()
+            raise ExpertSlotError(str(exc)) from exc
+        except BaseException:
+            internal_cancel.set()
+            self._route_released()
+            raise
+
+        return ReadyRoute(
+            self,
+            plan,
+            tuple(bindings),
+            tuple(unique_pins.values()),
+        )
+
+    def _route_released(self) -> None:
+        with self._lifecycle:
+            self.metrics.update(active_routes=-1)
+            self._lifecycle.notify_all()
+
+    def invalidate(self, layer: int, logical_slot: int) -> None:
+        slot = self._physical(layer, logical_slot)
+        with slot.condition:
+            if slot.state is ExpertSlotState.LOADING or slot.pins:
+                raise ExpertSlotError("cannot invalidate an active expert slot")
+            slot.state = ExpertSlotState.EMPTY
+            slot.layer = None
+            slot.expert = None
+            slot.digest = None
+            slot.error = None
+            slot.condition.notify_all()
+
+    def snapshot(self) -> dict[str, Any]:
+        states: dict[str, int] = {state.value: 0 for state in ExpertSlotState}
+        pins = 0
+        for slot in (*self._persistent.values(), *self._transient):
+            with slot.condition:
+                states[slot.state.value] += 1
+                pins += slot.pins
+        return {
+            "buffer_backend": self.buffer_backend,
+            "allocated_bytes": self.allocated_bytes,
+            "max_inflight_io_bytes": self.max_inflight_io_bytes,
+            "persistent_slot_count": len(self._persistent),
+            "transient_slot_count": len(self._transient),
+            "states": states,
+            "pins": pins,
+            "metrics": self.metrics.as_dict(),
+            "io": self.reader.metrics.as_dict(),
+        }
+
+    def reset(self) -> None:
+        with self._lifecycle:
+            if self.metrics.as_dict()["active_routes"]:
+                raise ExpertSlotError("cannot reset while expert routes are active")
+        for slot in (*self._persistent.values(), *self._transient):
+            with slot.condition:
+                if slot.state is ExpertSlotState.LOADING or slot.pins:
+                    raise ExpertSlotError("cannot reset an active expert slot")
+                slot.state = ExpertSlotState.EMPTY
+                slot.layer = None
+                slot.expert = None
+                slot.digest = None
+                slot.error = None
+                slot.condition.notify_all()
+
+    def close(self, *, timeout: float | None = None) -> None:
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._lifecycle:
+            self._closed = True
+            while self.metrics.as_dict()["active_routes"]:
+                if deadline is None:
+                    self._lifecycle.wait()
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            "active expert routes did not release before close"
+                        )
+                    self._lifecycle.wait(remaining)
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        for slot in (*self._persistent.values(), *self._transient):
+            with slot.condition:
+                slot.state = ExpertSlotState.CLOSED
+                slot.condition.notify_all()
+        self.reader.close()
+
+    def __enter__(self) -> ExpertSlotPool:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+def release_routes(routes: Iterable[ReadyRoute]) -> None:
+    for route in routes:
+        route.release()

--- a/mtplx/expert_streaming.py
+++ b/mtplx/expert_streaming.py
@@ -10,7 +10,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from math import isfinite
+from operator import index
 from typing import Iterable
+
+
+def _integer(name: str, value: object, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, not bool")
+    try:
+        normalized = index(value)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be an integer") from exc
+    if minimum is not None and normalized < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return normalized
 
 
 class RoutingPhase(str, Enum):
@@ -69,12 +83,15 @@ class CacheCounters:
     bytes_read: int = 0
 
     def observe(self, plan: RoutePlan, *, expert_record_bytes: int) -> None:
-        if expert_record_bytes < 0:
-            raise ValueError("expert_record_bytes must be non-negative")
+        expert_record_bytes = _integer(
+            "expert_record_bytes", expert_record_bytes, minimum=0
+        )
+        hit_experts = set(plan.hits)
+        assignment_hits = sum(expert in hit_experts for expert in plan.experts)
         self.route_calls += 1
-        self.expert_requests += len(plan.hits) + len(plan.misses)
-        self.expert_hits += len(plan.hits)
-        self.expert_misses += len(plan.misses)
+        self.expert_requests += len(plan.experts)
+        self.expert_hits += assignment_hits
+        self.expert_misses += len(plan.experts) - assignment_hits
         self.persistent_loads += sum(load.persistent for load in plan.loads)
         self.transient_loads += sum(not load.persistent for load in plan.loads)
         self.evictions += len(plan.evictions)
@@ -127,13 +144,18 @@ class LayerExpertSlotBank:
         transient_slots: int,
         frequency_decay: float = 0.995,
     ) -> None:
-        if expert_count <= 0:
-            raise ValueError("expert_count must be positive")
-        if persistent_slots < 0:
-            raise ValueError("persistent_slots must be non-negative")
-        if transient_slots <= 0:
-            raise ValueError("transient_slots must be positive")
-        if not 0.0 < frequency_decay <= 1.0:
+        expert_count = _integer("expert_count", expert_count, minimum=1)
+        persistent_slots = _integer("persistent_slots", persistent_slots, minimum=0)
+        transient_slots = _integer("transient_slots", transient_slots, minimum=1)
+        if persistent_slots > expert_count:
+            raise ValueError("persistent_slots cannot exceed expert_count")
+        if isinstance(frequency_decay, bool):
+            raise TypeError("frequency_decay must be a finite number")
+        try:
+            frequency_decay = float(frequency_decay)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("frequency_decay must be a finite number") from exc
+        if not isfinite(frequency_decay) or not 0.0 < frequency_decay <= 1.0:
             raise ValueError("frequency_decay must be in (0, 1]")
 
         self.expert_count = expert_count
@@ -142,7 +164,10 @@ class LayerExpertSlotBank:
         self.slot_count = persistent_slots + transient_slots
         self.frequency_decay = frequency_decay
 
-        self._epoch = 0
+        # Prefill traffic must neither age nor refresh decode admission state.
+        # A separate decode-only epoch keeps a long prompt from erasing the
+        # hot set immediately before generation starts.
+        self._decode_epoch = 0
         self._slot_to_expert: list[int | None] = [None] * self.persistent_slots
         self._expert_to_slot: dict[int, int] = {}
         self._history = [_ExpertHistory() for _ in range(expert_count)]
@@ -156,7 +181,12 @@ class LayerExpertSlotBank:
         return len(self._expert_to_slot)
 
     def _validate_experts(self, expert_ids: Iterable[int]) -> tuple[int, ...]:
-        experts = tuple(int(expert) for expert in expert_ids)
+        try:
+            experts = tuple(
+                _integer("expert id", expert, minimum=0) for expert in expert_ids
+            )
+        except TypeError as exc:
+            raise TypeError("expert ids must be exact integers") from exc
         if not experts:
             raise ValueError("a route must select at least one expert")
         for expert in experts:
@@ -173,7 +203,7 @@ class LayerExpertSlotBank:
 
     def _score(self, expert: int) -> float:
         history = self._history[expert]
-        age = self._epoch - history.score_epoch
+        age = self._decode_epoch - history.score_epoch
         if age <= 0 or history.score == 0.0:
             return history.score
         return history.score * (self.frequency_decay**age)
@@ -181,8 +211,8 @@ class LayerExpertSlotBank:
     def _touch_decode(self, expert: int) -> None:
         history = self._history[expert]
         history.score = self._score(expert) + 1.0
-        history.score_epoch = self._epoch
-        history.last_used = self._epoch
+        history.score_epoch = self._decode_epoch
+        history.last_used = self._decode_epoch
 
     def _empty_persistent_slot(self) -> int | None:
         for slot, expert in enumerate(self._slot_to_expert):
@@ -229,11 +259,11 @@ class LayerExpertSlotBank:
 
         experts = self._validate_experts(expert_ids)
         phase = RoutingPhase(phase)
-        self._epoch += 1
         unique_experts = tuple(dict.fromkeys(experts))
 
         if phase is RoutingPhase.DECODE:
-            for expert in unique_experts:
+            self._decode_epoch += 1
+            for expert in experts:
                 self._touch_decode(expert)
 
         hit_set = {
@@ -257,7 +287,11 @@ class LayerExpertSlotBank:
                     if victim_slot is not None:
                         victim = self._slot_to_expert[victim_slot]
                         assert victim is not None
-                        if self._score(expert) > self._score(victim):
+                        # Do not let a first-seen singleton evict a resident
+                        # merely because decay made the resident score < 1.
+                        # A second decode observation (or older history) must
+                        # first lift the candidate above this admission floor.
+                        if self._score(expert) > max(1.0, self._score(victim)):
                             persistent_slot = victim_slot
 
             if persistent_slot is None:
@@ -279,8 +313,9 @@ class LayerExpertSlotBank:
             resolved[expert] = slot
             loads.append(SlotLoad(expert=expert, slot=slot, persistent=False))
 
-        for expert in hit_set:
-            self._history[expert].last_used = self._epoch
+        if phase is RoutingPhase.DECODE:
+            for expert in hit_set:
+                self._history[expert].last_used = self._decode_epoch
 
         return RoutePlan(
             phase=phase,
@@ -301,14 +336,45 @@ class ExpertCacheSimulation:
     persistent_slots: int
     transient_slots: int
     expert_record_bytes: int
+    allocated_layer_count: int | None = None
     frequency_decay: float = 0.995
     counters: CacheCounters = field(default_factory=CacheCounters)
     _layers: dict[int, LayerExpertSlotBank] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.expert_count = _integer("expert_count", self.expert_count, minimum=1)
+        self.persistent_slots = _integer(
+            "persistent_slots", self.persistent_slots, minimum=0
+        )
+        self.transient_slots = _integer(
+            "transient_slots", self.transient_slots, minimum=1
+        )
+        self.expert_record_bytes = _integer(
+            "expert_record_bytes", self.expert_record_bytes, minimum=1
+        )
+        if self.persistent_slots > self.expert_count:
+            raise ValueError("persistent_slots cannot exceed expert_count")
+        if self.allocated_layer_count is not None:
+            self.allocated_layer_count = _integer(
+                "allocated_layer_count", self.allocated_layer_count, minimum=1
+            )
+        if isinstance(self.frequency_decay, bool):
+            raise TypeError("frequency_decay must be a finite number")
+        try:
+            self.frequency_decay = float(self.frequency_decay)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("frequency_decay must be a finite number") from exc
+        if not isfinite(self.frequency_decay) or not 0.0 < self.frequency_decay <= 1.0:
+            raise ValueError("frequency_decay must be in (0, 1]")
+
     def layer(self, layer_index: int) -> LayerExpertSlotBank:
-        if layer_index < 0:
-            raise ValueError("layer_index must be non-negative")
+        layer_index = _integer("layer_index", layer_index, minimum=0)
         if layer_index not in self._layers:
+            if (
+                self.allocated_layer_count is not None
+                and len(self._layers) >= self.allocated_layer_count
+            ):
+                raise ValueError("trace exceeds allocated_layer_count")
             self._layers[layer_index] = LayerExpertSlotBank(
                 expert_count=self.expert_count,
                 persistent_slots=self.persistent_slots,
@@ -329,15 +395,38 @@ class ExpertCacheSimulation:
         return plan
 
     def summary(self, *, effective_ssd_bytes_per_second: float) -> dict[str, object]:
-        if effective_ssd_bytes_per_second <= 0:
+        if isinstance(effective_ssd_bytes_per_second, bool):
+            raise TypeError("effective_ssd_bytes_per_second must be finite")
+        try:
+            effective_ssd_bytes_per_second = float(effective_ssd_bytes_per_second)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("effective_ssd_bytes_per_second must be finite") from exc
+        if (
+            not isfinite(effective_ssd_bytes_per_second)
+            or effective_ssd_bytes_per_second <= 0
+        ):
             raise ValueError("effective_ssd_bytes_per_second must be positive")
         counters = self.counters.as_dict()
+        layer_count = (
+            len(self._layers)
+            if self.allocated_layer_count is None
+            else self.allocated_layer_count
+        )
         return {
             **counters,
             "estimated_io_seconds": self.counters.bytes_read
             / effective_ssd_bytes_per_second,
             "layers_observed": len(self._layers),
-            "persistent_cache_bytes": len(self._layers)
+            "allocated_layer_count": layer_count,
+            "persistent_cache_scope": (
+                "observed_layers_only"
+                if self.allocated_layer_count is None
+                else "configured_model"
+            ),
+            "persistent_cache_bytes": layer_count
+            * self.persistent_slots
+            * self.expert_record_bytes,
+            "observed_layer_cache_bytes": len(self._layers)
             * self.persistent_slots
             * self.expert_record_bytes,
             # Native execution reuses one top-k scratch bank across sequential

--- a/mtplx/expert_streaming.py
+++ b/mtplx/expert_streaming.py
@@ -180,6 +180,27 @@ class LayerExpertSlotBank:
     def occupancy(self) -> int:
         return len(self._expert_to_slot)
 
+    def invalidate_expert(self, expert_id: int) -> int | None:
+        """Forget a failed/stale persistent mapping and return its slot."""
+
+        expert = _integer("expert id", expert_id, minimum=0)
+        if expert >= self.expert_count:
+            raise ValueError(
+                f"expert id {expert} is outside [0, {self.expert_count})"
+            )
+        slot = self._expert_to_slot.pop(expert, None)
+        if slot is not None:
+            self._slot_to_expert[slot] = None
+        return slot
+
+    def reset(self) -> None:
+        """Clear residency and decode history without changing capacity."""
+
+        self._decode_epoch = 0
+        self._slot_to_expert = [None] * self.persistent_slots
+        self._expert_to_slot.clear()
+        self._history = [_ExpertHistory() for _ in range(self.expert_count)]
+
     def _validate_experts(self, expert_ids: Iterable[int]) -> tuple[int, ...]:
         try:
             experts = tuple(

--- a/mtplx/expert_streaming.py
+++ b/mtplx/expert_streaming.py
@@ -1,0 +1,350 @@
+"""Policy primitives for SSD-backed routed-expert slot banks.
+
+This module deliberately has no MLX dependency.  It owns the cache decision
+that sits between a resident MoE router and a future native Metal slot-bank
+loader.  Keeping the policy pure makes route traces reproducible and lets us
+size a cache before allocating multi-gigabyte Metal buffers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable
+
+
+class RoutingPhase(str, Enum):
+    """Inference phase used to select the admission policy."""
+
+    PREFILL = "prefill"
+    DECODE = "decode"
+
+
+@dataclass(frozen=True)
+class SlotLoad:
+    """One expert record that must be loaded before dispatch."""
+
+    expert: int
+    slot: int
+    persistent: bool
+
+
+@dataclass(frozen=True)
+class SlotEviction:
+    """A persistent slot reassigned to a hotter expert."""
+
+    slot: int
+    previous_expert: int
+    next_expert: int
+
+
+@dataclass(frozen=True)
+class RoutePlan:
+    """Resolved slot mapping for one layer invocation.
+
+    ``slots`` preserves the router's input order.  A native executor can use
+    it in place of the original expert ids after all ``loads`` have completed.
+    """
+
+    phase: RoutingPhase
+    experts: tuple[int, ...]
+    slots: tuple[int, ...]
+    hits: tuple[int, ...]
+    misses: tuple[int, ...]
+    loads: tuple[SlotLoad, ...]
+    evictions: tuple[SlotEviction, ...]
+
+
+@dataclass
+class CacheCounters:
+    """Aggregate counters suitable for CLI/server metrics."""
+
+    route_calls: int = 0
+    expert_requests: int = 0
+    expert_hits: int = 0
+    expert_misses: int = 0
+    persistent_loads: int = 0
+    transient_loads: int = 0
+    evictions: int = 0
+    bytes_read: int = 0
+
+    def observe(self, plan: RoutePlan, *, expert_record_bytes: int) -> None:
+        if expert_record_bytes < 0:
+            raise ValueError("expert_record_bytes must be non-negative")
+        self.route_calls += 1
+        self.expert_requests += len(plan.hits) + len(plan.misses)
+        self.expert_hits += len(plan.hits)
+        self.expert_misses += len(plan.misses)
+        self.persistent_loads += sum(load.persistent for load in plan.loads)
+        self.transient_loads += sum(not load.persistent for load in plan.loads)
+        self.evictions += len(plan.evictions)
+        self.bytes_read += len(plan.loads) * expert_record_bytes
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.expert_hits + self.expert_misses
+        return self.expert_hits / total if total else 0.0
+
+    def as_dict(self) -> dict[str, int | float]:
+        return {
+            "route_calls": self.route_calls,
+            "expert_requests": self.expert_requests,
+            "expert_hits": self.expert_hits,
+            "expert_misses": self.expert_misses,
+            "hit_rate": self.hit_rate,
+            "persistent_loads": self.persistent_loads,
+            "transient_loads": self.transient_loads,
+            "evictions": self.evictions,
+            "bytes_read": self.bytes_read,
+        }
+
+
+@dataclass
+class _ExpertHistory:
+    score: float = 0.0
+    score_epoch: int = 0
+    last_used: int = -1
+
+
+class LayerExpertSlotBank:
+    """Per-layer TinyLFU-like hot bank with transient service slots.
+
+    The persistent tier learns only from decode routes.  Prefill misses use the
+    transient tier and therefore cannot evict a useful decode hot set.  Decode
+    misses are admitted only once their decayed frequency beats the coldest
+    unpinned resident; otherwise they are served through a transient slot.
+
+    This class plans I/O but never performs it.  The future native layer owns
+    fixed Metal buffers and applies the returned ``SlotLoad`` operations using
+    aligned ``pread``.
+    """
+
+    def __init__(
+        self,
+        *,
+        expert_count: int,
+        persistent_slots: int,
+        transient_slots: int,
+        frequency_decay: float = 0.995,
+    ) -> None:
+        if expert_count <= 0:
+            raise ValueError("expert_count must be positive")
+        if persistent_slots < 0:
+            raise ValueError("persistent_slots must be non-negative")
+        if transient_slots <= 0:
+            raise ValueError("transient_slots must be positive")
+        if not 0.0 < frequency_decay <= 1.0:
+            raise ValueError("frequency_decay must be in (0, 1]")
+
+        self.expert_count = expert_count
+        self.persistent_slots = persistent_slots
+        self.transient_slots = transient_slots
+        self.slot_count = persistent_slots + transient_slots
+        self.frequency_decay = frequency_decay
+
+        self._epoch = 0
+        self._slot_to_expert: list[int | None] = [None] * self.persistent_slots
+        self._expert_to_slot: dict[int, int] = {}
+        self._history = [_ExpertHistory() for _ in range(expert_count)]
+
+    @property
+    def resident_experts(self) -> tuple[int, ...]:
+        return tuple(expert for expert in self._slot_to_expert if expert is not None)
+
+    @property
+    def occupancy(self) -> int:
+        return len(self._expert_to_slot)
+
+    def _validate_experts(self, expert_ids: Iterable[int]) -> tuple[int, ...]:
+        experts = tuple(int(expert) for expert in expert_ids)
+        if not experts:
+            raise ValueError("a route must select at least one expert")
+        for expert in experts:
+            if not 0 <= expert < self.expert_count:
+                raise ValueError(
+                    f"expert id {expert} is outside [0, {self.expert_count})"
+                )
+        unique_count = len(dict.fromkeys(experts))
+        if unique_count > self.transient_slots:
+            raise ValueError(
+                "transient_slots must cover the maximum unique experts in one route"
+            )
+        return experts
+
+    def _score(self, expert: int) -> float:
+        history = self._history[expert]
+        age = self._epoch - history.score_epoch
+        if age <= 0 or history.score == 0.0:
+            return history.score
+        return history.score * (self.frequency_decay**age)
+
+    def _touch_decode(self, expert: int) -> None:
+        history = self._history[expert]
+        history.score = self._score(expert) + 1.0
+        history.score_epoch = self._epoch
+        history.last_used = self._epoch
+
+    def _empty_persistent_slot(self) -> int | None:
+        for slot, expert in enumerate(self._slot_to_expert):
+            if expert is None:
+                return slot
+        return None
+
+    def _victim_slot(self, *, pinned: set[int]) -> int | None:
+        candidates: list[tuple[float, int, int]] = []
+        for slot, expert in enumerate(self._slot_to_expert):
+            if expert is None or expert in pinned:
+                continue
+            history = self._history[expert]
+            candidates.append((self._score(expert), history.last_used, slot))
+        return min(candidates)[2] if candidates else None
+
+    def _assign_persistent(
+        self,
+        *,
+        slot: int,
+        expert: int,
+        evictions: list[SlotEviction],
+    ) -> None:
+        previous = self._slot_to_expert[slot]
+        if previous is not None:
+            del self._expert_to_slot[previous]
+            evictions.append(
+                SlotEviction(
+                    slot=slot,
+                    previous_expert=previous,
+                    next_expert=expert,
+                )
+            )
+        self._slot_to_expert[slot] = expert
+        self._expert_to_slot[expert] = slot
+
+    def plan(
+        self,
+        expert_ids: Iterable[int],
+        *,
+        phase: RoutingPhase | str,
+    ) -> RoutePlan:
+        """Resolve router expert ids to persistent or transient slots."""
+
+        experts = self._validate_experts(expert_ids)
+        phase = RoutingPhase(phase)
+        self._epoch += 1
+        unique_experts = tuple(dict.fromkeys(experts))
+
+        if phase is RoutingPhase.DECODE:
+            for expert in unique_experts:
+                self._touch_decode(expert)
+
+        hit_set = {
+            expert for expert in unique_experts if expert in self._expert_to_slot
+        }
+        miss_order = [expert for expert in unique_experts if expert not in hit_set]
+        resolved: dict[int, int] = {
+            expert: self._expert_to_slot[expert] for expert in hit_set
+        }
+        loads: list[SlotLoad] = []
+        evictions: list[SlotEviction] = []
+        pinned = set(hit_set)
+        transient_experts: list[int] = []
+
+        for expert in miss_order:
+            persistent_slot: int | None = None
+            if phase is RoutingPhase.DECODE and self.persistent_slots:
+                persistent_slot = self._empty_persistent_slot()
+                if persistent_slot is None:
+                    victim_slot = self._victim_slot(pinned=pinned)
+                    if victim_slot is not None:
+                        victim = self._slot_to_expert[victim_slot]
+                        assert victim is not None
+                        if self._score(expert) > self._score(victim):
+                            persistent_slot = victim_slot
+
+            if persistent_slot is None:
+                transient_experts.append(expert)
+                continue
+
+            self._assign_persistent(
+                slot=persistent_slot,
+                expert=expert,
+                evictions=evictions,
+            )
+            pinned.add(expert)
+            resolved[expert] = persistent_slot
+            loads.append(SlotLoad(expert=expert, slot=persistent_slot, persistent=True))
+
+        transient_base = self.persistent_slots
+        for offset, expert in enumerate(transient_experts):
+            slot = transient_base + offset
+            resolved[expert] = slot
+            loads.append(SlotLoad(expert=expert, slot=slot, persistent=False))
+
+        for expert in hit_set:
+            self._history[expert].last_used = self._epoch
+
+        return RoutePlan(
+            phase=phase,
+            experts=experts,
+            slots=tuple(resolved[expert] for expert in experts),
+            hits=tuple(expert for expert in unique_experts if expert in hit_set),
+            misses=tuple(miss_order),
+            loads=tuple(loads),
+            evictions=tuple(evictions),
+        )
+
+
+@dataclass
+class ExpertCacheSimulation:
+    """Multi-layer cache simulator and aggregate I/O accounting."""
+
+    expert_count: int
+    persistent_slots: int
+    transient_slots: int
+    expert_record_bytes: int
+    frequency_decay: float = 0.995
+    counters: CacheCounters = field(default_factory=CacheCounters)
+    _layers: dict[int, LayerExpertSlotBank] = field(default_factory=dict)
+
+    def layer(self, layer_index: int) -> LayerExpertSlotBank:
+        if layer_index < 0:
+            raise ValueError("layer_index must be non-negative")
+        if layer_index not in self._layers:
+            self._layers[layer_index] = LayerExpertSlotBank(
+                expert_count=self.expert_count,
+                persistent_slots=self.persistent_slots,
+                transient_slots=self.transient_slots,
+                frequency_decay=self.frequency_decay,
+            )
+        return self._layers[layer_index]
+
+    def observe(
+        self,
+        *,
+        layer_index: int,
+        expert_ids: Iterable[int],
+        phase: RoutingPhase | str,
+    ) -> RoutePlan:
+        plan = self.layer(layer_index).plan(expert_ids, phase=phase)
+        self.counters.observe(plan, expert_record_bytes=self.expert_record_bytes)
+        return plan
+
+    def summary(self, *, effective_ssd_bytes_per_second: float) -> dict[str, object]:
+        if effective_ssd_bytes_per_second <= 0:
+            raise ValueError("effective_ssd_bytes_per_second must be positive")
+        counters = self.counters.as_dict()
+        return {
+            **counters,
+            "estimated_io_seconds": self.counters.bytes_read
+            / effective_ssd_bytes_per_second,
+            "layers_observed": len(self._layers),
+            "persistent_cache_bytes": len(self._layers)
+            * self.persistent_slots
+            * self.expert_record_bytes,
+            # Native execution reuses one top-k scratch bank across sequential
+            # layers; it is intentionally not multiplied by layer count.
+            "transient_scratch_bytes": self.transient_slots * self.expert_record_bytes,
+            "resident_experts_by_layer": {
+                str(layer): list(bank.resident_experts)
+                for layer, bank in sorted(self._layers.items())
+            },
+        }

--- a/mtplx/expert_streaming_models.py
+++ b/mtplx/expert_streaming_models.py
@@ -1,0 +1,378 @@
+"""Pinned MoE layouts and memory budgeting for SSD expert streaming.
+
+The routed expert tensors are intentionally excluded from the fixed resident
+footprint.  At every sparse layer, a resident router chooses global expert
+IDs, then :mod:`mtplx.expert_streaming` resolves those IDs into bounded Metal
+slots.  This module converts a user-visible byte limit into a uniform number
+of persistent slots per sparse layer while reserving resident model state, KV
+cache, runtime headroom, and one globally reused transient service bank.
+
+This is layout and policy scaffolding.  It does not load model weights or
+allocate MLX arrays.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from operator import index
+
+
+def _integer(name: str, value: object, *, minimum: int | None = None) -> int:
+    """Normalize an integer-like value without accepting lossy coercions."""
+
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, not bool")
+    try:
+        normalized = index(value)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be an integer") from exc
+    if minimum is not None and normalized < minimum:
+        qualifier = "positive" if minimum == 1 else f"at least {minimum}"
+        raise ValueError(f"{name} must be {qualifier}")
+    return normalized
+
+
+@dataclass(frozen=True)
+class ExpertStreamingModelSpec:
+    """Revision-pinned geometry needed to size a streamed Q4 expert bank."""
+
+    key: str
+    display_name: str
+    source_model: str
+    source_revision: str
+    quant_model: str
+    quant_revision: str
+    total_tensor_bytes: int
+    total_layers: int
+    routed_layer_start: int
+    routed_layer_count: int
+    expert_count: int
+    top_k: int
+    hidden_size: int
+    expert_hidden_size: int
+    quant_bits: int
+    quant_group_size: int
+    quant_parameter_bytes: int
+    router_storage: str
+    router_matmul_dtype: str
+    router_bytes: int
+    kv_bytes_per_token: int
+    mtp_layer_index: int | None
+    mtp_included: bool
+    full_indexer_layers: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        integer_fields = {
+            "total_tensor_bytes": 1,
+            "total_layers": 1,
+            "routed_layer_start": 0,
+            "routed_layer_count": 1,
+            "expert_count": 1,
+            "top_k": 1,
+            "hidden_size": 1,
+            "expert_hidden_size": 1,
+            "quant_bits": 1,
+            "quant_group_size": 1,
+            "quant_parameter_bytes": 1,
+            "router_bytes": 0,
+            "kv_bytes_per_token": 0,
+        }
+        for name, minimum in integer_fields.items():
+            normalized = _integer(name, getattr(self, name), minimum=minimum)
+            object.__setattr__(self, name, normalized)
+        if not isinstance(self.mtp_included, bool):
+            raise TypeError("mtp_included must be bool")
+        if self.mtp_layer_index is not None:
+            object.__setattr__(
+                self,
+                "mtp_layer_index",
+                _integer("mtp_layer_index", self.mtp_layer_index, minimum=0),
+            )
+        if not isinstance(self.full_indexer_layers, tuple):
+            raise TypeError("full_indexer_layers must be a tuple")
+        object.__setattr__(
+            self,
+            "full_indexer_layers",
+            tuple(
+                _integer("full_indexer_layer", layer, minimum=0)
+                for layer in self.full_indexer_layers
+            ),
+        )
+        if self.routed_layer_start + self.routed_layer_count > self.total_layers:
+            raise ValueError("routed layers must be inside the target model")
+        if self.top_k > self.expert_count:
+            raise ValueError("top_k cannot exceed expert_count")
+        if (
+            self.hidden_size % self.quant_group_size
+            or self.expert_hidden_size % self.quant_group_size
+        ):
+            raise ValueError("each expert projection input must divide into groups")
+        projection_parameters = self.hidden_size * self.expert_hidden_size
+        if projection_parameters * self.quant_bits % 8:
+            raise ValueError("packed expert weights must occupy whole bytes")
+        invalid_indexers = set(self.full_indexer_layers) - set(range(self.total_layers))
+        if invalid_indexers:
+            raise ValueError("full indexer layers must be inside the target model")
+        if tuple(sorted(set(self.full_indexer_layers))) != self.full_indexer_layers:
+            raise ValueError("full indexer layers must be sorted and unique")
+        if self.routed_expert_bytes >= self.total_tensor_bytes:
+            raise ValueError("resident model footprint must be positive")
+        if self.router_bytes > self.resident_bytes:
+            raise ValueError("router bytes cannot exceed the resident footprint")
+        if (
+            self.mtp_layer_index is not None
+            and self.mtp_layer_index < self.total_layers
+        ):
+            raise ValueError("MTP layer must follow the target transformer layers")
+
+    @property
+    def routed_layer_indices(self) -> tuple[int, ...]:
+        """Target layer indices whose routed experts are streamed."""
+
+        stop = self.routed_layer_start + self.routed_layer_count
+        return tuple(range(self.routed_layer_start, stop))
+
+    @property
+    def expert_source_parameters(self) -> int:
+        """Unquantized gate, up, and down values in one routed expert."""
+
+        return 3 * self.hidden_size * self.expert_hidden_size
+
+    @property
+    def packed_weight_bytes(self) -> int:
+        return self.expert_source_parameters * self.quant_bits // 8
+
+    @property
+    def scale_bias_bytes(self) -> int:
+        """Affine scales plus biases for all quantization groups."""
+
+        group_count = self.expert_source_parameters // self.quant_group_size
+        return group_count * 2 * self.quant_parameter_bytes
+
+    @property
+    def expert_record_bytes(self) -> int:
+        """Packed Q4 weights plus affine scale and bias leaves for one expert."""
+
+        return self.packed_weight_bytes + self.scale_bias_bytes
+
+    @property
+    def routed_expert_bytes(self) -> int:
+        return self.routed_layer_count * self.expert_count * self.expert_record_bytes
+
+    @property
+    def resident_bytes(self) -> int:
+        """All target tensors except routed experts, before runtime/KV reserve."""
+
+        return self.total_tensor_bytes - self.routed_expert_bytes
+
+    @property
+    def cold_expert_bytes_per_token(self) -> int:
+        return self.routed_layer_count * self.top_k * self.expert_record_bytes
+
+    @property
+    def transient_scratch_bytes(self) -> int:
+        """One global top-k service bank, reused after each layer fence."""
+
+        return self.top_k * self.expert_record_bytes
+
+    def persistent_cache_bytes(self, slots_per_layer: int) -> int:
+        """Bytes used by a uniform persistent bank across all sparse layers."""
+
+        slots_per_layer = _integer("slots_per_layer", slots_per_layer, minimum=0)
+        if not 0 <= slots_per_layer <= self.expert_count:
+            raise ValueError(f"slots_per_layer must be inside [0, {self.expert_count}]")
+        return self.routed_layer_count * slots_per_layer * self.expert_record_bytes
+
+
+@dataclass(frozen=True)
+class ExpertMemoryPlan:
+    """Resolved memory allocation under a user-provided total byte limit."""
+
+    model_key: str
+    total_limit_bytes: int
+    runtime_reserve_bytes: int
+    io_staging_bytes: int
+    execution_workspace_bytes: int
+    context_tokens: int
+    resident_bytes: int
+    kv_bytes: int
+    transient_slots: int
+    transient_bytes: int
+    expert_cache_limit_bytes: int | None
+    persistent_budget_bytes: int
+    slots_per_layer: int
+    persistent_cache_bytes: int
+    unallocated_bytes: int
+    fits_fixed: bool
+
+    @property
+    def fixed_bytes(self) -> int:
+        return (
+            self.resident_bytes
+            + self.kv_bytes
+            + self.transient_bytes
+            + self.io_staging_bytes
+            + self.execution_workspace_bytes
+            + self.runtime_reserve_bytes
+        )
+
+    @property
+    def allocated_bytes(self) -> int:
+        return self.fixed_bytes + self.persistent_cache_bytes
+
+
+HY3_Q4 = ExpertStreamingModelSpec(
+    key="hy3-q4",
+    display_name="Tencent Hy3 affine Q4",
+    source_model="tencent/Hy3",
+    source_revision="716aa7241bd6d95896be4ebfc761162a9c4d49ef",
+    quant_model="pipenetwork/Hy3-4bit",
+    quant_revision="160619d3f96c8470350b6dac0ef033a8381551e3",
+    total_tensor_bytes=165_988_461_824,
+    total_layers=80,
+    routed_layer_start=1,
+    routed_layer_count=79,
+    expert_count=192,
+    top_k=8,
+    hidden_size=4096,
+    expert_hidden_size=1536,
+    quant_bits=4,
+    quant_group_size=64,
+    quant_parameter_bytes=2,
+    router_storage="affine-q8 with fp32 correction bias",
+    router_matmul_dtype="float32",
+    router_bytes=66_071_808,
+    kv_bytes_per_token=327_680,
+    mtp_layer_index=80,
+    mtp_included=False,
+)
+
+
+GLM52_Q4 = ExpertStreamingModelSpec(
+    key="glm52-q4",
+    display_name="GLM-5.2 affine Q4",
+    source_model="zai-org/GLM-5.2",
+    source_revision="b4734de4facf877f85769a911abafc5283eab3d9",
+    quant_model="mlx-community/GLM-5.2-4bit",
+    quant_revision="6b347a6472d46bf55de65ee34032136a3929d778",
+    total_tensor_bytes=418_320_895_488,
+    total_layers=78,
+    routed_layer_start=3,
+    routed_layer_count=75,
+    expert_count=256,
+    top_k=8,
+    hidden_size=6144,
+    expert_hidden_size=2048,
+    quant_bits=4,
+    quant_group_size=64,
+    quant_parameter_bytes=2,
+    router_storage="bfloat16 with fp32 correction bias",
+    router_matmul_dtype="float32",
+    router_bytes=236_006_400,
+    kv_bytes_per_token=95_232,
+    mtp_layer_index=78,
+    mtp_included=False,
+    full_indexer_layers=(0, 1, 2, *range(6, 75, 4)),
+)
+
+
+MODEL_SPECS: dict[str, ExpertStreamingModelSpec] = {
+    spec.key: spec for spec in (HY3_Q4, GLM52_Q4)
+}
+
+
+def get_model_spec(model: str) -> ExpertStreamingModelSpec:
+    """Return a pinned streaming descriptor by CLI key."""
+
+    try:
+        return MODEL_SPECS[model]
+    except KeyError as exc:
+        choices = ", ".join(sorted(MODEL_SPECS))
+        raise ValueError(f"unknown model {model!r}; choose one of: {choices}") from exc
+
+
+def plan_expert_memory(
+    spec: ExpertStreamingModelSpec,
+    *,
+    total_limit_bytes: int,
+    context_tokens: int,
+    runtime_reserve_bytes: int = 0,
+    expert_cache_limit_bytes: int | None = None,
+    transient_slots: int | None = None,
+    io_staging_bytes: int = 0,
+    execution_workspace_bytes: int = 0,
+) -> ExpertMemoryPlan:
+    """Fit uniform persistent expert slots under an explicit memory ceiling.
+
+    The total limit is never treated as an expert-cache-only setting: resident
+    weights, KV state, runtime headroom, and transient miss service are removed
+    first.  ``expert_cache_limit_bytes`` can impose a stricter secondary cap.
+    The returned slot count is bounded by the model's expert count.
+
+    A plan with ``fits_fixed=False`` is diagnostic and must not be used to
+    start inference.  Its negative ``unallocated_bytes`` is the fixed-footprint
+    deficit.  ``context_tokens=0`` is an explicit load-only plan; an inference
+    runtime must reject KV growth beyond the planned live-token total.
+    """
+
+    if not isinstance(spec, ExpertStreamingModelSpec):
+        raise TypeError("spec must be an ExpertStreamingModelSpec")
+    total_limit_bytes = _integer("total_limit_bytes", total_limit_bytes, minimum=1)
+    context_tokens = _integer("context_tokens", context_tokens, minimum=0)
+    runtime_reserve_bytes = _integer(
+        "runtime_reserve_bytes", runtime_reserve_bytes, minimum=0
+    )
+    io_staging_bytes = _integer("io_staging_bytes", io_staging_bytes, minimum=0)
+    execution_workspace_bytes = _integer(
+        "execution_workspace_bytes", execution_workspace_bytes, minimum=0
+    )
+    if expert_cache_limit_bytes is not None:
+        expert_cache_limit_bytes = _integer(
+            "expert_cache_limit_bytes", expert_cache_limit_bytes, minimum=0
+        )
+
+    service_slots = spec.top_k if transient_slots is None else transient_slots
+    service_slots = _integer("transient_slots", service_slots, minimum=0)
+    if service_slots < spec.top_k:
+        raise ValueError(f"transient_slots must be at least top_k ({spec.top_k})")
+
+    kv_bytes = context_tokens * spec.kv_bytes_per_token
+    transient_bytes = service_slots * spec.expert_record_bytes
+    fixed_bytes = (
+        spec.resident_bytes
+        + kv_bytes
+        + runtime_reserve_bytes
+        + transient_bytes
+        + io_staging_bytes
+        + execution_workspace_bytes
+    )
+    available_bytes = max(0, total_limit_bytes - fixed_bytes)
+    persistent_budget_bytes = min(available_bytes, spec.routed_expert_bytes)
+    if expert_cache_limit_bytes is not None:
+        persistent_budget_bytes = min(persistent_budget_bytes, expert_cache_limit_bytes)
+
+    bytes_per_uniform_slot = spec.routed_layer_count * spec.expert_record_bytes
+    slots_per_layer = min(
+        spec.expert_count, persistent_budget_bytes // bytes_per_uniform_slot
+    )
+    persistent_cache_bytes = spec.persistent_cache_bytes(slots_per_layer)
+    unallocated_bytes = total_limit_bytes - fixed_bytes - persistent_cache_bytes
+
+    return ExpertMemoryPlan(
+        model_key=spec.key,
+        total_limit_bytes=total_limit_bytes,
+        runtime_reserve_bytes=runtime_reserve_bytes,
+        io_staging_bytes=io_staging_bytes,
+        execution_workspace_bytes=execution_workspace_bytes,
+        context_tokens=context_tokens,
+        resident_bytes=spec.resident_bytes,
+        kv_bytes=kv_bytes,
+        transient_slots=service_slots,
+        transient_bytes=transient_bytes,
+        expert_cache_limit_bytes=expert_cache_limit_bytes,
+        persistent_budget_bytes=persistent_budget_bytes,
+        slots_per_layer=slots_per_layer,
+        persistent_cache_bytes=persistent_cache_bytes,
+        unallocated_bytes=unallocated_bytes,
+        fits_fixed=fixed_bytes <= total_limit_bytes,
+    )

--- a/mtplx/models/__init__.py
+++ b/mtplx/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model overlays used by optional MTPLX execution paths."""

--- a/mtplx/models/expert_mlx.py
+++ b/mtplx/models/expert_mlx.py
@@ -1,0 +1,279 @@
+"""MLX execution adapters for slot-backed affine-Q4 routed experts."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Callable, Iterator
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from mlx_lm.models.activations import swiglu
+
+from mtplx.expert_runtime import ExpertStreamingRuntime
+from mtplx.expert_slots import ExpertSlotBinding
+from mtplx.expert_streaming import RoutingPhase
+from mtplx.expert_streaming_models import ExpertMemoryPlan, ExpertStreamingModelSpec
+
+
+_ROUTING_PHASE: ContextVar[RoutingPhase | None] = ContextVar(
+    "mtplx_expert_routing_phase",
+    default=None,
+)
+
+
+@contextmanager
+def expert_routing_phase(phase: RoutingPhase | str) -> Iterator[None]:
+    token = _ROUTING_PHASE.set(RoutingPhase(phase))
+    try:
+        yield
+    finally:
+        _ROUTING_PHASE.reset(token)
+
+
+def current_expert_routing_phase(*, token_count: int) -> RoutingPhase:
+    explicit = _ROUTING_PHASE.get()
+    if explicit is not None:
+        return explicit
+    return RoutingPhase.PREFILL if token_count > 1 else RoutingPhase.DECODE
+
+
+class UnboundExpertSwitch(nn.Module):
+    """Parameter-free placeholder installed before resident-only loading."""
+
+    def __init__(self, layer_index: int):
+        super().__init__()
+        self.layer_index = int(layer_index)
+
+    def __call__(self, _x: mx.array, _indices: mx.array) -> mx.array:
+        raise RuntimeError(
+            f"streamed expert layer {self.layer_index} has no bound runtime"
+        )
+
+
+def _component_array(binding: ExpertSlotBinding, component: str) -> mx.array:
+    segment = None
+    offset = 0
+    for candidate in binding.record.segments:
+        if candidate.component == component:
+            segment = candidate
+            break
+        offset += candidate.length
+    if segment is None:
+        raise KeyError(component)
+    if isinstance(binding.buffer, mx.array):
+        raw = binding.buffer[offset : offset + segment.length]
+        if segment.dtype == "U32":
+            return raw.view(mx.uint32).reshape(segment.shape)
+        if segment.dtype == "BF16":
+            return raw.view(mx.bfloat16).reshape(segment.shape)
+        raise TypeError(f"unsupported streamed component dtype {segment.dtype}")
+    view = binding.component_view(component)
+    if segment.dtype == "U32":
+        host = np.frombuffer(view, dtype=np.dtype("<u4")).reshape(segment.shape)
+        value = mx.array(host)
+    elif segment.dtype == "BF16":
+        host = np.frombuffer(view, dtype=np.dtype("<u2")).reshape(segment.shape)
+        value = mx.array(host).view(mx.bfloat16)
+    else:
+        raise TypeError(f"unsupported streamed component dtype {segment.dtype}")
+    return value
+
+
+def mlx_slot_buffer_allocator(size: int, _label: str) -> mx.array:
+    """Allocate one stable writable MLX/Metal byte buffer for direct ``pread``."""
+
+    value = mx.zeros((int(size),), dtype=mx.uint8)
+    mx.eval(value)
+    view = memoryview(value)
+    if view.readonly or not view.c_contiguous or view.nbytes != int(size):
+        raise RuntimeError("MLX slot buffer is not writable contiguous shared memory")
+    view.release()
+    return value
+
+
+def make_mlx_slot_buffer_allocator(
+    plan: ExpertMemoryPlan,
+    spec: ExpertStreamingModelSpec,
+) -> Callable[[int, str], mx.array]:
+    """Create banked stable slot views backed by a small number of MTLBuffers."""
+
+    banks: dict[str, mx.array] = {}
+    backend = "mlx-metal-slot-bank"
+
+    def make_bank(count: int, size: int) -> mx.array:
+        bank = mx.zeros((count, size), dtype=mx.uint8)
+        mx.eval(bank)
+        return bank
+
+    def allocate(size: int, label: str) -> mx.array:
+        if size != spec.expert_record_bytes:
+            raise ValueError("slot allocator size differs from the model descriptor")
+        parts = label.split("-")
+        if label.startswith("layer-") and "-persistent-" in label:
+            layer = int(parts[1])
+            slot = int(parts[-1])
+            key = f"layer-{layer}"
+            count = plan.slots_per_layer
+        elif label.startswith("global-transient-"):
+            slot = int(parts[-1])
+            key = "transient"
+            count = plan.transient_slots
+        else:
+            raise ValueError(f"unknown expert slot label {label!r}")
+        if count <= 0:
+            raise ValueError(f"slot bank {key} has no planned capacity")
+        bank = banks.get(key)
+        if bank is None:
+            bank = make_bank(count, size)
+            banks[key] = bank
+        value = bank[slot]
+        mx.eval(value)
+        return value
+
+    setattr(allocate, "backend", backend)
+    setattr(allocate, "banks", banks)
+    return allocate
+
+
+def _run_q4_expert(
+    x: mx.array, binding: ExpertSlotBinding, *, group_size: int
+) -> mx.array:
+    gate_weight = _component_array(binding, "gate_proj.weight")
+    gate_scales = _component_array(binding, "gate_proj.scales")
+    gate_biases = _component_array(binding, "gate_proj.biases")
+    up_weight = _component_array(binding, "up_proj.weight")
+    up_scales = _component_array(binding, "up_proj.scales")
+    up_biases = _component_array(binding, "up_proj.biases")
+    down_weight = _component_array(binding, "down_proj.weight")
+    down_scales = _component_array(binding, "down_proj.scales")
+    down_biases = _component_array(binding, "down_proj.biases")
+
+    gate = mx.quantized_matmul(
+        x,
+        gate_weight,
+        scales=gate_scales,
+        biases=gate_biases,
+        group_size=group_size,
+        bits=4,
+        mode="affine",
+    )
+    up = mx.quantized_matmul(
+        x,
+        up_weight,
+        scales=up_scales,
+        biases=up_biases,
+        group_size=group_size,
+        bits=4,
+        mode="affine",
+    )
+    hidden = swiglu(gate, up)
+    return mx.quantized_matmul(
+        hidden,
+        down_weight,
+        scales=down_scales,
+        biases=down_biases,
+        group_size=group_size,
+        bits=4,
+        mode="affine",
+    )
+
+
+class HotExpertSwitchGLU(nn.Module):
+    """Correctness-first slot-backed replacement for ``SwitchGLU``.
+
+    This portable path reconstructs MLX arrays from each fixed host slot and
+    evaluates a bounded wave before releasing it.  The native extension can
+    replace the component binding without changing router or cache semantics.
+    """
+
+    def __init__(self, runtime: ExpertStreamingRuntime, layer_index: int):
+        super().__init__()
+        self.runtime = runtime
+        self.layer_index = int(layer_index)
+        self.group_size = runtime.spec.quant_group_size
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        if indices.ndim < 1:
+            raise ValueError("expert indices must include a top-k dimension")
+        if int(indices.shape[-1]) != self.runtime.spec.top_k:
+            raise ValueError(
+                f"router selected {indices.shape[-1]} experts; expected "
+                f"{self.runtime.spec.top_k}"
+            )
+        hidden_size = int(x.shape[-1])
+        if hidden_size != self.runtime.spec.hidden_size:
+            raise ValueError(
+                f"expert input width {hidden_size} does not match "
+                f"{self.runtime.spec.hidden_size}"
+            )
+        tokens = x.reshape(-1, hidden_size)
+        top_k = int(indices.shape[-1])
+        mx.eval(indices)
+        expert_ids = tuple(int(value) for value in indices.reshape(-1).tolist())
+        phase = current_expert_routing_phase(token_count=int(tokens.shape[0]))
+
+        outputs: list[mx.array] = []
+        output_positions: list[int] = []
+        for wave in self.runtime.route_waves(expert_ids):
+            ready = self.runtime.ensure_route(
+                self.layer_index,
+                wave.experts,
+                phase=phase,
+            )
+            try:
+                by_expert: dict[int, list[int]] = {}
+                binding_by_expert: dict[int, ExpertSlotBinding] = {}
+                for global_position, binding in zip(
+                    wave.positions, ready.bindings, strict=True
+                ):
+                    by_expert.setdefault(binding.expert, []).append(global_position)
+                    binding_by_expert.setdefault(binding.expert, binding)
+                wave_outputs: list[mx.array] = []
+                wave_positions: list[int] = []
+                for expert, positions in by_expert.items():
+                    token_positions = mx.array(
+                        [position // top_k for position in positions],
+                        dtype=mx.int32,
+                    )
+                    selected = mx.take(tokens, token_positions, axis=0)
+                    result = _run_q4_expert(
+                        selected,
+                        binding_by_expert[expert],
+                        group_size=self.group_size,
+                    )
+                    wave_outputs.append(result)
+                    wave_positions.extend(positions)
+                mx.eval(wave_outputs)
+                outputs.extend(wave_outputs)
+                output_positions.extend(wave_positions)
+            finally:
+                # All Q4 component copies and qmm outputs above are evaluated,
+                # so the source byte slots can be reused without a stale read.
+                ready.release(synchronize=True)
+
+        if not outputs:
+            raise ValueError("router produced no expert assignments")
+        joined = mx.concatenate(outputs, axis=0)
+        order = mx.argsort(mx.array(output_positions, dtype=mx.int32))
+        joined = mx.take(joined, order, axis=0)
+        return joined.reshape((*indices.shape, hidden_size))
+
+
+def bind_streamed_switches(model: Any, runtime: ExpertStreamingRuntime) -> int:
+    layers = getattr(getattr(model, "model", None), "layers", None)
+    if layers is None:
+        layers = getattr(model, "layers", None)
+    if layers is None:
+        raise TypeError("model does not expose transformer layers")
+    bound = 0
+    for layer_index in runtime.spec.routed_layer_indices:
+        layer = layers[layer_index]
+        mlp = getattr(layer, "mlp", None)
+        if mlp is None or not hasattr(mlp, "switch_mlp"):
+            raise TypeError(f"layer {layer_index} has no switch_mlp seam")
+        mlp.switch_mlp = HotExpertSwitchGLU(runtime, layer_index)
+        bound += 1
+    return bound

--- a/mtplx/models/glm52_mlx.py
+++ b/mtplx/models/glm52_mlx.py
@@ -1,0 +1,353 @@
+"""GLM-5.2 MLX overlay with IndexShare and FP32 MoE routing.
+
+IndexShare structure is adapted from mlx-lm PR #1410 (MIT), the branch used to
+produce the pinned community Q4 checkpoint.  Router projection precision is
+aligned with the official Transformers GLM-5.2 implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import CacheList, KVCache
+from mlx_lm.models.deepseek_v32 import (
+    DeepseekV32Attention,
+    DeepseekV32MLP,
+    Model as DeepseekV32CausalModel,
+    MoEGate,
+    group_expert_select,
+)
+
+from .expert_mlx import UnboundExpertSwitch
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    index_head_dim: int
+    index_n_heads: int
+    index_topk: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    n_shared_experts: Optional[int]
+    n_routed_experts: Optional[int]
+    routed_scaling_factor: float
+    kv_lora_rank: int
+    q_lora_rank: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    qk_nope_head_dim: int
+    topk_method: str
+    scoring_func: str
+    norm_topk_prob: bool
+    n_group: int
+    topk_group: int
+    num_experts_per_tok: int
+    moe_layer_freq: int
+    first_k_dense_replace: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    rope_parameters: Dict[str, Any]
+    attention_bias: bool
+    rope_scaling: Optional[Dict[str, Any]] = None
+    rope_theta: Optional[float] = None
+    indexer_rope_interleave: bool = True
+    indexer_types: Optional[List[str]] = None
+    index_topk_pattern: Optional[Any] = None
+    index_topk_freq: int = 1
+    index_skip_topk_offset: int = 2
+    num_nextn_predict_layers: int = 0
+    index_share_for_mtp_iteration: bool = False
+    moe_router_dtype: str = "float32"
+
+    def __post_init__(self) -> None:
+        self.rope_scaling = self.rope_parameters
+        self.rope_theta = float(self.rope_parameters["rope_theta"])
+        if self.indexer_types is None:
+            if self.index_topk_pattern is not None:
+                pattern = self.index_topk_pattern
+                if isinstance(pattern, str):
+                    self.indexer_types = [
+                        {"F": "full", "S": "shared"}[character] for character in pattern
+                    ]
+                else:
+                    self.indexer_types = list(pattern)
+            else:
+                frequency = max(self.index_topk_freq, 1)
+                offset = self.index_skip_topk_offset
+                self.indexer_types = [
+                    "full"
+                    if (max(index - offset + 1, 0) % frequency) == 0
+                    else "shared"
+                    for index in range(self.num_hidden_layers)
+                ]
+        if len(self.indexer_types) != self.num_hidden_layers:
+            raise ValueError("indexer_types must cover every GLM layer")
+        if any(value not in {"full", "shared"} for value in self.indexer_types):
+            raise ValueError("indexer_types values must be 'full' or 'shared'")
+
+
+class FP32MoEGate(nn.Module):
+    def __init__(self, original: nn.Module):
+        super().__init__()
+        for name in (
+            "top_k",
+            "norm_topk_prob",
+            "n_routed_experts",
+            "routed_scaling_factor",
+            "n_group",
+            "topk_group",
+        ):
+            setattr(self, name, getattr(original, name))
+        self.weight = original.weight
+        self.e_score_correction_bias = original.e_score_correction_bias
+
+    def __call__(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        logits = x.astype(mx.float32) @ self.weight.astype(mx.float32).T
+        return group_expert_select(
+            logits,
+            self.e_score_correction_bias.astype(mx.float32),
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class GlmMoeDsaAttention(DeepseekV32Attention):
+    def __init__(self, config: ModelArgs, layer_index: int):
+        super().__init__(config)
+        self.skip_topk = config.indexer_types[layer_index] == "shared"
+        if self.skip_topk:
+            self.indexer = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
+    ) -> tuple[mx.array, mx.array | None]:
+        batch, length, _ = x.shape
+        qr = self.q_a_layernorm(self.q_a_proj(x))
+        queries = self.q_b_proj(qr)
+        queries = queries.reshape(
+            batch,
+            length,
+            self.num_heads,
+            self.q_head_dim,
+        ).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(queries, [self.qk_nope_head_dim], axis=-1)
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(
+            batch,
+            length,
+            1,
+            self.qk_rope_head_dim,
+        ).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+        offset = cache[0].offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+        if cache is not None:
+            kv_latent, k_pe = cache[0].update_and_fetch(kv_latent, k_pe)
+        else:
+            cache = [None] * 2
+        topk_indices = (
+            self.indexer(x, qr, mask, cache=cache[1])
+            if self.indexer is not None
+            else prev_topk_indices
+        )
+        if topk_indices is not None:
+            if length == 1:
+                index = topk_indices[:, :, 0, :, None]
+                kv_latent = mx.take_along_axis(
+                    kv_latent,
+                    mx.broadcast_to(index, index.shape[:-1] + (kv_latent.shape[-1],)),
+                    axis=2,
+                )
+                k_pe = mx.take_along_axis(
+                    k_pe,
+                    mx.broadcast_to(index, index.shape[:-1] + (k_pe.shape[-1],)),
+                    axis=2,
+                )
+                if mask is not None:
+                    mask = mx.take_along_axis(mask, topk_indices, axis=-1)
+            else:
+                shape = list(topk_indices.shape)
+                shape[-1] = kv_latent.shape[2]
+                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+                sparse_mask = mx.put_along_axis(
+                    sparse_mask,
+                    topk_indices,
+                    mx.array(True),
+                    axis=-1,
+                )
+                if mask is not None:
+                    sparse_mask = sparse_mask & mask
+                mask = sparse_mask
+        if self.indexer is not None and cache is not None and cache[0] is not None:
+            cache[0].keys = mx.depends(
+                cache[0].keys,
+                (cache[1].keys, cache[1].values),
+            )
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+        if length == 1:
+            q_nope = self.embed_q(q_nope)
+            keys = values = kv_latent
+        else:
+            keys = self.embed_q(kv_latent, transpose=False)
+            values = self.unembed_out(kv_latent)
+        output = scaled_dot_product_attention(
+            q_nope,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=pe_scores,
+        )
+        if length == 1:
+            output = self.unembed_out(output)
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output), topk_indices
+
+
+class StreamedMoE(nn.Module):
+    def __init__(self, config: ModelArgs, layer_index: int):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.switch_mlp = UnboundExpertSwitch(layer_index)
+        self.gate = FP32MoEGate(MoEGate(config))
+        if config.n_shared_experts is not None:
+            self.shared_experts = DeepseekV32MLP(
+                config=config,
+                intermediate_size=config.moe_intermediate_size
+                * config.n_shared_experts,
+            )
+        self.sharding_group = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        indices, scores = self.gate(x)
+        output = self.switch_mlp(x, indices)
+        output = (output * scores[..., None]).sum(axis=-2).astype(output.dtype)
+        if self.config.n_shared_experts is not None:
+            output = output + self.shared_experts(x)
+        return output
+
+
+class GlmMoeDsaDecoderLayer(nn.Module):
+    def __init__(self, config: ModelArgs, layer_index: int):
+        super().__init__()
+        self.self_attn = GlmMoeDsaAttention(config, layer_index)
+        self.mlp = (
+            StreamedMoE(config, layer_index)
+            if (
+                config.n_routed_experts is not None
+                and layer_index >= config.first_k_dense_replace
+                and layer_index % config.moe_layer_freq == 0
+            )
+            else DeepseekV32MLP(config)
+        )
+        self.input_layernorm = nn.RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
+    ) -> tuple[mx.array, mx.array | None]:
+        residual, topk_indices = self.self_attn(
+            self.input_layernorm(x),
+            mask,
+            cache,
+            prev_topk_indices,
+        )
+        hidden = x + residual
+        residual = self.mlp(self.post_attention_layernorm(hidden))
+        return hidden + residual, topk_indices
+
+
+class GlmMoeDsaModel(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            GlmMoeDsaDecoderLayer(config, index)
+            for index in range(config.num_hidden_layers)
+        ]
+        self.start_idx = 0
+        self.end_idx = len(self.layers)
+        self.num_layers = self.end_idx
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pipeline_rank = 0
+        self.pipeline_size = 1
+
+    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
+        hidden = self.embed_tokens(inputs)
+        if cache is None:
+            cache = [None] * self.num_layers
+        mask = create_attention_mask(
+            hidden,
+            cache[0][0] if cache[0] else None,
+            return_array=True,
+        )
+        previous_topk = None
+        for index in range(self.num_layers):
+            hidden, previous_topk = self.layers[self.start_idx + index](
+                hidden,
+                mask,
+                cache[index],
+                previous_topk,
+            )
+        return self.norm(hidden)
+
+
+class Model(DeepseekV32CausalModel):
+    def __init__(self, config: ModelArgs):
+        nn.Module.__init__(self)
+        self.args = config
+        self.model_type = config.model_type
+        self.model = GlmMoeDsaModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if getattr(layer.self_attn, "skip_topk", False):
+                caches.append(CacheList(KVCache()))
+            else:
+                caches.append(CacheList(KVCache(), KVCache()))
+        return caches

--- a/mtplx/models/hy3_mlx.py
+++ b/mtplx/models/hy3_mlx.py
@@ -1,0 +1,288 @@
+"""MLX implementation of Tencent Hy3 with parameter-free routed experts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import KVCache
+from mlx_lm.models.rope_utils import initialize_rope
+
+from .expert_mlx import UnboundExpertSwitch
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    first_k_dense_replace: int
+    rms_norm_eps: float
+    vocab_size: int
+    max_position_embeddings: int
+    head_dim: int = 128
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    hidden_act: str = "silu"
+    qk_norm: bool = True
+    route_norm: bool = True
+    router_scaling_factor: float = 1.0
+    moe_router_enable_expert_bias: bool = True
+    enable_moe_fp32_combine: bool = False
+    enable_attention_fp32_softmax: bool = False
+    enable_lm_head_fp32: bool = False
+    tie_word_embeddings: bool = False
+    rope_parameters: Optional[Dict[str, Any]] = None
+    rope_theta: float = 10000.0
+    mlp_layer_types: Optional[List[str]] = None
+    num_nextn_predict_layers: int = 0
+
+    def __post_init__(self) -> None:
+        if self.rope_parameters:
+            self.rope_theta = float(
+                self.rope_parameters.get("rope_theta", self.rope_theta)
+            )
+        if self.mlp_layer_types is None:
+            self.mlp_layer_types = [
+                "dense" if index < self.first_k_dense_replace else "sparse"
+                for index in range(self.num_hidden_layers)
+            ]
+        if len(self.mlp_layer_types) != self.num_hidden_layers:
+            raise ValueError("mlp_layer_types must cover every Hy3 layer")
+        if self.hidden_act != "silu":
+            raise ValueError("Hy3 MLX currently supports only silu/SwiGLU")
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.q_proj = nn.Linear(
+            args.hidden_size,
+            self.n_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size,
+            self.n_kv_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size,
+            self.n_kv_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim,
+            args.hidden_size,
+            bias=args.attention_bias,
+        )
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.rope = initialize_rope(
+            dims=self.head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=None,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        queries = (
+            self.q_proj(x)
+            .reshape(batch, length, self.n_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        keys = (
+            self.k_proj(x)
+            .reshape(batch, length, self.n_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        values = (
+            self.v_proj(x)
+            .reshape(batch, length, self.n_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        queries = self.q_norm(queries)
+        keys = self.k_norm(keys)
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelArgs, *, intermediate_size: int | None = None):
+        super().__init__()
+        width = intermediate_size or args.intermediate_size
+        self.gate_proj = nn.Linear(args.hidden_size, width, bias=args.mlp_bias)
+        self.up_proj = nn.Linear(args.hidden_size, width, bias=args.mlp_bias)
+        self.down_proj = nn.Linear(width, args.hidden_size, bias=args.mlp_bias)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Router(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.num_experts = args.num_experts
+        self.route_norm = args.route_norm
+        self.router_scaling_factor = args.router_scaling_factor
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = mx.zeros((args.num_experts,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        logits = self.gate(x.astype(mx.float32)).astype(mx.float32)
+        scores = mx.sigmoid(logits)
+        selection_scores = scores + self.expert_bias.astype(mx.float32)
+        top_k = self.top_k
+        indices = mx.argpartition(-selection_scores, kth=top_k - 1, axis=-1)[
+            ..., :top_k
+        ]
+        weights = mx.take_along_axis(scores, indices, axis=-1)
+        if self.route_norm:
+            weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+        return indices, weights * self.router_scaling_factor
+
+
+class SparseMLP(nn.Module):
+    def __init__(self, args: ModelArgs, layer_index: int):
+        super().__init__()
+        self.router = Router(args)
+        self.switch_mlp = UnboundExpertSwitch(layer_index)
+        self.shared_mlp = MLP(
+            args,
+            intermediate_size=args.moe_intermediate_size * args.num_shared_experts,
+        )
+        self.enable_moe_fp32_combine = args.enable_moe_fp32_combine
+
+    def __call__(self, x: mx.array) -> mx.array:
+        indices, scores = self.router(x)
+        routed = self.switch_mlp(x, indices)
+        routed = (routed * scores[..., None]).sum(axis=-2)
+        shared = self.shared_mlp(x)
+        if self.enable_moe_fp32_combine:
+            return (routed.astype(mx.float32) + shared.astype(mx.float32)).astype(
+                x.dtype
+            )
+        return routed.astype(x.dtype) + shared
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_index: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        self.mlp = (
+            SparseMLP(args, layer_index)
+            if args.mlp_layer_types[layer_index] == "sparse"
+            else MLP(args)
+        )
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        hidden = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return hidden + self.mlp(self.post_attention_layernorm(hidden))
+
+
+class Hy3Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(args, layer_index)
+            for layer_index in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
+        hidden = self.embed_tokens(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(hidden, cache[0])
+        for layer, layer_cache in zip(self.layers, cache, strict=True):
+            hidden = layer(hidden, mask, layer_cache)
+        return self.norm(hidden)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = Hy3Model(args)
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs: mx.array, cache: Optional[Any] = None) -> mx.array:
+        hidden = self.model(inputs, cache)
+        if self.args.enable_lm_head_fp32:
+            hidden = hidden.astype(mx.float32)
+        return self.lm_head(hidden)
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        result: dict[str, mx.array] = {}
+        for key, value in weights.items():
+            if "rotary_emb.inv_freq" in key:
+                continue
+            parts = key.split(".")
+            if len(parts) >= 3 and parts[0] == "model" and parts[1] == "layers":
+                try:
+                    if int(parts[2]) >= self.args.num_hidden_layers:
+                        continue
+                except ValueError:
+                    pass
+            result[key] = value
+        return result
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [KVCache() for _layer in self.layers]

--- a/mtplx/resident_loader.py
+++ b/mtplx/resident_loader.py
@@ -1,0 +1,288 @@
+"""Resident-only MLX model construction for streamed MoE checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .expert_manifest import (
+    ExpertManifest,
+    ExpertManifestError,
+    resolve_artifact_member,
+)
+from .expert_runtime import ExpertStreamingRuntime
+
+
+class ResidentLoadError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResidentLoadReport:
+    shard_count: int
+    tensor_count: int
+    raw_tensor_bytes: int
+    evaluated_parameter_count: int
+    bound_sparse_layers: int
+    strict: bool
+
+    def as_dict(self) -> dict[str, int | bool]:
+        return {
+            "shard_count": self.shard_count,
+            "tensor_count": self.tensor_count,
+            "raw_tensor_bytes": self.raw_tensor_bytes,
+            "evaluated_parameter_count": self.evaluated_parameter_count,
+            "bound_sparse_layers": self.bound_sparse_layers,
+            "strict": self.strict,
+        }
+
+
+@dataclass(frozen=True)
+class ResidentModel:
+    model: Any
+    config: dict[str, Any]
+    report: ResidentLoadReport
+
+
+def _dtype_name(value: Any) -> str:
+    text = str(getattr(value, "dtype", ""))
+    name = text.rsplit(".", 1)[-1].upper()
+    return {
+        "BOOL_": "BOOL",
+        "INT8": "I8",
+        "UINT8": "U8",
+        "INT16": "I16",
+        "UINT16": "U16",
+        "FLOAT16": "F16",
+        "BFLOAT16": "BF16",
+        "INT32": "I32",
+        "UINT32": "U32",
+        "FLOAT32": "F32",
+        "INT64": "I64",
+        "UINT64": "U64",
+        "FLOAT64": "F64",
+    }.get(name, name)
+
+
+def load_resident_arrays(
+    root: Path | str,
+    manifest: ExpertManifest,
+    *,
+    mx_module: Any | None = None,
+) -> dict[str, Any]:
+    """Create lazy MLX arrays for only manifest-allowlisted resident tensors."""
+
+    if mx_module is None:
+        try:
+            import mlx.core as mx
+        except Exception as exc:
+            raise ResidentLoadError(
+                f"MLX is required for resident loading: {exc}"
+            ) from exc
+    else:
+        mx = mx_module
+    artifact_root = Path(root).resolve()
+    by_shard: dict[str, list[Any]] = {}
+    for tensor in manifest.resident_tensors:
+        by_shard.setdefault(tensor.shard, []).append(tensor)
+    selected: dict[str, Any] = {}
+    for shard_name, expected_tensors in sorted(by_shard.items()):
+        shard_path = resolve_artifact_member(artifact_root, shard_name)
+        try:
+            loaded = mx.load(str(shard_path))
+        except Exception as exc:
+            raise ResidentLoadError(
+                f"could not lazily load {shard_name}: {exc}"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise ResidentLoadError(f"MLX returned a non-dictionary for {shard_name}")
+        for expected in expected_tensors:
+            try:
+                value = loaded[expected.tensor]
+            except KeyError as exc:
+                raise ResidentLoadError(
+                    f"resident tensor {expected.tensor} is missing from {shard_name}"
+                ) from exc
+            shape = tuple(int(dimension) for dimension in value.shape)
+            if shape != expected.shape:
+                raise ResidentLoadError(
+                    f"resident tensor {expected.tensor} shape {shape} != {expected.shape}"
+                )
+            dtype = _dtype_name(value)
+            if dtype != expected.dtype:
+                raise ResidentLoadError(
+                    f"resident tensor {expected.tensor} dtype {dtype} != {expected.dtype}"
+                )
+            if int(value.nbytes) != expected.length:
+                raise ResidentLoadError(
+                    f"resident tensor {expected.tensor} bytes {value.nbytes} != {expected.length}"
+                )
+            if expected.tensor in selected:
+                raise ResidentLoadError(f"duplicate resident tensor {expected.tensor}")
+            selected[expected.tensor] = value
+        # Routed arrays returned by mx.load stay lazy and become unreachable
+        # here; only the selected resident leaves survive to mx.eval.
+        del loaded
+    if len(selected) != len(manifest.resident_tensors):
+        raise ResidentLoadError("resident allowlist was not loaded completely")
+    return selected
+
+
+def get_streaming_model_classes(config: dict[str, Any]) -> tuple[type, type]:
+    model_type = str(config.get("model_type") or "")
+    if model_type == "hy_v3":
+        from .models.hy3_mlx import Model, ModelArgs
+
+        return Model, ModelArgs
+    if model_type == "glm_moe_dsa":
+        from .models.glm52_mlx import Model, ModelArgs
+
+        return Model, ModelArgs
+    raise ResidentLoadError(f"no streamed model overlay for model_type={model_type!r}")
+
+
+def _quantize_resident_model(
+    model: Any,
+    config: dict[str, Any],
+    weights: dict[str, Any],
+) -> None:
+    try:
+        import mlx.nn as nn
+    except Exception as exc:
+        raise ResidentLoadError(
+            f"MLX NN is required for quantized loading: {exc}"
+        ) from exc
+    quantization = config.get("quantization")
+    if not isinstance(quantization, dict):
+        quantization = config.get("quantization_config")
+    if not isinstance(quantization, dict):
+        return
+    try:
+        default_group_size = int(quantization["group_size"])
+        default_bits = int(quantization["bits"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ResidentLoadError("invalid affine quantization config") from exc
+    default_mode = str(quantization.get("mode", "affine"))
+
+    def predicate(path: str, module: Any) -> bool | dict[str, Any]:
+        if not hasattr(module, "to_quantized"):
+            return False
+        override = quantization.get(path)
+        if override is not None:
+            if not isinstance(override, dict):
+                raise ResidentLoadError(
+                    f"quantization override {path!r} must be an object"
+                )
+            return dict(override)
+        return f"{path}.scales" in weights
+
+    nn.quantize(
+        model,
+        group_size=default_group_size,
+        bits=default_bits,
+        mode=default_mode,
+        class_predicate=predicate,
+    )
+
+
+def construct_resident_model(
+    root: Path | str,
+    runtime: ExpertStreamingRuntime,
+    *,
+    config: dict[str, Any] | None = None,
+    mx_module: Any | None = None,
+    model_class_resolver: Callable[[dict[str, Any]], tuple[type, type]] | None = None,
+    strict: bool = True,
+) -> ResidentModel:
+    """Instantiate, bind, strictly load, and evaluate only resident parameters."""
+
+    artifact_root = Path(root).resolve()
+    if config is None:
+        try:
+            from mlx_lm.utils import load_config
+
+            config = load_config(artifact_root)
+        except Exception as exc:
+            raise ResidentLoadError(f"could not load model config: {exc}") from exc
+    config = dict(config)
+    if str(config.get("model_type") or "") not in {"hy_v3", "glm_moe_dsa"}:
+        raise ResidentLoadError(
+            "resident streaming supports only hy_v3 and glm_moe_dsa"
+        )
+    resolver = model_class_resolver or get_streaming_model_classes
+    model_class, args_class = resolver(config)
+    try:
+        model_args = args_class.from_dict(config)
+        model = model_class(model_args)
+    except Exception as exc:
+        raise ResidentLoadError(f"could not construct streamed model: {exc}") from exc
+    from .models.expert_mlx import bind_streamed_switches
+
+    try:
+        bound = bind_streamed_switches(model, runtime)
+    except Exception as exc:
+        raise ResidentLoadError(
+            f"could not bind streamed expert layers: {exc}"
+        ) from exc
+    if bound != runtime.spec.routed_layer_count:
+        raise ResidentLoadError(
+            f"bound {bound} sparse layers; expected {runtime.spec.routed_layer_count}"
+        )
+    weights = load_resident_arrays(artifact_root, runtime.manifest, mx_module=mx_module)
+    try:
+        if hasattr(model, "sanitize"):
+            weights = model.sanitize(weights)
+        _quantize_resident_model(model, config, weights)
+        model.eval()
+        model.load_weights(list(weights.items()), strict=strict)
+    except Exception as exc:
+        raise ResidentLoadError(f"resident parameter validation failed: {exc}") from exc
+    if mx_module is None:
+        import mlx.core as mx
+    else:
+        mx = mx_module
+    try:
+        parameters = model.parameters()
+        mx.eval(parameters)
+    except Exception as exc:
+        raise ResidentLoadError(f"resident parameter evaluation failed: {exc}") from exc
+    parameter_count = sum(1 for _name, _value in _flatten_tree(parameters))
+    report = ResidentLoadReport(
+        shard_count=len({tensor.shard for tensor in runtime.manifest.resident_tensors}),
+        tensor_count=len(runtime.manifest.resident_tensors),
+        raw_tensor_bytes=runtime.manifest.resident_tensor_bytes,
+        evaluated_parameter_count=parameter_count,
+        bound_sparse_layers=bound,
+        strict=strict,
+    )
+    setattr(model, "_mtplx_expert_runtime", runtime)
+    setattr(model, "_mtplx_resident_load_report", report.as_dict())
+    return ResidentModel(model=model, config=config, report=report)
+
+
+def _flatten_tree(value: Any, prefix: str = ""):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _flatten_tree(child, child_prefix)
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            child_prefix = f"{prefix}.{index}" if prefix else str(index)
+            yield from _flatten_tree(child, child_prefix)
+    else:
+        yield prefix, value
+
+
+def assert_no_routed_weights_loaded(
+    weights: dict[str, Any],
+    manifest: ExpertManifest,
+) -> None:
+    routed_names = {
+        segment.tensor for record in manifest.records for segment in record.segments
+    }
+    overlap = routed_names & set(weights)
+    if overlap:
+        raise ExpertManifestError(
+            f"resident loader materialized routed tensors: {sorted(overlap)[:4]}"
+        )

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect as py_inspect
 import json
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,8 @@ class MTPLXRuntime:
     mtp_adapter_path: Path | None = None
     mtp_adapter_metadata: dict[str, Any] | None = None
     mtp_adapter_merge_report: dict[str, Any] | None = None
+    expert_streaming: Any | None = None
+    resident_load_report: dict[str, Any] | None = None
     diagnostic_counters: dict[str, int] = field(default_factory=dict)
     _forward_ar_supports_emit_logits: bool | None = field(default=None, init=False, repr=False)
     _forward_ar_supports_logits_keep: bool | None = field(default=None, init=False, repr=False)
@@ -77,6 +80,19 @@ class MTPLXRuntime:
         text_model = getattr(self.model, "language_model", self.model)
         return text_model.model.embed_tokens(input_ids)
 
+    def _expert_routing_context(self, input_ids: Any):
+        if self.expert_streaming is None:
+            return nullcontext()
+        from .expert_streaming import RoutingPhase
+        from .models.expert_mlx import expert_routing_phase
+
+        phase = (
+            RoutingPhase.PREFILL
+            if self._sequence_len(input_ids) > 1
+            else RoutingPhase.DECODE
+        )
+        return expert_routing_phase(phase)
+
     def forward_ar(
         self,
         input_ids,
@@ -119,14 +135,15 @@ class MTPLXRuntime:
                 self._count("final_logits_tokens_emitted", 1)
             else:
                 self._count("full_logits_tokens_emitted", emitted)
-        if not return_hidden and hidden_variant is None and not kwargs:
-            return self.model(input_ids, cache=cache)
-        return self.model(
-            input_ids,
-            cache=cache,
-            return_hidden=return_hidden,
-            **kwargs,
-        )
+        with self._expert_routing_context(input_ids):
+            if not return_hidden and hidden_variant is None and not kwargs:
+                return self.model(input_ids, cache=cache)
+            return self.model(
+                input_ids,
+                cache=cache,
+                return_hidden=return_hidden,
+                **kwargs,
+            )
 
     def forward_ar_capture(
         self,
@@ -138,14 +155,15 @@ class MTPLXRuntime:
     ):
         from .gdn_capture import forward_with_gdn_capture
 
-        return forward_with_gdn_capture(
-            self.model,
-            input_ids,
-            cache=cache,
-            return_hidden=return_hidden,
-            hidden_variant=hidden_variant,
-            capture_backend=capture_backend,
-        )
+        with self._expert_routing_context(input_ids):
+            return forward_with_gdn_capture(
+                self.model,
+                input_ids,
+                cache=cache,
+                return_hidden=return_hidden,
+                hidden_variant=hidden_variant,
+                capture_backend=capture_backend,
+            )
 
     def draft_mtp(
         self,
@@ -276,6 +294,22 @@ class MTPLXRuntime:
         configure_mtp_attention_kv_cache(cache)
         return cache
 
+    def admit_kv_tokens(self, tokens: int):
+        """Reserve request KV capacity under the streamed memory plan."""
+
+        if self.expert_streaming is None:
+            return nullcontext()
+        return self.expert_streaming.admit_kv_tokens(tokens)
+
+    def expert_streaming_snapshot(self) -> dict[str, Any] | None:
+        if self.expert_streaming is None:
+            return None
+        return self.expert_streaming.snapshot()
+
+    def close(self, *, timeout: float | None = None) -> None:
+        if self.expert_streaming is not None:
+            self.expert_streaming.close(timeout=timeout)
+
 
 def load(
     model_path: Path | str,
@@ -286,13 +320,24 @@ def load(
     merge_mtp_adapter: bool = False,
     gemma4_draft_block_size: int | None = None,
     gemma4_target_distribution_mode: str | None = None,
+    expert_streaming_config: Any | None = None,
+    expert_manifest: Path | str | None = None,
 ) -> MTPLXRuntime:
     """Load an MLX model and optionally inject native MTP support."""
     path = Path(model_path)
+    streaming_requested = (
+        expert_streaming_config is not None or expert_manifest is not None
+    )
+    if (expert_streaming_config is None) != (expert_manifest is None):
+        raise ValueError(
+            "expert_streaming_config and expert_manifest must be supplied together"
+        )
     from .gemma4_pair import resolve_gemma4_pair_paths
 
     gemma4_pair = resolve_gemma4_pair_paths(path)
     if gemma4_pair is not None:
+        if streaming_requested:
+            raise ValueError("expert streaming does not support Gemma assistant pairs")
         if mtp:
             from .backends.gemma4_assistant import (
                 DEFAULT_DRAFT_BLOCK_SIZE,
@@ -330,7 +375,52 @@ def load(
     config = load_config(path)
     from .step3p5_mtp_patch import is_step3p5_mtp_config
 
-    if is_step3p5_mtp_config(config):
+    expert_runtime = None
+    resident_load_report = None
+    if streaming_requested:
+        from .expert_runtime import ExpertStreamingConfig, ExpertStreamingRuntime
+        from .expert_streaming_models import get_model_spec
+        from .models.expert_mlx import make_mlx_slot_buffer_allocator
+        from .resident_loader import construct_resident_model
+
+        import mlx.core as mx
+
+        streaming_spec = get_model_spec(expert_streaming_config.model_key)
+        streaming_plan = expert_streaming_config.memory_plan(streaming_spec)
+        slot_allocator = make_mlx_slot_buffer_allocator(
+            streaming_plan, streaming_spec
+        )
+
+        if not isinstance(expert_streaming_config, ExpertStreamingConfig):
+            raise TypeError(
+                "expert_streaming_config must be an ExpertStreamingConfig"
+            )
+        if mtp:
+            raise RuntimeError(
+                "the pinned Hy3-4bit and GLM-5.2-4bit artifacts omit MTP weights; "
+                "load streamed checkpoints with mtp=False"
+            )
+        if mtp_adapter is not None or merge_mtp_adapter:
+            raise RuntimeError("MTP adapters are unavailable for streamed AR loading")
+        expert_runtime = ExpertStreamingRuntime.open(
+            path,
+            expert_manifest,
+            expert_streaming_config,
+            spec=streaming_spec,
+            buffer_allocator=slot_allocator,
+            device_synchronize=mx.synchronize,
+            apply_memory_cap=True,
+            mx_module=mx,
+        )
+        try:
+            resident = construct_resident_model(path, expert_runtime, config=config)
+            model = resident.model
+            resident_load_report = resident.report.as_dict()
+            tokenizer = _load_tokenizer_resilient(path, config)
+        except BaseException:
+            expert_runtime.close()
+            raise
+    elif is_step3p5_mtp_config(config):
         from mlx_lm.utils import load_model
 
         tokenizer = _load_tokenizer_resilient(path, config)
@@ -403,6 +493,8 @@ def load(
         mtp_adapter_path=adapter_path,
         mtp_adapter_metadata=adapter_metadata,
         mtp_adapter_merge_report=adapter_merge_report,
+        expert_streaming=expert_runtime,
+        resident_load_report=resident_load_report,
     )
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1414,6 +1414,26 @@ def _apply_metal_memory_caps(
 class ServerState:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
+        from mtplx.expert_cli import expert_streaming_load_kwargs
+
+        self.expert_streaming_load_kwargs = expert_streaming_load_kwargs(
+            args, args.model
+        )
+        if self.expert_streaming_load_kwargs:
+            args.load_mtp = False
+            args.generation_mode = "ar"
+            stream_config = self.expert_streaming_load_kwargs[
+                "expert_streaming_config"
+            ]
+            from mtplx.expert_runtime import reconcile_mlx_memory_cap
+            from mtplx.expert_streaming_models import get_model_spec
+
+            stream_plan = stream_config.memory_plan(
+                get_model_spec(stream_config.model_key)
+            )
+            os.environ["MTPLX_MEMORY_LIMIT_BYTES"] = str(
+                reconcile_mlx_memory_cap(stream_plan)
+            )
         try:
             args.paged_kv_quantization = normalize_paged_kv_quantization(
                 getattr(args, "paged_kv_quantization", "off")
@@ -1498,11 +1518,13 @@ class ServerState:
         )
         _startup_line("      Model load in progress (this may take a minute).")
         load_heartbeat = _startup_heartbeat("Model still loading")
+        streaming_kwargs = dict(self.expert_streaming_load_kwargs)
+        runtime_mtp = bool(streaming_kwargs.pop("mtp", bool(args.load_mtp)))
         try:
             self.runtime = self.model_scheduler.submit_foreground(
                 load,
                 args.model,
-                mtp=bool(args.load_mtp),
+                mtp=runtime_mtp,
                 contract=MTPContract(
                     mtp_quant_bits=getattr(args, "mtp_quant_bits", None),
                     mtp_quant_group_size=getattr(args, "mtp_quant_group_size", 64),
@@ -1515,6 +1537,7 @@ class ServerState:
                     args,
                     startup_backend,
                 ),
+                **streaming_kwargs,
                 batch_key="startup.load",
             ).result()
         except BaseException as exc:
@@ -14513,6 +14536,11 @@ class _SmartFanArrivalMiddleware:
             _end_smart_fan_request(self.state, lease)
 
 
+def _runtime_kv_admission(runtime: Any, tokens: int):
+    admit = getattr(runtime, "admit_kv_tokens", None)
+    return admit(tokens) if callable(admit) else nullcontext()
+
+
 def _run_generation_dispatched(
     state: ServerState,
     prompt_ids: list[int],
@@ -14610,10 +14638,19 @@ def _run_generation_dispatched(
             request_observability=request_observability,
         )
         state.begin_foreground()
+        kv_admission = None
         try:
+            kv_admission = _runtime_kv_admission(
+                state.runtime,
+                len(prompt_ids) + response_max
+            )
             future = state.ar_batch_service.submit(job)
             generated = future.result()
         finally:
+            if kv_admission is not None:
+                release_kv = getattr(kv_admission, "release", None)
+                if callable(release_kv):
+                    release_kv()
             state.end_foreground()
             _end_smart_fan_request(state, smart_fan_lease)
         ar_stats = dict(generated.get("stats") or {})
@@ -14783,9 +14820,14 @@ def _run_generation(
             state.begin_foreground()
             state.lock.acquire()
         lock_wait_time_s += time.perf_counter() - lock_started
+        kv_admission = None
         try:
             if cancel_event is not None and cancel_event.is_set():
                 raise _StreamCancelled("request cancelled before generation")
+            kv_admission = _runtime_kv_admission(
+                state.runtime,
+                len(prompt_ids) + response_max
+            )
             dynamic_kv_reservation = _dynamic_paged_kv_reservation(
                 prompt_tokens=len(prompt_ids),
                 max_new_tokens=response_max,
@@ -14898,6 +14940,10 @@ def _run_generation(
             # disconnects already take during decode.
             raise _StreamCancelled("client disconnected during prefill")
         finally:
+            if kv_admission is not None:
+                release_kv = getattr(kv_admission, "release", None)
+                if callable(release_kv):
+                    release_kv()
             state.lock.release()
             if not background_request:
                 state.end_foreground()
@@ -18209,6 +18255,10 @@ def create_app(state: ServerState) -> FastAPI:
                 pass
             for task in bg_tasks:
                 task.cancel()
+            runtime = getattr(state, "runtime", None)
+            close_runtime = getattr(runtime, "close", None)
+            if callable(close_runtime):
+                close_runtime(timeout=5.0)
             scheduler = getattr(state, "model_scheduler", None)
             if scheduler is not None:
                 scheduler.shutdown(wait=False, cancel_futures=True)
@@ -18452,6 +18502,12 @@ def create_app(state: ServerState) -> FastAPI:
             ),
             "paged_kv_quantization": _effective_paged_kv_quantization(),
             "kernel_selfcheck": _kernel_selfcheck_health_payload(),
+            "expert_streaming": (
+                runtime.expert_streaming_snapshot()
+                if runtime is not None
+                and getattr(runtime, "expert_streaming", None) is not None
+                else None
+            ),
             "rate_limit_per_minute": int(state.args.rate_limit),
             "stream_interval": int(state.args.stream_interval),
             "warmup": state.warmup_status,
@@ -18901,6 +18957,9 @@ def create_app(state: ServerState) -> FastAPI:
             state.draft_head_identity = None
             state.template_hash = None
             state.aime_parent_runtime_released = True
+            close_runtime = getattr(runtime, "close", None)
+            if callable(close_runtime):
+                close_runtime(timeout=5.0)
             gc.collect()
             cleanup = _clear_mlx_cache_after_request(
                 state,
@@ -24041,6 +24100,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if postcommit_default not in {"inline", "async"}:
         postcommit_default = "async"
     parser.add_argument("--model", default=DEFAULT_HF_MODEL_ID)
+    from mtplx.expert_cli import add_expert_streaming_args
+
+    add_expert_streaming_args(parser)
     parser.add_argument("--model-id", default="mtplx-qwen36-27b-native-mtp")
     parser.add_argument("--backend-id", default="qwen3_next", help=argparse.SUPPRESS)
     parser.add_argument(

--- a/native_extensions/expert_io/.gitignore
+++ b/native_extensions/expert_io/.gitignore
@@ -1,0 +1,5 @@
+build/
+dist/
+*.egg-info/
+*.so
+*.dylib

--- a/native_extensions/expert_io/CMakeLists.txt
+++ b/native_extensions/expert_io/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.25)
+
+project(mtplx_native_expert_io LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(
+  Python 3.11
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+nanobind_add_module(
+  _ext
+  NB_STATIC
+  STABLE_ABI
+  LTO
+  NOMINSIZE
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)

--- a/native_extensions/expert_io/bindings.cpp
+++ b/native_extensions/expert_io/bindings.cpp
@@ -1,0 +1,122 @@
+#include <Python.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#include <nanobind/nanobind.h>
+
+#include <unistd.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace {
+
+class BufferLease {
+ public:
+  explicit BufferLease(nb::handle value) {
+    if (PyObject_GetBuffer(
+            value.ptr(),
+            &view_,
+            PyBUF_WRITABLE | PyBUF_C_CONTIGUOUS) != 0) {
+      throw nb::python_error();
+    }
+    active_ = true;
+  }
+
+  BufferLease(const BufferLease&) = delete;
+  BufferLease& operator=(const BufferLease&) = delete;
+
+  ~BufferLease() {
+    if (active_) {
+      PyBuffer_Release(&view_);
+    }
+  }
+
+  void* data() const { return view_.buf; }
+  Py_ssize_t size() const { return view_.len; }
+
+ private:
+  Py_buffer view_{};
+  bool active_{false};
+};
+
+std::size_t pread_exact_into(
+    int fd,
+    std::uint64_t offset,
+    nb::handle destination) {
+  if (fd < 0) {
+    throw std::invalid_argument("fd must be non-negative");
+  }
+  if (offset > static_cast<std::uint64_t>(
+                   std::numeric_limits<off_t>::max())) {
+    throw std::overflow_error("file offset exceeds off_t");
+  }
+  BufferLease lease(destination);
+  if (lease.size() < 0) {
+    throw std::invalid_argument("destination has a negative size");
+  }
+  auto* bytes = static_cast<std::uint8_t*>(lease.data());
+  const auto requested = static_cast<std::size_t>(lease.size());
+  std::size_t total = 0;
+  int error_number = 0;
+
+  {
+    nb::gil_scoped_release release;
+    while (total < requested) {
+      const auto max_offset = static_cast<std::uint64_t>(
+          std::numeric_limits<off_t>::max());
+      if (total > max_offset || offset > max_offset - total) {
+        error_number = EOVERFLOW;
+        break;
+      }
+      const std::uint64_t current_offset = offset + total;
+      const std::size_t requested_count = std::min(
+          requested - total,
+          static_cast<std::size_t>(std::numeric_limits<ssize_t>::max()));
+      const ssize_t read_count = ::pread(
+          fd,
+          bytes + total,
+          requested_count,
+          static_cast<off_t>(current_offset));
+      if (read_count > 0) {
+        total += static_cast<std::size_t>(read_count);
+        continue;
+      }
+      if (read_count == 0) {
+        break;
+      }
+      if (errno == EINTR) {
+        continue;
+      }
+      error_number = errno;
+      break;
+    }
+  }
+
+  if (error_number != 0) {
+    throw std::system_error(
+        error_number,
+        std::generic_category(),
+        "pread failed");
+  }
+  return total;
+}
+
+}  // namespace
+
+NB_MODULE(_ext, module) {
+  module.doc() = "Bounded GIL-free positional reads for MTPLX expert slots";
+  module.def(
+      "pread_exact_into",
+      &pread_exact_into,
+      "fd"_a,
+      "offset"_a,
+      "destination"_a,
+      "Read from an existing descriptor into a writable contiguous buffer.");
+}

--- a/native_extensions/expert_io/mtplx_native_expert_io/__init__.py
+++ b/native_extensions/expert_io/mtplx_native_expert_io/__init__.py
@@ -1,0 +1,3 @@
+from ._ext import pread_exact_into
+
+__all__ = ["pread_exact_into"]

--- a/native_extensions/expert_io/pyproject.toml
+++ b/native_extensions/expert_io/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=69",
+  "cmake>=3.25",
+  "mlx==0.31.2",
+  "nanobind>=2",
+]
+build-backend = "setuptools.build_meta"

--- a/native_extensions/expert_io/setup.py
+++ b/native_extensions/expert_io/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+
+from mlx import extension
+
+
+if __name__ == "__main__":
+    setup(
+        name="mtplx_native_expert_io",
+        version="0.1.0",
+        description="Bounded positional expert reads for MTPLX.",
+        ext_modules=[extension.CMakeExtension("mtplx_native_expert_io._ext")],
+        cmdclass={"build_ext": extension.CMakeBuild},
+        packages=["mtplx_native_expert_io"],
+        package_data={"mtplx_native_expert_io": ["*.so", "*.dylib"]},
+        zip_safe=False,
+        python_requires=">=3.11",
+    )

--- a/scripts/audit_streamed_model_layout.py
+++ b/scripts/audit_streamed_model_layout.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Compare streamed model parameter keys with a pinned Hub Q4 index."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from huggingface_hub import hf_hub_download  # noqa: E402
+from mlx.utils import tree_flatten  # noqa: E402
+
+from mtplx.expert_streaming_models import MODEL_SPECS, get_model_spec  # noqa: E402
+from mtplx.resident_loader import (  # noqa: E402
+    _quantize_resident_model,
+    get_streaming_model_classes,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download only config/index metadata, construct the parameter-free "
+            "streamed model, and require an exact resident key match."
+        )
+    )
+    parser.add_argument("--model", choices=sorted(MODEL_SPECS), required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    spec = get_model_spec(args.model)
+    config_path = hf_hub_download(
+        spec.quant_model,
+        "config.json",
+        revision=spec.quant_revision,
+    )
+    index_path = hf_hub_download(
+        spec.quant_model,
+        "model.safetensors.index.json",
+        revision=spec.quant_revision,
+    )
+    config = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    index = json.loads(Path(index_path).read_text(encoding="utf-8"))["weight_map"]
+    model_class, args_class = get_streaming_model_classes(config)
+    model = model_class(args_class.from_dict(config))
+    resident = {key: None for key in index if ".switch_mlp." not in key}
+    if hasattr(model, "sanitize"):
+        resident = model.sanitize(resident)
+    _quantize_resident_model(model, config, resident)
+    parameter_keys = {key for key, _value in tree_flatten(model.parameters())}
+    resident_keys = set(resident)
+    missing = sorted(parameter_keys - resident_keys)
+    extra = sorted(resident_keys - parameter_keys)
+    routed = sorted(set(index) - set(resident))
+    expected_routed_tensors = spec.routed_layer_count * 9
+    report = {
+        "model_key": spec.key,
+        "quant_model": spec.quant_model,
+        "quant_revision": spec.quant_revision,
+        "parameter_keys": len(parameter_keys),
+        "resident_index_keys": len(resident_keys),
+        "routed_index_keys": len(routed),
+        "expected_routed_index_keys": expected_routed_tensors,
+        "missing_parameter_keys": missing,
+        "extra_resident_keys": extra,
+        "valid": not missing and not extra and len(routed) == expected_routed_tensors,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["valid"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_expert_io.py
+++ b/scripts/benchmark_expert_io.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Benchmark checked expert-record reads into fixed MLX/Metal slot buffers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_io import PositionalExpertReader  # noqa: E402
+from mtplx.expert_manifest import load_expert_manifest  # noqa: E402
+from mtplx.expert_runtime import mlx_memory_telemetry  # noqa: E402
+from mtplx.expert_streaming_models import get_model_spec  # noqa: E402
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, int(round((len(ordered) - 1) * fraction)))
+    return ordered[index]
+
+
+def _sysctl(name: str) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["/usr/sbin/sysctl", "-n", name], text=True, timeout=2
+        ).strip()
+    except Exception:
+        return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--operations", type=_positive_int, default=64)
+    parser.add_argument("--warmup-operations", type=int, default=8)
+    parser.add_argument("--queue-depth", type=_positive_int, default=4)
+    parser.add_argument("--layer", type=int)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--source-only", action="store_true")
+    parser.add_argument("--no-verify-record-hashes", action="store_true")
+    parser.add_argument(
+        "--cache-state",
+        choices=["unknown", "cold", "warm", "steady"],
+        default="unknown",
+        help="Provenance label only; this script never claims to purge macOS caches.",
+    )
+    parser.add_argument("--ssd-label", default="unspecified")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.warmup_operations < 0:
+        raise SystemExit("--warmup-operations must be non-negative")
+    root = args.model_root.expanduser().resolve()
+    manifest = load_expert_manifest(args.manifest)
+    spec = get_model_spec(manifest.model_key)
+    records = [
+        record
+        for record in manifest.records
+        if args.layer is None or record.layer == args.layer
+    ]
+    if not records:
+        raise SystemExit("no manifest records match the requested layer")
+    if args.queue_depth > len(records):
+        raise SystemExit("--queue-depth cannot exceed the selected record count")
+
+    import mlx.core as mx
+
+    slot_bank = mx.zeros(
+        (args.queue_depth, spec.expert_record_bytes), dtype=mx.uint8
+    )
+    mx.eval(slot_bank)
+    rng = random.Random(args.seed)
+    rng.shuffle(records)
+    sequence = [
+        records[index % len(records)]
+        for index in range(args.warmup_operations + args.operations)
+    ]
+    verify_hash = not args.no_verify_record_hashes
+    reader = PositionalExpertReader(
+        root,
+        max_open_files=max(2, args.queue_depth * 2),
+    )
+
+    def read_one(index: int, record) -> float:
+        slot = slot_bank[index % args.queue_depth]
+        started = time.perf_counter_ns()
+        reader.read_record_into(
+            manifest,
+            record,
+            slot,
+            prefer_sidecar=not args.source_only,
+            verify_hash=verify_hash,
+        )
+        return (time.perf_counter_ns() - started) / 1e6
+
+    try:
+        for start in range(0, args.warmup_operations, args.queue_depth):
+            batch = sequence[start : min(args.warmup_operations, start + args.queue_depth)]
+            with ThreadPoolExecutor(max_workers=args.queue_depth) as pool:
+                list(pool.map(lambda pair: read_one(*pair), enumerate(batch)))
+
+        measured = sequence[args.warmup_operations :]
+        latencies_ms: list[float] = []
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=args.queue_depth) as pool:
+            for batch_start in range(0, len(measured), args.queue_depth):
+                batch = measured[batch_start : batch_start + args.queue_depth]
+                indexed = [
+                    (index, record) for index, record in enumerate(batch)
+                ]
+                latencies_ms.extend(pool.map(lambda pair: read_one(*pair), indexed))
+        elapsed = time.perf_counter() - started
+        metrics = reader.metrics.as_dict()
+    finally:
+        reader.close()
+
+    total_bytes = args.operations * spec.expert_record_bytes
+    payload = {
+        "schema": "mtplx-expert-io-benchmark-v1",
+        "model_key": spec.key,
+        "source_repo": manifest.source_repo,
+        "source_revision": manifest.source_revision,
+        "manifest_sha256": manifest.manifest_sha256,
+        "sidecar_sha256": manifest.sidecar.sha256 if manifest.sidecar else None,
+        "sidecar_used": bool(manifest.sidecar and not args.source_only),
+        "record_bytes": spec.expert_record_bytes,
+        "operations": args.operations,
+        "queue_depth": args.queue_depth,
+        "hash_verification": verify_hash,
+        "cache_state": args.cache_state,
+        "ssd_label": args.ssd_label,
+        "elapsed_seconds": elapsed,
+        "bytes": total_bytes,
+        "gib_per_second": total_bytes / 1024**3 / elapsed,
+        "records_per_second": args.operations / elapsed,
+        "latency_ms": {
+            "mean": statistics.fmean(latencies_ms),
+            "p50": _percentile(latencies_ms, 0.50),
+            "p95": _percentile(latencies_ms, 0.95),
+            "max": max(latencies_ms),
+        },
+        "reader": {**metrics, "backend": reader.backend},
+        "mlx_memory": mlx_memory_telemetry(mx),
+        "host": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "machine": platform.machine(),
+            "chip": _sysctl("machdep.cpu.brand_string"),
+            "memory_bytes": _sysctl("hw.memsize"),
+        },
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_streamed_generation.py
+++ b/scripts/benchmark_streamed_generation.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Run provenance-rich deterministic AR benchmarks through streamed experts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_runtime import ExpertStreamingConfig, parse_memory_bytes  # noqa: E402
+from mtplx.runtime import load  # noqa: E402
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _git_commit() -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=_ROOT, text=True, timeout=2
+        ).strip()
+    except Exception:
+        return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--model-key", choices=["hy3-q4", "glm52-q4"], required=True)
+    parser.add_argument("--memory-limit", required=True)
+    parser.add_argument("--max-live-kv-tokens", type=_positive_int, required=True)
+    parser.add_argument("--runtime-reserve", default="16GiB")
+    parser.add_argument("--expert-cache-limit")
+    parser.add_argument("--prompt", default="Explain why the sky is blue in one paragraph.")
+    parser.add_argument("--max-tokens", type=_positive_int, default=64)
+    parser.add_argument("--repeats", type=_positive_int, default=2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--reset-between", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    root = args.model_root.expanduser().resolve()
+    config = ExpertStreamingConfig(
+        model_key=args.model_key,
+        memory_limit_bytes=parse_memory_bytes(args.memory_limit),
+        max_live_kv_tokens=args.max_live_kv_tokens,
+        runtime_reserve_bytes=parse_memory_bytes(args.runtime_reserve),
+        expert_cache_limit_bytes=(
+            parse_memory_bytes(args.expert_cache_limit)
+            if args.expert_cache_limit
+            else None
+        ),
+    )
+    runtime = load(
+        root,
+        mtp=False,
+        expert_streaming_config=config,
+        expert_manifest=args.manifest,
+    )
+    rows = []
+    try:
+        from mtplx.generation import generate_ar
+        from mtplx.sampling import SamplerConfig
+
+        prompt_ids = runtime.tokenizer.encode(args.prompt)
+        sampler = SamplerConfig(temperature=0.0, top_p=1.0, top_k=1)
+        for repeat in range(args.repeats):
+            if args.reset_between and repeat:
+                runtime.expert_streaming.reset()
+            before = runtime.expert_streaming_snapshot()
+            started = time.perf_counter()
+            with runtime.admit_kv_tokens(len(prompt_ids) + args.max_tokens):
+                result = generate_ar(
+                    runtime,
+                    prompt_ids,
+                    max_tokens=args.max_tokens,
+                    sampler=sampler,
+                    seed=args.seed,
+                )
+            elapsed = time.perf_counter() - started
+            after = runtime.expert_streaming_snapshot()
+            token_ids = [int(token) for token in result.tokens]
+            rows.append(
+                {
+                    "repeat": repeat,
+                    "elapsed_seconds": elapsed,
+                    "prompt_tokens": len(prompt_ids),
+                    "completion_tokens": len(token_ids),
+                    "completion_tokens_per_second": len(token_ids) / elapsed,
+                    "token_ids": token_ids,
+                    "text": runtime.tokenizer.decode(token_ids),
+                    "streaming_before": before,
+                    "streaming_after": after,
+                    "generation_stats": result.stats.to_dict(),
+                }
+            )
+    finally:
+        runtime.close(timeout=10.0)
+
+    payload = {
+        "schema": "mtplx-streamed-generation-benchmark-v1",
+        "git_commit": _git_commit(),
+        "model_root": str(root),
+        "model_key": args.model_key,
+        "manifest": str(args.manifest.resolve()),
+        "config": config.to_dict(),
+        "seed": args.seed,
+        "reset_between": args.reset_between,
+        "host": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+        },
+        "runs": rows,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_expert_manifest.py
+++ b/scripts/build_expert_manifest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Build a revision-pinned safetensors expert manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_manifest import (  # noqa: E402
+    ExpertManifestError,
+    build_expert_manifest,
+    save_expert_manifest,
+)
+from mtplx.expert_streaming_models import MODEL_SPECS  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect safetensors headers, validate all affine-Q4 expert slices, "
+            "and emit a deterministic manifest."
+        )
+    )
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("--model", choices=sorted(MODEL_SPECS), required=True)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--source-repo")
+    parser.add_argument("--source-revision")
+    parser.add_argument(
+        "--hash-records",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Hash every reconstructed expert record (default: enabled).",
+    )
+    parser.add_argument(
+        "--hash-shards",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Also hash whole shard files; expensive and redundant with record hashes.",
+    )
+    parser.add_argument(
+        "--allow-unpinned-size",
+        action="store_true",
+        help="Development fixtures only: do not require the pinned total tensor bytes.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    root = args.model_root.expanduser().resolve()
+    output = args.output or (root / "expert-manifest.json")
+    try:
+        manifest = build_expert_manifest(
+            root,
+            args.model,
+            source_repo=args.source_repo,
+            source_revision=args.source_revision,
+            hash_records=args.hash_records,
+            hash_shards=args.hash_shards,
+            require_pinned_tensor_bytes=not args.allow_unpinned_size,
+        )
+        manifest = save_expert_manifest(manifest, output)
+    except ExpertManifestError as exc:
+        raise SystemExit(f"expert manifest build failed: {exc}") from exc
+    print(
+        json.dumps(
+            {
+                "manifest": str(output.resolve()),
+                "manifest_sha256": manifest.manifest_sha256,
+                "model_key": manifest.model_key,
+                "shards": len(manifest.shards),
+                "records": len(manifest.records),
+                "artifact_tensor_bytes": manifest.artifact_tensor_bytes,
+                "resident_tensor_bytes": manifest.resident_tensor_bytes,
+                "routed_expert_bytes": manifest.routed_expert_bytes,
+                "record_hashes": sum(
+                    record.sha256 is not None for record in manifest.records
+                ),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_expert_sidecar.py
+++ b/scripts/build_expert_sidecar.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Build a resumable aligned expert-major sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_manifest import (  # noqa: E402
+    DEFAULT_ALIGNMENT,
+    ExpertManifestError,
+    build_expert_sidecar,
+    load_expert_manifest,
+    save_expert_manifest,
+)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Pack manifest-described source slices into aligned expert records."
+    )
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--manifest-output", type=Path)
+    parser.add_argument("--alignment", type=_positive_int, default=DEFAULT_ALIGNMENT)
+    parser.add_argument("--no-resume", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    root = args.model_root.expanduser().resolve()
+    manifest_output = args.manifest_output or args.manifest
+    try:
+        manifest = load_expert_manifest(args.manifest)
+        manifest = build_expert_sidecar(
+            manifest,
+            root,
+            args.output,
+            alignment=args.alignment,
+            resume=not args.no_resume,
+            overwrite=args.overwrite,
+        )
+        manifest = save_expert_manifest(manifest, manifest_output)
+    except ExpertManifestError as exc:
+        raise SystemExit(f"expert sidecar build failed: {exc}") from exc
+    assert manifest.sidecar is not None
+    print(
+        json.dumps(
+            {
+                "manifest": str(manifest_output.resolve()),
+                "manifest_sha256": manifest.manifest_sha256,
+                "sidecar": str((root / manifest.sidecar.file).resolve()),
+                "sidecar_sha256": manifest.sidecar.sha256,
+                "sidecar_bytes": manifest.sidecar.size,
+                "alignment": manifest.sidecar.alignment,
+                "records": len(manifest.records),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plan_expert_memory.py
+++ b/scripts/plan_expert_memory.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Size an SSD-backed MoE expert bank under a total memory threshold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_streaming_models import (  # noqa: E402
+    MODEL_SPECS,
+    get_model_spec,
+    plan_expert_memory,
+)
+
+
+GIB = 1024**3
+
+
+def _decimal(value: str, *, allow_zero: bool) -> Decimal:
+    try:
+        parsed = Decimal(value)
+    except InvalidOperation as exc:
+        raise argparse.ArgumentTypeError("value must be a decimal number") from exc
+    if not parsed.is_finite():
+        raise argparse.ArgumentTypeError("value must be finite")
+    if parsed < 0 or (not allow_zero and parsed == 0):
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise argparse.ArgumentTypeError(f"value must be {qualifier}")
+    return parsed
+
+
+def _positive_decimal(value: str) -> Decimal:
+    return _decimal(value, allow_zero=False)
+
+
+def _nonnegative_decimal(value: str) -> Decimal:
+    return _decimal(value, allow_zero=True)
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
+
+
+def _as_gib(value: int) -> float:
+    return value / GIB
+
+
+def _gib_to_bytes(value: Decimal) -> int:
+    """Convert exactly parsed GiB to a conservative whole-byte floor."""
+
+    return int(value * GIB)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reserve resident weights, KV cache, runtime headroom, and top-k "
+            "scratch before assigning persistent routed-expert slots."
+        )
+    )
+    parser.add_argument("--model", choices=sorted(MODEL_SPECS), required=True)
+    parser.add_argument(
+        "--memory-limit-gib",
+        type=_positive_decimal,
+        required=True,
+        help="Total memory ceiling for resident state, KV, scratch, and hot experts.",
+    )
+    parser.add_argument(
+        "--context-tokens",
+        type=_nonnegative_int,
+        required=True,
+        help="Required maximum live KV tokens across admitted sequences; use 0 only for load-only planning.",
+    )
+    parser.add_argument(
+        "--runtime-reserve-gib",
+        type=_nonnegative_decimal,
+        default=Decimal("16"),
+        help="Headroom for activations, Metal, MTPLX, and macOS (default: 16).",
+    )
+    parser.add_argument(
+        "--expert-cache-limit-gib",
+        type=_nonnegative_decimal,
+        help="Optional stricter cap for persistent experts alone.",
+    )
+    parser.add_argument(
+        "--transient-slots",
+        type=_nonnegative_int,
+        help="Global miss-service slots; defaults to the model's top-k.",
+    )
+    parser.add_argument(
+        "--io-staging-gib",
+        type=_nonnegative_decimal,
+        default=Decimal("0"),
+        help="Known staging/in-flight I/O buffers not aliased to expert slots.",
+    )
+    parser.add_argument(
+        "--execution-workspace-gib",
+        type=_nonnegative_decimal,
+        default=Decimal("0"),
+        help="Known router/kernel workspace outside resident and slot buffers.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    spec = get_model_spec(args.model)
+    cache_cap = (
+        None
+        if args.expert_cache_limit_gib is None
+        else _gib_to_bytes(args.expert_cache_limit_gib)
+    )
+    try:
+        plan = plan_expert_memory(
+            spec,
+            total_limit_bytes=_gib_to_bytes(args.memory_limit_gib),
+            context_tokens=args.context_tokens,
+            runtime_reserve_bytes=_gib_to_bytes(args.runtime_reserve_gib),
+            expert_cache_limit_bytes=cache_cap,
+            transient_slots=args.transient_slots,
+            io_staging_bytes=_gib_to_bytes(args.io_staging_gib),
+            execution_workspace_bytes=_gib_to_bytes(args.execution_workspace_gib),
+        )
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+    payload = {
+        "model": {
+            "key": spec.key,
+            "display_name": spec.display_name,
+            "source_model": spec.source_model,
+            "source_revision": spec.source_revision,
+            "quant_model": spec.quant_model,
+            "quant_revision": spec.quant_revision,
+            "routed_layers": spec.routed_layer_count,
+            "experts_per_layer": spec.expert_count,
+            "top_k": spec.top_k,
+            "expert_record_bytes": spec.expert_record_bytes,
+            "expert_record_mib": spec.expert_record_bytes / 1024**2,
+        },
+        "plan": {
+            "fits_fixed": plan.fits_fixed,
+            "scope": (
+                "planned MTPLX buffers and explicit reserves; runtime must also "
+                "enforce the MLX cap and reject unplanned context growth"
+            ),
+            "memory_limit_gib_input": str(args.memory_limit_gib),
+            "memory_limit_bytes": plan.total_limit_bytes,
+            "memory_limit_gib": _as_gib(plan.total_limit_bytes),
+            "context_tokens": plan.context_tokens,
+            "kv_bytes_per_token": spec.kv_bytes_per_token,
+            "resident_bytes": plan.resident_bytes,
+            "resident_gib": _as_gib(plan.resident_bytes),
+            "kv_bytes": plan.kv_bytes,
+            "kv_gib": _as_gib(plan.kv_bytes),
+            "runtime_reserve_bytes": plan.runtime_reserve_bytes,
+            "runtime_reserve_gib": _as_gib(plan.runtime_reserve_bytes),
+            "runtime_reserve_gib_input": str(args.runtime_reserve_gib),
+            "io_staging_bytes": plan.io_staging_bytes,
+            "io_staging_gib": _as_gib(plan.io_staging_bytes),
+            "io_staging_gib_input": str(args.io_staging_gib),
+            "execution_workspace_bytes": plan.execution_workspace_bytes,
+            "execution_workspace_gib": _as_gib(plan.execution_workspace_bytes),
+            "execution_workspace_gib_input": str(args.execution_workspace_gib),
+            "transient_slots": plan.transient_slots,
+            "transient_bytes": plan.transient_bytes,
+            "transient_gib": _as_gib(plan.transient_bytes),
+            "expert_cache_limit_bytes": plan.expert_cache_limit_bytes,
+            "expert_cache_limit_gib_input": (
+                None
+                if args.expert_cache_limit_gib is None
+                else str(args.expert_cache_limit_gib)
+            ),
+            "fixed_bytes": plan.fixed_bytes,
+            "fixed_gib": _as_gib(plan.fixed_bytes),
+            "available_after_fixed_bytes": max(
+                0, plan.total_limit_bytes - plan.fixed_bytes
+            ),
+            "persistent_budget_bytes": plan.persistent_budget_bytes,
+            "persistent_budget_gib": _as_gib(plan.persistent_budget_bytes),
+            "persistent_slots_per_layer": plan.slots_per_layer,
+            "persistent_cache_bytes": plan.persistent_cache_bytes,
+            "persistent_cache_gib": _as_gib(plan.persistent_cache_bytes),
+            "accounted_bytes": plan.allocated_bytes,
+            "accounted_gib": _as_gib(plan.allocated_bytes),
+            "unallocated_bytes": plan.unallocated_bytes,
+            "unallocated_gib": _as_gib(plan.unallocated_bytes),
+        },
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if plan.fits_fixed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simulate_expert_cache.py
+++ b/scripts/simulate_expert_cache.py
@@ -5,15 +5,46 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+from math import isfinite
 from pathlib import Path
 
-from mtplx.expert_streaming import ExpertCacheSimulation, RoutingPhase
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_streaming import ExpertCacheSimulation, RoutingPhase  # noqa: E402
+from mtplx.expert_streaming_models import (  # noqa: E402
+    MODEL_SPECS,
+    get_model_spec,
+)
 
 
 def _positive_int(value: str) -> int:
     parsed = int(value)
     if parsed <= 0:
         raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be finite and positive")
+    return parsed
+
+
+def _frequency_decay(value: str) -> float:
+    parsed = float(value)
+    if not isfinite(parsed) or not 0.0 < parsed <= 1.0:
+        raise argparse.ArgumentTypeError("value must be finite and in (0, 1]")
     return parsed
 
 
@@ -25,29 +56,65 @@ def build_parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument("trace", type=Path)
-    parser.add_argument("--expert-count", type=_positive_int, default=192)
-    parser.add_argument("--persistent-slots-per-layer", type=int, required=True)
-    parser.add_argument("--transient-slots", type=_positive_int, default=8)
-    parser.add_argument("--expert-record-bytes", type=_positive_int, required=True)
+    parser.add_argument(
+        "--model",
+        choices=sorted(MODEL_SPECS),
+        help="Derive expert geometry and validate sparse-layer indices.",
+    )
+    parser.add_argument("--expert-count", type=_positive_int)
+    parser.add_argument(
+        "--persistent-slots-per-layer", type=_nonnegative_int, required=True
+    )
+    parser.add_argument("--transient-slots", type=_positive_int)
+    parser.add_argument("--expert-record-bytes", type=_positive_int)
+    parser.add_argument(
+        "--allocated-layer-count",
+        type=_positive_int,
+        help="Required for full-bank sizing in generic mode; derived with --model.",
+    )
     parser.add_argument(
         "--ssd-gib-per-second",
-        type=float,
+        type=_positive_float,
         default=5.5,
         help="Effective random-read throughput, not headline sequential speed.",
     )
-    parser.add_argument("--frequency-decay", type=float, default=0.995)
+    parser.add_argument("--frequency-decay", type=_frequency_decay, default=0.995)
     return parser
 
 
 def main() -> int:
     args = build_parser().parse_args()
-    if args.persistent_slots_per_layer < 0:
-        raise SystemExit("--persistent-slots-per-layer must be non-negative")
+    spec = get_model_spec(args.model) if args.model else None
+    if spec is not None and (
+        args.expert_count is not None
+        or args.expert_record_bytes is not None
+        or args.allocated_layer_count is not None
+    ):
+        raise SystemExit(
+            "--model derives expert count, record bytes, and allocated layer count; "
+            "do not override them"
+        )
+    expert_count = args.expert_count or (spec.expert_count if spec else 192)
+    transient_slots = args.transient_slots or (spec.top_k if spec else 8)
+    expert_record_bytes = args.expert_record_bytes or (
+        spec.expert_record_bytes if spec else None
+    )
+    if expert_record_bytes is None:
+        raise SystemExit("--expert-record-bytes is required when --model is omitted")
+    if spec is None and args.allocated_layer_count is None:
+        raise SystemExit("--allocated-layer-count is required when --model is omitted")
+    if spec is not None and transient_slots < spec.top_k:
+        raise SystemExit(f"--transient-slots must be at least {spec.top_k}")
+    if args.persistent_slots_per_layer > expert_count:
+        raise SystemExit("--persistent-slots-per-layer cannot exceed the expert count")
     simulation = ExpertCacheSimulation(
-        expert_count=args.expert_count,
+        expert_count=expert_count,
         persistent_slots=args.persistent_slots_per_layer,
-        transient_slots=args.transient_slots,
-        expert_record_bytes=args.expert_record_bytes,
+        transient_slots=transient_slots,
+        expert_record_bytes=expert_record_bytes,
+        allocated_layer_count=(
+            spec.routed_layer_count if spec else args.allocated_layer_count
+        ),
         frequency_decay=args.frequency_decay,
     )
 
@@ -58,20 +125,35 @@ def main() -> int:
             try:
                 event = json.loads(line)
                 phase = RoutingPhase(event["phase"])
-                layer = int(event["layer"])
+                layer = event["layer"]
+                if isinstance(layer, bool) or not isinstance(layer, int):
+                    raise TypeError("layer must be an exact integer")
                 experts = event["experts"]
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
                 raise SystemExit(f"{args.trace}:{line_number}: invalid route: {exc}")
-            simulation.observe(
-                layer_index=layer,
-                expert_ids=experts,
-                phase=phase,
-            )
+            if spec is not None and layer not in spec.routed_layer_indices:
+                raise SystemExit(
+                    f"{args.trace}:{line_number}: layer {layer} is not a routed "
+                    f"{spec.key} layer"
+                )
+            try:
+                simulation.observe(
+                    layer_index=layer,
+                    expert_ids=experts,
+                    phase=phase,
+                )
+            except (TypeError, ValueError) as exc:
+                raise SystemExit(f"{args.trace}:{line_number}: invalid route: {exc}")
 
     gib = 1024**3
     summary = simulation.summary(
         effective_ssd_bytes_per_second=args.ssd_gib_per_second * gib
     )
+    if spec is not None:
+        summary["model_key"] = spec.key
+    summary["effective_expert_count"] = expert_count
+    summary["effective_expert_record_bytes"] = expert_record_bytes
+    summary["effective_transient_slots"] = transient_slots
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/simulate_expert_cache.py
+++ b/scripts/simulate_expert_cache.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Replay routed-expert JSONL through MTPLX's proposed SSD slot-bank policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from mtplx.expert_streaming import ExpertCacheSimulation, RoutingPhase
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Replay JSONL routes shaped as "
+            "{phase, layer, experts} and estimate expert-cache I/O."
+        )
+    )
+    parser.add_argument("trace", type=Path)
+    parser.add_argument("--expert-count", type=_positive_int, default=192)
+    parser.add_argument("--persistent-slots-per-layer", type=int, required=True)
+    parser.add_argument("--transient-slots", type=_positive_int, default=8)
+    parser.add_argument("--expert-record-bytes", type=_positive_int, required=True)
+    parser.add_argument(
+        "--ssd-gib-per-second",
+        type=float,
+        default=5.5,
+        help="Effective random-read throughput, not headline sequential speed.",
+    )
+    parser.add_argument("--frequency-decay", type=float, default=0.995)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.persistent_slots_per_layer < 0:
+        raise SystemExit("--persistent-slots-per-layer must be non-negative")
+    simulation = ExpertCacheSimulation(
+        expert_count=args.expert_count,
+        persistent_slots=args.persistent_slots_per_layer,
+        transient_slots=args.transient_slots,
+        expert_record_bytes=args.expert_record_bytes,
+        frequency_decay=args.frequency_decay,
+    )
+
+    with args.trace.open(encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+                phase = RoutingPhase(event["phase"])
+                layer = int(event["layer"])
+                experts = event["experts"]
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise SystemExit(f"{args.trace}:{line_number}: invalid route: {exc}")
+            simulation.observe(
+                layer_index=layer,
+                expert_ids=experts,
+                phase=phase,
+            )
+
+    gib = 1024**3
+    summary = simulation.summary(
+        effective_ssd_bytes_per_second=args.ssd_gib_per_second * gib
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_expert_manifest.py
+++ b/scripts/verify_expert_manifest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Verify an expert manifest against its checkpoint and optional sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_manifest import (  # noqa: E402
+    ExpertManifestError,
+    load_expert_manifest,
+    verify_expert_manifest,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fail-closed expert artifact verification."
+    )
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--records", action="store_true")
+    parser.add_argument("--shards", action="store_true")
+    parser.add_argument("--sidecar", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        manifest = load_expert_manifest(args.manifest)
+        report = verify_expert_manifest(
+            manifest,
+            args.model_root,
+            verify_records=args.records,
+            verify_shard_hashes=args.shards,
+            verify_sidecar_hash=args.sidecar,
+        )
+    except ExpertManifestError as exc:
+        raise SystemExit(f"expert manifest verification failed: {exc}") from exc
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_streamed_parity.py
+++ b/scripts/verify_streamed_parity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Verify streamed AR token/logit probes against a checked-in golden JSONL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from mtplx.expert_runtime import ExpertStreamingConfig, parse_memory_bytes  # noqa: E402
+from mtplx.runtime import load  # noqa: E402
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model_root", type=Path)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("probes", type=Path)
+    parser.add_argument("--model-key", choices=["hy3-q4", "glm52-q4"], required=True)
+    parser.add_argument("--memory-limit", required=True)
+    parser.add_argument("--max-live-kv-tokens", type=_positive_int, required=True)
+    parser.add_argument("--runtime-reserve", default="16GiB")
+    parser.add_argument("--atol", type=float, default=2e-2)
+    parser.add_argument("--rtol", type=float, default=2e-2)
+    return parser
+
+
+def _load_probes(path: Path) -> list[dict]:
+    probes = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{path}:{line_number}: {exc}") from exc
+        if not isinstance(value, dict):
+            raise SystemExit(f"{path}:{line_number}: probe must be an object")
+        ids = value.get("input_ids")
+        expected_ids = value.get("topk_ids")
+        expected_logits = value.get("topk_logits")
+        if (
+            not isinstance(ids, list)
+            or not ids
+            or not isinstance(expected_ids, list)
+            or not expected_ids
+            or not isinstance(expected_logits, list)
+            or len(expected_ids) != len(expected_logits)
+        ):
+            raise SystemExit(
+                f"{path}:{line_number}: input_ids/topk_ids/topk_logits are required"
+            )
+        probes.append(value)
+    if not probes:
+        raise SystemExit("probe file is empty")
+    return probes
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not math.isfinite(args.atol) or args.atol < 0:
+        raise SystemExit("--atol must be finite and non-negative")
+    if not math.isfinite(args.rtol) or args.rtol < 0:
+        raise SystemExit("--rtol must be finite and non-negative")
+    probes = _load_probes(args.probes)
+    config = ExpertStreamingConfig(
+        model_key=args.model_key,
+        memory_limit_bytes=parse_memory_bytes(args.memory_limit),
+        max_live_kv_tokens=args.max_live_kv_tokens,
+        runtime_reserve_bytes=parse_memory_bytes(args.runtime_reserve),
+    )
+    runtime = load(
+        args.model_root,
+        mtp=False,
+        expert_streaming_config=config,
+        expert_manifest=args.manifest,
+    )
+    results = []
+    try:
+        import mlx.core as mx
+
+        for index, probe in enumerate(probes):
+            input_ids = [int(token) for token in probe["input_ids"]]
+            expected_ids = [int(token) for token in probe["topk_ids"]]
+            expected_logits = [float(value) for value in probe["topk_logits"]]
+            runtime.expert_streaming.reset()
+            cache = runtime.make_cache()
+            with runtime.admit_kv_tokens(len(input_ids)):
+                logits = runtime.forward_ar(
+                    mx.array([input_ids], dtype=mx.int32), cache=cache
+                )
+                last = logits[0, -1].astype(mx.float32)
+                order = mx.argsort(last)[-len(expected_ids) :][::-1]
+                actual = mx.take(last, order)
+                mx.eval(order, actual)
+            actual_ids = [int(value) for value in order.tolist()]
+            actual_logits = [float(value) for value in actual.tolist()]
+            ids_match = actual_ids == expected_ids
+            logits_match = all(
+                math.isclose(actual_value, expected_value, rel_tol=args.rtol, abs_tol=args.atol)
+                for actual_value, expected_value in zip(
+                    actual_logits, expected_logits, strict=True
+                )
+            )
+            results.append(
+                {
+                    "index": index,
+                    "name": probe.get("name") or f"probe-{index}",
+                    "passed": ids_match and logits_match,
+                    "expected_topk_ids": expected_ids,
+                    "actual_topk_ids": actual_ids,
+                    "max_abs_logit_error": max(
+                        abs(actual_value - expected_value)
+                        for actual_value, expected_value in zip(
+                            actual_logits, expected_logits, strict=True
+                        )
+                    ),
+                }
+            )
+    finally:
+        snapshot = runtime.expert_streaming_snapshot()
+        runtime.close(timeout=10.0)
+
+    passed = all(result["passed"] for result in results)
+    print(
+        json.dumps(
+            {
+                "schema": "mtplx-streamed-parity-v1",
+                "passed": passed,
+                "model_key": args.model_key,
+                "probe_count": len(results),
+                "atol": args.atol,
+                "rtol": args.rtol,
+                "results": results,
+                "streaming": snapshot,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_expert_cli_runtime.py
+++ b/tests/test_expert_cli_runtime.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.expert_cli import (
+    add_expert_streaming_args,
+    append_expert_streaming_child_args,
+    expert_streaming_load_kwargs,
+)
+from mtplx.expert_streaming import RoutingPhase
+from mtplx.models.expert_mlx import current_expert_routing_phase
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    add_expert_streaming_args(parser)
+    return parser
+
+
+def _model_root(tmp_path: Path, model_type: str = "hy_v3") -> Path:
+    root = tmp_path / "model"
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps({"model_type": model_type}), encoding="utf-8"
+    )
+    (root / "expert-manifest.json").write_text("{}", encoding="utf-8")
+    return root
+
+
+def test_expert_cli_builds_explicit_bounded_config(tmp_path: Path) -> None:
+    root = _model_root(tmp_path)
+    args = _parser().parse_args(
+        [
+            "--expert-streaming",
+            "--expert-memory-limit",
+            "96GiB",
+            "--expert-max-live-kv-tokens",
+            "8192",
+            "--expert-cache-limit",
+            "24GiB",
+            "--expert-runtime-reserve",
+            "8GiB",
+            "--no-expert-prefer-sidecar",
+        ]
+    )
+
+    kwargs = expert_streaming_load_kwargs(args, root)
+    config = kwargs["expert_streaming_config"]
+
+    assert kwargs["mtp"] is False
+    assert kwargs["expert_manifest"] == root / "expert-manifest.json"
+    assert config.model_key == "hy3-q4"
+    assert config.memory_limit_bytes == 96 * 1024**3
+    assert config.max_live_kv_tokens == 8192
+    assert config.expert_cache_limit_bytes == 24 * 1024**3
+    assert config.runtime_reserve_bytes == 8 * 1024**3
+    assert config.prefer_sidecar is False
+
+
+def test_expert_cli_json_and_flags_are_strict_and_forwarded(tmp_path: Path) -> None:
+    root = _model_root(tmp_path, "glm_moe_dsa")
+    config_path = tmp_path / "stream.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "model_key": "glm52-q4",
+                "memory_limit_bytes": "256GiB",
+                "max_live_kv_tokens": 4096,
+                "runtime_reserve_bytes": "12GiB",
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = _parser().parse_args(
+        [
+            "--expert-streaming-config",
+            str(config_path),
+            "--expert-memory-limit",
+            "320GiB",
+            "--no-expert-verify-record-hashes",
+        ]
+    )
+
+    kwargs = expert_streaming_load_kwargs(args, root)
+    assert kwargs["expert_streaming_config"].memory_limit_bytes == 320 * 1024**3
+    assert kwargs["expert_streaming_config"].verify_record_hashes is False
+
+    command = ["python", "-m", "mtplx.server.openai"]
+    append_expert_streaming_child_args(command, args)
+    assert "--expert-streaming" in command
+    assert command[command.index("--expert-memory-limit") + 1] == "320GiB"
+    assert "--no-expert-verify-record-hashes" in command
+
+
+def test_expert_cli_requires_memory_and_kv_limits(tmp_path: Path) -> None:
+    root = _model_root(tmp_path)
+    args = _parser().parse_args(["--expert-streaming"])
+    with pytest.raises(ValueError, match="missing memory-limit-bytes, max-live-kv-tokens"):
+        expert_streaming_load_kwargs(args, root)
+
+
+class _PhaseModel:
+    def __init__(self) -> None:
+        self.phases: list[RoutingPhase] = []
+
+    def __call__(self, input_ids, cache=None):
+        del cache
+        self.phases.append(current_expert_routing_phase(token_count=999))
+        return input_ids
+
+
+class _StreamingStub:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self, *, timeout=None) -> None:
+        del timeout
+        self.closed = True
+
+    def snapshot(self):
+        return {"ok": True}
+
+    def admit_kv_tokens(self, tokens):
+        return SimpleNamespace(tokens=tokens)
+
+
+def test_mtplx_runtime_marks_prefill_decode_and_closes_streaming_runtime() -> None:
+    model = _PhaseModel()
+    streaming = _StreamingStub()
+    runtime = MTPLXRuntime(
+        model=model,
+        tokenizer=None,
+        model_path=Path("model"),
+        mtp_enabled=False,
+        contract=MTPContract(),
+        expert_streaming=streaming,
+    )
+
+    runtime.forward_ar(SimpleNamespace(shape=(1, 3)))
+    runtime.forward_ar(SimpleNamespace(shape=(1, 1)))
+
+    assert model.phases == [RoutingPhase.PREFILL, RoutingPhase.DECODE]
+    assert runtime.expert_streaming_snapshot() == {"ok": True}
+    runtime.close()
+    assert streaming.closed is True

--- a/tests/test_expert_manifest.py
+++ b/tests/test_expert_manifest.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from mtplx.expert_manifest import (
+    ExpertManifest,
+    ExpertManifestError,
+    build_expert_manifest,
+    build_expert_sidecar,
+    load_expert_manifest,
+    read_expert_record,
+    save_expert_manifest,
+    verify_expert_manifest,
+)
+from mtplx.expert_streaming_models import ExpertStreamingModelSpec
+
+
+COMPONENTS = (
+    "gate_proj.weight",
+    "gate_proj.scales",
+    "gate_proj.biases",
+    "up_proj.weight",
+    "up_proj.scales",
+    "up_proj.biases",
+    "down_proj.weight",
+    "down_proj.scales",
+    "down_proj.biases",
+)
+
+
+def _tiny_spec(*, resident_bytes: int = 8) -> ExpertStreamingModelSpec:
+    record_bytes = 6_912
+    return ExpertStreamingModelSpec(
+        key="tiny-q4",
+        display_name="Tiny affine Q4",
+        source_model="test/tiny",
+        source_revision="source-revision",
+        quant_model="test/tiny-q4",
+        quant_revision="quant-revision",
+        total_tensor_bytes=2 * record_bytes + resident_bytes,
+        total_layers=2,
+        routed_layer_start=1,
+        routed_layer_count=1,
+        expert_count=2,
+        top_k=1,
+        hidden_size=64,
+        expert_hidden_size=64,
+        quant_bits=4,
+        quant_group_size=64,
+        quant_parameter_bytes=2,
+        router_storage="bfloat16",
+        router_matmul_dtype="float32",
+        router_bytes=0,
+        kv_bytes_per_token=0,
+        mtp_layer_index=2,
+        mtp_included=False,
+    )
+
+
+def _component_info(component: str, *, stacked: bool) -> tuple[str, list[int], int]:
+    leaf = component.rsplit(".", 1)[1]
+    if leaf == "weight":
+        dtype = "U32"
+        per_expert_shape = [64, 8]
+        per_expert_bytes = 2_048
+    else:
+        dtype = "BF16"
+        per_expert_shape = [64, 1]
+        per_expert_bytes = 128
+    shape = [2, *per_expert_shape] if stacked else per_expert_shape
+    return dtype, shape, per_expert_bytes
+
+
+def _write_safetensors(
+    path: Path,
+    tensors: list[tuple[str, str, list[int], bytes]],
+) -> None:
+    header: dict[str, object] = {}
+    payload = bytearray()
+    for name, dtype, shape, raw in tensors:
+        start = len(payload)
+        payload.extend(raw)
+        header[name] = {
+            "dtype": dtype,
+            "shape": shape,
+            "data_offsets": [start, len(payload)],
+        }
+    encoded = json.dumps(header, separators=(",", ":")).encode()
+    path.write_bytes(len(encoded).to_bytes(8, "little") + encoded + payload)
+
+
+def _make_checkpoint(
+    root: Path, *, numbered: bool = False
+) -> tuple[ExpertStreamingModelSpec, dict[int, bytes]]:
+    root.mkdir()
+    spec = _tiny_spec()
+    shards: list[list[tuple[str, str, list[int], bytes]]] = [[], []]
+    expected: dict[int, bytearray] = {0: bytearray(), 1: bytearray()}
+    weight_map: dict[str, str] = {}
+    for component_index, component in enumerate(COMPONENTS):
+        dtype, shape, per_expert_bytes = _component_info(
+            component, stacked=not numbered
+        )
+        projection, leaf = component.split(".")
+        if numbered:
+            for expert in range(2):
+                name = f"model.layers.1.mlp.experts.{expert}.{projection}.{leaf}"
+                raw = bytes([component_index * 2 + expert + 1]) * per_expert_bytes
+                shard_index = (component_index + expert) % 2
+                shards[shard_index].append((name, dtype, shape, raw))
+                weight_map[name] = f"model-{shard_index + 1:05d}-of-00002.safetensors"
+                expected[expert].extend(raw)
+        else:
+            name = f"model.layers.1.mlp.switch_mlp.{component}"
+            raw_parts = [
+                bytes([component_index * 2 + expert + 1]) * per_expert_bytes
+                for expert in range(2)
+            ]
+            raw = b"".join(raw_parts)
+            shard_index = component_index % 2
+            shards[shard_index].append((name, dtype, shape, raw))
+            weight_map[name] = f"model-{shard_index + 1:05d}-of-00002.safetensors"
+            for expert, part in enumerate(raw_parts):
+                expected[expert].extend(part)
+    resident_name = "model.embed_tokens.weight"
+    resident_raw = bytes(range(8))
+    shards[0].append((resident_name, "F32", [2], resident_raw))
+    weight_map[resident_name] = "model-00001-of-00002.safetensors"
+    for index, tensors in enumerate(shards, 1):
+        _write_safetensors(root / f"model-{index:05d}-of-00002.safetensors", tensors)
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map}),
+        encoding="utf-8",
+    )
+    return spec, {expert: bytes(value) for expert, value in expected.items()}
+
+
+@pytest.mark.parametrize("numbered", [False, True])
+def test_build_manifest_for_stacked_and_numbered_experts(
+    tmp_path: Path,
+    numbered: bool,
+) -> None:
+    root = tmp_path / "model"
+    spec, expected = _make_checkpoint(root, numbered=numbered)
+
+    manifest = build_expert_manifest(
+        root,
+        spec,
+        hash_records=True,
+        hash_shards=True,
+    )
+
+    assert manifest.artifact_tensor_bytes == spec.total_tensor_bytes
+    assert manifest.resident_tensor_bytes == 8
+    assert manifest.routed_expert_bytes == spec.routed_expert_bytes
+    assert len(manifest.shards) == 2
+    assert len(manifest.resident_tensors) == 1
+    assert len(manifest.records) == 2
+    assert all(shard.sha256 for shard in manifest.shards)
+    for expert in range(2):
+        record = manifest.record(1, expert)
+        assert tuple(segment.component for segment in record.segments) == COMPONENTS
+        assert record.logical_bytes == spec.expert_record_bytes
+        assert record.sha256 == hashlib.sha256(expected[expert]).hexdigest()
+        assert read_expert_record(manifest, root, 1, expert) == expected[expert]
+
+    report = verify_expert_manifest(
+        manifest,
+        root,
+        verify_records=True,
+        verify_shard_hashes=True,
+    )
+    assert report["valid"] is True
+    assert report["checked_records"] == 2
+
+
+def test_manifest_roundtrip_digest_and_unknown_fields_fail_closed(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "model"
+    spec, _expected = _make_checkpoint(root)
+    manifest = build_expert_manifest(root, spec)
+    path = root / "expert-manifest.json"
+
+    saved = save_expert_manifest(manifest, path)
+    loaded = load_expert_manifest(path)
+
+    assert loaded == saved
+    tampered = loaded.to_dict()
+    tampered["model_key"] = "wrong"
+    with pytest.raises(ExpertManifestError, match="digest mismatch"):
+        ExpertManifest.from_dict(tampered)
+    unknown = loaded.to_dict()
+    unknown["surprise"] = True
+    with pytest.raises(ExpertManifestError, match="unknown keys"):
+        ExpertManifest.from_dict(unknown, verify_digest=False)
+    escaped = loaded.to_dict()
+    escaped["records"][0]["segments"][0]["shard"] = "../escape"
+    with pytest.raises(ExpertManifestError, match="unsafe"):
+        ExpertManifest.from_dict(escaped, verify_digest=False)
+
+
+def test_aligned_sidecar_is_readable_and_verifiable(tmp_path: Path) -> None:
+    root = tmp_path / "model"
+    spec, expected = _make_checkpoint(root)
+    manifest = build_expert_manifest(root, spec)
+
+    updated = build_expert_sidecar(manifest, root, root / "experts.bin")
+
+    assert updated.sidecar is not None
+    assert updated.sidecar.file == "experts.bin"
+    assert updated.sidecar.alignment == 16_384
+    assert updated.records[0].sidecar_offset == 0
+    assert updated.records[1].sidecar_offset == 16_384
+    assert updated.sidecar.size == 16_384 + spec.expert_record_bytes
+    assert read_expert_record(updated, root, 1, 0) == expected[0]
+    assert read_expert_record(updated, root, 1, 1) == expected[1]
+    report = verify_expert_manifest(updated, root, verify_sidecar_hash=True)
+    assert report["sidecar_verified"] is True
+
+
+def test_corrupt_payload_and_truncated_sidecar_fail_closed(tmp_path: Path) -> None:
+    root = tmp_path / "model"
+    spec, _expected = _make_checkpoint(root)
+    manifest = build_expert_manifest(root, spec)
+    record = manifest.records[0]
+    segment = record.segments[0]
+    shard = root / segment.shard
+    fd = os.open(shard, os.O_RDWR)
+    try:
+        original = os.pread(fd, 1, segment.offset)
+        os.pwrite(fd, bytes([original[0] ^ 0xFF]), segment.offset)
+    finally:
+        os.close(fd)
+    with pytest.raises(ExpertManifestError, match="record hash mismatch"):
+        read_expert_record(manifest, root, record.layer, record.expert)
+
+    # Rebuild a clean model before testing the independent sidecar failure.
+    clean_root = tmp_path / "clean"
+    clean_spec, _ = _make_checkpoint(clean_root)
+    clean_manifest = build_expert_manifest(clean_root, clean_spec)
+    updated = build_expert_sidecar(
+        clean_manifest, clean_root, clean_root / "experts.bin"
+    )
+    assert updated.sidecar is not None
+    (clean_root / "experts.bin").write_bytes(b"short")
+    with pytest.raises(ExpertManifestError, match="sidecar size mismatch"):
+        verify_expert_manifest(updated, clean_root)
+
+
+def test_missing_component_and_index_mismatch_are_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "model"
+    spec, _expected = _make_checkpoint(root)
+    index_path = root / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    missing_key = "model.layers.1.mlp.switch_mlp.down_proj.biases"
+    del index["weight_map"][missing_key]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(ExpertManifestError, match="wrong shard|mismatch"):
+        build_expert_manifest(root, spec)
+
+
+def test_sidecar_must_stay_inside_artifact_root(tmp_path: Path) -> None:
+    root = tmp_path / "model"
+    spec, _expected = _make_checkpoint(root)
+    manifest = build_expert_manifest(root, spec)
+
+    with pytest.raises(ExpertManifestError, match="inside the artifact root"):
+        build_expert_sidecar(manifest, root, tmp_path / "outside.bin")
+
+
+def test_manifest_builder_can_skip_pinned_total_only_for_fixtures(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "model"
+    spec, _expected = _make_checkpoint(root)
+    wrong_total = replace(spec, total_tensor_bytes=spec.total_tensor_bytes + 4)
+
+    with pytest.raises(ExpertManifestError, match="pinned"):
+        build_expert_manifest(root, wrong_total)
+    manifest = build_expert_manifest(
+        root,
+        wrong_total,
+        require_pinned_tensor_bytes=False,
+    )
+    assert manifest.artifact_tensor_bytes == spec.total_tensor_bytes

--- a/tests/test_expert_slots_runtime.py
+++ b/tests/test_expert_slots_runtime.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from mtplx.expert_io import (
+    ExpertIOCancelled,
+    ExpertIOIntegrityError,
+    ExpertIOShortRead,
+    PositionalExpertReader,
+)
+from mtplx.expert_manifest import (
+    ExpertManifest,
+    ExpertRecord,
+    ResidentTensor,
+    ShardInfo,
+    TensorSegment,
+    save_expert_manifest,
+)
+from mtplx.expert_runtime import (
+    ExpertStreamingConfig,
+    ExpertStreamingConfigurationError,
+    ExpertStreamingRuntime,
+    apply_mlx_memory_cap,
+    partition_route_waves,
+    reconcile_mlx_memory_cap,
+)
+from mtplx.expert_slots import ExpertSlotError, ExpertSlotPool
+from mtplx.expert_streaming import (
+    LayerExpertSlotBank,
+    RoutePlan,
+    RoutingPhase,
+    SlotLoad,
+)
+from mtplx.expert_streaming_models import ExpertStreamingModelSpec, plan_expert_memory
+
+
+COMPONENTS = (
+    ("gate_proj.weight", 2_048, "U32", (64, 8)),
+    ("gate_proj.scales", 128, "BF16", (64, 1)),
+    ("gate_proj.biases", 128, "BF16", (64, 1)),
+    ("up_proj.weight", 2_048, "U32", (64, 8)),
+    ("up_proj.scales", 128, "BF16", (64, 1)),
+    ("up_proj.biases", 128, "BF16", (64, 1)),
+    ("down_proj.weight", 2_048, "U32", (64, 8)),
+    ("down_proj.scales", 128, "BF16", (64, 1)),
+    ("down_proj.biases", 128, "BF16", (64, 1)),
+)
+
+
+def _spec() -> ExpertStreamingModelSpec:
+    record_bytes = sum(item[1] for item in COMPONENTS)
+    return ExpertStreamingModelSpec(
+        key="tiny-q4",
+        display_name="Tiny Q4",
+        source_model="test/tiny",
+        source_revision="source-revision",
+        quant_model="test/tiny-q4",
+        quant_revision="quant-revision",
+        total_tensor_bytes=2 * record_bytes + 1,
+        total_layers=2,
+        routed_layer_start=1,
+        routed_layer_count=1,
+        expert_count=2,
+        top_k=1,
+        hidden_size=64,
+        expert_hidden_size=64,
+        quant_bits=4,
+        quant_group_size=64,
+        quant_parameter_bytes=2,
+        router_storage="bfloat16",
+        router_matmul_dtype="float32",
+        router_bytes=0,
+        kv_bytes_per_token=16,
+        mtp_layer_index=2,
+        mtp_included=False,
+    )
+
+
+def _artifact(
+    tmp_path: Path,
+) -> tuple[Path, ExpertStreamingModelSpec, ExpertManifest, dict[int, bytes]]:
+    root = tmp_path / "artifact"
+    root.mkdir()
+    spec = _spec()
+    raw = bytearray()
+    records: list[ExpertRecord] = []
+    expected: dict[int, bytes] = {}
+    for expert in range(spec.expert_count):
+        segments: list[TensorSegment] = []
+        record_payload = bytearray()
+        for component_index, (component, length, dtype, shape) in enumerate(COMPONENTS):
+            payload = bytes([expert * 16 + component_index + 1]) * length
+            offset = len(raw)
+            raw.extend(payload)
+            record_payload.extend(payload)
+            segments.append(
+                TensorSegment(
+                    component=component,
+                    tensor=f"model.layers.1.mlp.switch_mlp.{component}",
+                    shard="source.bin",
+                    offset=offset,
+                    length=length,
+                    dtype=dtype,
+                    shape=shape,
+                )
+            )
+        expected[expert] = bytes(record_payload)
+        records.append(
+            ExpertRecord(
+                layer=1,
+                expert=expert,
+                logical_bytes=len(record_payload),
+                segments=tuple(segments),
+                sha256=hashlib.sha256(record_payload).hexdigest(),
+            )
+        )
+    resident_offset = len(raw)
+    raw.append(123)
+    (root / "source.bin").write_bytes(raw)
+    manifest = ExpertManifest(
+        model_key=spec.key,
+        source_repo=spec.quant_model,
+        source_revision=spec.quant_revision,
+        quant_bits=4,
+        quant_group_size=64,
+        quant_mode="affine",
+        artifact_tensor_bytes=spec.total_tensor_bytes,
+        resident_tensor_bytes=1,
+        routed_expert_bytes=spec.routed_expert_bytes,
+        shards=(
+            ShardInfo(
+                name="source.bin",
+                size=len(raw),
+                header_bytes=1,
+                header_sha256="fixture-header",
+            ),
+        ),
+        resident_tensors=(
+            ResidentTensor(
+                tensor="model.norm.flag",
+                shard="source.bin",
+                offset=resident_offset,
+                length=1,
+                dtype="U8",
+                shape=(1,),
+            ),
+        ),
+        records=tuple(records),
+    ).with_digest()
+    manifest.validate_structure()
+    return root, spec, manifest, expected
+
+
+def _plan(spec: ExpertStreamingModelSpec):
+    fixed = spec.resident_bytes + spec.transient_scratch_bytes
+    return plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed + spec.persistent_cache_bytes(1),
+        context_tokens=0,
+        runtime_reserve_bytes=0,
+    )
+
+
+def test_positional_reader_fills_and_hashes_source_record(tmp_path: Path) -> None:
+    root, _spec_value, manifest, expected = _artifact(tmp_path)
+    destination = bytearray(manifest.records[0].logical_bytes)
+
+    with PositionalExpertReader(root, max_open_files=1, use_native=False) as reader:
+        digest = reader.read_record_into(manifest, manifest.records[0], destination)
+        metrics = reader.metrics.as_dict()
+
+    assert bytes(destination) == expected[0]
+    assert digest == manifest.records[0].sha256
+    assert metrics["source_record_requests"] == 1
+    assert metrics["read_operations"] == 9
+    assert metrics["read_bytes"] == len(destination)
+    assert metrics["open_files_peak"] == 1
+
+
+def test_reader_cancellation_integrity_and_short_read_fail_closed(
+    tmp_path: Path,
+) -> None:
+    root, _spec_value, manifest, _expected = _artifact(tmp_path)
+    destination = bytearray(manifest.records[0].logical_bytes)
+    cancel = threading.Event()
+    cancel.set()
+    with PositionalExpertReader(root, use_native=False) as reader:
+        with pytest.raises(ExpertIOCancelled):
+            reader.read_record_into(
+                manifest,
+                manifest.records[0],
+                destination,
+                cancel_event=cancel,
+            )
+
+    corrupt = bytearray((root / "source.bin").read_bytes())
+    corrupt[0] ^= 0xFF
+    (root / "source.bin").write_bytes(corrupt)
+    with PositionalExpertReader(root, use_native=False) as reader:
+        with pytest.raises(ExpertIOIntegrityError):
+            reader.read_record_into(manifest, manifest.records[0], destination)
+
+    (root / "source.bin").write_bytes(b"short")
+    with PositionalExpertReader(root, use_native=False) as reader:
+        with pytest.raises(ExpertIOShortRead):
+            reader.read_record_into(manifest, manifest.records[0], destination)
+
+
+def test_slot_pool_loads_hits_replaces_and_preserves_component_views(
+    tmp_path: Path,
+) -> None:
+    root, spec, manifest, expected = _artifact(tmp_path)
+    plan = _plan(spec)
+    reader = PositionalExpertReader(root, use_native=False)
+    pool = ExpertSlotPool(spec, plan, manifest, reader)
+    bank = LayerExpertSlotBank(
+        expert_count=2,
+        persistent_slots=1,
+        transient_slots=1,
+    )
+    try:
+        first_plan = bank.plan([0], phase="decode")
+        first = pool.ensure_route(1, first_plan)
+        assert bytes(first.bindings[0].buffer) == expected[0]
+        assert len(first.bindings[0].component_view("gate_proj.weight")) == 2_048
+        first_generation = first.generations[0]
+        first.release(synchronize=False)
+
+        hit_plan = bank.plan([0], phase="decode")
+        hit = pool.ensure_route(1, hit_plan)
+        assert hit.plan.loads == ()
+        assert hit.generations[0] == first_generation
+        hit.release(synchronize=False)
+
+        cold_plan = bank.plan([1], phase="decode")
+        assert all(not load.persistent for load in cold_plan.loads)
+        cold = pool.ensure_route(1, cold_plan)
+        assert bytes(cold.bindings[0].buffer) == expected[1]
+        cold.release(synchronize=False)
+
+        admitted_plan = bank.plan([1], phase="decode")
+        assert any(load.persistent for load in admitted_plan.loads)
+        admitted = pool.ensure_route(1, admitted_plan)
+        assert admitted.generations[0] > first_generation
+        admitted.release(synchronize=False)
+
+        snapshot = pool.snapshot()
+        assert snapshot["allocated_bytes"] == 2 * spec.expert_record_bytes
+        assert snapshot["metrics"]["generation_replacements"] == 1
+        assert snapshot["io"]["record_requests"] == 3
+    finally:
+        pool.close()
+
+
+def _manual_plan(expert: int, slot: int) -> RoutePlan:
+    return RoutePlan(
+        phase=RoutingPhase.DECODE,
+        experts=(expert,),
+        slots=(slot,),
+        hits=(),
+        misses=(expert,),
+        loads=(SlotLoad(expert=expert, slot=slot, persistent=False),),
+        evictions=(),
+    )
+
+
+def test_transient_slot_waits_for_pinned_generation_before_overwrite(
+    tmp_path: Path,
+) -> None:
+    root, spec, manifest, _expected = _artifact(tmp_path)
+    plan = _plan(spec)
+    reader = PositionalExpertReader(root, use_native=False)
+    pool = ExpertSlotPool(spec, plan, manifest, reader)
+    transient_slot = plan.slots_per_layer
+    first = pool.ensure_route(1, _manual_plan(0, transient_slot))
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(pool.ensure_route, 1, _manual_plan(1, transient_slot))
+        time.sleep(0.05)
+        assert pending.done() is False
+        first.release(synchronize=False)
+        second = pending.result(timeout=2)
+    assert second.bindings[0].expert == 1
+    second.release(synchronize=False)
+    pool.close()
+
+
+def test_runtime_handles_kv_admission_routes_waves_and_reset(tmp_path: Path) -> None:
+    root, spec, manifest, expected = _artifact(tmp_path)
+    manifest_path = root / "expert-manifest.json"
+    save_expert_manifest(manifest, manifest_path)
+    plan = _plan(spec)
+    config = ExpertStreamingConfig(
+        model_key=spec.key,
+        memory_limit_bytes=plan.total_limit_bytes + 4 * spec.kv_bytes_per_token,
+        max_live_kv_tokens=4,
+        runtime_reserve_bytes=0,
+        verify_artifact_headers=False,
+        max_inflight_io_bytes=spec.expert_record_bytes,
+    )
+    runtime = ExpertStreamingRuntime.open(
+        root,
+        manifest_path,
+        config,
+        spec=spec,
+        apply_memory_cap=False,
+    )
+    try:
+        admission = runtime.admit_kv_tokens(4)
+        with pytest.raises(ExpertStreamingConfigurationError, match="exceeds"):
+            runtime.admit_kv_tokens(1)
+        admission.release()
+
+        ready = runtime.ensure_route(1, [0], phase="decode")
+        assert bytes(ready.bindings[0].buffer) == expected[0]
+        ready.release(synchronize=False)
+
+        waves = runtime.route_waves([0, 1, 0, 1])
+        assert len(waves) == 2
+        assert waves[0].positions == (0, 2)
+        assert waves[1].positions == (1, 3)
+        snapshot = runtime.snapshot(mx_module=object())
+        assert snapshot["cache"]["expert_requests"] == 1
+        assert snapshot["slots"]["pins"] == 0
+        runtime.reset()
+        assert runtime.snapshot(mx_module=object())["slots"]["states"]["empty"] == 2
+    finally:
+        runtime.close()
+
+
+def test_runtime_rolls_back_policy_mapping_after_integrity_failure(
+    tmp_path: Path,
+) -> None:
+    root, spec, manifest, _expected = _artifact(tmp_path)
+    manifest_path = root / "expert-manifest.json"
+    save_expert_manifest(manifest, manifest_path)
+    plan = _plan(spec)
+    config = ExpertStreamingConfig(
+        model_key=spec.key,
+        memory_limit_bytes=plan.total_limit_bytes,
+        max_live_kv_tokens=0,
+        runtime_reserve_bytes=0,
+        verify_artifact_headers=False,
+    )
+    runtime = ExpertStreamingRuntime.open(
+        root,
+        manifest_path,
+        config,
+        spec=spec,
+        apply_memory_cap=False,
+    )
+    payload = bytearray((root / "source.bin").read_bytes())
+    payload[0] ^= 0xFF
+    (root / "source.bin").write_bytes(payload)
+    try:
+        with pytest.raises(ExpertSlotError, match="hash mismatch"):
+            runtime.ensure_route(1, [0], phase="decode")
+        assert runtime._banks[1].occupancy == 0
+        assert runtime.snapshot(mx_module=object())["slots"]["states"]["empty"] == 2
+    finally:
+        runtime.close()
+
+
+def test_memory_cap_reconciliation_and_fake_mlx_application() -> None:
+    spec = _spec()
+    plan = plan_expert_memory(
+        spec,
+        total_limit_bytes=100_000,
+        context_tokens=0,
+        runtime_reserve_bytes=10_000,
+        io_staging_bytes=5_000,
+    )
+    expected = 85_000
+    assert reconcile_mlx_memory_cap(plan, env={}) == expected
+    with pytest.raises(ExpertStreamingConfigurationError, match="conflicts"):
+        reconcile_mlx_memory_cap(plan, env={"MTPLX_MEMORY_LIMIT_BYTES": "84kb"})
+
+    class FakeMX:
+        value = 0
+
+        @classmethod
+        def set_memory_limit(cls, value: int) -> None:
+            cls.value = value
+
+    env: dict[str, str] = {}
+    report = apply_mlx_memory_cap(plan, mx_module=FakeMX, env=env)
+    assert report == {"applied": True, "limit": expected}
+    assert FakeMX.value == expected
+    assert env["MTPLX_MEMORY_LIMIT_BYTES"] == str(expected)
+
+
+def test_partition_route_waves_rejects_non_integral_ids() -> None:
+    with pytest.raises(TypeError, match="exact integers"):
+        partition_route_waves([0, 1.5], max_unique_experts=1)

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+
+from mtplx.expert_streaming import (
+    CacheCounters,
+    ExpertCacheSimulation,
+    LayerExpertSlotBank,
+    RoutingPhase,
+)
+
+
+def test_decode_fills_persistent_slots_and_then_hits() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=4,
+        transient_slots=2,
+        frequency_decay=1.0,
+    )
+
+    first = bank.plan([2, 5], phase=RoutingPhase.DECODE)
+    second = bank.plan([5, 2], phase=RoutingPhase.DECODE)
+
+    assert first.hits == ()
+    assert first.misses == (2, 5)
+    assert all(load.persistent for load in first.loads)
+    assert second.hits == (5, 2)
+    assert second.misses == ()
+    assert second.loads == ()
+    assert second.slots == (first.slots[1], first.slots[0])
+
+
+def test_prefill_uses_transient_slots_without_polluting_decode_hotset() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=32,
+        persistent_slots=2,
+        transient_slots=2,
+    )
+    bank.plan([1, 2], phase="decode")
+    resident_before = bank.resident_experts
+
+    prefill = bank.plan([10, 11], phase="prefill")
+
+    assert bank.resident_experts == resident_before
+    assert prefill.slots == (2, 3)
+    assert all(not load.persistent for load in prefill.loads)
+    assert prefill.evictions == ()
+
+
+def test_frequent_decode_expert_eventually_displaces_a_cold_resident() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=1,
+        frequency_decay=1.0,
+    )
+    bank.plan([1], phase="decode")
+    bank.plan([2], phase="decode")
+
+    first_three = bank.plan([3], phase="decode")
+    second_three = bank.plan([3], phase="decode")
+
+    assert all(not load.persistent for load in first_three.loads)
+    assert any(load.persistent for load in second_three.loads)
+    assert len(second_three.evictions) == 1
+    assert 3 in bank.resident_experts
+
+
+def test_active_hit_is_pinned_during_multi_expert_admission() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=2,
+        frequency_decay=1.0,
+    )
+    bank.plan([1, 2], phase="decode")
+    for _ in range(3):
+        bank.plan([3, 1], phase="decode")
+
+    assert 1 in bank.resident_experts
+
+
+def test_duplicate_router_ids_share_one_load_and_slot() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=8,
+        persistent_slots=1,
+        transient_slots=2,
+    )
+
+    plan = bank.plan([4, 4, 6], phase="prefill")
+
+    assert plan.misses == (4, 6)
+    assert len(plan.loads) == 2
+    assert plan.slots[0] == plan.slots[1]
+
+
+def test_route_larger_than_transient_service_tier_is_rejected() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=2,
+    )
+
+    with pytest.raises(ValueError, match="transient_slots"):
+        bank.plan([1, 2, 3], phase="decode")
+
+
+def test_counters_charge_only_cache_misses_for_io() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=2,
+    )
+    counters = CacheCounters()
+    first = bank.plan([1, 2], phase="decode")
+    second = bank.plan([1, 2], phase="decode")
+    counters.observe(first, expert_record_bytes=1024)
+    counters.observe(second, expert_record_bytes=1024)
+
+    assert counters.expert_requests == 4
+    assert counters.expert_hits == 2
+    assert counters.expert_misses == 2
+    assert counters.bytes_read == 2048
+    assert counters.hit_rate == 0.5
+
+
+def test_simulation_reports_io_time_and_layer_hotsets() -> None:
+    simulation = ExpertCacheSimulation(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=2,
+        expert_record_bytes=100,
+    )
+    simulation.observe(layer_index=0, expert_ids=[1, 2], phase="decode")
+    simulation.observe(layer_index=0, expert_ids=[1, 2], phase="decode")
+    simulation.observe(layer_index=1, expert_ids=[3, 4], phase="prefill")
+
+    summary = simulation.summary(effective_ssd_bytes_per_second=1000)
+
+    assert summary["bytes_read"] == 400
+    assert summary["estimated_io_seconds"] == pytest.approx(0.4)
+    assert summary["layers_observed"] == 2
+    assert summary["persistent_cache_bytes"] == 400
+    assert summary["transient_scratch_bytes"] == 200
+    assert summary["resident_experts_by_layer"]["0"] == [1, 2]
+    assert summary["resident_experts_by_layer"]["1"] == []

--- a/tests/test_expert_streaming.py
+++ b/tests/test_expert_streaming.py
@@ -66,6 +66,43 @@ def test_frequent_decode_expert_eventually_displaces_a_cold_resident() -> None:
     assert 3 in bank.resident_experts
 
 
+def test_singleton_decode_miss_does_not_win_only_because_resident_decayed() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=16,
+        persistent_slots=2,
+        transient_slots=1,
+    )
+    bank.plan([1], phase="decode")
+    bank.plan([2], phase="decode")
+    resident_before = bank.resident_experts
+
+    singleton = bank.plan([3], phase="decode")
+
+    assert bank.resident_experts == resident_before
+    assert all(not load.persistent for load in singleton.loads)
+    assert singleton.evictions == ()
+
+
+def test_prefill_does_not_age_decode_admission_history() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=32,
+        persistent_slots=2,
+        transient_slots=1,
+        frequency_decay=0.5,
+    )
+    bank.plan([1], phase="decode")
+    bank.plan([2], phase="decode")
+    resident_before = bank.resident_experts
+
+    for _ in range(32):
+        bank.plan([10], phase="prefill")
+    singleton = bank.plan([3], phase="decode")
+
+    assert bank.resident_experts == resident_before
+    assert all(not load.persistent for load in singleton.loads)
+    assert singleton.evictions == ()
+
+
 def test_active_hit_is_pinned_during_multi_expert_admission() -> None:
     bank = LayerExpertSlotBank(
         expert_count=16,
@@ -94,6 +131,35 @@ def test_duplicate_router_ids_share_one_load_and_slot() -> None:
     assert plan.slots[0] == plan.slots[1]
 
 
+def test_counters_preserve_router_assignment_multiplicity() -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=8,
+        persistent_slots=0,
+        transient_slots=2,
+    )
+    counters = CacheCounters()
+
+    plan = bank.plan([4, 4, 6], phase="decode")
+    counters.observe(plan, expert_record_bytes=100)
+
+    assert counters.expert_requests == 3
+    assert counters.expert_misses == 3
+    assert counters.transient_loads == 2
+    assert counters.bytes_read == 200
+
+
+@pytest.mark.parametrize("invalid_id", [1.9, "1", True])
+def test_router_ids_must_be_exact_integers(invalid_id: object) -> None:
+    bank = LayerExpertSlotBank(
+        expert_count=8,
+        persistent_slots=0,
+        transient_slots=2,
+    )
+
+    with pytest.raises(TypeError, match="exact integers"):
+        bank.plan([invalid_id], phase="decode")
+
+
 def test_route_larger_than_transient_service_tier_is_rejected() -> None:
     bank = LayerExpertSlotBank(
         expert_count=16,
@@ -103,6 +169,15 @@ def test_route_larger_than_transient_service_tier_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="transient_slots"):
         bank.plan([1, 2, 3], phase="decode")
+
+
+def test_persistent_capacity_cannot_exceed_the_model_expert_count() -> None:
+    with pytest.raises(ValueError, match="cannot exceed"):
+        LayerExpertSlotBank(
+            expert_count=16,
+            persistent_slots=17,
+            transient_slots=8,
+        )
 
 
 def test_counters_charge_only_cache_misses_for_io() -> None:
@@ -144,3 +219,22 @@ def test_simulation_reports_io_time_and_layer_hotsets() -> None:
     assert summary["transient_scratch_bytes"] == 200
     assert summary["resident_experts_by_layer"]["0"] == [1, 2]
     assert summary["resident_experts_by_layer"]["1"] == []
+
+
+def test_simulation_reports_full_allocated_bank_for_a_partial_trace() -> None:
+    simulation = ExpertCacheSimulation(
+        expert_count=256,
+        persistent_slots=32,
+        transient_slots=8,
+        expert_record_bytes=21_233_664,
+        allocated_layer_count=75,
+    )
+    simulation.observe(layer_index=3, expert_ids=range(8), phase="decode")
+
+    summary = simulation.summary(effective_ssd_bytes_per_second=1)
+
+    assert summary["layers_observed"] == 1
+    assert summary["allocated_layer_count"] == 75
+    assert summary["persistent_cache_scope"] == "configured_model"
+    assert summary["persistent_cache_bytes"] == 75 * 32 * 21_233_664
+    assert summary["observed_layer_cache_bytes"] == 32 * 21_233_664

--- a/tests/test_expert_streaming_models.py
+++ b/tests/test_expert_streaming_models.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from mtplx.expert_streaming_models import (
+    MODEL_SPECS,
+    get_model_spec,
+    plan_expert_memory,
+)
+
+
+GIB = 1 << 30
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_hy3_q4_exact_expert_layout() -> None:
+    spec = get_model_spec("hy3-q4")
+
+    assert MODEL_SPECS["hy3-q4"] is spec
+    assert spec.total_layers == 80
+    assert spec.total_tensor_bytes == 165_988_461_824
+    assert spec.routed_layer_indices == tuple(range(1, 80))
+    assert spec.expert_count == 192
+    assert spec.top_k == 8
+    assert spec.hidden_size == 4096
+    assert spec.expert_hidden_size == 1536
+    assert spec.quant_bits == 4
+    assert spec.quant_group_size == 64
+    assert spec.quant_parameter_bytes == 2
+    assert spec.expert_record_bytes == 10_616_832
+    assert spec.routed_expert_bytes == 161_036_107_776
+    assert spec.cold_expert_bytes_per_token == 6_709_837_824
+    assert spec.transient_scratch_bytes == 84_934_656
+    assert spec.persistent_cache_bytes(0) == 0
+    assert spec.persistent_cache_bytes(8) == 6_709_837_824
+    assert spec.persistent_cache_bytes(32) == 26_839_351_296
+    assert spec.resident_bytes == 4_952_354_048
+    assert spec.routed_expert_bytes + spec.resident_bytes == spec.total_tensor_bytes
+    assert spec.router_bytes == 66_071_808
+    assert spec.router_storage == "affine-q8 with fp32 correction bias"
+    assert spec.router_matmul_dtype == "float32"
+    assert spec.source_revision == "716aa7241bd6d95896be4ebfc761162a9c4d49ef"
+    assert spec.quant_revision == "160619d3f96c8470350b6dac0ef033a8381551e3"
+    assert spec.kv_bytes_per_token == 327_680
+    assert spec.mtp_layer_index == 80
+    assert spec.mtp_included is False
+    assert spec.full_indexer_layers == ()
+
+
+def test_glm52_q4_exact_expert_and_indexshare_layout() -> None:
+    spec = get_model_spec("glm52-q4")
+
+    assert MODEL_SPECS["glm52-q4"] is spec
+    assert spec.total_layers == 78
+    assert spec.total_tensor_bytes == 418_320_895_488
+    assert spec.routed_layer_indices == tuple(range(3, 78))
+    assert spec.expert_count == 256
+    assert spec.top_k == 8
+    assert spec.hidden_size == 6144
+    assert spec.expert_hidden_size == 2048
+    assert spec.quant_bits == 4
+    assert spec.quant_group_size == 64
+    assert spec.quant_parameter_bytes == 2
+    assert spec.expert_record_bytes == 21_233_664
+    assert spec.routed_expert_bytes == 407_686_348_800
+    assert spec.cold_expert_bytes_per_token == 12_740_198_400
+    assert spec.transient_scratch_bytes == 169_869_312
+    assert spec.persistent_cache_bytes(0) == 0
+    assert spec.persistent_cache_bytes(8) == 12_740_198_400
+    assert spec.persistent_cache_bytes(32) == 50_960_793_600
+    assert spec.persistent_cache_bytes(64) == 101_921_587_200
+    assert spec.resident_bytes == 10_634_546_688
+    assert spec.routed_expert_bytes + spec.resident_bytes == spec.total_tensor_bytes
+    assert spec.router_bytes == 236_006_400
+    assert spec.router_storage == "bfloat16 with fp32 correction bias"
+    assert spec.router_matmul_dtype == "float32"
+    assert spec.source_revision == "b4734de4facf877f85769a911abafc5283eab3d9"
+    assert spec.quant_revision == "6b347a6472d46bf55de65ee34032136a3929d778"
+    assert spec.kv_bytes_per_token == 95_232
+    assert spec.mtp_layer_index == 78
+    assert spec.mtp_included is False
+    assert spec.full_indexer_layers == (0, 1, 2, *range(6, 75, 4))
+    assert len(spec.full_indexer_layers) == 21
+
+
+def test_model_registry_contains_both_q4_targets() -> None:
+    assert {"hy3-q4", "glm52-q4"} <= MODEL_SPECS.keys()
+    with pytest.raises(ValueError, match="unknown model"):
+        get_model_spec("unknown-model")
+
+
+@pytest.mark.parametrize("model_key", ["hy3-q4", "glm52-q4"])
+def test_memory_plan_turns_a_total_limit_into_whole_per_layer_slots(
+    model_key: str,
+) -> None:
+    spec = get_model_spec(model_key)
+    context_tokens = 32_768
+    runtime_reserve = 2 * GIB
+    fixed_bytes = (
+        spec.resident_bytes
+        + context_tokens * spec.kv_bytes_per_token
+        + spec.transient_scratch_bytes
+        + runtime_reserve
+    )
+    total_limit = fixed_bytes + spec.persistent_cache_bytes(20) + 12_345
+
+    plan = plan_expert_memory(
+        spec,
+        total_limit_bytes=total_limit,
+        context_tokens=context_tokens,
+        runtime_reserve_bytes=runtime_reserve,
+    )
+
+    assert plan.fits_fixed is True
+    assert plan.total_limit_bytes == total_limit
+    assert plan.context_tokens == context_tokens
+    assert plan.runtime_reserve_bytes == runtime_reserve
+    assert plan.resident_bytes == spec.resident_bytes
+    assert plan.kv_bytes == context_tokens * spec.kv_bytes_per_token
+    assert plan.transient_bytes == spec.transient_scratch_bytes
+    assert plan.persistent_budget_bytes == spec.persistent_cache_bytes(20) + 12_345
+    assert plan.slots_per_layer == 20
+    assert plan.persistent_cache_bytes == spec.persistent_cache_bytes(20)
+    assert plan.unallocated_bytes == 12_345
+    assert plan.allocated_bytes <= plan.total_limit_bytes
+
+
+def test_explicit_expert_cache_limit_caps_slots_below_available_memory() -> None:
+    spec = get_model_spec("glm52-q4")
+    per_layer_bank_slot = spec.persistent_cache_bytes(1)
+    fixed_bytes = spec.resident_bytes + spec.transient_scratch_bytes
+    total_limit = fixed_bytes + spec.persistent_cache_bytes(40)
+    expert_cache_limit = spec.persistent_cache_bytes(12) + per_layer_bank_slot - 1
+
+    plan = plan_expert_memory(
+        spec,
+        total_limit_bytes=total_limit,
+        context_tokens=0,
+        expert_cache_limit_bytes=expert_cache_limit,
+    )
+
+    assert plan.fits_fixed is True
+    assert plan.persistent_budget_bytes == expert_cache_limit
+    assert plan.slots_per_layer == 12
+    assert plan.persistent_cache_bytes == spec.persistent_cache_bytes(12)
+    assert plan.unallocated_bytes == spec.persistent_cache_bytes(28)
+
+
+def test_memory_plan_reports_when_fixed_footprint_does_not_fit() -> None:
+    spec = get_model_spec("hy3-q4")
+    context_tokens = 65_536
+    runtime_reserve = 4 * GIB
+    fixed_bytes = (
+        spec.resident_bytes
+        + context_tokens * spec.kv_bytes_per_token
+        + spec.transient_scratch_bytes
+        + runtime_reserve
+    )
+
+    plan = plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed_bytes - 1,
+        context_tokens=context_tokens,
+        runtime_reserve_bytes=runtime_reserve,
+    )
+
+    assert plan.fits_fixed is False
+    assert plan.persistent_budget_bytes == 0
+    assert plan.slots_per_layer == 0
+    assert plan.persistent_cache_bytes == 0
+    assert plan.unallocated_bytes == -1
+
+
+@pytest.mark.parametrize("model_key", ["hy3-q4", "glm52-q4"])
+def test_memory_plan_exact_fixed_one_slot_and_full_residency(model_key: str) -> None:
+    spec = get_model_spec(model_key)
+    fixed = spec.resident_bytes + spec.transient_scratch_bytes
+
+    fixed_only = plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed,
+        context_tokens=0,
+    )
+    one_slot = plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed + spec.persistent_cache_bytes(1),
+        context_tokens=0,
+    )
+    full = plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed + spec.routed_expert_bytes + GIB,
+        context_tokens=0,
+    )
+
+    assert fixed_only.fits_fixed is True
+    assert fixed_only.slots_per_layer == 0
+    assert fixed_only.unallocated_bytes == 0
+    assert one_slot.slots_per_layer == 1
+    assert one_slot.unallocated_bytes == 0
+    assert full.slots_per_layer == spec.expert_count
+    assert full.persistent_budget_bytes == spec.routed_expert_bytes
+    assert full.persistent_cache_bytes == spec.routed_expert_bytes
+    assert full.unallocated_bytes == GIB
+    assert all(
+        plan.allocated_bytes <= plan.total_limit_bytes
+        for plan in (fixed_only, one_slot, full)
+    )
+
+
+def test_zero_cache_cap_and_explicit_fixed_workspaces_are_accounted() -> None:
+    spec = get_model_spec("glm52-q4")
+    transient_slots = 12
+    io_staging = 512 * 2**20
+    execution_workspace = 256 * 2**20
+    fixed = (
+        spec.resident_bytes
+        + transient_slots * spec.expert_record_bytes
+        + io_staging
+        + execution_workspace
+    )
+
+    plan = plan_expert_memory(
+        spec,
+        total_limit_bytes=fixed + 10 * GIB,
+        context_tokens=0,
+        transient_slots=transient_slots,
+        io_staging_bytes=io_staging,
+        execution_workspace_bytes=execution_workspace,
+        expert_cache_limit_bytes=0,
+    )
+
+    assert plan.transient_slots == transient_slots
+    assert plan.transient_bytes == transient_slots * spec.expert_record_bytes
+    assert plan.io_staging_bytes == io_staging
+    assert plan.execution_workspace_bytes == execution_workspace
+    assert plan.fixed_bytes == fixed
+    assert plan.persistent_budget_bytes == 0
+    assert plan.slots_per_layer == 0
+    assert plan.unallocated_bytes == 10 * GIB
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        ({"total_limit_bytes": 100.5}, TypeError),
+        ({"context_tokens": 1.5}, TypeError),
+        ({"transient_slots": 8.5}, TypeError),
+        ({"expert_cache_limit_bytes": True}, TypeError),
+        ({"transient_slots": 7}, ValueError),
+    ],
+)
+def test_memory_plan_rejects_lossy_or_undersized_inputs(
+    kwargs: dict[str, object], error: type[Exception]
+) -> None:
+    spec = get_model_spec("hy3-q4")
+    arguments: dict[str, object] = {
+        "total_limit_bytes": 128 * GIB,
+        "context_tokens": 0,
+    }
+    arguments.update(kwargs)
+
+    with pytest.raises(error):
+        plan_expert_memory(spec, **arguments)  # type: ignore[arg-type]
+
+
+def test_model_spec_rejects_float_dimensions_and_misaligned_projections() -> None:
+    spec = get_model_spec("hy3-q4")
+
+    with pytest.raises(TypeError, match="total_layers must be an integer"):
+        replace(spec, total_layers=80.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="projection input"):
+        replace(spec, expert_hidden_size=1537)
+
+
+def test_glm_model_key_drives_trace_simulator_geometry(tmp_path: Path) -> None:
+    trace = tmp_path / "glm-routes.jsonl"
+    trace.write_text(
+        json.dumps(
+            {
+                "phase": "decode",
+                "layer": 3,
+                "experts": list(range(8)),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "simulate_expert_cache.py"),
+            str(trace),
+            "--model",
+            "glm52-q4",
+            "--persistent-slots-per-layer",
+            "0",
+        ],
+        cwd=ROOT,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["model_key"] == "glm52-q4"
+    assert payload["expert_misses"] == 8
+    assert payload["bytes_read"] == 8 * 21_233_664
+    assert payload["transient_scratch_bytes"] == 8 * 21_233_664
+    assert payload["allocated_layer_count"] == 75
+    assert payload["persistent_cache_scope"] == "configured_model"
+
+
+def test_memory_planner_cli_runs_from_a_clean_checkout_environment() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "plan_expert_memory.py"),
+            "--model",
+            "glm52-q4",
+            "--memory-limit-gib",
+            "128",
+            "--context-tokens",
+            "131072",
+            "--runtime-reserve-gib",
+            "16",
+        ],
+        cwd=ROOT,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["model"]["key"] == "glm52-q4"
+    assert payload["plan"]["persistent_slots_per_layer"] == 60
+    assert payload["plan"]["fits_fixed"] is True
+    assert payload["plan"]["context_tokens"] == 131072
+    assert payload["plan"]["transient_slots"] == 8
+    assert payload["plan"]["expert_cache_limit_bytes"] is None
+    assert payload["plan"]["fixed_bytes"] < payload["plan"]["accounted_bytes"]
+    assert payload["plan"]["accounted_bytes"] <= payload["plan"]["memory_limit_bytes"]
+
+
+def test_memory_planner_cli_returns_json_and_exit_two_for_fixed_deficit() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "plan_expert_memory.py"),
+            "--model",
+            "glm52-q4",
+            "--memory-limit-gib",
+            "1",
+            "--context-tokens",
+            "0",
+            "--runtime-reserve-gib",
+            "0",
+        ],
+        cwd=ROOT,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 2, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["plan"]["fits_fixed"] is False
+    assert payload["plan"]["persistent_slots_per_layer"] == 0
+    assert payload["plan"]["unallocated_bytes"] < 0

--- a/tests/test_streamed_models.py
+++ b/tests/test_streamed_models.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.deepseek_v32 import group_expert_select
+
+from mtplx.expert_manifest import build_expert_manifest, save_expert_manifest
+from mtplx.expert_runtime import ExpertStreamingConfig, ExpertStreamingRuntime
+from mtplx.expert_slots import ExpertSlotBinding
+from mtplx.expert_streaming_models import ExpertStreamingModelSpec
+from mtplx.models.expert_mlx import _run_q4_expert, make_mlx_slot_buffer_allocator
+from mtplx.models.glm52_mlx import FP32MoEGate
+from mtplx.models.glm52_mlx import Model as GlmModel
+from mtplx.models.glm52_mlx import ModelArgs as GlmArgs
+from mtplx.models.hy3_mlx import Model as Hy3Model
+from mtplx.models.hy3_mlx import ModelArgs as Hy3Args
+from mtplx.resident_loader import construct_resident_model
+
+
+def _hy3_args() -> Hy3Args:
+    return Hy3Args(
+        model_type="hy_v3",
+        hidden_size=64,
+        num_hidden_layers=2,
+        intermediate_size=128,
+        moe_intermediate_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_experts=2,
+        num_experts_per_tok=1,
+        num_shared_experts=1,
+        first_k_dense_replace=1,
+        rms_norm_eps=1e-5,
+        vocab_size=128,
+        max_position_embeddings=128,
+        head_dim=16,
+        router_scaling_factor=2.0,
+    )
+
+
+def _glm_args(*, layers: int = 6, first_sparse: int = 1) -> GlmArgs:
+    return GlmArgs(
+        model_type="glm_moe_dsa",
+        vocab_size=128,
+        hidden_size=64,
+        index_head_dim=8,
+        index_n_heads=4,
+        index_topk=4,
+        intermediate_size=128,
+        moe_intermediate_size=64,
+        num_hidden_layers=layers,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        n_shared_experts=1,
+        n_routed_experts=4,
+        routed_scaling_factor=2.5,
+        kv_lora_rank=16,
+        q_lora_rank=24,
+        qk_rope_head_dim=8,
+        v_head_dim=16,
+        qk_nope_head_dim=8,
+        topk_method="noaux_tc",
+        scoring_func="sigmoid",
+        norm_topk_prob=True,
+        n_group=1,
+        topk_group=1,
+        num_experts_per_tok=2,
+        moe_layer_freq=1,
+        first_k_dense_replace=first_sparse,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10_000.0},
+        attention_bias=False,
+        index_topk_pattern="FSFSFS" if layers == 6 else None,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+    )
+
+
+def test_hy3_router_uses_unbiased_scores_for_weights() -> None:
+    model = Hy3Model(_hy3_args())
+    router = model.model.layers[1].mlp.router
+    router.gate.weight = mx.array(
+        [
+            [1.0] + [0.0] * 63,
+            [0.5] + [0.0] * 63,
+        ],
+        dtype=mx.float32,
+    )
+    router.expert_bias = mx.array([0.0, 10.0], dtype=mx.float32)
+    hidden = mx.array([[[1.0] + [0.0] * 63]], dtype=mx.bfloat16)
+
+    indices, weights = router(hidden)
+    mx.eval(indices, weights)
+
+    assert indices.item() == 1
+    # Correction bias selects expert 1 but is not part of its returned weight.
+    assert weights.item() == pytest.approx(2.0)
+
+
+def test_glm_router_fp32_projection_changes_a_near_tie_route() -> None:
+    x = mx.array(
+        [
+            [
+                0.0205078125,
+                -0.006805419921875,
+                -0.05859375,
+                0.080078125,
+                -0.21484375,
+                -0.1875,
+                -0.01318359375,
+                0.1767578125,
+                -0.01556396484375,
+                0.10498046875,
+                0.212890625,
+                0.06640625,
+                0.04541015625,
+                0.058349609375,
+                0.044921875,
+                -0.021484375,
+            ]
+        ],
+        dtype=mx.bfloat16,
+    )
+    weight = mx.array(
+        [
+            [
+                0.0267333984375,
+                0.134765625,
+                0.22265625,
+                -0.043212890625,
+                -0.1826171875,
+                -0.109375,
+                0.06298828125,
+                0.1552734375,
+                0.01214599609375,
+                -0.06591796875,
+                -0.09814453125,
+                0.1787109375,
+                -0.02294921875,
+                -0.12353515625,
+                -0.050048828125,
+                -0.00023937225341796875,
+            ],
+            [
+                0.002044677734375,
+                -0.01202392578125,
+                -0.1279296875,
+                0.04296875,
+                -0.166015625,
+                0.0634765625,
+                -0.173828125,
+                -0.072265625,
+                -0.171875,
+                -0.0294189453125,
+                -0.057373046875,
+                0.2001953125,
+                0.039306640625,
+                -0.0859375,
+                -0.029541015625,
+                -0.052734375,
+            ],
+            [
+                -0.0888671875,
+                0.205078125,
+                0.12060546875,
+                0.031005859375,
+                -0.1337890625,
+                -0.0220947265625,
+                0.006866455078125,
+                -0.0166015625,
+                0.05810546875,
+                0.076171875,
+                -0.006439208984375,
+                0.103515625,
+                -0.031494140625,
+                0.134765625,
+                0.01409912109375,
+                -0.06005859375,
+            ],
+            [
+                0.060791015625,
+                -0.022216796875,
+                -0.0181884765625,
+                -0.049072265625,
+                -0.1259765625,
+                0.1298828125,
+                0.09375,
+                0.0126953125,
+                -0.126953125,
+                -0.111328125,
+                -0.1494140625,
+                0.0869140625,
+                -0.0034027099609375,
+                0.015869140625,
+                0.11572265625,
+                -0.038330078125,
+            ],
+        ],
+        dtype=mx.bfloat16,
+    )
+    original = SimpleNamespace(
+        top_k=1,
+        norm_topk_prob=True,
+        n_routed_experts=4,
+        routed_scaling_factor=1.0,
+        n_group=1,
+        topk_group=1,
+        weight=weight,
+        e_score_correction_bias=mx.zeros((4,), dtype=mx.float32),
+    )
+    fp32_router = FP32MoEGate(original)
+
+    fp32_indices, _ = fp32_router(x)
+    legacy_indices, _ = group_expert_select(
+        x @ weight.T,
+        original.e_score_correction_bias,
+        1,
+        1,
+        1,
+        1.0,
+        True,
+    )
+    mx.eval(fp32_indices, legacy_indices)
+
+    assert fp32_indices.item() == 2
+    assert legacy_indices.item() == 0
+
+
+def test_glm_indexshare_schedule_and_asymmetric_caches_execute() -> None:
+    args = _glm_args(first_sparse=6)
+    model = GlmModel(args)
+
+    assert args.indexer_types == ["full", "shared", "full", "shared", "full", "shared"]
+    assert [layer.self_attn.indexer is not None for layer in model.model.layers] == [
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]
+    cache = model.make_cache()
+    assert [len(item.caches) for item in cache] == [2, 1, 2, 1, 2, 1]
+    prompt = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+    logits = model(prompt, cache=cache)
+    mx.eval(logits)
+    assert logits.shape == (1, 4, args.vocab_size)
+    assert mx.all(mx.isfinite(logits)).item()
+
+
+def _raw_array(value: mx.array, dtype: str) -> bytes:
+    mx.eval(value)
+    if dtype == "U32":
+        return np.array(value, copy=True).astype("<u4", copy=False).tobytes()
+    return (
+        np.array(value.view(mx.uint16), copy=True).astype("<u2", copy=False).tobytes()
+    )
+
+
+def test_portable_q4_slot_execution_matches_direct_quantized_matmul() -> None:
+    mx.random.seed(7)
+    hidden = 64
+    intermediate = 64
+    gate_source = mx.random.normal((intermediate, hidden)).astype(mx.bfloat16)
+    up_source = mx.random.normal((intermediate, hidden)).astype(mx.bfloat16)
+    down_source = mx.random.normal((hidden, intermediate)).astype(mx.bfloat16)
+    gate = mx.quantize(gate_source, group_size=64, bits=4)
+    up = mx.quantize(up_source, group_size=64, bits=4)
+    down = mx.quantize(down_source, group_size=64, bits=4)
+    arrays = {
+        "gate_proj.weight": (gate[0], "U32"),
+        "gate_proj.scales": (gate[1], "BF16"),
+        "gate_proj.biases": (gate[2], "BF16"),
+        "up_proj.weight": (up[0], "U32"),
+        "up_proj.scales": (up[1], "BF16"),
+        "up_proj.biases": (up[2], "BF16"),
+        "down_proj.weight": (down[0], "U32"),
+        "down_proj.scales": (down[1], "BF16"),
+        "down_proj.biases": (down[2], "BF16"),
+    }
+    from mtplx.expert_manifest import ExpertRecord, TensorSegment
+
+    payload = bytearray()
+    segments = []
+    for component, (value, dtype) in arrays.items():
+        raw = _raw_array(value, dtype)
+        segments.append(
+            TensorSegment(
+                component=component,
+                tensor=component,
+                shard="fixture",
+                offset=len(payload),
+                length=len(raw),
+                dtype=dtype,
+                shape=tuple(value.shape),
+            )
+        )
+        payload.extend(raw)
+    record = ExpertRecord(
+        layer=1,
+        expert=0,
+        logical_bytes=len(payload),
+        segments=tuple(segments),
+    )
+    binding = ExpertSlotBinding(1, 0, 0, 1, record, payload)
+    x = mx.random.normal((3, hidden)).astype(mx.bfloat16)
+
+    actual = _run_q4_expert(x, binding, group_size=64)
+    reference_gate = mx.quantized_matmul(
+        x,
+        gate[0],
+        scales=gate[1],
+        biases=gate[2],
+        group_size=64,
+        bits=4,
+    )
+    reference_up = mx.quantized_matmul(
+        x,
+        up[0],
+        scales=up[1],
+        biases=up[2],
+        group_size=64,
+        bits=4,
+    )
+    reference = mx.quantized_matmul(
+        swiglu(reference_gate, reference_up),
+        down[0],
+        scales=down[1],
+        biases=down[2],
+        group_size=64,
+        bits=4,
+    )
+    mx.eval(actual, reference)
+    assert mx.allclose(actual, reference, atol=1e-5, rtol=1e-5).item()
+
+
+def _integrated_hy3_artifact(tmp_path: Path):
+    args = _hy3_args()
+    model = Hy3Model(args)
+    weights = dict(tree_flatten(model.parameters()))
+    expert_shapes = {
+        "gate_proj.weight": (2, 64, 8),
+        "gate_proj.scales": (2, 64, 1),
+        "gate_proj.biases": (2, 64, 1),
+        "up_proj.weight": (2, 64, 8),
+        "up_proj.scales": (2, 64, 1),
+        "up_proj.biases": (2, 64, 1),
+        "down_proj.weight": (2, 64, 8),
+        "down_proj.scales": (2, 64, 1),
+        "down_proj.biases": (2, 64, 1),
+    }
+    for component, shape in expert_shapes.items():
+        dtype = mx.uint32 if component.endswith("weight") else mx.bfloat16
+        value = mx.zeros(shape, dtype=dtype)
+        if component.endswith("scales"):
+            value = mx.ones(shape, dtype=dtype)
+        weights[f"model.layers.1.mlp.switch_mlp.{component}"] = value
+    mx.eval(weights)
+    root = tmp_path / "hy3"
+    root.mkdir()
+    mx.save_safetensors(str(root / "model.safetensors"), weights)
+    config = asdict(args)
+    config["model_type"] = "hy_v3"
+    (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    routed_bytes = 2 * 6_912
+    total_bytes = sum(int(value.nbytes) for value in weights.values())
+    spec = ExpertStreamingModelSpec(
+        key="tiny-hy3-q4",
+        display_name="Tiny Hy3 Q4",
+        source_model="test/tiny-hy3",
+        source_revision="source",
+        quant_model="test/tiny-hy3-q4",
+        quant_revision="quant",
+        total_tensor_bytes=total_bytes,
+        total_layers=2,
+        routed_layer_start=1,
+        routed_layer_count=1,
+        expert_count=2,
+        top_k=1,
+        hidden_size=64,
+        expert_hidden_size=64,
+        quant_bits=4,
+        quant_group_size=64,
+        quant_parameter_bytes=2,
+        router_storage="float32",
+        router_matmul_dtype="float32",
+        router_bytes=2 * 64 * 4 + 2 * 4,
+        kv_bytes_per_token=0,
+        mtp_layer_index=2,
+        mtp_included=False,
+    )
+    assert spec.routed_expert_bytes == routed_bytes
+    manifest = build_expert_manifest(root, spec)
+    manifest_path = root / "expert-manifest.json"
+    save_expert_manifest(manifest, manifest_path)
+    return root, config, spec, manifest_path
+
+
+def test_resident_loader_runs_hy3_without_materializing_routed_parameters(
+    tmp_path: Path,
+) -> None:
+    root, config, spec, manifest_path = _integrated_hy3_artifact(tmp_path)
+    fixed = spec.resident_bytes + spec.transient_scratch_bytes
+    stream_config = ExpertStreamingConfig(
+        model_key=spec.key,
+        memory_limit_bytes=fixed + spec.persistent_cache_bytes(1),
+        max_live_kv_tokens=0,
+        runtime_reserve_bytes=0,
+    )
+    runtime = ExpertStreamingRuntime.open(
+        root,
+        manifest_path,
+        stream_config,
+        spec=spec,
+        buffer_allocator=make_mlx_slot_buffer_allocator(
+            stream_config.memory_plan(spec), spec
+        ),
+        device_synchronize=mx.synchronize,
+        apply_memory_cap=False,
+    )
+    try:
+        resident = construct_resident_model(root, runtime, config=config)
+        parameter_names = {
+            name for name, _ in tree_flatten(resident.model.parameters())
+        }
+        assert not any("switch_mlp" in name for name in parameter_names)
+        assert resident.report.raw_tensor_bytes == spec.resident_bytes
+        assert resident.report.bound_sparse_layers == 1
+
+        logits = resident.model(mx.array([[1]], dtype=mx.int32))
+        mx.eval(logits)
+        assert logits.shape == (1, 1, config["vocab_size"])
+        assert mx.all(mx.isfinite(logits)).item()
+        snapshot = runtime.snapshot(mx_module=mx)
+        assert snapshot["cache"]["expert_requests"] == 1
+        assert snapshot["slots"]["pins"] == 0
+        assert snapshot["slots"]["buffer_backend"] == "mlx-metal-slot-bank"
+    finally:
+        runtime.close()
+
+
+def _integrated_glm_artifact(tmp_path: Path):
+    args = _glm_args(layers=6, first_sparse=1)
+    model = GlmModel(args)
+    weights = dict(tree_flatten(model.parameters()))
+    expert_shapes = {
+        "gate_proj.weight": (4, 64, 8),
+        "gate_proj.scales": (4, 64, 1),
+        "gate_proj.biases": (4, 64, 1),
+        "up_proj.weight": (4, 64, 8),
+        "up_proj.scales": (4, 64, 1),
+        "up_proj.biases": (4, 64, 1),
+        "down_proj.weight": (4, 64, 8),
+        "down_proj.scales": (4, 64, 1),
+        "down_proj.biases": (4, 64, 1),
+    }
+    for layer in range(1, 6):
+        for component, shape in expert_shapes.items():
+            dtype = mx.uint32 if component.endswith("weight") else mx.bfloat16
+            value = mx.zeros(shape, dtype=dtype)
+            if component.endswith("scales"):
+                value = mx.ones(shape, dtype=dtype)
+            weights[f"model.layers.{layer}.mlp.switch_mlp.{component}"] = value
+    mx.eval(weights)
+    root = tmp_path / "glm"
+    root.mkdir()
+    mx.save_safetensors(str(root / "model.safetensors"), weights)
+    config = asdict(args)
+    (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    total_bytes = sum(int(value.nbytes) for value in weights.values())
+    spec = ExpertStreamingModelSpec(
+        key="tiny-glm52-q4",
+        display_name="Tiny GLM-5.2 Q4",
+        source_model="test/tiny-glm",
+        source_revision="source",
+        quant_model="test/tiny-glm-q4",
+        quant_revision="quant",
+        total_tensor_bytes=total_bytes,
+        total_layers=6,
+        routed_layer_start=1,
+        routed_layer_count=5,
+        expert_count=4,
+        top_k=2,
+        hidden_size=64,
+        expert_hidden_size=64,
+        quant_bits=4,
+        quant_group_size=64,
+        quant_parameter_bytes=2,
+        router_storage="float32",
+        router_matmul_dtype="float32",
+        router_bytes=5 * (4 * 64 * 4 + 4 * 4),
+        kv_bytes_per_token=0,
+        mtp_layer_index=6,
+        mtp_included=False,
+        full_indexer_layers=(0, 2, 4),
+    )
+    manifest = build_expert_manifest(root, spec)
+    manifest_path = root / "expert-manifest.json"
+    save_expert_manifest(manifest, manifest_path)
+    return root, config, spec, manifest_path
+
+
+def test_resident_loader_runs_indexshare_glm_with_streamed_sparse_layers(
+    tmp_path: Path,
+) -> None:
+    root, config, spec, manifest_path = _integrated_glm_artifact(tmp_path)
+    fixed = spec.resident_bytes + spec.transient_scratch_bytes
+    stream_config = ExpertStreamingConfig(
+        model_key=spec.key,
+        memory_limit_bytes=fixed,
+        max_live_kv_tokens=0,
+        runtime_reserve_bytes=0,
+    )
+    runtime = ExpertStreamingRuntime.open(
+        root,
+        manifest_path,
+        stream_config,
+        spec=spec,
+        apply_memory_cap=False,
+    )
+    try:
+        resident = construct_resident_model(root, runtime, config=config)
+        parameter_names = {
+            name for name, _ in tree_flatten(resident.model.parameters())
+        }
+        assert not any("switch_mlp" in name for name in parameter_names)
+        assert [
+            layer.self_attn.indexer is not None for layer in resident.model.model.layers
+        ] == [True, False, True, False, True, False]
+
+        logits = resident.model(mx.array([[1]], dtype=mx.int32))
+        mx.eval(logits)
+        assert logits.shape == (1, 1, config["vocab_size"])
+        assert mx.all(mx.isfinite(logits)).item()
+        assert runtime.snapshot(mx_module=mx)["cache"]["route_calls"] == 5
+    finally:
+        runtime.close()


### PR DESCRIPTION
## What changed

- Adds revision-pinned Hy3 Q4 and GLM-5.2 Q4 layout descriptors, strict safetensors manifests, resumable aligned sidecars, and bounded positional reads.
- Adds fixed generation-safe expert slot banks with decode-aware hot admission, transient-only prefill misses, bounded batch waves, cancellation, rollback, hashes, and telemetry.
- Adds resident-only MLX overlays for Hy3 and GLM-5.2. GLM preserves FP32 MoE routing and the 21-full-layer IndexShare schedule.
- Runs each resident router first, reads only selected Q4 records directly into stable MLX/Metal slot buffers, executes zero-copy component views, and fences before slot reuse.
- Integrates the path into `runtime.load`, one-shot CLI, `mtplx serve`, request KV admission, MLX memory caps, shutdown, and `/health`.
- Adds a native nanobind GIL-free `pread` extension plus artifact-audit, I/O benchmark, deterministic generation benchmark, and golden-logit parity tools.

## Why

Hy3-4bit and GLM-5.2-4bit are dominated by routed expert weights, but only top-k experts execute at each sparse layer. Keeping resident attention/router/shared state while paging selected experts allows the user to trade a fixed hot-bank budget against SSD reads without constructing the full routed parameter tree.

Routing is layer-local: later expert decisions cannot be run ahead because they consume hidden states produced by earlier layers.

## Validation

- Full repository `pytest` suite passes (four expected skips).
- Focused model/CLI/server suite passes, including existing MTPLX behavior.
- Tiny end-to-end Hy3 and GLM artifacts strictly resident-load and execute streamed model forwards.
- Short-read, corruption, truncation, cancellation, pin/replacement, rollback, path escape, digest, KV admission, and memory-cap tests pass.
- Native extension builds and performs direct bounded reads into caller-owned buffers.
- Pinned metadata-only audits pass exactly:
  - Hy3: 2,323 resident keys and 711 routed leaves.
  - GLM-5.2: 2,806 resident keys and 675 routed leaves.

## Important limits

- This is a draft because the full 166 GB Hy3 and 418 GB GLM checkpoints have not yet completed hardware parity, high-water memory, thermal, and sustained SSD benchmark gates.
- The pinned community Q4 artifacts omit their declared MTP layers. Streamed loading is therefore AR-only and fails closed on MTP/adapters; no random or broad-shard fallback is allowed.
- No performance claim is made from tiny fixtures or another implementation's measurements.

Design and tracking epic: https://github.com/davidtai/MTPLX/issues/7
