### PR TITLE
fix(openai): suppress tool preambles for Hermes streams

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6472,11 +6472,13 @@ class _ToolAwareContentStreamTranslator:
         argument_chunk_chars: int,
         tokenizer: Any | None = None,
         repair_unclosed_complete: bool = True,
+        suppress_tool_call_preamble: bool = False,
     ) -> None:
         self._tools = tools
         self._argument_chunk_chars = max(1, int(argument_chunk_chars))
         self._tokenizer = tokenizer
         self._repair_unclosed_complete = bool(repair_unclosed_complete)
+        self._suppress_tool_call_preamble = bool(suppress_tool_call_preamble)
         self._marker_pairs = _tool_marker_pairs_from_tokenizer(tokenizer)
         self._pending = ""
         self._trailing = ""
@@ -6488,6 +6490,7 @@ class _ToolAwareContentStreamTranslator:
         self._suppress_remaining_tool_text = False
         self._emitted_tool_deltas = False
         self._suppressed_tool_markup = False
+        self._deferred_content = ""
 
     @property
     def has_tool_calls(self) -> bool:
@@ -6556,6 +6559,10 @@ class _ToolAwareContentStreamTranslator:
         self._mode = "done"
         self._suppress_remaining_tool_text = True
         if emitted_tool_deltas or self.tool_calls:
+            self._deferred_content = ""
+            return []
+        if self._suppress_tool_call_preamble:
+            self._deferred_content += visible_text
             return []
         return [{"content": visible_text}] if visible_text else []
 
@@ -6563,7 +6570,27 @@ class _ToolAwareContentStreamTranslator:
         visible_text = _strip_orphan_tool_control_markup(text)
         if visible_text != text:
             self._suppressed_tool_markup = True
+        if self._suppress_tool_call_preamble:
+            self._deferred_content += visible_text
+            return []
         return [{"content": visible_text}] if visible_text else []
+
+    def _flush_deferred_content(self) -> list[dict[str, Any]]:
+        content = self._deferred_content
+        self._deferred_content = ""
+        return [{"content": content}] if content else []
+
+    def resolve_deferred_content(
+        self,
+        *,
+        has_tool_calls: bool,
+    ) -> list[dict[str, Any]]:
+        if not self._suppress_tool_call_preamble:
+            return []
+        if has_tool_calls:
+            self._deferred_content = ""
+            return []
+        return self._flush_deferred_content()
 
     def feed(self, field: str, text: str) -> list[dict[str, Any]]:
         if not text:
@@ -6760,10 +6787,18 @@ class _ToolAwareContentStreamTranslator:
             return max(keep, len(text) - bracket_idx)
         return min(keep, 128)
 
-    def finish(self) -> list[dict[str, Any]]:
+    def finish(
+        self,
+        *,
+        defer_content_resolution: bool = False,
+    ) -> list[dict[str, Any]]:
         if self._mode == "tool":
             return self._tool_deltas_if_complete(final=True)
         if self._mode == "done":
+            if self._suppress_tool_call_preamble and self.tool_calls:
+                self._deferred_content = ""
+                self._trailing = ""
+                return []
             if self._suppress_remaining_tool_text:
                 self._trailing = ""
                 return []
@@ -6786,13 +6821,23 @@ class _ToolAwareContentStreamTranslator:
                 self._trailing = ""
                 self._mode = "content"
                 return self._content_delta(trailing)
-            return []
+            if defer_content_resolution and self._suppress_tool_call_preamble:
+                return []
+            return self._flush_deferred_content()
         if self._pending:
             content = self._pending
             self._pending = ""
             self._mode = "content"
-            return self._content_delta(content)
-        return []
+            deltas = self._content_delta(content)
+            if (
+                self._suppress_tool_call_preamble
+                and not defer_content_resolution
+            ):
+                deltas.extend(self._flush_deferred_content())
+            return deltas
+        if defer_content_resolution and self._suppress_tool_call_preamble:
+            return []
+        return self._flush_deferred_content()
 
     def _tool_deltas_if_complete(self, *, final: bool) -> list[dict[str, Any]]:
         if self._tool_parser is None:
