### PR TITLE
fix(server): apply presence/frequency penalties in the ar_batch sampler

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1889,18 +1889,29 @@ class _BatchedARGenerationService:
                 top_k=int(getattr(job.sampler, "top_k", 0) or 0),
             )
         rng = np.random.default_rng(job.seed)
+        # Closure-local completion-token histogram. Each sampler is bound to one
+        # sequence and is invoked once per decode step, so counts is updated the
+        # instant a token is produced — before the NEXT sample is drawn. This
+        # avoids the one-step staleness of reading job.tokens at sample time:
+        # emit_token runs after generator.next() returns, but the sampler runs
+        # one step ahead inside next() (mlx-lm's one-step-lookahead pipeline),
+        # so job.tokens is missing the token generated immediately before —
+        # precisely the token a loop-breaking penalty most needs to see. Keeping
+        # the histogram in the closure makes the penalty see that token,
+        # matching the serial generate_ar path's Counter(tokens). Per-sampler
+        # scope also means no cross-request count leakage: mlx-lm keeps
+        # samplers index-aligned with uids across filter()/extend().
+        counts: Counter = Counter()
 
         def sample_one(logprobs: Any) -> Any:
-            # Presence/frequency penalties subtract against the completion tokens
-            # emitted so far for THIS job. ``job.tokens`` holds exactly those
-            # (emit_token appends after the pump samples), so Counter(job.tokens)
-            # mirrors the serial/MTP paths; without it the penalty has nothing to
-            # subtract against and silently no-ops (issue #156).
-            token_counts = Counter(job.tokens) if penalties_active else None
             token, _distribution = _sample_from_logits(
-                logprobs[0], job.sampler, rng, token_counts=token_counts
+                logprobs[0], job.sampler, rng,
+                token_counts=counts if penalties_active else None,
             )
-            return mx.array([int(token)])
+            token = int(token)
+            if penalties_active:
+                counts[token] += 1
+            return mx.array([token])
 
         return sample_one
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -32,6 +32,7 @@ import time
 import urllib.parse
 import uuid
 import webbrowser
+from collections import Counter
 from concurrent.futures import Future
 from contextlib import asynccontextmanager, contextmanager, nullcontext, suppress
 from dataclasses import asdict, dataclass, is_dataclass
@@ -1868,12 +1869,13 @@ class _BatchedARGenerationService:
     def _make_sampler(self, job: _BatchedARJob) -> Callable[[Any], Any]:
         import mlx.core as mx
 
-        if float(job.sampler.temperature) <= 0:
-            return lambda logprobs: mx.argmax(logprobs, axis=-1)
-        if not job.seed_is_explicit and not (
+        penalties_active = bool(
             float(getattr(job.sampler, "presence_penalty", 0.0) or 0.0)
             or float(getattr(job.sampler, "frequency_penalty", 0.0) or 0.0)
-        ):
+        )
+        if float(job.sampler.temperature) <= 0 and not penalties_active:
+            return lambda logprobs: mx.argmax(logprobs, axis=-1)
+        if not job.seed_is_explicit and not penalties_active:
             # Fast path: mlx-lm's fused GPU sampler. The numpy fallback below
             # synchronizes the full logits row to the CPU for every decode
             # step of every active sequence, which serializes the whole batch
@@ -1889,7 +1891,15 @@ class _BatchedARGenerationService:
         rng = np.random.default_rng(job.seed)
 
         def sample_one(logprobs: Any) -> Any:
-            token, _distribution = _sample_from_logits(logprobs[0], job.sampler, rng)
+            # Presence/frequency penalties subtract against the completion tokens
+            # emitted so far for THIS job. ``job.tokens`` holds exactly those
+            # (emit_token appends after the pump samples), so Counter(job.tokens)
+            # mirrors the serial/MTP paths; without it the penalty has nothing to
+            # subtract against and silently no-ops (issue #156).
+            token_counts = Counter(job.tokens) if penalties_active else None
+            token, _distribution = _sample_from_logits(
+                logprobs[0], job.sampler, rng, token_counts=token_counts
+            )
             return mx.array([int(token)])
 
         return sample_one

