### PR TITLE
fix(ar_batch): honor presence/frequency penalties in the batched AR sampler (closes #156)

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -32,6 +32,7 @@ import time
 import urllib.parse
 import uuid
 import webbrowser
+from collections import Counter
 from concurrent.futures import Future
 from contextlib import asynccontextmanager, contextmanager, nullcontext, suppress
 from dataclasses import asdict, dataclass, is_dataclass
@@ -1868,12 +1869,13 @@ class _BatchedARGenerationService:
     def _make_sampler(self, job: _BatchedARJob) -> Callable[[Any], Any]:
         import mlx.core as mx
 
-        if float(job.sampler.temperature) <= 0:
-            return lambda logprobs: mx.argmax(logprobs, axis=-1)
-        if not job.seed_is_explicit and not (
+        penalties_active = bool(
             float(getattr(job.sampler, "presence_penalty", 0.0) or 0.0)
             or float(getattr(job.sampler, "frequency_penalty", 0.0) or 0.0)
-        ):
+        )
+        if float(job.sampler.temperature) <= 0 and not penalties_active:
+            return lambda logprobs: mx.argmax(logprobs, axis=-1)
+        if not job.seed_is_explicit and not penalties_active:
             # Fast path: mlx-lm's fused GPU sampler. The numpy fallback below
             # synchronizes the full logits row to the CPU for every decode
             # step of every active sequence, which serializes the whole batch
@@ -1887,10 +1889,27 @@ class _BatchedARGenerationService:
                 top_k=int(getattr(job.sampler, "top_k", 0) or 0),
             )
         rng = np.random.default_rng(job.seed)
+        # Penalty counts must come from what THIS sampler emitted, not from
+        # job.tokens: mlx-lm's BatchGenerator is pipelined and samples t_k in
+        # the same GenerationBatch._step() that returns t_(k-1) to the pump, so
+        # job.tokens (appended in emit_token, after generator.next() returns) is
+        # always one token stale here and would leave the token just emitted
+        # unpenalized at its first opportunity. This sampler is bound to exactly
+        # one sequence and sees every token it generates, which reproduces
+        # generate_ar's per-position Counter(tokens).
+        counts: Counter[int] = Counter()
 
         def sample_one(logprobs: Any) -> Any:
-            token, _distribution = _sample_from_logits(logprobs[0], job.sampler, rng)
-            return mx.array([int(token)])
+            token, _distribution = _sample_from_logits(
+                logprobs[0],
+                job.sampler,
+                rng,
+                token_counts=counts if penalties_active else None,
+            )
+            token = int(token)
+            if penalties_active:
+                counts[token] += 1
+            return mx.array([token])
 
         return sample_one
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1896,7 +1896,9 @@ class _BatchedARGenerationService:
         # always one token stale here and would leave the token just emitted
         # unpenalized at its first opportunity. This sampler is bound to exactly
         # one sequence and sees every token it generates, which reproduces
-        # generate_ar's per-position Counter(tokens).
+        # generate_ar's per-position Counter(tokens). That same pipelining also
+        # samples one token past the last delivered one; it is counted here but
+        # never read, because the row leaves the batch in the same next().
         counts: Counter[int] = Counter()
 
         def sample_one(logprobs: Any) -> Any:

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -734,6 +734,92 @@ def test_ar_batch_greedy_sampler_without_penalties_stays_on_fused_argmax():
     assert int(sampler(logprobs)[0].item()) == 7
 
 