@@ -6821,6 +6866,8 @@ class _ToolAwareContentStreamTranslator:
                 )
             if self._tool_parser.tool_calls:
                 self.tool_calls = (self.tool_calls or []) + self._tool_parser.tool_calls
+                if self._suppress_tool_call_preamble:
+                    self._deferred_content = ""
                 remaining = getattr(self._tool_parser, "remaining_text", "")
                 self._tool_parser = None
                 if not remaining:
@@ -6862,6 +6909,8 @@ class _ToolAwareContentStreamTranslator:
                 deltas.extend(final_deltas)
             if self._tool_parser.tool_calls:
                 self.tool_calls = (self.tool_calls or []) + self._tool_parser.tool_calls
+                if self._suppress_tool_call_preamble:
+                    self._deferred_content = ""
                 remaining = getattr(self._tool_parser, "remaining_text", "")
                 self._tool_parser = None
                 if not remaining:
@@ -6899,6 +6948,8 @@ class _ToolAwareContentStreamTranslator:
             self._tool_parser = None
             if buffered.tool_calls:
                 self.tool_calls = (self.tool_calls or []) + buffered.tool_calls
+                if self._suppress_tool_call_preamble:
+                    self._deferred_content = ""
                 self._mode = "done"
                 if any(delta.get("tool_calls") for delta in buffered_deltas):
                     self._emitted_tool_deltas = True
@@ -6933,6 +6984,8 @@ class _ToolAwareContentStreamTranslator:
         self._tool_parser = None
         if buffered.tool_calls:
             self.tool_calls = (self.tool_calls or []) + buffered.tool_calls
+            if self._suppress_tool_call_preamble:
+                self._deferred_content = ""
             self._mode = "done"
             return buffered_deltas
         if buffered.fallback_reason:
@@ -12922,6 +12975,15 @@ def _is_opencode_client(
 ) -> bool:
     client_hint = str(_request_client_hint_from_headers(headers, metadata) or "")
     return "opencode" in client_hint
+
+
+def _is_hermes_client(
+    *,
+    headers: Mapping[str, str],
+    metadata: Mapping[str, Any],
+) -> bool:
+    client_hint = str(_request_client_hint_from_headers(headers, metadata) or "")
+    return "hermes" in client_hint
 
 
 def _request_tool_prompt_mode_override(
@@ -20741,6 +20803,10 @@ def create_app(state: ServerState) -> FastAPI:
                         repair_unclosed_complete=(
                             str(raw_request.url.path or "") != "/v1/messages"
                         ),
+                        suppress_tool_call_preamble=_is_hermes_client(
+                            headers=headers,
+                            metadata=metadata,
+                        ),
                     )
                     # Forced final-answer turns stream sanitized visible text
                     # through the buffered marker path; the tool-call
@@ -22149,14 +22215,19 @@ def create_app(state: ServerState) -> FastAPI:
                         )
                     return chunks
 
-                def finish_translated_stream_chunks() -> list[str]:
+                def finish_translated_stream_chunks(
+                    *,
+                    defer_content_resolution: bool = False,
+                ) -> list[str]:
                     nonlocal streamed_assistant_tool_calls
                     nonlocal streamed_tool_deltas_emitted
                     chunks: list[str] = []
                     if early_tool_cancel_used and streamed_assistant_tool_calls:
                         return chunks
                     if content_tool_translator is not None:
-                        for delta in content_tool_translator.finish():
+                        for delta in content_tool_translator.finish(
+                            defer_content_resolution=defer_content_resolution,
+                        ):
                             if not delta:
                                 continue
                             if "content" in delta or "reasoning_content" in delta:
@@ -22543,7 +22614,9 @@ def create_app(state: ServerState) -> FastAPI:
                                             monitor_stop=False,
                                         ):
                                             yield mark_sse_sent(chunk)
-                                for chunk in finish_translated_stream_chunks():
+                                for chunk in finish_translated_stream_chunks(
+                                    defer_content_resolution=True,
+                                ):
                                     yield mark_sse_sent(chunk)
                             raw_generated_text = _strip_mtplx_internal_continuation_markers(
                                 _strip_generated_chat_template_sentinels(
@@ -22575,6 +22648,14 @@ def create_app(state: ServerState) -> FastAPI:
                             assistant_tool_calls = streamed_assistant_tool_calls or (
                                 extraction.tool_calls if extraction is not None else None
                             )
+                            if content_tool_translator is not None:
+                                for delta in (
+                                    content_tool_translator.resolve_deferred_content(
+                                        has_tool_calls=bool(assistant_tool_calls),
+                                    )
+                                ):
+                                    remember_stream_delta(delta)
+                                    yield mark_sse_sent(delta_payload_chunk(delta))
                             stats = generated.setdefault("stats", {})
                             stats["openai_bridge_mode"] = "omlx_style"
                             stats["legacy_bridge_used"] = False

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -9431,6 +9431,107 @@ def test_chat_stream_tool_call_preamble_is_stored_for_postcommit(monkeypatch):
         }
 
 
+def test_chat_stream_hermes_suppresses_tool_call_preamble(monkeypatch):
+    state = _fake_streaming_session_state()
+    state.args.stream_interval = 1
+    state.args.enable_thinking = False
+    monkeypatch.setattr(
+        openai,
+        "_run_generation",
+        _fake_streaming_generation(
+            "search\n\nMac Studio M4 Max\n\n"
+            "<tool_call>\n<function=session_status>\n</function>\n</tool_call>"
+        ),
+    )
+
+    with TestClient(create_app(state)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"x-mtplx-client": "hermes"},
+            json={
+                "messages": [{"role": "user", "content": "Status."}],
+                "tools": [_tool_schema()],
+                "tool_choice": "auto",
+                "stream": True,
+                "max_tokens": 64,
+                "enable_thinking": False,
+            },
+        )
+
+    assert response.status_code == 200
+    payloads = _stream_payloads(response.text)
+    assert any(
+        payload["choices"][0]["delta"].get("tool_calls") for payload in payloads
+    )
+    assert not any(
+        payload["choices"][0]["delta"].get("content") for payload in payloads
+    )
+    assert any(
+        payload["choices"][0].get("finish_reason") == "tool_calls"
+        for payload in payloads
+    )
+
+
+def test_chat_stream_hermes_defers_content_until_native_tool_extraction(monkeypatch):
+    state = _fake_streaming_session_state()
+    state.args.stream_interval = 1
+    state.args.enable_thinking = False
+    monkeypatch.setattr(
+        openai,
+        "_run_generation",
+        _fake_streaming_generation("search\n\nMac Studio M4 Max\n\n"),
+    )
+    monkeypatch.setattr(
+        openai,
+        "omlx_extract_tool_calls_with_thinking",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            cleaned_text="",
+            cleaned_thinking="",
+            tool_calls=[
+                {
+                    "id": "call_fact_store",
+                    "type": "function",
+                    "function": {
+                        "name": "session_status",
+                        "arguments": "{}",
+                    },
+                }
+            ],
+            parser_source="native",
+            status="parsed",
+            malformed_reason=None,
+            raw_tool_markup_suppressed=True,
+        ),
+    )
+
+    with TestClient(create_app(state)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            headers={"x-mtplx-client": "hermes"},
+            json={
+                "messages": [{"role": "user", "content": "Status."}],
+                "tools": [_tool_schema()],
+                "tool_choice": "auto",
+                "stream": True,
+                "max_tokens": 64,
+                "enable_thinking": False,
+            },
+        )
+
+    assert response.status_code == 200
+    payloads = _stream_payloads(response.text)
+    assert any(
+        payload["choices"][0]["delta"].get("tool_calls") for payload in payloads
+    )
+    assert not any(
+        payload["choices"][0]["delta"].get("content") for payload in payloads
+    )
+    assert any(
+        payload["choices"][0].get("finish_reason") == "tool_calls"
+        for payload in payloads
+    )
+
+
 def test_chat_stream_tool_call_postcommit_strips_reasoning_content(monkeypatch):
     state = _fake_streaming_session_state()
     state.args.stream_interval = 1