--- a/tests/test_ar_batch_penalty_parity.py
+++ b/tests/test_ar_batch_penalty_parity.py
@@ -1,0 +1,170 @@
+"""End-to-end ar_batch penalty parity test (PR #157, mmmugh review).
+
+Drives the REAL ``mlx_lm.generate.BatchGenerator`` with the real pump
+append-after-``next()`` ordering and compares per-position output to the serial
+``generate_ar`` path. Covers the mmmugh repro: token 7 leads token 3 by
+exactly 1.0, so ``presence_penalty=1.5`` must flip the winner the instant 7
+has been emitted once.
+
+Why this test exists
+--------------------
+``tests/test_penalties.py`` (``_ar_batch_sample_once``) fabricates
+``job.tokens`` directly and calls the sampler closure in isolation. That
+verifies the penalty *math* but is blind to the *staleness* bug: the pump's
+``emit_token`` runs AFTER ``generator.next()`` returns, but the sampler runs
+one step ahead INSIDE ``next()`` (mlx-lm's one-step-lookahead pipeline). So
+``Counter(job.tokens)`` is missing the token generated immediately before —
+precisely the token a loop-breaking penalty most needs to see.
+
+This test closes that gap by driving the real BatchGenerator round trip:
+
+- FAILS when ``_make_sampler`` reads ``Counter(job.tokens)`` (one step stale:
+  position 1 outputs 7 — an immediate repeat that escapes the penalty —
+  instead of 3).
+- PASSES when ``_make_sampler`` maintains a closure-local ``counts: Counter``
+  updated the instant a token is sampled (no lag, matching serial
+  ``generate_ar``).
+
+Evaluate with ``git stash`` (reverts the openai.py fix, keeps this test) to
+verify the FAIL/PASS flip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+from mtplx.generation import generate_ar
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+from mtplx.sampling import SamplerConfig
+from mtplx.server import openai
+
+
+VOCAB = 8
+
+
+class _FixedLogitsModel:
+    """Scripted model: constant logits regardless of input.
+
+    Token 7 = 5.0, token 3 = 4.0, all others = 0.0. The 1.0 margin means a
+    ``presence_penalty`` of 1.5 (one-off flat subtraction) flips the argmax
+    the moment 7 has appeared in the completion: 5.0 - 1.5 = 3.5 < 4.0.
+    """
+
+    def make_cache(self):
+        return []
+
+    def __call__(self, input_ids, *, cache=None, **_kwargs):
+        shape = input_ids.shape
+        if len(shape) == 1:
+            batch, seq = 1, int(shape[0])
+        else:
+            batch, seq = int(shape[0]), int(shape[1])
+        logits = np.zeros((batch, seq, VOCAB), dtype=np.float32)
+        logits[:, :, 7] = 5.0
+        logits[:, :, 3] = 4.0
+        return mx.array(logits)
+
+
+class _NoopTokenizer:
+    def decode(self, tokens, **_kwargs):
+        return "".join(str(int(t)) for t in tokens)
+
+
+def _runtime(model) -> MTPLXRuntime:
+    return MTPLXRuntime(
+        model=model,
+        tokenizer=_NoopTokenizer(),
+        model_path=Path("fixed-logits"),
+        mtp_enabled=True,
+        contract=MTPContract(),
+    )
+
+
+def _make_job(sampler: SamplerConfig, *, max_tokens: int = 6) -> "openai._BatchedARJob":
+    return openai._BatchedARJob(
+        request_id="penalty-parity",
+        prompt_ids=[0],
+        max_tokens=max_tokens,
+        sampler=sampler,
+        seed=0,
+        stop_token_ids=set(),
+        token_callback=None,
+        prefill_callback=None,
+        request_observability=None,
+        mtp_disabled_reason=None,
+        generation_limits={},
+        seed_is_explicit=True,
+    )
+
+
+def _run_ar_batch(job, model, sampler_fn, *, max_tokens: int = 6) -> list[int]:
+    """Drive the real BatchGenerator with the pump's append-after-next() order.
+
+    Mirrors ``_BatchedARGenerationService._pump``: insert with the per-job
+    sampler, then loop calling ``generator.next()`` and emit each returned
+    token AFTER next() returns (never before).
+    """
+    from mlx_lm.generate import BatchGenerator
+
+    generator = BatchGenerator(
+        model,
+        max_tokens=max_tokens,
+        stop_tokens=[],
+        completion_batch_size=1,
+        prefill_batch_size=1,
+        prefill_step_size=1,
+    )
+    try:
+        uids = generator.insert(
+            [job.prompt_ids],
+            max_tokens=[max_tokens],
+            samplers=[sampler_fn],
+        )
+        job.uid = int(uids[0])
+        while len(job.tokens) < max_tokens:
+            _prompt_resps, gen_resps = generator.next()
+            for resp in gen_resps:
+                if int(resp.uid) == job.uid:
+                    job.emit_token(int(resp.token))
+    finally:
+        generator.close()
+    return list(job.tokens)
+
+
+def test_ar_batch_penalty_parity_matches_serial():
+    # mmmugh repro: token 7 leads token 3 by exactly 1.0; presence_penalty=1.5
+    # must demote 7 the moment it has been emitted once, flipping to 3. The
+    # expected sequence is [7, 3, 7, 7, 7, 7]: 7 wins the first step (no
+    # penalty yet), 3 wins the second (7 just seen), then 7 wins again (both
+    # seen, 3.5 > 2.5), and so on.
+    cfg = SamplerConfig(
+        temperature=0.0, top_p=1.0, top_k=0, presence_penalty=1.5
+    )
+    model = _FixedLogitsModel()
+
+    # Serial reference (mtplx/generation.py:3945) — the correctness oracle.
+    # generate_ar uses Counter(tokens) where tokens already includes the
+    # immediately-preceding sample, so there is no staleness.
+    ar = generate_ar(
+        _runtime(model),
+        [0],
+        max_tokens=6,
+        sampler=cfg,
+        seed=0,
+        stop_token_ids=set(),
+    )
+    assert list(ar.tokens) == [7, 3, 7, 7, 7, 7]
+
+    # Real ar_batch round trip through BatchGenerator + append-after-next().
+    job = _make_job(cfg)
+    service = object.__new__(openai._BatchedARGenerationService)
+    sampler_fn = service._make_sampler(job)
+    batch_tokens = _run_ar_batch(job, model, sampler_fn, max_tokens=6)
+
+    assert batch_tokens == [7, 3, 7, 7, 7, 7]
+    # Per-position equality with serial generate_ar — the core parity claim.
+    assert batch_tokens == list(ar.tokens)

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -604,6 +604,74 @@ def test_ar_batch_detects_nonmergeable_history_cache_entries():
     )
 
 
+def _ar_batch_sample_once(job) -> int:
+    """Run one decode step of the ar_batch sampler for ``job`` and return the token.
+
+    Mirrors how ``BatchGenerator`` calls the per-job sampler: a single-row
+    ``[1, vocab]`` logits batch in, one token id out. Token 0 leads token 1 by
+    exactly 1.0, so a presence_penalty of 2.0 (5.0 -> 3.0) flips the winner to
+    token 1 once token 0 has appeared in the completion.
+    """
+    mx = pytest.importorskip("mlx.core")
+    service = object.__new__(openai._BatchedARGenerationService)
+    sampler = service._make_sampler(job)
+    logits = mx.array([[5.0, 4.0, 0.0, 0.0]])
+    return int(sampler(logits)[0])
+
+
+def test_ar_batch_sampler_applies_penalty_in_hot_sampling_path():
+    # temperature > 0 with a penalty set routes through ``sample_one``. top_k=1
+    # collapses the (penalized) distribution to a deterministic argmax, so the
+    # completion token counts are the only thing that can move the result.
+    from mtplx.sampling import SamplerConfig
+
+    cfg = SamplerConfig(temperature=1.0, top_p=1.0, top_k=1, presence_penalty=2.0)
+    seen = SimpleNamespace(sampler=cfg, seed=0, seed_is_explicit=True, tokens=[0, 0, 0])
+    unseen = SimpleNamespace(sampler=cfg, seed=0, seed_is_explicit=True, tokens=[])
+
+    # token 0 already emitted -> penalty demotes it below token 1.
+    assert _ar_batch_sample_once(seen) == 1
+    # nothing emitted yet -> penalty is a no-op, token 0 still wins.
+    assert _ar_batch_sample_once(unseen) == 0
+
+
+def test_ar_batch_sampler_applies_penalty_in_greedy_path():
+    # temperature <= 0 is greedy, but a penalty must still be honoured before
+    # the argmax (the serial/MTP paths do). The seen token is demoted below its
+    # rival exactly as in the hot path.
+    from mtplx.sampling import SamplerConfig
+
+    cfg = SamplerConfig(temperature=0.0, top_p=1.0, top_k=0, presence_penalty=2.0)
+    seen = SimpleNamespace(sampler=cfg, seed=0, seed_is_explicit=False, tokens=[0, 0, 0])
+    unseen = SimpleNamespace(sampler=cfg, seed=0, seed_is_explicit=False, tokens=[])
+
+    assert _ar_batch_sample_once(seen) == 1
+    assert _ar_batch_sample_once(unseen) == 0
+
+
+def test_ar_batch_sampler_penalty_free_paths_are_unchanged():
+    # With no penalty set, both the greedy and the temperature>0 fast paths must
+    # keep their prior byte-identical argmax behaviour (token 0 wins), so the
+    # penalty wiring cannot regress the common no-penalty case.
+    from mtplx.sampling import SamplerConfig
+
+    greedy = SimpleNamespace(
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=0,
+        seed_is_explicit=False,
+        tokens=[0, 0, 0],
+    )
+    hot = SimpleNamespace(
+        sampler=SamplerConfig(temperature=1.0, top_p=1.0, top_k=1),
+        seed=0,
+        seed_is_explicit=False,
+        tokens=[0, 0, 0],
+    )
+
+    assert _ar_batch_sample_once(greedy) == 0
+    assert _ar_batch_sample_once(hot) == 0
+
+
 def test_long_prompt_commits_prompt_prefix_when_ssd_cache_is_enabled():
     state = SimpleNamespace(
         session_bank_cold_tier=SimpleNamespace(enabled=True, min_prefix_tokens=512)


### PR DESCRIPTION
## What

Under `--scheduler-mode ar_batch`, presence/frequency penalties are silently dropped at **every** temperature. `_BatchedARGenerationService._make_sampler` calls `_sample_from_logits` without any completion `token_counts`, so the penalty term has nothing to subtract against and no-ops. `grep -c token_counts mtplx/server/openai.py` is `0` today — the serial and MTP paths thread it, the batched-AR pump doesn't.

This is the flagship agentic lane: `mtplx start opencode` auto-selects `ar_batch` (`OPENCODE_FAIR_BATCHING_DEFAULTS`), so the exact loop-prone workloads penalties exist for are the ones where they go dead. Fixes #156.

## Why the fix looks the way it does

- Compute `penalties_active` once and **stop short-circuiting** to the `temp<=0` argmax fast-path and the fused-sampler fast-path when a penalty is set. Without this, a *greedy* request with a penalty still hit the bare `mx.argmax` and dropped the penalty too — so the bug really was "at every temperature", not just in `sample_one`.
- In `sample_one`, thread `Counter(job.tokens)` into `_sample_from_logits`. `job.tokens` holds exactly the completion tokens emitted so far for that job — `emit_token` appends *after* the pump samples (`generator.next()` returns, then `emit_token`), so at decode step N the counter sees tokens `0..N-1`, the same prefix the serial path uses (`Counter(tokens)` in `generation.py`). Prompt/prefix tokens live in the separate `insert_all_tokens` list and are never counted.
- Requests with **no** penalty keep their prior byte-identical paths (greedy argmax; fused mlx sampler; explicit-seed numpy path), so nothing on the hot no-penalty path changes.

## Behaviour

| scheduler mode | before | after |
|---|---|---|
| `serial` / MTP | penalties honoured | unchanged |
| `ar_batch`, penalty set | **silently dropped** (all temps) | penalties applied |
| `ar_batch`, no penalty | fast path | unchanged (byte-identical) |

## Tests

`tests/test_server_openai.py` gains three tests that drive the real `_make_sampler` → `sample_one` → `_sample_from_logits` chain (no mock of the function under fix), using the existing `object.__new__(_BatchedARGenerationService)` idiom:

- `test_ar_batch_sampler_applies_penalty_in_hot_sampling_path` — `temp>0`, `top_k=1` collapses to a deterministic argmax; a seen token is demoted below its rival.
- `test_ar_batch_sampler_applies_penalty_in_greedy_path` — same for the `temp<=0` greedy branch.
- `test_ar_batch_sampler_penalty_free_paths_are_unchanged` — no-penalty greedy and hot paths still return the plain argmax.

The first two are red without the source change (they return the un-penalized token 0) and green with it. Full `ci.yml` test set passes locally (macOS, py3.11); `compileall` clean.