+def test_ar_batch_sampler_stays_bound_to_its_own_sequence_when_a_row_finishes():
+    """A row finishing mid-batch must not shift its penalty counts onto another.
+
+    Each sampler owns a private counter, so correctness rests on mlx-lm keeping
+    `samplers` index-aligned with `uids` when it compacts a finished sequence out
+    of the batch (GenerationBatch.filter). That is an mlx-lm implementation
+    detail, not an API contract -- if a version bump ever broke the alignment,
+    one request's penalty histogram would silently start driving another's
+    tokens. The single-sequence test above cannot see that; this one can.
+
+    The two rows use DIFFERENT penalty kinds (presence vs frequency), which
+    produce different token streams from the same logits, and the short row is
+    given a smaller max_tokens so it terminates first and forces the compaction.
+    The survivor must still reproduce its own serial reference.
+    """
+    pytest.importorskip("mlx_lm.generate")
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.generate import BatchGenerator
+
+    from mtplx.sampling import SamplerConfig
+
+    seed = 1234
+    short_steps, long_steps = 3, 9
+    short_sampler = SamplerConfig(
+        temperature=0.0, top_p=1.0, top_k=0, presence_penalty=1.5
+    )
+    long_sampler = SamplerConfig(
+        temperature=0.0, top_p=1.0, top_k=0, frequency_penalty=0.6
+    )
+    expected_long = _ar_batch_serial_reference(long_sampler, long_steps, seed=seed)
+
+    class _Layer(nn.Module):
+        pass
+
+    class _StubModel(nn.Module):
+        """Constant-logit stub that still writes KV entries.
+
+        Unlike the single-sequence test, a row terminates here, so mlx-lm runs
+        cache.filter() on the compaction -- which needs real cache state.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.layers = [_Layer()]
+
+        def __call__(self, inputs, cache=None):
+            batch, length = inputs.shape
+            for entry in cache or ():
+                if entry is not None:
+                    keys = mx.zeros((batch, 2, length, 4))
+                    entry.update_and_fetch(keys, keys)
+            row = mx.array(_AR_BATCH_STUB_LOGITS)
+            return mx.broadcast_to(row, (batch, length, len(_AR_BATCH_STUB_LOGITS)))
+
+    service = object.__new__(openai._BatchedARGenerationService)
+    short_job = SimpleNamespace(
+        sampler=short_sampler, seed=seed, seed_is_explicit=True, tokens=[]
+    )
+    long_job = SimpleNamespace(
+        sampler=long_sampler, seed=seed, seed_is_explicit=True, tokens=[]
+    )
+
+    generator = BatchGenerator(_StubModel(), max_tokens=long_steps)
+    uids = generator.insert(
+        [[1], [1]],
+        max_tokens=[short_steps, long_steps],
+        samplers=[
+            service._make_sampler(short_job),
+            service._make_sampler(long_job),
+        ],
+    )
+    by_uid = {int(uids[0]): short_job, int(uids[1]): long_job}
+
+    while len(long_job.tokens) < long_steps:
+        _prompt_responses, generation_responses = generator.next()
+        for response in generation_responses:
+            by_uid[int(response.uid)].tokens.append(int(response.token))
+
+    # The short row terminated (and was compacted out) well before the long one.
+    assert len(short_job.tokens) == short_steps
+    assert short_job.tokens != long_job.tokens
+    # The survivor kept its OWN frequency-penalty histogram across the compaction.
+    assert long_job.tokens == expected_long
+
+
 def test_long_prompt_commits_prompt_prefix_when_ssd_cache_is_enabled():
     state = SimpleNamespace(
         session_bank_cold_tier=SimpleNamespace(enabled=True, min_prefix_tokens=512)

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -604,6 +604,136 @@ def test_ar_batch_detects_nonmergeable_history_cache_entries():
     )
 
 
+def _ar_batch_serial_reference(sampler, steps, *, seed):
+    """Per-position reference: the serial generate_ar penalty loop.
+
+    Mirrors generate_ar -- Counter(tokens) is built from the completion so far
+    and the sampled token is appended only afterwards.
+    """
+    from collections import Counter
+
+    import mlx.core as mx
+    import numpy as np
+
+    from mtplx.generation import _sample_from_logits
+
+    rng = np.random.default_rng(seed)
+    tokens: list[int] = []
+    for _ in range(steps):
+        token, _ = _sample_from_logits(
+            mx.array(_AR_BATCH_STUB_LOGITS),
+            sampler,
+            rng,
+            token_counts=Counter(tokens)
+            if (sampler.presence_penalty or sampler.frequency_penalty)
+            else None,
+        )
+        tokens.append(int(token))
+    return tokens
+
+
+# Token 7 leads runner-up token 3 by exactly 1.0, so any penalty above 1.0 flips
+# the argmax on the token's second occurrence -- and only if the count is current.
+_AR_BATCH_STUB_LOGITS = [0.0, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0, 5.0]
+
+
+@pytest.mark.parametrize(
+    "temperature,presence_penalty,frequency_penalty",
+    [
+        (0.0, 1.5, 0.0),
+        (0.0, 0.0, 0.6),
+        (0.8, 1.5, 0.0),
+    ],
+)
+def test_ar_batch_sampler_penalties_match_serial_generate_ar_per_position(
+    temperature, presence_penalty, frequency_penalty
+):
+    """ar_batch penalties must be per-position identical to serial generate_ar.
+
+    This drives the real mlx-lm BatchGenerator and the real pump append order
+    (openai.py: generator.next() -> job.emit_token), because that is the only
+    way to catch BOTH defects this guards:
+
+      1. penalties were a no-op on the ar_batch lane entirely (temp<=0
+         short-circuited to a bare mx.argmax; the numpy path never forwarded
+         token_counts), and
+      2. sourcing the counts from job.tokens is one token stale -- mlx-lm
+         samples t_k in the same _step() that returns t_(k-1) -- so the token
+         just emitted escapes its penalty at the one position it matters most.
+
+    Calling the sampler closure in isolation cannot see (2); only the round trip
+    through BatchGenerator + the pump's append-after-next() ordering can.
+    """
+    pytest.importorskip("mlx_lm.generate")
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.generate import BatchGenerator
+
+    from mtplx.sampling import SamplerConfig
+
+    steps = 8
+    seed = 1234
+    sampler = SamplerConfig(
+        temperature=temperature,
+        top_p=1.0,
+        top_k=0,
+        presence_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
+    )
+    expected = _ar_batch_serial_reference(sampler, steps, seed=seed)
+
+    class _StubModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = [nn.Identity()]
+
+        def __call__(self, inputs, cache=None):
+            batch, length = inputs.shape
+            row = mx.array(_AR_BATCH_STUB_LOGITS)
+            return mx.broadcast_to(row, (batch, length, len(_AR_BATCH_STUB_LOGITS)))
+
+    service = object.__new__(openai._BatchedARGenerationService)
+    job = SimpleNamespace(sampler=sampler, seed=seed, seed_is_explicit=True, tokens=[])
+
+    # max_tokens is left above `steps` so the stub never hits mlx-lm's terminal
+    # cache extraction; the pump loop below stops the run instead.
+    generator = BatchGenerator(_StubModel(), max_tokens=steps + 5)
+    generator.insert(
+        [[1]],
+        max_tokens=[steps + 5],
+        samplers=[service._make_sampler(job)],
+    )
+    while len(job.tokens) < steps:
+        _prompt_responses, generation_responses = generator.next()
+        for response in generation_responses:
+            job.tokens.append(int(response.token))  # mirrors job.emit_token
+
+    assert job.tokens == expected
+
+
+def test_ar_batch_greedy_sampler_without_penalties_stays_on_fused_argmax():
+    """Control: with no penalty the greedy short-circuit must survive untouched.
+
+    Proves the flip in the test above is the penalty, not the plumbing, and pins
+    the fast path that penalized requests are deliberately diverted away from.
+    """
+    pytest.importorskip("mlx_lm.generate")
+    import mlx.core as mx
+
+    from mtplx.sampling import SamplerConfig
+
+    service = object.__new__(openai._BatchedARGenerationService)
+    job = SimpleNamespace(
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=1234,
+        seed_is_explicit=False,
+        tokens=[7, 7, 7],
+    )
+    sampler = service._make_sampler(job)
+    logprobs = mx.array([_AR_BATCH_STUB_LOGITS])
+    assert int(sampler(logprobs)[0].item()) == 7
+
+
 def test_long_prompt_commits_prompt_prefix_when_ssd_cache_is_enabled():
     state = SimpleNamespace(
         session_bank_cold_tier=SimpleNamespace(enabled=True, min_prefix_tokens=512)


### PR DESCRIPTION
Closes #156. Completes #120.

## The bug

Under `--scheduler-mode ar_batch`, `presence_penalty` and `frequency_penalty` are a **no-op at every temperature**. `_BatchedARGenerationService._make_sampler` has two independent holes:

1. `temp <= 0` short-circuits to a bare `mx.argmax` that bypasses `_sample_from_logits` entirely, so penalties can never apply on the greedy path.
2. The numpy path calls `_sample_from_logits` **without** `token_counts`, so penalties no-op at `temp > 0` too.

`grep -c token_counts mtplx/server/openai.py` → `0` on `main`.

This matters because `ar_batch` is the lane agentic clients land in, and `--default-presence-penalty` / `--default-frequency-penalty` bake a penalty into every request — which then silently does nothing.

## The fix

Compute `penalties_active` once, route penalized greedy requests through `_sample_from_logits` (which already applies penalties in its `temp <= 0` branch), and thread per-sequence completion counts into it.

**The counts come from a closure-local `Counter`, not from `job.tokens`.** This is the subtle part, and the obvious implementation is wrong:

mlx-lm's `BatchGenerator` is a one-step-lookahead pipeline — the same `GenerationBatch._step()` that samples `t_k` returns `t_(k-1)` to the pump (`mlx_lm/generate.py:1327-1378`). So `job.tokens` — appended in `emit_token`, *after* `generator.next()` returns — is always **one token stale** at sampler-call time. Sourcing counts from it leaves the token just emitted unpenalized at its first opportunity, which is exactly the immediate repeat a loop-breaking penalty exists to suppress.

Each sampler closure is bound to one sequence and sees every token it generates, so a closure-local counter is lag-free by construction and independent of mlx-lm's pipeline depth. It is also O(1) per step, versus serial `generate_ar`'s O(n) `Counter(tokens)` rebuild.

## Scope

- Serial `generate_ar` and `generate_mtpk` are untouched.
- The fused mlx-lm fast path is preserved for unpenalized requests. Only penalized requests leave it — and penalized `temp > 0` requests already took the numpy path before this change, so the only new cost is on `temp <= 0` + penalty, which is 100% broken today.
- No cross-request bleed: mlx-lm compacts `samplers` in lockstep with `uids` (`filter(keep)`, `generate.py:1383-1397`), and each closure owns a private counter regardless.

## Tests

`tests/test_server_openai.py` gains a test that drives the **real `BatchGenerator`** through the **real pump append ordering** and asserts per-position equality with a serial `generate_ar` reference, parametrized over greedy+presence, greedy+frequency, and temp>0+presence — plus a control pinning the unpenalized fused argmax path.

The round-trip shape is load-bearing: a closure-level unit test passes against the stale-`job.tokens` implementation and cannot see defect (2).

- RED on unpatched `main` (3/3)
- RED on the naive `Counter(job.tokens)` fix (3/3) — it emits `[7, 7, ...]` where serial emits `[7, 3, ...]`
- GREEN on this fix
- Full suite: 1674 passed, 5 skipped (`test_penalties.py` + `test_penalty_request_wiring.py` green — serial/MTP unaffected)

## Verified on a real model

Qwen3.6-27B, `--scheduler-mode ar_batch`, `temperature=0`, prompt driving a degenerate loop, 400 max tokens:

| | `presence_penalty=0.0` | `presence_penalty=1.5` |
|---|---|---|
| most-repeated word | **`hello` × 119** | `i` × 17 |
| lexical diversity | 0.377 | 0.514 |

Unpenalized burns the full budget in a `hello hello hello…` loop; penalized never forms it. Server log confirms `scheduler_lane: "ar_batch"` for both.

## Follow-ups (not in this diff)

- Greedy + penalties could stay fused on-device via `apply_penalties_mlx` + `mx.argmax` instead of the per-step host sync. Correctness first; the per-position test would keep such a variant honest.
- Serial's Loop Guard `penalty_overlay` is still unwired in the `ar_batch` lane.

---

## Relationship to #157

@SuperMarioYL opened #157 for this same issue two days before this PR — that one came first, and I only found it afterwards. The two diffs agree exactly on the `penalties_active` refactor and on routing penalized greedy requests off the bare `mx.argmax` short-circuit.

They differ in **where the penalty counts come from**, and I believe that difference is load-bearing:

| | counts source | result |
|---|---|---|
| #157 | `Counter(job.tokens)` | penalties fire **one token late** |
| #164 | closure-local `Counter` | per-position identical to serial `generate_ar` |

`job.tokens` is appended by `emit_token` *after* `generator.next()` returns, but the sampler runs one step **ahead** inside `next()` — mlx-lm's `GenerationBatch._step()` samples `t_k` in the same call that returns `t_(k-1)` (`generate.py:1327/1367/1378`). So at sampler-call time `job.tokens` is missing the token generated immediately before, which is exactly the token a loop-breaking penalty most needs to see:

```
serial generate_ar (correct)      : [7, 3, 7, 7, 7, 7]
ar_batch w/ Counter(job.tokens)   : [7, 7, 3, 3, 7, 7]   <- #157
ar_batch w/ closure-local counter : [7, 3, 7, 7, 7, 7]   <- this PR
```

At position 1 the immediate repeat (`7, 7`) escapes unpenalized. Details and a standalone repro are in https://github.com/youssofal/MTPLX/pull/157#issuecomment-4971854889.

This is easy to miss — my first patch was byte-identical to #157 here, and it passed a sampler-closure unit test. It is only visible on a round trip through the real `BatchGenerator` with the pump's append-after-`next()` ordering, which is why the test in this PR is shaped that way.

**I'm happy to close this in favor of #157 if that change is applied there** — @SuperMarioYL got to the issue first. I care more about the correct version shipping than about which PR it ships in.