--- a/tests/test_tool_aware_stream_translator.py
+++ b/tests/test_tool_aware_stream_translator.py
@@ -123,11 +123,12 @@ OPENCODE_QUESTIONS_TOOL_SPECS = [
 ]
 
 
-def _make(*, tools=TOOL_SPECS, tokenizer=None):
+def _make(*, tools=TOOL_SPECS, tokenizer=None, suppress_tool_call_preamble=False):
     return _ToolAwareContentStreamTranslator(
         tools=tools,
         argument_chunk_chars=64,
         tokenizer=tokenizer,
+        suppress_tool_call_preamble=suppress_tool_call_preamble,
     )
 
 
@@ -256,6 +257,33 @@ def test_mixed_text_then_tool_call_streamed_in_pieces():
     all_deltas.extend(t.finish())
     assert t.has_tool_calls is True
     assert any("tool_calls" in d for d in all_deltas)
+
+
+def test_hermes_mode_suppresses_preamble_when_turn_contains_tool_calls():
+    """Hermes renders streamed content immediately, so internal tool-plan labels
+    must not be emitted as visible text alongside structured tool calls."""
+    t = _make(suppress_tool_call_preamble=True)
+
+    assert t.feed("content", "search\n\nMac Studio M4 Max\n\n") == []
+    out = t.feed(
+        "content",
+        "<tool_call>\n<function=lookup>\n"
+        "<parameter=q>\nMac Studio M4 Max\n</parameter>\n"
+        "</function>\n</tool_call>",
+    )
+    out.extend(t.finish())
+
+    assert t.has_tool_calls is True
+    assert any("tool_calls" in delta for delta in out)
+    assert _content_text(out) == ""
+
+
+def test_hermes_mode_releases_buffer_for_genuine_text_only_turn():
+    t = _make(suppress_tool_call_preamble=True)
+
+    assert t.feed("content", "A normal ") == []
+    assert t.feed("content", "answer.") == []
+    assert t.finish() == [{"content": "A normal answer."}]
 
 
 def test_partial_marker_held_across_chunks_in_content_mode():


### PR DESCRIPTION
## Summary
- add a Hermes-specific OpenAI stream policy that buffers ambiguous content while tools are active
- defer the content/tool decision until both incremental and completion-time native tool parsers have run
- discard buffered preamble text when a valid structured tool call is found
- release buffered content for genuine text-only responses
- preserve existing incremental behavior for non-Hermes clients

## Why
Hermes Agent renders streamed `delta.content` immediately. Qwen-family models can emit internal plan labels before a valid native tool envelope, so users see fragments such as `search` and tool argument values alongside the structured tool call. Hermes requests identified by `X-MTPLX-Client: hermes` now receive a clean tool-only assistant turn.

## Verification
- `38 passed`: `tests/test_tool_aware_stream_translator.py`
- `12 passed`: focused OpenAI streaming/tool parser tests
- integration coverage tests both the incremental XML parser and completion-time native extractor
- live replay of the captured 71-tool Hermes request produced 0 visible content characters, both `fact_store` calls, and `finish_reason=tool_calls`
- a fresh Hermes Agent E2E turn executed four tools with an empty assistant tool-call content field, then returned a clean final answer
