### PR TITLE
Experimental Qwen dense-MLP gate/up row-traversal fusion (default-off)

### DIFF
--- a/docs/specs/2026-07-17-qwen-experimental-row-traversal.md
+++ b/docs/specs/2026-07-17-qwen-experimental-row-traversal.md
@@ -1,4 +1,4 @@
-# Experimental Qwen Gate/Up Row-Traversal Fusion
+# Experimental Qwen Row Traversal: Exact-M Verify Tiles
 
 ## Status
 
@@ -10,67 +10,131 @@ Two independent flags are added, both off by default and mutually exclusive:
 
 Neither changes any default profile.
 
-## What it does
+Row traversal has two cooperating parts, both engaged by the one flag:
 
-Qwen3-Next's dense MLP runs `down_proj(swiglu(gate_proj(x), up_proj(x)))`. On
-the speculative-verify path the stock activation launches two separate Q4
-projection kernels and a third SwiGLU kernel, materializing the full `gate` and
-`up` projections as BF16 intermediates between launches.
+1. **Fused gate/up+SwiGLU MLP tile** — one Metal kernel per exact verify tile
+   (M2-M6) on the vk_k split-K geometry, replacing the two dense-MLP
+   projection launches plus the SwiGLU launch, so the full `gate` and `up`
+   BF16 intermediates are never materialized.
+2. **Exact-M QuantizedLinear routing** — every other eligible 4-bit verify
+   matmul at M in {2, 3, 5} (attention, GDN, `down_proj`, lm_head at M3/M5)
+   is routed through the proven vk_k split-K codegen compiled at the true row
+   count (`MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR` overrides this half explicitly
+   in either direction for A/B work).
 
-The row-traversal flag fuses `gate_proj + up_proj + precise SwiGLU` into one
-Metal kernel built on the existing small-M split-K (`vk_k`) ownership. One
-output tile is owned by one threadgroup, which reads the two original Q4 arrays,
-reduces both projections through the same fixed split-K tree in FP32 registers,
-applies precise SwiGLU at the projection boundary, and writes only the activated
-tile. `down_proj` stays on its existing path.
+## Where the wins actually come from
 
-The point of the fusion is to keep the whole gate/up + SwiGLU chain in registers
-and threadgroup memory so the two BF16 projection intermediates are never
-materialized. There is no packed weight copy and no peak-memory increase.
+The shipped turbo profile already routes 4-bit `QuantizedLinear` calls with
+M in 4..16 (non-prefill) through the MTPLX verify kernels
+(`install_nax_qlinear_patch`): M4 runs the vk_k split-K tile, M5/M6 run the
+M6 split-K tile (M5 zero-padded). **M1-M3 stay on stock MLX `qmv`, which
+re-reads the full weight matrix once per output row**, and M5 pays the
+padded-M6 waste.
+
+Speculative depth K verifies M = K+1 rows, so the per-depth in-context
+baselines differ structurally:
+
+| depth | verify tile | turbo in-context baseline | row-traversal change |
+| :---: | :---: | :--- | :--- |
+| K1 | M2 | stock `qmv` (2x weight reads) | fused MLP tile + exact-M2 routing |
+| K2 | M3 | stock `qmv` (3x weight reads) | fused MLP tile + exact-M3 routing |
+| K3 | M4 | NAX vk_k pair (already 1x) | fused MLP tile (merges 2 launches) |
+| K4 | M5 | NAX padded-M6 tile | fused MLP tile + exact-M5 routing |
+| K5 | M6 | NAX M6 tile (already 1x) | fused MLP tile (merges 2 launches) |
+
+This is why the original MLP-only measurement was large at K1/K2, moderate at
+K4, and flat at K3/K5: the flat cells were already served by the tuned vk_k
+family, so merging two already-fast launches buys launch overhead only. The
+earlier draft attributed the K3/K5 flatness to attention dilution; the NAX
+coverage map above is the verified cause (control verify-forward time at K3,
+40.9 ms, is *lower* than K2's 49.7 ms despite one more row — the M3->M4
+baseline kernel handoff is visible in control itself).
+
+For the same reason, the isolated MLP microbench's `stock` arm (raw MLX
+modules) is the correct in-context baseline **only at M2/M3**; at M4-M6 the
+shipped baseline is the vk_k family, so the +33..42% isolated columns there do
+not translate end-to-end.
+
+## Verify-call census (live shapes)
+
+QuantizedLinear call census over real generations (turbo control config,
+1K context, per depth; counts per verify forward, 64-layer trunk):
+
+| shape (K -> N) | calls/verify fwd | role | exact-M eligible |
+| :--- | ---: | :--- | :---: |
+| 5120 -> 17408 | 128 | MLP gate+up (fused MLP tile handles these) | via MLP tile |
+| 17408 -> 5120 | 64 | MLP down_proj | yes |
+| 6144 -> 5120 | 64 | GDN/attention out projections | yes |
+| 5120 -> 6144 | 48 | GDN in projections | yes |
+| 5120 -> 10240 | 48 | GDN in projections | yes |
+| 5120 -> 12288 | 16 | full-attention QKV | yes |
+| 5120 -> 248320 | 1 | quantized lm_head | M3/M5 only |
+| 5120 -> 48 | 96 | GDN b/a projections | no (tiny-N floor) |
+| 5120 -> 1024 | 32 | KV projections | no (tiny-N floor) |
+
+The lazy-bonus commit forwards also run M in {2, 3, 5} at depths 2-5
+("unknown" phase, same shapes) and are covered by the same routing — including
+M3 commits at the shipped depth-3 configuration.
 
 ## Design
 
-- Reads the original gate/up Q4 arrays directly; no packed duplicate.
-- Output-tile-major traversal with BN=2 and two fixed K parts.
-- Compiles one kernel per exact verify tile (M2-M6). Owning the true row count
-  keeps every live row's reduction in its own FP32 accumulator and removes the
-  zero-padded activation copy a fixed M4/M6 tile would otherwise materialize on
-  every call. Because each output row reduces over an independent accumulator,
-  the live rows are bit-identical whether or not the tile is padded.
-- Keeps the current Q4 storage, BF16/FP16 activation/output types, and FP32
-  products and accumulators.
-- Falls back to the stock path outside the narrow Q4 affine M2-M6 eligibility
-  contract (autoregressive M1 / K0 always runs stock).
+- Reads the original Q4 arrays directly; no packed duplicate, no
+  peak-memory increase.
+- MLP tile: output-tile-major traversal, BN=2, two fixed K parts, one kernel
+  per exact verify tile (M2-M6). Each output row reduces in its own FP32
+  accumulator, so live rows are bit-identical whether or not the tile is
+  padded; removing the pad removes the zero-padded activation copy the fixed
+  M4/M6 tiles materialized on every call. BN=4 needs 32 FP32 accumulators
+  (over the register ceiling) and measured slower.
+- Exact-M routing: `verify_kernels._build_ksplit_kernel` (the shipped vk_k
+  codegen, already parameterized over M) compiled at M in {2, 3, 5} with the
+  K constant baked (vk_k morphology), grid `N/4` column tiles.
+- Eligibility floors are measured, not guessed: tiny-N projections (N=48 GDN
+  b/a, N=1024 KV) lose to stock qmv at every M (launch-bound), and M2 loses
+  on lm_head-class N (>= 100k), so those stay stock. Everything else with
+  N >= 2048 wins.
+- Install order: the exact-M wrapper installs after the NAX patch so exact-M5
+  takes precedence over the padded-M6 NAX route; M4/M6/M7-16 fall through to
+  NAX unchanged, everything else to stock.
+- Autoregressive decode (M1) and prefill are untouched in both halves.
 
-BN=4 was measured slower than the two-call path: carrying both projections at
-BN=4 needs 32 FP32 accumulators per thread, over the register ceiling. BN=2
-stays at 16 accumulators for the M4 tile and 24 for M6, at the ceiling, and
-restores occupancy while retaining one dispatch.
+## Numerical contract and measured characterization
 
-## Numerical contract
+The row traversal does not reduce dtype precision: Q4 storage, BF16/FP16
+projection boundaries, FP32 products and accumulators are unchanged. It does
+change the FP32 addition tree, and FP32 addition is non-associative, so
+low-order bits can differ from stock. This is the same accepted numerics class
+as the shipped turbo vk_k verify kernels ("argmax- and
+sampler-distribution-validated, not bit-exact vs stock"), and every lane
+self-validates at model load through `kernel_selfcheck` with the same
+disable-on-mismatch contract as the NAX lanes (`qwen_rt_qmm_m2/m3/m5`,
+`qwen_rt_gateup`).
 
-The fusion does not reduce dtype precision: Q4 storage, BF16/FP16 projection
-boundaries, and FP32 accumulation are unchanged. It does change the FP32
-addition tree relative to the two stock projection kernels. Floating-point
-addition is non-associative, so regrouping the same FP32 products can change
-low-order bits even though precision is unchanged. "Same precision" therefore
-does not promise bitwise identity with stock.
+Measured characterization of the divergence (overflow/saturation probe, real
+gate/up weights from layers 0/31/63, fp64 numpy reference, activation-RMS
+ladder 0.03..30 at M2/M3):
 
-In practice most verify cells stay bit-parity with stock. In a few cells a
-low-order rounding difference crosses a greedy decision boundary and changes the
-downstream accepted/drafted workload; those cells are reported for completeness
-and not credited as isolated kernel speedups.
+- Zero non-finite values in either arm at any magnitude; pre-activations up
+  to 130 and outputs up to ~9.6e3 stay far inside BF16/FP32 range.
+- Fused-vs-fp64 max error: 0.78-3.23 BF16 ULP; stock-vs-fp64: 1.64-3.95 ULP.
+  The fused tile is at or slightly below stock's own rounding error, flat
+  across a 1000x magnitude range (no error growth with contraction length,
+  no clipping signature).
+- Fused-vs-stock disagreement: 1.4-5.2 ULP — symmetric low-order rounding.
 
-The exact-tile change is numerically inert: it only removes the zero-pad, so its
-output is bit-identical to the padded tile on the live rows, and it does not move
-any cell across the parity boundary.
+At greedy temperature this low-order noise can cross a decision boundary and
+fork the generation. In the diverged cells the forked texts were decoded and
+inspected: both arms coherent and on-task, the fused arm with equal-or-higher
+distinct-token ratio (0.74-0.75 vs 0.69-0.73) and no repetition degeneracy.
+Verify-forward times improve identically in parity and diverged cells of the
+same depth, so diverged-cell tok/s deltas are trajectory effects (different
+text, different draft acceptance) and are disclosed, never credited.
 
-## Isolated kernel microbench (queued lane)
+## Isolated microbenches (queued lane)
 
-Real dense-MLP shape K=5120, N=17408, Q4 affine group_size=64. Median per-call
-microseconds on the queued lane (fill the command buffer with independent calls,
-single synchronize). `stock` is two Q4 projections + SwiGLU; `padded` is the
-fixed-M4/M6 tile with the zero-pad copy; `exact` is the per-tile kernel.
+Fused MLP tile, real dense-MLP shape K=5120, N=17408, Q4 gs=64. `stock` is
+two raw MLX projections + SwiGLU — the in-context baseline only at M2/M3 (see
+above); `padded` is the fixed-M4/M6 fused tile.
 
 | verify tile | K | stock us | padded us | exact us | exact vs padded | exact vs stock |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -80,76 +144,196 @@ fixed-M4/M6 tile with the zero-pad copy; `exact` is the per-tile kernel.
 | M5 | 4 | 473.99 | 316.66 | 268.07 | +15.35% | +43.44% |
 | M6 | 5 | 582.60 | 348.93 | 337.16 | +3.37% | +42.13% |
 
-Removing the zero-pad recovers 12-18% of kernel time at the padded tiles
-(M2/M3/M5). M4 and M6 are never padded, so exact and padded coincide within
-measurement noise, which doubles as a harness sanity check. Against stock, the
-fused kernel is faster everywhere except M2, where the two stock projections are
-already cheap.
+Exact-M QuantizedLinear routing vs stock `qmv` on the live census shapes
+(medians; `padded M6` shown at M5 where it is the shipped turbo route):
 
-## End-to-end K0-K5 x 4K/8K/16K matrix
+| shape | M2 | M3 | M5 | M5 vs padded M6 |
+| :--- | ---: | ---: | ---: | ---: |
+| 5120 -> 6144 | +17.9% | +26.2% | +31.8% | 63.5 -> 58.8 us |
+| 5120 -> 10240 | +8.3% | +27.2% | +39.1% | 98.4 -> 83.6 us |
+| 5120 -> 12288 | +9.5% | +27.8% | +39.4% | 116.7 -> 99.5 us |
+| 5120 -> 17408 | +13.1% | +28.5% | +40.1% | 166.9 -> 143.5 us |
+| 6144 -> 5120 | +8.9% | +25.4% | +38.9% | 69.5 -> 62.5 us |
+| 17408 -> 5120 | +18.7% | +32.2% | +41.4% | 167.1 -> 152.1 us |
+| 5120 -> 248320 (lm_head) | -6.4% (stays stock) | +34.0% | +45.0% | 2704.8 -> 2134.4 us |
+| 5120 -> 1024 | -3.1% (stays stock) | -6.2% (stays stock) | +10.2% (stays stock, floor) | — |
+| 5120 -> 48 | -72% (stays stock) | -95% (stays stock) | -81% (stays stock) | — |
 
-Control (stock) and the exact-tile candidate were measured back to back in one
-exclusive GPU window (turbo profile, greedy, seed 51, 96 generated tokens, three
-repeats after one warmup per cell), on public upstream `a391973`.
+## End-to-end: definitive quiet pairing (16K, K0-K4)
 
-| context | K | control tok/s | exact-M tok/s | delta | verify delta | accepted/drafted (control -> exact-M) | token parity |
-| ---: | ---: | ---: | ---: | ---: | ---: | :--- | :---: |
-| 4096 | 0 | 29.486 | 29.317 | -0.57% | +0.58% | 0/0 -> 0/0 | yes (stock fallback) |
-| 4096 | 1 | 45.665 | 49.182 | +7.70% | -7.61% | 46/50 -> 46/49 | no |
-| 4096 | 2 | 47.470 | 56.465 | +18.95% | -17.34% | 59/72 -> 61/68 | no |
-| 4096 | 3 | 72.002 | 71.958 | -0.06% | -0.31% | 69/80 -> 69/80 | yes |
-| 4096 | 4 | 65.570 | 68.053 | +3.79% | -4.61% | 73/91 -> 73/91 | yes |
-| 4096 | 5 | 71.371 | 71.536 | +0.23% | -0.31% | 76/98 -> 76/98 | yes |
-| 8192 | 0 | 29.174 | 29.106 | -0.23% | +0.26% | 0/0 -> 0/0 | yes (stock fallback) |
-| 8192 | 1 | 44.376 | 46.777 | +5.41% | -5.66% | 46/50 -> 46/50 | yes |
-| 8192 | 2 | 46.332 | 51.397 | +10.93% | -11.25% | 60/72 -> 60/72 | yes |
-| 8192 | 3 | 64.552 | 64.002 | -0.85% | +0.54% | 67/87 -> 67/87 | yes |
-| 8192 | 4 | 44.862 | 46.389 | +3.40% | -4.45% | 65/123 -> 65/123 | yes |
-| 8192 | 5 | 59.933 | 59.901 | -0.05% | +0.09% | 74/107 -> 74/107 | yes |
-| 16384 | 0 | 28.077 | 27.873 | -0.73% | +0.76% | 0/0 -> 0/0 | yes (stock fallback) |
-| 16384 | 1 | 40.394 | 45.067 | +11.57% | -10.79% | 44/52 -> 46/49 | no |
-| 16384 | 2 | 42.096 | 49.315 | +17.15% | -15.95% | 59/74 -> 61/70 | no |
-| 16384 | 3 | 61.790 | 61.415 | -0.61% | +0.62% | 67/84 -> 67/84 | yes |
-| 16384 | 4 | 54.783 | 56.325 | +2.81% | -3.47% | 72/94 -> 72/94 | yes |
-| 16384 | 5 | 54.325 | 53.679 | -1.19% | +1.33% | 74/105 -> 74/105 | yes |
+Total-quiet protocol: exclusive GPU window (serving booted out under the
+guard), the rANS converter SIGSTOPped for the duration (verified `T` state),
+no other process above 50% CPU, arms in alternating fresh processes
+(control, fused, control, fused, ...) so drift cannot favor an arm, three
+repeats, greedy seed 51, 96 tokens, fresh 16K prefill per generation.
+Control drift across the window: at most 1.34% (K1), 0.0% at K0. Repeat
+spread within each cell: under 0.6%. Fused = the full flag (fused MLP tile +
+exact-M2/M3/M5 routing). Engagement verified in-window by dispatch counters.
 
-Every exact-M cell produced tokens bit-identical to the prior padded fused run
-(18/18), confirming the exact-tile change is numerically inert and that the
-fused kernel engaged rather than silently falling back to stock.
+| K @16K | control tok/s | fused tok/s | delta | verify/fwd | acceptance | tokens |
+| ---: | ---: | ---: | ---: | ---: | :--- | :--- |
+| K0 | 28.06 [28.05, 28.06] | 27.75 [27.75, 27.92] | -1.08% | 35.1 -> 35.5 ms | - | identical |
+| K1 | 41.27 [40.87, 41.43] | 47.15 [47.13, 47.20] | +14.25% | 40.9 -> 37.8 ms (-7.7%) | 44/52 -> 46/49 | fork |
+| K2 | 44.25 [43.99, 44.29] | 57.91 [57.89, 57.94] | +30.86% | 51.7 -> 40.3 ms (-21.9%) | 59/74 -> 61/70 | fork |
+| K3 | 63.72 [63.56, 63.77] | 63.40 [63.28, 63.54] | -0.51% | 44.0 -> 44.1 ms | 67/84 = | identical |
+| K4 | 56.76 [56.51, 56.84] | 62.01 [61.96, 62.14] | +9.23% | 59.1 -> 53.0 ms (-10.3%) | 72/94 = | identical |
 
-K0 is a stock-fallback control (the fusion applies only to M2-M6); its small
-deltas are run noise. Among the affected cells with identical tokens and
-acceptance, the padded verify shapes where the zero-pad was removed improve
-clearly: K1/8K went from -0.95% in the prior padded run to +5.41% here, K2/8K is
-+10.93%, and K4 is +2.8 to +3.8% across contexts. The direct M4/M6 shapes (K3,
-K5) land flat within +/-1.2%. The isolated microbench shows the fused kernel is
-30-42% faster than stock at those shapes, but the MLP is a small fraction of
-per-token time -- especially at 8K/16K where attention over the KV cache
-dominates -- so the kernel win dilutes to noise at the token level. No parity
-cell regresses beyond run-to-run noise, and the exact-tile change removed the
-only regression the padded path had shown (K1/8K), so no shape is scoped out.
+Reading it honestly:
 
-The four non-parity cells are K1/K2 at 4K and 16K. Each arm is deterministic,
-but the changed FP32 reduction tree moved a low-order value across a greedy
-decision boundary and changed the downstream acceptance workload, so their
-throughput deltas are reported for completeness, not credited as isolated kernel
-speedups.
+- K4 is the cleanest cell in the whole investigation: +9.23% end-to-end with
+  bitwise-identical tokens and identical acceptance — pure kernel effect
+  (exact-M5 routing replacing the padded-M6 route plus the M5 MLP tile).
+- K1/K2 combine two effects. The kernel-real component is the verify-forward
+  drop (-7.7% and -21.9%): stock `qmv` re-reads the full weight matrix per
+  output row at M2/M3, so depths 1-2 are where the routing bites hardest.
+  The rest of the tok/s delta is the acceptance ratchet on the forked
+  trajectory (below) and is workload-dependent serving throughput, not
+  kernel speed.
+- K0 (-1.08%) and K3 (-0.51%) price the Python dispatch wrappers: at depths
+  where no new kernel engages (M1 decode, M4 already NAX-served) the patch
+  costs ~0.2-0.4 ms/forward of per-call eligibility checks. Acceptable for
+  an experimental flag; a phase-first short-circuit would trim it if the
+  flag ever graduates.
+- The production serving depth is K3 under turbo, where this flag is net
+  ~0.5% negative today. The flag pays at K1/K2/K4 and any config where
+  depth-1/2 tiles dominate (short-depth speculative serving, draft-heavy
+  regimes).
+
+### Context sweep (4K/8K/16K, corroboration only)
+
+The full K0-K5 x three-context matrices from the earlier (non-quiet) windows
+reproduce the same shape: M2/M3-heavy depths win large, K3/K5 flat-positive,
+parity in exactly the same cells every window. Those absolute deltas carried
+up to 4-7% cross-window drift (a CPU-heavy rANS conversion ran on the box
+and arms were sequential), which is why the quiet interleaved pairing above
+is the citable table. 8K quiet spot-check (same protocol, alternating fresh
+processes, 3 repeats):
+
+| K @8K | control tok/s | fused tok/s | delta | verify/fwd | acceptance | tokens |
+| ---: | ---: | ---: | ---: | ---: | :--- | :--- |
+| K1 | 45.15 | 48.75 | +7.95% | 38.8 -> 35.7 ms (-8.2%) | 46/50 = | identical |
+| K2 | 47.73 | 59.66 | +25.00% | 49.0 -> 38.0 ms (-22.5%) | 60/72 = | identical |
+
+These two cells are the flag's cleanest end-to-end statement: bitwise
+token parity, identical acceptance, and +8/+25% wall speed from kernel time
+alone — at 8K no near-tie happens to sit on the trajectory, so the M2/M3
+association difference never surfaces in the tokens.
+
+### Method note: how the box fooled us, twice
+
+Two failure modes surfaced during verification and are now protocol here:
+
+1. Environmental contamination: sequential arm blocks measured 25+ minutes
+   apart, with a CPU-bound converter sharing the box, moved controls by
+   4-7% between windows — the same order as several claimed wins. Rule: no
+   end-to-end claim without same-window interleaved arms under the quiet
+   protocol (bootout + SIGSTOP + hog check + drift anchors).
+2. Harness self-deception: an in-process arm-toggle harness produced a
+   plausible-looking all-flat grid because the fused path silently never
+   engaged (verify-forward times identical to control to 0.0% was the tell;
+   dispatch counters confirmed). Rule: every arm must carry an engagement
+   signature (counter deltas or the mechanical verify/fwd drop), and a
+   too-clean null is a bug until proven otherwise.
+
+## Divergence: mechanism, measurement, and the acceptance ratchet
+
+The exact-M kernels are bit-identical to the padded tiles they replace at
+M4/M5/M6 (proven by construction and by token parity at K3/K4/K5 in every
+window). At M2/M3 the association differs from stock `qmv` (lane-strided
+8-value packs, split-K partials, factored-vs-per-element dequant), so
+low-order bits differ, and at greedy temperature a near-tie can fork.
+
+Measured at the actual forks (logit dumps at the first diverging verify
+call, stock and fused arms replayed to the same state):
+
+- 16K fork: stock's top-2 margin was 0.25 logits (`<|im_end|>` 20.625 vs
+  `\n\n` 20.375); fused swapped the same two candidates (19.0 vs 18.75). The
+  fused pick was stock's runner-up. 4K fork: same junction character, 2.0
+  margin crossed.
+- In the same verify forward, the non-fork row agreed within 0.25 logits
+  while the fork row reshuffled by ~4 — junction-local amplification of
+  sub-ULP per-layer noise through 64 layers, not kernel distortion. The
+  fp64 ladder bounds the per-call error at or below stock's own (0.8-3.2
+  vs 1.6-4.0 BF16 ULP), flat across a 1000x magnitude range.
+- Stock replay is bit-identical run-to-run (logit delta 0.0), and the BN2
+  and BN4 tile layouts are bit-identical to each other (the association is
+  layout-invariant): the fork is a deterministic property of the two valid
+  association classes, not nondeterminism.
+
+The acceptance ratchet explains why forked cells post outsized tok/s gains:
+the MTP draft's disagreements with the target concentrate at the target's
+near-ties, so target-side tie-flips convert prior draft-rejections into
+acceptances about half the time while rarely breaking prior agreements.
+Acceptance can only drift up under divergence. Measured: diverged cells
+jumped +7.4 to +9.3 acceptance points, the jump anti-correlated with base
+acceptance (92% base -> +1.9pt; 80-85% base -> +7-9pt); all parity cells
+moved 0.0pt. Forked-cell tok/s is therefore disclosed as workload throughput
+and the verify-forward time is reported alongside as the kernel-real metric.
+
+Forked texts were decoded and inspected in every diverged cell: both arms
+coherent and on-task, fused with equal-or-higher distinct-token ratio, no
+repetition degeneracy.
+
+### Bit-parity option (prototype)
+
+A stock-order variant of both kernels — reproducing stock `qmv_fast`'s
+association exactly (contiguous 16-value spans per lane in block order,
+factored qdot with the separate Sigma-x accumulator, one sequential fp32
+accumulator per output, single `simd_sum`, T-arithmetic quad sums) while
+still amortizing the weight read across the m verify rows — was prototyped
+and gate-tested:
+
+- Single-matrix QMM: **bit-exact vs `mx.quantized_matmul` at M2 and M3**
+  across all six live trunk shapes, three activation scales, `mx.array_equal`
+  — 36/36 checks in two independent runs. Kernel speed: +9-11% vs stock at
+  M2 (within 5-7% of the vk_k variant), +15-16% vs stock at M3 (vk_k keeps a
+  ~19-20% lead there — the register cost of stock's 16-value contiguous
+  spans at m rows is real).
+- M5-vs-stock-qmv mismatches at all scales: expected and moot — MLX
+  dispatches a different kernel family above M3/M4, and the turbo baseline
+  at M5 is the NAX padded route, against which the shipped exact-M5 kernel
+  is bitwise-identical (below).
+- Gate/up stock-order tile: bit-exact at M2 in the first build; the
+  register-restructured build regressed large-activation inputs (RMS ~2,
+  where gate pre-activations reach the measured 130 range) — defect known,
+  unresolved, so the tile half is prototype-only.
+
+Separately, the structural parity of the SHIPPED kernels against the turbo
+baseline was gate-tested with `mx.array_equal` on real shapes:
+
+- exact-M5 QMM vs NAX padded-M6: **bitwise equal (dmax 0.0)**.
+- fused MLP tile at M4 vs turbo vk_k pair + compiled swiglu: **bitwise
+  equal (dmax 0.0)**; same at M6.
+
+So K3/K4/K5 token parity is bit-parity **by construction**, and the flag's
+entire numerics delta versus the turbo baseline is confined to the M2/M3
+tiles. A follow-up could ship stock-order kernels for exactly those two
+row counts (QMM half proven today) and make the whole flag bit-identical
+to baseline at a quantified kernel-speed cost.
 
 ## Standalone fast sigmoid
 
 Fast sigmoid is deliberately separate and not bundled with row traversal. A
-Vec8 standalone SwiGLU keeps both projections on their stock paths (so it keeps
-the two intermediates) and changes only precise `metal::exp` to
+Vec8 standalone SwiGLU keeps both projections on their stock paths (so it
+keeps the two intermediates) and changes only precise `metal::exp` to
 `metal::fast::exp`. It is the counter-example to the fusion: it adds a launch
-that reads the intermediates instead of removing them, and it does not show a
-matched-cell win. It is exposed only for explicit A/B work behind
-`--experimental-qwen-fast-sigmoid` and remains default-off.
+that reads the intermediates instead of removing them.
+
+Measured end-to-end (4K, K0-K5, non-quiet window): deltas within noise
+(-3.0% to +3.2%), while introducing K1/K2 forks of its own (fast::exp is a
+different numerics class from the MLX `Sigmoid` op). No speed, new
+divergence: not worth pursuing. The flag stays available and default-off.
 
 ## Decisions
 
-Keep both paths experimental and default-off. The exact-tile fusion is the
-adopted design because it eliminates the gate/up intermediates, removes the
-zero-pad copy, and is no worse than the padded tile everywhere while recovering
-12-18% at the padded verify shapes. Context-dependent numerical differences from
-the changed FP32 reduction tree remain, so this is not proposed for any default
-profile.
+Keep both flags experimental and default-off. Row traversal ships as the
+fused exact-M MLP tile plus the exact-M2/M3/M5 QuantizedLinear routing under
+the one flag: the fusion eliminates the gate/up intermediates, and the
+routing removes the per-row weight re-reads that stock `qmv` pays at the
+depth-1/depth-2 verify tiles and the padded-M6 waste at depth 4. The
+established turbo numerics class (vk family, load-time self-validated)
+applies. Not proposed for any default profile: at the production serving
+depth (K3 turbo) the flag is ~0.5% negative from wrapper overhead; its wins
+live at K1/K2/K4. If a serving config ever moves to those depths, the
+stock-order bit-parity variant should be re-evaluated as the default
+numerics for the M2/M3 tiles (kernel-level tradeoff quantified above).

--- a/docs/specs/2026-07-17-qwen-experimental-row-traversal.md
+++ b/docs/specs/2026-07-17-qwen-experimental-row-traversal.md
@@ -1,0 +1,155 @@
+# Experimental Qwen Gate/Up Row-Traversal Fusion
+
+## Status
+
+Experimental and default-off. Based on public upstream `a391973` (`v2.1.0`).
+Two independent flags are added, both off by default and mutually exclusive:
+
+- `--experimental-qwen-row-traversal`
+- `--experimental-qwen-fast-sigmoid`
+
+Neither changes any default profile.
+
+## What it does
+
+Qwen3-Next's dense MLP runs `down_proj(swiglu(gate_proj(x), up_proj(x)))`. On
+the speculative-verify path the stock activation launches two separate Q4
+projection kernels and a third SwiGLU kernel, materializing the full `gate` and
+`up` projections as BF16 intermediates between launches.
+
+The row-traversal flag fuses `gate_proj + up_proj + precise SwiGLU` into one
+Metal kernel built on the existing small-M split-K (`vk_k`) ownership. One
+output tile is owned by one threadgroup, which reads the two original Q4 arrays,
+reduces both projections through the same fixed split-K tree in FP32 registers,
+applies precise SwiGLU at the projection boundary, and writes only the activated
+tile. `down_proj` stays on its existing path.
+
+The point of the fusion is to keep the whole gate/up + SwiGLU chain in registers
+and threadgroup memory so the two BF16 projection intermediates are never
+materialized. There is no packed weight copy and no peak-memory increase.
+
+## Design
+
+- Reads the original gate/up Q4 arrays directly; no packed duplicate.
+- Output-tile-major traversal with BN=2 and two fixed K parts.
+- Compiles one kernel per exact verify tile (M2-M6). Owning the true row count
+  keeps every live row's reduction in its own FP32 accumulator and removes the
+  zero-padded activation copy a fixed M4/M6 tile would otherwise materialize on
+  every call. Because each output row reduces over an independent accumulator,
+  the live rows are bit-identical whether or not the tile is padded.
+- Keeps the current Q4 storage, BF16/FP16 activation/output types, and FP32
+  products and accumulators.
+- Falls back to the stock path outside the narrow Q4 affine M2-M6 eligibility
+  contract (autoregressive M1 / K0 always runs stock).
+
+BN=4 was measured slower than the two-call path: carrying both projections at
+BN=4 needs 32 FP32 accumulators per thread, over the register ceiling. BN=2
+stays at 16 accumulators for the M4 tile and 24 for M6, at the ceiling, and
+restores occupancy while retaining one dispatch.
+
+## Numerical contract
+
+The fusion does not reduce dtype precision: Q4 storage, BF16/FP16 projection
+boundaries, and FP32 accumulation are unchanged. It does change the FP32
+addition tree relative to the two stock projection kernels. Floating-point
+addition is non-associative, so regrouping the same FP32 products can change
+low-order bits even though precision is unchanged. "Same precision" therefore
+does not promise bitwise identity with stock.
+
+In practice most verify cells stay bit-parity with stock. In a few cells a
+low-order rounding difference crosses a greedy decision boundary and changes the
+downstream accepted/drafted workload; those cells are reported for completeness
+and not credited as isolated kernel speedups.
+
+The exact-tile change is numerically inert: it only removes the zero-pad, so its
+output is bit-identical to the padded tile on the live rows, and it does not move
+any cell across the parity boundary.
+
+## Isolated kernel microbench (queued lane)
+
+Real dense-MLP shape K=5120, N=17408, Q4 affine group_size=64. Median per-call
+microseconds on the queued lane (fill the command buffer with independent calls,
+single synchronize). `stock` is two Q4 projections + SwiGLU; `padded` is the
+fixed-M4/M6 tile with the zero-pad copy; `exact` is the per-tile kernel.
+
+| verify tile | K | stock us | padded us | exact us | exact vs padded | exact vs stock |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| M2 | 1 | 151.74 | 191.48 | 156.35 | +18.34% | -3.04% |
+| M3 | 2 | 223.45 | 210.59 | 184.68 | +12.30% | +17.35% |
+| M4 | 3 | 360.87 | 241.75 | 241.97 | -0.09% | +32.95% |
+| M5 | 4 | 473.99 | 316.66 | 268.07 | +15.35% | +43.44% |
+| M6 | 5 | 582.60 | 348.93 | 337.16 | +3.37% | +42.13% |
+
+Removing the zero-pad recovers 12-18% of kernel time at the padded tiles
+(M2/M3/M5). M4 and M6 are never padded, so exact and padded coincide within
+measurement noise, which doubles as a harness sanity check. Against stock, the
+fused kernel is faster everywhere except M2, where the two stock projections are
+already cheap.
+
+## End-to-end K0-K5 x 4K/8K/16K matrix
+
+Control (stock) and the exact-tile candidate were measured back to back in one
+exclusive GPU window (turbo profile, greedy, seed 51, 96 generated tokens, three
+repeats after one warmup per cell), on public upstream `a391973`.
+
+| context | K | control tok/s | exact-M tok/s | delta | verify delta | accepted/drafted (control -> exact-M) | token parity |
+| ---: | ---: | ---: | ---: | ---: | ---: | :--- | :---: |
+| 4096 | 0 | 29.486 | 29.317 | -0.57% | +0.58% | 0/0 -> 0/0 | yes (stock fallback) |
+| 4096 | 1 | 45.665 | 49.182 | +7.70% | -7.61% | 46/50 -> 46/49 | no |
+| 4096 | 2 | 47.470 | 56.465 | +18.95% | -17.34% | 59/72 -> 61/68 | no |
+| 4096 | 3 | 72.002 | 71.958 | -0.06% | -0.31% | 69/80 -> 69/80 | yes |
+| 4096 | 4 | 65.570 | 68.053 | +3.79% | -4.61% | 73/91 -> 73/91 | yes |
+| 4096 | 5 | 71.371 | 71.536 | +0.23% | -0.31% | 76/98 -> 76/98 | yes |
+| 8192 | 0 | 29.174 | 29.106 | -0.23% | +0.26% | 0/0 -> 0/0 | yes (stock fallback) |
+| 8192 | 1 | 44.376 | 46.777 | +5.41% | -5.66% | 46/50 -> 46/50 | yes |
+| 8192 | 2 | 46.332 | 51.397 | +10.93% | -11.25% | 60/72 -> 60/72 | yes |
+| 8192 | 3 | 64.552 | 64.002 | -0.85% | +0.54% | 67/87 -> 67/87 | yes |
+| 8192 | 4 | 44.862 | 46.389 | +3.40% | -4.45% | 65/123 -> 65/123 | yes |
+| 8192 | 5 | 59.933 | 59.901 | -0.05% | +0.09% | 74/107 -> 74/107 | yes |
+| 16384 | 0 | 28.077 | 27.873 | -0.73% | +0.76% | 0/0 -> 0/0 | yes (stock fallback) |
+| 16384 | 1 | 40.394 | 45.067 | +11.57% | -10.79% | 44/52 -> 46/49 | no |
+| 16384 | 2 | 42.096 | 49.315 | +17.15% | -15.95% | 59/74 -> 61/70 | no |
+| 16384 | 3 | 61.790 | 61.415 | -0.61% | +0.62% | 67/84 -> 67/84 | yes |
+| 16384 | 4 | 54.783 | 56.325 | +2.81% | -3.47% | 72/94 -> 72/94 | yes |
+| 16384 | 5 | 54.325 | 53.679 | -1.19% | +1.33% | 74/105 -> 74/105 | yes |
+
+Every exact-M cell produced tokens bit-identical to the prior padded fused run
+(18/18), confirming the exact-tile change is numerically inert and that the
+fused kernel engaged rather than silently falling back to stock.
+
+K0 is a stock-fallback control (the fusion applies only to M2-M6); its small
+deltas are run noise. Among the affected cells with identical tokens and
+acceptance, the padded verify shapes where the zero-pad was removed improve
+clearly: K1/8K went from -0.95% in the prior padded run to +5.41% here, K2/8K is
++10.93%, and K4 is +2.8 to +3.8% across contexts. The direct M4/M6 shapes (K3,
+K5) land flat within +/-1.2%. The isolated microbench shows the fused kernel is
+30-42% faster than stock at those shapes, but the MLP is a small fraction of
+per-token time -- especially at 8K/16K where attention over the KV cache
+dominates -- so the kernel win dilutes to noise at the token level. No parity
+cell regresses beyond run-to-run noise, and the exact-tile change removed the
+only regression the padded path had shown (K1/8K), so no shape is scoped out.
+
+The four non-parity cells are K1/K2 at 4K and 16K. Each arm is deterministic,
+but the changed FP32 reduction tree moved a low-order value across a greedy
+decision boundary and changed the downstream acceptance workload, so their
+throughput deltas are reported for completeness, not credited as isolated kernel
+speedups.
+
+## Standalone fast sigmoid
+
+Fast sigmoid is deliberately separate and not bundled with row traversal. A
+Vec8 standalone SwiGLU keeps both projections on their stock paths (so it keeps
+the two intermediates) and changes only precise `metal::exp` to
+`metal::fast::exp`. It is the counter-example to the fusion: it adds a launch
+that reads the intermediates instead of removing them, and it does not show a
+matched-cell win. It is exposed only for explicit A/B work behind
+`--experimental-qwen-fast-sigmoid` and remains default-off.
+
+## Decisions
+
+Keep both paths experimental and default-off. The exact-tile fusion is the
+adopted design because it eliminates the gate/up intermediates, removes the
+zero-pad copy, and is no worse than the padded tile everywhere while recovering
+12-18% at the padded verify shapes. Context-dependent numerical differences from
+the changed FP32 reduction tree remain, so this is not proposed for any default
+profile.

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -655,6 +655,28 @@ def _add_batching_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_qwen_experimental_kernel_args(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--experimental-qwen-row-traversal",
+        action="store_true",
+        help=(
+            "Experimental Qwen dense-MLP gate/up traversal: fuse the original "
+            "Q4 arrays in output-tile order and apply precise SwiGLU in-kernel. "
+            "Default off; preserves dtypes but changes the FP32 reduction tree."
+        ),
+    )
+    group.add_argument(
+        "--experimental-qwen-fast-sigmoid",
+        action="store_true",
+        help=(
+            "Experimental standalone Qwen SwiGLU fast-sigmoid A/B. Default "
+            "off; keeps stock projections but uses approximate fast exp and "
+            "must be benchmarked separately from row traversal."
+        ),
+    )
+
+
 def _add_ssd_session_cache_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--ssd-session-cache",
@@ -1926,6 +1948,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_PROFILE_NAME,
         help="Runtime profile; start defaults to Sustained. Use --profile turbo for the verify-kernel fast path (4/8-bit affine), or --profile performance-cold --max for Burst.",
     )
+    _add_qwen_experimental_kernel_args(start_flow_p)
     start_flow_p.add_argument("--download", action="store_true", help="Download the selected/default model if it is missing")
     start_flow_p.add_argument("--yes", action="store_true", help="Use defaults without interactive model prompts")
     start_flow_p.add_argument("--unsafe-force-unverified", action="store_true")
@@ -2108,6 +2131,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_PROFILE_NAME,
         help="Runtime profile. Direct server quickstart defaults to Sustained; use --profile performance-cold --max for Burst.",
     )
+    _add_qwen_experimental_kernel_args(quickstart_server_p)
     quickstart_server_p.add_argument("--unsafe-force-unverified", action="store_true")
     quickstart_server_p.add_argument("--yes", action="store_true", help="Confirm unsafe non-interactive actions")
     quickstart_server_p.add_argument("--host", default="127.0.0.1")
@@ -2557,6 +2581,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Committed-token batch size per chat SSE chunk.",
     )
     _add_batching_args(serve_p)
+    _add_qwen_experimental_kernel_args(serve_p)
     _add_ssd_session_cache_args(serve_p)
     _add_paged_kv_quant_args(serve_p)
     _add_adaptive_args(serve_p)

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -8176,6 +8176,10 @@ def cmd_serve_public(args: Any) -> int:
         )
     if bool(getattr(args, "experimental_mtp_cohorts", False)):
         cmd.append("--experimental-mtp-cohorts")
+    if bool(getattr(args, "experimental_qwen_row_traversal", False)):
+        cmd.append("--experimental-qwen-row-traversal")
+    if bool(getattr(args, "experimental_qwen_fast_sigmoid", False)):
+        cmd.append("--experimental-qwen-fast-sigmoid")
     ssd_session_cache = str(getattr(args, "ssd_session_cache", "on") or "on")
     cmd.extend(["--ssd-session-cache", ssd_session_cache])
     ssd_dir = getattr(args, "ssd_session_cache_dir", None)
@@ -11023,6 +11027,8 @@ def _with_server_policy_args(target: Any, source: Any) -> Any:
         ("adaptive_ev_min_extra_accept_probability", 0.18),
         ("adaptive_ev_warmup_full_depth_cycles", 4),
         ("adaptive_ev_exploration_interval", 32),
+        ("experimental_qwen_row_traversal", False),
+        ("experimental_qwen_fast_sigmoid", False),
     ):
         setattr(target, attr, getattr(source, attr, default))
     return target

--- a/mtplx/kernel_selfcheck.py
+++ b/mtplx/kernel_selfcheck.py
@@ -69,7 +69,11 @@ def selfcheck_enabled() -> bool:
         return False
     if raw in {"1", "true", "on", "yes"}:
         return True
-    return _env_on("MTPLX_NAX_VERIFY") or _env_on("MTPLX_GQA_PACKED_SDPA")
+    if _env_on("MTPLX_NAX_VERIFY") or _env_on("MTPLX_GQA_PACKED_SDPA"):
+        return True
+    from .qwen_row_traversal import qwen_row_traversal_qlinear_enabled
+
+    return _qwen_rt_mlp_variant_active() or qwen_row_traversal_qlinear_enabled()
 
 
 def lane_disabled(lane: str) -> bool:
@@ -165,6 +169,48 @@ def _check_gqa_packed(mx, dtype) -> float:
         mask=mask,
     )
     return _max_abs_diff(mx, out, ref)
+
+
+def _qwen_rt_mlp_variant_active() -> bool:
+    variant = os.environ.get("MTPLX_MLP_CALL_VARIANT", "").strip().lower()
+    return variant.replace("-", "_") in {
+        "fused_gateup_vk_k",
+        "fused_gateup_vkk",
+        "fused_gateup_vk_k_bn2",
+    }
+
+
+def _check_qwen_rt_gateup_lane(mx, group_size: int, dtype) -> float:
+    """Fused gate/up+SwiGLU tile vs the stock two-projection reference.
+
+    Uses the widest verify tile (M6) at an eligible shape (N >= 4096); the
+    per-row accumulators are independent, so one tile validates the family.
+    """
+    import mlx.nn as nn
+
+    from .kernels.qwen_verify_mlp_fused_k import qwen_gate_up_swiglu_vk_k
+
+    k, n = _K, 4096
+    mx.random.seed(7)
+    gate = nn.QuantizedLinear(k, n, bias=False, group_size=group_size, bits=4)
+    up = nn.QuantizedLinear(k, n, bias=False, group_size=group_size, bits=4)
+    gate.scales = gate.scales.astype(dtype)
+    gate.biases = gate.biases.astype(dtype)
+    up.scales = up.scales.astype(dtype)
+    up.biases = up.biases.astype(dtype)
+    x = (mx.random.normal((6, k), dtype=mx.float32) * 0.5).astype(dtype)
+    candidate = qwen_gate_up_swiglu_vk_k(x, gate, up, tile_cols=2)
+    gate_ref = _qmm_reference(
+        mx, x, gate.weight, gate.scales, gate.biases, bits=4, group_size=group_size
+    )
+    up_ref = _qmm_reference(
+        mx, x, up.weight, up.scales, up.biases, bits=4, group_size=group_size
+    )
+    gate_f = gate_ref.astype(mx.float32)
+    reference = gate_f * mx.sigmoid(gate_f) * up_ref.astype(mx.float32)
+    if tuple(candidate.shape) != tuple(reference.shape):
+        return float("inf")
+    return _max_abs_diff(mx, candidate, reference)
 
 
 def _check_fused_add_rmsnorm(mx, dtype) -> float:
@@ -387,6 +433,44 @@ def run_kernel_selfcheck(dtype, bits: int, group_size: int) -> dict[str, Any]:
     lanes["qmm_m8_ksplit"] = _STATUS_SKIPPED
     # lm_head_topk kernels exist but are not routed on the serve path.
     lanes["lm_head_topk"] = _STATUS_SKIPPED
+
+    # Experimental Qwen row-traversal lanes (default off): exact-M2/M3/M5
+    # QuantizedLinear routing and the fused gate/up+SwiGLU MLP tile. Same
+    # vk-family ULP band and same disable-on-mismatch contract as the NAX
+    # lanes above.
+    from .qwen_row_traversal import (
+        qwen_qmm_exact_m,
+        qwen_row_traversal_qlinear_enabled,
+    )
+
+    if qwen_row_traversal_qlinear_enabled() and bits == 4:
+        for rows in (2, 3, 5):
+            _record(
+                f"qwen_rt_qmm_m{rows}",
+                _QMM_TOLERANCE,
+                lambda rows=rows: _check_qmm_lane(
+                    mx,
+                    lambda x, w, s, b: qwen_qmm_exact_m(
+                        x, w, s, b, group_size=group_size
+                    ),
+                    rows,
+                    4,
+                    group_size,
+                    dtype,
+                ),
+            )
+    else:
+        for rows in (2, 3, 5):
+            lanes[f"qwen_rt_qmm_m{rows}"] = _STATUS_SKIPPED
+
+    if _qwen_rt_mlp_variant_active() and bits == 4:
+        _record(
+            "qwen_rt_gateup",
+            _QMM_TOLERANCE,
+            lambda: _check_qwen_rt_gateup_lane(mx, group_size, dtype),
+        )
+    else:
+        lanes["qwen_rt_gateup"] = _STATUS_SKIPPED
 
     if _env_on("MTPLX_GQA_PACKED_SDPA"):
         _record("gqa_packed_sdpa", _SDPA_TOLERANCE, lambda: _check_gqa_packed(mx, dtype))

--- a/mtplx/kernels/qwen_fast_sigmoid.py
+++ b/mtplx/kernels/qwen_fast_sigmoid.py
@@ -1,0 +1,84 @@
+"""Standalone precise/fast Qwen SwiGLU kernels for experimental A/Bs."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import mlx.core as mx
+
+
+def _qwen_swiglu_source(*, fast: bool) -> str:
+    exp_call = "metal::fast::exp" if fast else "metal::exp"
+    return f"""
+        using namespace metal;
+
+        uint vec_idx = thread_position_in_grid.x;
+        int vec_count = int(size) / 8;
+        if (int(vec_idx) >= vec_count) {{
+            return;
+        }}
+
+        using Vec8 = vec<T, 8>;
+        const device Vec8 *gate_v = (const device Vec8*)gate;
+        const device Vec8 *up_v = (const device Vec8*)up;
+        device Vec8 *out_v = (device Vec8*)out;
+        Vec8 gate_values = gate_v[vec_idx];
+        Vec8 up_values = up_v[vec_idx];
+        Vec8 result;
+        _Pragma("unroll")
+        for (int i = 0; i < 8; ++i) {{
+            T gate_value = gate_values[i];
+            T up_value = up_values[i];
+            auto sigmoid_tail = 1 / (
+                1 + {exp_call}(metal::abs(gate_value))
+            );
+            T sigmoid_value = (gate_value < T(0))
+                ? T(sigmoid_tail)
+                : T(1 - sigmoid_tail);
+            result[i] = T((gate_value * sigmoid_value) * up_value);
+        }}
+        out_v[vec_idx] = result;
+    """
+
+
+@lru_cache(maxsize=None)
+def _qwen_swiglu_kernel(dtype: mx.Dtype, fast: bool):
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    mode = "fast" if fast else "precise"
+    return mx.fast.metal_kernel(
+        name=f"mtplx_qwen_swiglu_vec8_{mode}_{dtype_tag}",
+        input_names=["gate", "up", "size"],
+        output_names=["out"],
+        source=_qwen_swiglu_source(fast=fast),
+    )
+
+
+def qwen_swiglu(gate: mx.array, up: mx.array, *, fast: bool) -> mx.array:
+    """Apply standalone Qwen SwiGLU, falling back when Vec8 is ineligible."""
+    from mlx_lm.models.qwen3_next import swiglu
+
+    if (
+        not mx.metal.is_available()
+        or gate.dtype not in (mx.bfloat16, mx.float16)
+        or gate.dtype != up.dtype
+        or tuple(gate.shape) != tuple(up.shape)
+    ):
+        return swiglu(gate, up)
+    size = int(gate.size)
+    if size <= 0 or size % 8:
+        return swiglu(gate, up)
+
+    gate_c = mx.contiguous(gate)
+    up_c = mx.contiguous(up)
+    kernel = _qwen_swiglu_kernel(gate.dtype, bool(fast))
+    vectors = size // 8
+    threads = ((vectors + 255) // 256) * 256
+    (out,) = kernel(
+        inputs=[gate_c, up_c, size],
+        template=[("T", gate.dtype)],
+        grid=(threads, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[tuple(gate.shape)],
+        output_dtypes=[gate.dtype],
+    )
+    return out

--- a/mtplx/kernels/qwen_verify_mlp_fused_k.py
+++ b/mtplx/kernels/qwen_verify_mlp_fused_k.py
@@ -1,0 +1,308 @@
+"""Experimental no-copy Qwen small-M gate/up fusion on ``vk_k`` geometry.
+
+The default runtime remains unchanged.  When explicitly selected, this keeps
+the two original Q4 affine weight arrays and the two-way split-K ownership used
+by the current Qwen verifier, compiling one kernel per exact verify tile
+(M2-M6).  Owning the true row count keeps the whole gate/up + SwiGLU chain in
+registers and threadgroup memory, so no zero-padded activation copy is
+materialized on any call.  The only fused boundary is gate projection + up
+projection + precise SwiGLU; down projection remains on the existing path.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _fused_q4_pack_block(m: int, suffix: str, tile_cols: int) -> str:
+    """Emit one shared-x Q4 pack for the gate and up projections."""
+    pack = f"pack{suffix}"
+    lines = [
+        f"int k_base{suffix} = {pack} * 8;",
+        f"int gi{suffix} = k_base{suffix} / GS;",
+    ]
+    for row in range(m):
+        lines.append(f"Vec8 v{suffix}_{row} = xv[({row} * K + k_base{suffix}) / 8];")
+    for col in range(tile_cols):
+        lines.extend(
+            [
+                f"uint32_t gate_p{suffix}_{col} = "
+                f"gate_w_q[(n0 + {col}) * K_by_p + {pack}];",
+                f"uint32_t up_p{suffix}_{col} = "
+                f"up_w_q[(n0 + {col}) * K_by_p + {pack}];",
+                f"float gate_s{suffix}_{col} = float("
+                f"gate_scales[(n0 + {col}) * K_by_gs + gi{suffix}]);",
+                f"float gate_b{suffix}_{col} = float("
+                f"gate_biases[(n0 + {col}) * K_by_gs + gi{suffix}]);",
+                f"float up_s{suffix}_{col} = float("
+                f"up_scales[(n0 + {col}) * K_by_gs + gi{suffix}]);",
+                f"float up_b{suffix}_{col} = float("
+                f"up_biases[(n0 + {col}) * K_by_gs + gi{suffix}]);",
+            ]
+        )
+    for col in range(tile_cols):
+        lines.extend(
+            [
+                "{",
+                f"    uint32_t gate_packed = gate_p{suffix}_{col};",
+                f"    uint32_t up_packed = up_p{suffix}_{col};",
+                f"    float gate_scale = gate_s{suffix}_{col};",
+                f"    float gate_bias = gate_b{suffix}_{col};",
+                f"    float up_scale = up_s{suffix}_{col};",
+                f"    float up_bias = up_b{suffix}_{col};",
+                '    _Pragma("unroll")',
+                "    for (int ki = 0; ki < 8; ++ki) {",
+                "        float gate_w = "
+                "float((gate_packed >> (ki * 4)) & 0xFu) * gate_scale + gate_bias;",
+                "        float up_w = "
+                "float((up_packed >> (ki * 4)) & 0xFu) * up_scale + up_bias;",
+            ]
+        )
+        for row in range(m):
+            acc_idx = col * m + row
+            lines.append(f"        float x_value_{row} = float(v{suffix}_{row}[ki]);")
+            lines.append(f"        gate_acc[{acc_idx}] += x_value_{row} * gate_w;")
+            lines.append(f"        up_acc[{acc_idx}] += x_value_{row} * up_w;")
+        lines.extend(["    }", "}"])
+    return "\n            ".join(lines)
+
+
+def _fused_gate_up_q4_ksplit_source(
+    *,
+    m: int,
+    group_size: int,
+    k_parts: int,
+    kconst: int,
+    tile_cols: int = 4,
+) -> str:
+    """Return the Metal body so source-shape invariants stay testable."""
+    if m not in {2, 3, 4, 5, 6}:
+        raise ValueError("the Qwen fusion supports M2-M6 compute tiles")
+    if group_size not in {32, 64, 128}:
+        raise ValueError("unsupported group size")
+    if k_parts != 2:
+        raise ValueError("the Qwen gate/up prototype requires two K parts")
+    if tile_cols not in {2, 4}:
+        raise ValueError("the Qwen gate/up prototype supports BN=2 or BN=4")
+    if kconst <= 0 or kconst % 64:
+        raise ValueError("K must be a positive multiple of 64")
+
+    n_acc = tile_cols * m
+    pack_block = _fused_q4_pack_block(m, "A", tile_cols)
+    return f"""
+        using namespace metal;
+        constexpr int GS = {group_size};
+        constexpr int K_PARTS = {k_parts};
+        constexpr int K = {kconst};
+        constexpr int K_by_p = K / 8;
+        constexpr int K_by_gs = K / GS;
+        constexpr int per_part = K_by_p / K_PARTS;
+
+        uint part = simdgroup_index_in_threadgroup;
+        uint lane = thread_index_in_simdgroup;
+        uint tg_n = threadgroup_position_in_grid.y;
+
+        int N = int(N_size);
+        int n0 = int(tg_n) * {tile_cols};
+        int p_start = int(part) * per_part;
+        int p_end = (int(part) == K_PARTS - 1) ? K_by_p : p_start + per_part;
+
+        float gate_acc[{n_acc}];
+        float up_acc[{n_acc}];
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            gate_acc[i] = 0.0f;
+            up_acc[i] = 0.0f;
+        }}
+
+        using Vec8 = vec<T, 8>;
+        const device Vec8 *xv = (const device Vec8*)x;
+
+        for (int packA = p_start + int(lane); packA < p_end; packA += 32) {{
+            {pack_block}
+        }}
+
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            gate_acc[i] = simd_sum(gate_acc[i]);
+            up_acc[i] = simd_sum(up_acc[i]);
+        }}
+
+        threadgroup float gate_partials[K_PARTS * {n_acc}];
+        threadgroup float up_partials[K_PARTS * {n_acc}];
+        if (lane == 0) {{
+            _Pragma("unroll")
+            for (int i = 0; i < {n_acc}; ++i) {{
+                gate_partials[int(part) * {n_acc} + i] = gate_acc[i];
+                up_partials[int(part) * {n_acc} + i] = up_acc[i];
+            }}
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (part == 0 && lane < {n_acc}) {{
+            float gate_total = 0.0f;
+            float up_total = 0.0f;
+            _Pragma("unroll")
+            for (int p = 0; p < K_PARTS; ++p) {{
+                gate_total += gate_partials[p * {n_acc} + int(lane)];
+                up_total += up_partials[p * {n_acc} + int(lane)];
+            }}
+            int j = int(lane) / {m};
+            int row = int(lane) - j * {m};
+            T gate_value = T(gate_total);
+            T up_value = T(up_total);
+            auto sigmoid_tail = 1 / (1 + metal::exp(metal::abs(gate_value)));
+            T sigmoid_value = (gate_value < T(0))
+                ? T(sigmoid_tail)
+                : T(1 - sigmoid_tail);
+            y[row * N + n0 + j] = T((gate_value * sigmoid_value) * up_value);
+        }}
+    """
+
+
+@lru_cache(maxsize=None)
+def _fused_gate_up_q4_ksplit_kernel(
+    m: int,
+    group_size: int,
+    dtype: mx.Dtype,
+    kconst: int,
+    tile_cols: int,
+):
+    source = _fused_gate_up_q4_ksplit_source(
+        m=m,
+        group_size=group_size,
+        k_parts=2,
+        kconst=kconst,
+        tile_cols=tile_cols,
+    )
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    return mx.fast.metal_kernel(
+        name=(
+            f"mtplx_qwen_gateup_vk_k_m{m}_bn{tile_cols}_q4_k{kconst}"
+            f"_gs{group_size}_{dtype_tag}"
+        ),
+        input_names=[
+            "x",
+            "gate_w_q",
+            "gate_scales",
+            "gate_biases",
+            "up_w_q",
+            "up_scales",
+            "up_biases",
+            "N_size",
+        ],
+        output_names=["y"],
+        source=source,
+    )
+
+
+def is_qwen_gate_up_swiglu_vk_k_eligible(
+    x: mx.array,
+    gate_module: Any,
+    up_module: Any,
+) -> bool:
+    """Return whether the internal M2-M6 Qwen fusion can run."""
+    if not mx.metal.is_available():
+        return False
+    if not isinstance(gate_module, nn.QuantizedLinear) or not isinstance(
+        up_module, nn.QuantizedLinear
+    ):
+        return False
+    if x.dtype not in (mx.bfloat16, mx.float16) or len(x.shape) < 2:
+        return False
+    if not 2 <= int(x.shape[-2]) <= 6:
+        return False
+    if any(
+        int(getattr(module, "bits", 0) or 0) != 4 for module in (gate_module, up_module)
+    ):
+        return False
+    group_size = int(getattr(gate_module, "group_size", 0) or 0)
+    if group_size not in {32, 64, 128} or group_size != int(
+        getattr(up_module, "group_size", 0) or 0
+    ):
+        return False
+    if any(
+        str(getattr(module, "mode", "affine")) != "affine"
+        for module in (gate_module, up_module)
+    ):
+        return False
+    if any("bias" in module for module in (gate_module, up_module)):
+        return False
+    if tuple(gate_module.weight.shape) != tuple(up_module.weight.shape):
+        return False
+    if tuple(gate_module.scales.shape) != tuple(up_module.scales.shape):
+        return False
+    if tuple(gate_module.biases.shape) != tuple(up_module.biases.shape):
+        return False
+    if any(
+        module.scales.dtype != x.dtype or module.biases.dtype != x.dtype
+        for module in (gate_module, up_module)
+    ):
+        return False
+
+    k = int(x.shape[-1])
+    n = int(gate_module.weight.shape[0])
+    if k != int(gate_module.weight.shape[1]) * 8:
+        return False
+    if k % 64 or n < 4096 or n % 4:
+        return False
+    batch_count = 1
+    for dim in x.shape[:-2]:
+        batch_count *= int(dim)
+    return batch_count == 1
+
+
+def qwen_gate_up_swiglu_vk_k(
+    x: mx.array,
+    gate_module: nn.QuantizedLinear,
+    up_module: nn.QuantizedLinear,
+    *,
+    tile_cols: int = 4,
+) -> mx.array:
+    """Compute Qwen gate/up + SwiGLU with the internal small-M prototype."""
+    from mlx_lm.models.qwen3_next import swiglu
+
+    if not is_qwen_gate_up_swiglu_vk_k_eligible(x, gate_module, up_module):
+        return swiglu(gate_module(x), up_module(x))
+    if tile_cols not in {2, 4}:
+        return swiglu(gate_module(x), up_module(x))
+
+    leading = x.shape[:-2]
+    m = int(x.shape[-2])
+    k = int(x.shape[-1])
+    n = int(gate_module.weight.shape[0])
+    # Compile one kernel per exact verify tile (M2-M6).  Owning the true row
+    # count keeps the gate/up + SwiGLU chain in registers and removes the
+    # zero-padded activation copy a fixed M4/M6 tile would materialize on every
+    # call.  Each output row reduces over an independent accumulator, so the
+    # live rows stay bit-identical to the padded tile.
+    x2 = mx.contiguous(x.reshape(m, k))
+    kernel = _fused_gate_up_q4_ksplit_kernel(
+        m,
+        int(gate_module.group_size),
+        x.dtype,
+        k,
+        tile_cols,
+    )
+    (y,) = kernel(
+        inputs=[
+            x2,
+            gate_module.weight,
+            gate_module.scales,
+            gate_module.biases,
+            up_module.weight,
+            up_module.scales,
+            up_module.biases,
+            n,
+        ],
+        template=[("T", x.dtype)],
+        grid=(64, n // tile_cols, 1),
+        threadgroup=(64, 1, 1),
+        output_shapes=[(m, n)],
+        output_dtypes=[x.dtype],
+    )
+    return y.reshape(*leading, m, n)

--- a/mtplx/native_mlp.py
+++ b/mtplx/native_mlp.py
@@ -227,8 +227,11 @@ def configure_native_mlp(model: Any | None = None) -> dict[str, int | bool | str
             return self.down_proj(act)
 
         if variant in {"fused_gateup_vk_k", "fused_gateup_vk_k_bn2"}:
+            from .kernel_selfcheck import lane_disabled
             from .kernels.qwen_verify_mlp_fused_k import qwen_gate_up_swiglu_vk_k
 
+            if lane_disabled("qwen_rt_gateup"):
+                return _fallback(self, x)
             act = qwen_gate_up_swiglu_vk_k(
                 x,
                 self.gate_proj,

--- a/mtplx/native_mlp.py
+++ b/mtplx/native_mlp.py
@@ -89,6 +89,10 @@ def _normalized_variant() -> str:
         "tiled_gateup": "tiled_gateup",
         "rowwise_sg4": "rowwise_sg4",
         "split_gateup": "split_gateup",
+        "fused_gateup_vk_k": "fused_gateup_vk_k",
+        "fused_gateup_vkk": "fused_gateup_vk_k",
+        "fused_gateup_vk_k_bn2": "fused_gateup_vk_k_bn2",
+        "fast_sigmoid": "fast_sigmoid",
         "native_rowwise": "native_rowwise",
         "native_full_rowwise": "native_full_rowwise",
     }
@@ -218,6 +222,29 @@ def configure_native_mlp(model: Any | None = None) -> dict[str, int | bool | str
                 x,
                 self.gate_proj,
                 self.up_proj,
+            )
+            _STATS["variant_calls"] = int(_STATS["variant_calls"]) + 1
+            return self.down_proj(act)
+
+        if variant in {"fused_gateup_vk_k", "fused_gateup_vk_k_bn2"}:
+            from .kernels.qwen_verify_mlp_fused_k import qwen_gate_up_swiglu_vk_k
+
+            act = qwen_gate_up_swiglu_vk_k(
+                x,
+                self.gate_proj,
+                self.up_proj,
+                tile_cols=2 if variant.endswith("_bn2") else 4,
+            )
+            _STATS["variant_calls"] = int(_STATS["variant_calls"]) + 1
+            return self.down_proj(act)
+
+        if variant == "fast_sigmoid":
+            from .kernels.qwen_fast_sigmoid import qwen_swiglu
+
+            act = qwen_swiglu(
+                self.gate_proj(x),
+                self.up_proj(x),
+                fast=True,
             )
             _STATS["variant_calls"] = int(_STATS["variant_calls"]) + 1
             return self.down_proj(act)

--- a/mtplx/qwen_row_traversal.py
+++ b/mtplx/qwen_row_traversal.py
@@ -1,0 +1,202 @@
+"""Experimental exact-M verify QuantizedLinear routing (Qwen row traversal).
+
+The turbo NAX verify patch routes 4-bit ``QuantizedLinear`` calls with M in
+4..16 through the MTPLX verify kernels, but the M2/M3 speculative verify tiles
+(depths 1-2) stay on stock MLX ``qmv``, which re-reads the full weight matrix
+once per live row, and M5 (depth 4) runs zero-padded into the M6 tile.
+
+When the experimental Qwen row-traversal variant is active this module wraps
+``QuantizedLinear.__call__`` once more and routes eligible non-prefill
+M in {2, 3, 5} calls through the proven vk_k split-K codegen
+(:func:`mtplx.verify_kernels._build_ksplit_kernel`) compiled at the true row
+count: one weight read for all rows and no zero-padded activation copy.
+
+Default off.  Enabled implicitly by ``--experimental-qwen-row-traversal``
+(the ``fused_gateup_vk_k*`` MLP variants) and explicitly overridable either
+way with ``MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR``.  Numerics are the established
+turbo vk-family class (fp32 accumulate, lane-strided reduction; not bit-exact
+vs stock), and every lane self-validates at model load through
+``kernel_selfcheck`` exactly like the shipped NAX lanes.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import mlx.core as mx
+
+_EXACT_M_ROWS = (2, 3, 5)
+
+_PATCH: dict[str, Any] = {"installed": False, "original": None}
+
+_STATS = {
+    "enabled": False,
+    "installed": False,
+    "calls_m2": 0,
+    "calls_m3": 0,
+    "calls_m5": 0,
+    "fallback_calls": 0,
+}
+
+
+def _fused_variant_active() -> bool:
+    variant = os.environ.get("MTPLX_MLP_CALL_VARIANT", "").strip().lower()
+    return variant.replace("-", "_") in {
+        "fused_gateup_vk_k",
+        "fused_gateup_vkk",
+        "fused_gateup_vk_k_bn2",
+    }
+
+
+def qwen_row_traversal_qlinear_enabled() -> bool:
+    """Explicit env wins; otherwise follow the row-traversal MLP variant."""
+    raw = os.environ.get("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "").strip().lower()
+    if raw in {"0", "false", "off", "no"}:
+        return False
+    if raw in {"1", "true", "on", "yes"}:
+        return True
+    return _fused_variant_active()
+
+
+def qwen_exact_m_eligible(
+    m: int, k: int, n: int, bits: int, group_size: int, dtype
+) -> bool:
+    """Mirror of ``vk_eligible_ksplit`` at the exact M2/M3/M5 tiles.
+
+    Floors from the 2026-07-17 queued-lane microbench on the live census
+    shapes: tiny-N projections (N=48 GDN b/a, N=1024 kv) lose to stock qmv at
+    every M (launch-bound), and M2 loses on lm_head-class N (its two stock
+    qmv passes stay bandwidth-competitive at 62k tiny threadgroups), so both
+    stay stock. Every trunk shape with N >= 2048 wins: M2 +8..19%, M3
+    +25..34%, M5 +32..45% vs stock qmv.
+    """
+    return (
+        int(bits) == 4
+        and int(group_size) in (32, 64, 128)
+        and dtype in (mx.bfloat16, mx.float16)
+        and int(m) in _EXACT_M_ROWS
+        and int(k) % 64 == 0
+        and int(n) % 4 == 0
+        and int(n) >= 2048
+        and not (int(m) == 2 and int(n) >= 100000)
+    )
+
+
+def qwen_qmm_exact_m(
+    x2: mx.array,
+    w_q: mx.array,
+    scales: mx.array,
+    biases: mx.array,
+    *,
+    group_size: int = 64,
+) -> mx.array:
+    """Exact-M split-K verify matmul; x2 must be (M in {2,3,5}, K).
+
+    Same morphology and numerics family as ``vk_qmm_m4_ksplit`` (vk_k: K baked
+    into the specialization), compiled at the true row count so no zero-padded
+    activation copy is materialized.
+    """
+    from .verify_kernels import _build_ksplit_kernel
+
+    m = int(x2.shape[0])
+    if m not in _EXACT_M_ROWS:
+        raise ValueError("qwen_qmm_exact_m supports M in {2, 3, 5}")
+    k = int(x2.shape[1])
+    n = int(w_q.shape[0])
+    k_parts = 2 if n >= 4096 else 4
+    kernel = _build_ksplit_kernel(
+        m,
+        4,
+        int(group_size),
+        x2.dtype,
+        k_parts=k_parts,
+        dual=False,
+        kconst=k,
+    )
+    (y,) = kernel(
+        inputs=[mx.contiguous(x2), w_q, scales, biases, k, n],
+        template=[("T", x2.dtype)],
+        grid=(32 * k_parts, n // 4, 1),
+        threadgroup=(32 * k_parts, 1, 1),
+        output_shapes=[(m, n)],
+        output_dtypes=[x2.dtype],
+    )
+    return y
+
+
+def install_qwen_exact_m_qlinear_patch() -> dict[str, object]:
+    """Wrap the current ``QuantizedLinear.__call__`` (post-NAX) once.
+
+    Must be installed after the NAX patch so exact-M5 takes precedence over
+    the padded-M6 NAX route; everything else falls through unchanged.
+    Idempotent.
+    """
+    import mlx.nn as nn
+
+    _STATS["enabled"] = True
+    if _PATCH["installed"]:
+        return {"installed": True, "already": True}
+
+    original = nn.QuantizedLinear.__call__
+
+    from .attention_context import current_attention_phase
+    from .kernel_selfcheck import lane_disabled
+
+    def patched(self, x: mx.array) -> mx.array:  # type: ignore[no-untyped-def]
+        bits = int(getattr(self, "bits", 0) or 0)
+        if (
+            bits == 4
+            and x.ndim >= 2
+            and str(getattr(self, "mode", "affine")) == "affine"
+            and current_attention_phase() != "prefill"
+        ):
+            m = 1
+            for d in x.shape[:-1]:
+                m *= int(d)
+            if m in _EXACT_M_ROWS and not lane_disabled(f"qwen_rt_qmm_m{m}"):
+                group_size = int(getattr(self, "group_size", 0) or 0)
+                w_q = self["weight"]
+                k = int(x.shape[-1])
+                n = int(w_q.shape[0])
+                scales = self["scales"]
+                biases = self["biases"]
+                if (
+                    qwen_exact_m_eligible(m, k, n, bits, group_size, x.dtype)
+                    and scales.dtype == x.dtype
+                    and biases.dtype == x.dtype
+                ):
+                    y = qwen_qmm_exact_m(
+                        x.reshape(m, k),
+                        w_q,
+                        scales,
+                        biases,
+                        group_size=group_size,
+                    )
+                    _STATS[f"calls_m{m}"] = int(_STATS[f"calls_m{m}"]) + 1
+                    y = y.reshape(*x.shape[:-1], n)
+                    if "bias" in self:
+                        y = y + self["bias"]
+                    return y
+                _STATS["fallback_calls"] = int(_STATS["fallback_calls"]) + 1
+        return original(self, x)
+
+    nn.QuantizedLinear.__call__ = patched
+    _PATCH["installed"] = True
+    _PATCH["original"] = original
+    _STATS["installed"] = True
+    return {"installed": True, "already": False}
+
+
+def uninstall_qwen_exact_m_qlinear_patch() -> None:
+    import mlx.nn as nn
+
+    if _PATCH["installed"] and _PATCH["original"] is not None:
+        nn.QuantizedLinear.__call__ = _PATCH["original"]
+    _PATCH["installed"] = False
+    _PATCH["original"] = None
+    _STATS["installed"] = False
+
+
+def qwen_row_traversal_stats() -> dict[str, object]:
+    return dict(_STATS)

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -415,6 +415,17 @@ def load(
     if nax_env_enabled():
         nax_report = install_nax_qlinear_patch()
         logger.info("[nax-verify] %s", nax_report)
+    from .qwen_row_traversal import (
+        install_qwen_exact_m_qlinear_patch,
+        qwen_row_traversal_qlinear_enabled,
+    )
+
+    # Experimental exact-M2/M3/M5 verify routing (default off); must install
+    # after the NAX patch so the exact-M5 tile takes precedence over the
+    # padded-M6 NAX route.
+    if qwen_row_traversal_qlinear_enabled():
+        rt_report = install_qwen_exact_m_qlinear_patch()
+        logger.info("[qwen-row-traversal] %s", rt_report)
     from .kernel_selfcheck import maybe_run_model_selfcheck
 
     # Turbo lanes validate themselves once per load on the model's actual

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -24824,6 +24824,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--profile", choices=PROFILE_CHOICES, default=DEFAULT_PROFILE_NAME
     )
+    qwen_kernel_group = parser.add_mutually_exclusive_group()
+    qwen_kernel_group.add_argument(
+        "--experimental-qwen-row-traversal",
+        action="store_true",
+        help=(
+            "Experimental Qwen dense-MLP gate/up output-tile traversal. "
+            "Preserves Q4/BF16/FP32 precision but changes the FP32 reduction tree."
+        ),
+    )
+    qwen_kernel_group.add_argument(
+        "--experimental-qwen-fast-sigmoid",
+        action="store_true",
+        help=(
+            "Experimental standalone Qwen fast-sigmoid A/B using approximate "
+            "fast exp; mutually exclusive with row traversal."
+        ),
+    )
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument(
@@ -25302,6 +25319,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(raw_args)
     args._raw_args = list(raw_args)
     args._cli_flags = _explicit_server_flags(raw_args)
+    if args.experimental_qwen_row_traversal:
+        os.environ["MTPLX_MLP_CALL_VARIANT"] = "fused_gateup_vk_k_bn2"
+    elif args.experimental_qwen_fast_sigmoid:
+        os.environ["MTPLX_MLP_CALL_VARIANT"] = "fast_sigmoid"
     try:
         resolved_key = resolve_api_key(
             explicit_api_key=getattr(args, "api_key", None),

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -5553,6 +5553,35 @@ def test_cli_parses_api_key_file_and_kv_quant_flags():
     assert serve.paged_kv_quantization == "off"
 
 
+def test_cli_parses_qwen_experimental_kernel_flags():
+    parser = build_parser()
+
+    start = parser.parse_args(
+        ["start", "opencode", "--experimental-qwen-row-traversal"]
+    )
+    quickstart = parser.parse_args(
+        ["quickstart", "--experimental-qwen-fast-sigmoid"]
+    )
+    serve = parser.parse_args(
+        ["serve", "--experimental-qwen-row-traversal"]
+    )
+
+    assert start.experimental_qwen_row_traversal is True
+    assert start.experimental_qwen_fast_sigmoid is False
+    assert quickstart.experimental_qwen_row_traversal is False
+    assert quickstart.experimental_qwen_fast_sigmoid is True
+    assert serve.experimental_qwen_row_traversal is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "quickstart",
+                "--experimental-qwen-row-traversal",
+                "--experimental-qwen-fast-sigmoid",
+            ]
+        )
+
+
 def test_quickstart_dry_run_json_previews_server_without_side_effects(
     monkeypatch, capsys
 ):
@@ -5591,6 +5620,7 @@ def test_quickstart_dry_run_json_previews_server_without_side_effects(
             "secret-value",
             "--warmup-tokens",
             "0",
+            "--experimental-qwen-row-traversal",
         ]
     )
 
@@ -5605,6 +5635,7 @@ def test_quickstart_dry_run_json_previews_server_without_side_effects(
     assert payload["port"] == 18191
     assert payload["api_base_url"] == "http://127.0.0.1:18191/v1"
     assert "--api-key" in payload["argv"]
+    assert "--experimental-qwen-row-traversal" in payload["argv"]
     assert payload["argv"][payload["argv"].index("--api-key") + 1] == "[redacted]"
     assert "secret-value" not in payload["server_command"]
 

--- a/tests/test_qwen_fast_sigmoid.py
+++ b/tests/test_qwen_fast_sigmoid.py
@@ -1,0 +1,54 @@
+"""Standalone experimental fast-sigmoid Qwen SwiGLU path."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mtplx.kernels.qwen_fast_sigmoid import (
+    _qwen_swiglu_source,
+    qwen_swiglu,
+)
+
+
+def test_fast_source_changes_only_the_exp_intrinsic() -> None:
+    precise = _qwen_swiglu_source(fast=False)
+    fast = _qwen_swiglu_source(fast=True)
+
+    assert "metal::exp(metal::abs(gate_value))" in precise
+    assert "metal::fast::exp(metal::abs(gate_value))" in fast
+    assert "metal::fast" not in precise
+    assert precise.replace("metal::exp", "metal::fast::exp") == fast
+    assert "using Vec8 = vec<T, 8>;" in precise
+
+
+def test_precise_and_fast_swiglu_are_deterministic_and_numerically_close() -> None:
+    from mlx_lm.models.qwen3_next import swiglu
+
+    mx.random.seed(31)
+    gate = (mx.random.normal((4, 4096), dtype=mx.float32) * 2.0).astype(mx.bfloat16)
+    up = (mx.random.normal((4, 4096), dtype=mx.float32) * 0.5).astype(mx.bfloat16)
+    reference = swiglu(gate, up)
+    precise = qwen_swiglu(gate, up, fast=False)
+    fast = qwen_swiglu(gate, up, fast=True)
+    replay = qwen_swiglu(gate, up, fast=True)
+    mx.eval(reference, precise, fast, replay)
+
+    precise_dmax = float(
+        mx.abs(precise.astype(mx.float32) - reference.astype(mx.float32)).max()
+    )
+    fast_dmax = float(
+        mx.abs(fast.astype(mx.float32) - precise.astype(mx.float32)).max()
+    )
+    replay_dmax = float(
+        mx.abs(fast.astype(mx.float32) - replay.astype(mx.float32)).max()
+    )
+    assert precise_dmax <= 0.03125
+    assert fast_dmax <= 0.125
+    assert replay_dmax == 0.0
+
+
+def test_internal_native_mlp_selector_accepts_fast_sigmoid(monkeypatch) -> None:
+    from mtplx import native_mlp
+
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "fast-sigmoid")
+    assert native_mlp._normalized_variant() == "fast_sigmoid"

--- a/tests/test_qwen_row_traversal.py
+++ b/tests/test_qwen_row_traversal.py
@@ -1,0 +1,161 @@
+"""Experimental exact-M2/M3/M5 verify QuantizedLinear routing."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mtplx.qwen_row_traversal import (
+    install_qwen_exact_m_qlinear_patch,
+    qwen_exact_m_eligible,
+    qwen_qmm_exact_m,
+    qwen_row_traversal_qlinear_enabled,
+    qwen_row_traversal_stats,
+    uninstall_qwen_exact_m_qlinear_patch,
+)
+
+
+def _q4_linear(k: int, n: int, *, group_size: int = 64) -> nn.QuantizedLinear:
+    module = nn.QuantizedLinear(
+        k,
+        n,
+        bias=False,
+        group_size=group_size,
+        bits=4,
+        mode="affine",
+    )
+    module.scales = module.scales.astype(mx.bfloat16)
+    module.biases = module.biases.astype(mx.bfloat16)
+    return module
+
+
+def test_enablement_follows_variant_with_env_override(monkeypatch) -> None:
+    monkeypatch.delenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", raising=False)
+    monkeypatch.delenv("MTPLX_MLP_CALL_VARIANT", raising=False)
+    assert not qwen_row_traversal_qlinear_enabled()
+
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "fused_gateup_vk_k_bn2")
+    assert qwen_row_traversal_qlinear_enabled()
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "fused-gateup-vk-k")
+    assert qwen_row_traversal_qlinear_enabled()
+
+    # Explicit env wins in both directions.
+    monkeypatch.setenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "0")
+    assert not qwen_row_traversal_qlinear_enabled()
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "stock")
+    monkeypatch.setenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "1")
+    assert qwen_row_traversal_qlinear_enabled()
+
+
+def test_eligibility_is_exact_m235_q4() -> None:
+    for rows in (2, 3, 5):
+        assert qwen_exact_m_eligible(rows, 512, 4096, 4, 64, mx.bfloat16)
+    for rows in (1, 4, 6, 7):
+        assert not qwen_exact_m_eligible(rows, 512, 4096, 4, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 512, 4096, 8, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 500, 4096, 4, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 512, 4098, 4, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 512, 4096, 4, 48, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 512, 4096, 4, 64, mx.float32)
+    # Measured floors: tiny-N projections and M2 x lm_head-class N stay stock.
+    assert not qwen_exact_m_eligible(3, 512, 1024, 4, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(5, 512, 48, 4, 64, mx.bfloat16)
+    assert not qwen_exact_m_eligible(2, 512, 248320, 4, 64, mx.bfloat16)
+    assert qwen_exact_m_eligible(3, 512, 248320, 4, 64, mx.bfloat16)
+    assert qwen_exact_m_eligible(5, 512, 248320, 4, 64, mx.bfloat16)
+    assert qwen_exact_m_eligible(2, 512, 2048, 4, 64, mx.bfloat16)
+
+
+def test_exact_m_matches_stock_within_vk_band() -> None:
+    mx.random.seed(31)
+    for rows in (2, 3, 5):
+        for n in (4096, 1024):  # exercises k_parts = 2 and 4
+            module = _q4_linear(512, n)
+            x = (mx.random.normal((rows, 512), dtype=mx.float32) * 0.5).astype(
+                mx.bfloat16
+            )
+            candidate = qwen_qmm_exact_m(
+                x,
+                module.weight,
+                module.scales,
+                module.biases,
+                group_size=64,
+            )
+            reference = mx.quantized_matmul(
+                x,
+                module.weight,
+                scales=module.scales,
+                biases=module.biases,
+                transpose=True,
+                group_size=64,
+                bits=4,
+            )
+            mx.eval(candidate, reference)
+            dmax = float(
+                mx.abs(
+                    candidate.astype(mx.float32) - reference.astype(mx.float32)
+                ).max()
+            )
+            assert candidate.shape == (rows, n)
+            assert dmax <= 0.25, f"M={rows} N={n} drift too large: {dmax}"
+
+
+def test_exact_m_rejects_other_row_counts() -> None:
+    module = _q4_linear(512, 4096)
+    x = mx.zeros((4, 512), dtype=mx.bfloat16)
+    with pytest.raises(ValueError):
+        qwen_qmm_exact_m(
+            x,
+            module.weight,
+            module.scales,
+            module.biases,
+            group_size=64,
+        )
+
+
+def test_patch_routes_m235_and_falls_through(monkeypatch) -> None:
+    monkeypatch.setenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "1")
+    original = nn.QuantizedLinear.__call__
+    try:
+        report = install_qwen_exact_m_qlinear_patch()
+        assert report["installed"]
+        again = install_qwen_exact_m_qlinear_patch()
+        assert again["already"]
+
+        module = _q4_linear(512, 4096)
+        before = qwen_row_traversal_stats()
+        mx.random.seed(37)
+        for rows in (2, 3, 5):
+            x = (
+                mx.random.normal((1, rows, 512), dtype=mx.float32) * 0.5
+            ).astype(mx.bfloat16)
+            routed = module(x)
+            monkeypatch.setenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "0")
+            # The patch decision is per-call via lane state, not env; the
+            # numeric contract is what matters here.
+            monkeypatch.setenv("MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR", "1")
+            stock = original(module, x)
+            mx.eval(routed, stock)
+            assert routed.shape == stock.shape
+            dmax = float(
+                mx.abs(
+                    routed.astype(mx.float32) - stock.astype(mx.float32)
+                ).max()
+            )
+            assert dmax <= 0.25, f"patched M={rows} drift too large: {dmax}"
+        after = qwen_row_traversal_stats()
+        assert int(after["calls_m2"]) == int(before["calls_m2"]) + 1
+        assert int(after["calls_m3"]) == int(before["calls_m3"]) + 1
+        assert int(after["calls_m5"]) == int(before["calls_m5"]) + 1
+
+        # M1/M4 fall through to the wrapped call (stock here).
+        x1 = mx.zeros((1, 1, 512), dtype=mx.bfloat16)
+        x4 = mx.zeros((1, 4, 512), dtype=mx.bfloat16)
+        mx.eval(module(x1), module(x4))
+        final = qwen_row_traversal_stats()
+        assert int(final["calls_m2"]) == int(after["calls_m2"])
+        assert int(final["calls_m5"]) == int(after["calls_m5"])
+    finally:
+        uninstall_qwen_exact_m_qlinear_patch()
+        assert nn.QuantizedLinear.__call__ is original

--- a/tests/test_qwen_verify_mlp_fused_k.py
+++ b/tests/test_qwen_verify_mlp_fused_k.py
@@ -1,0 +1,262 @@
+"""Experimental M2-M6 Qwen gate/up fusion on the measured vk_k geometry."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mtplx.kernels.qwen_verify_mlp_fused_k import (
+    _fused_gate_up_q4_ksplit_source,
+    is_qwen_gate_up_swiglu_vk_k_eligible,
+    qwen_gate_up_swiglu_vk_k,
+)
+
+
+def _q4_linear(k: int, n: int, *, group_size: int = 64) -> nn.QuantizedLinear:
+    module = nn.QuantizedLinear(
+        k,
+        n,
+        bias=False,
+        group_size=group_size,
+        bits=4,
+        mode="affine",
+    )
+    module.scales = module.scales.astype(mx.bfloat16)
+    module.biases = module.biases.astype(mx.bfloat16)
+    return module
+
+
+def test_source_preserves_vk_k_ownership_and_projection_rounding() -> None:
+    source = _fused_gate_up_q4_ksplit_source(
+        m=4,
+        group_size=64,
+        k_parts=2,
+        kconst=5120,
+    )
+
+    # Same output-tile-owned exact-M4 split-K geometry as the current winner.
+    assert "constexpr int K = 5120;" in source
+    assert "constexpr int K_PARTS = 2;" in source
+    assert "int n0 = int(tg_n) * 4;" in source
+    assert "float gate_acc[16];" in source
+    assert "float up_acc[16];" in source
+    assert "threadgroup float gate_partials[K_PARTS * 16];" in source
+    assert "threadgroup float up_partials[K_PARTS * 16];" in source
+    assert "for (int p = 0; p < K_PARTS; ++p)" in source
+
+    # The two original Q4 arrays share each activation load; no packed copy.
+    assert "gate_w_q" in source
+    assert "up_w_q" in source
+    assert "packed_gateup" not in source
+    for row in range(4):
+        assert source.count(f"Vec8 vA_{row} =") == 1
+
+    # Match stock's projection boundary: round each projection to T before
+    # precise SwiGLU. This changes the FP32 reduction tree, not its precision.
+    assert "T gate_value = T(gate_total);" in source
+    assert "T up_value = T(up_total);" in source
+    assert "metal::exp(metal::abs(gate_value))" in source
+    assert "metal::fast" not in source
+    assert "atomic" not in source
+
+
+def test_bn2_source_stays_below_the_proven_accumulator_ceiling() -> None:
+    source = _fused_gate_up_q4_ksplit_source(
+        m=4,
+        group_size=64,
+        k_parts=2,
+        kconst=5120,
+        tile_cols=2,
+    )
+
+    assert "int n0 = int(tg_n) * 2;" in source
+    assert "float gate_acc[8];" in source
+    assert "float up_acc[8];" in source
+    assert "threadgroup float gate_partials[K_PARTS * 8];" in source
+    assert "threadgroup float up_partials[K_PARTS * 8];" in source
+    assert "n0 + 2" not in source
+
+    source_m6 = _fused_gate_up_q4_ksplit_source(
+        m=6,
+        group_size=64,
+        k_parts=2,
+        kconst=5120,
+        tile_cols=2,
+    )
+    assert "float gate_acc[12];" in source_m6
+    assert "float up_acc[12];" in source_m6
+    assert "threadgroup float gate_partials[K_PARTS * 12];" in source_m6
+    assert "threadgroup float up_partials[K_PARTS * 12];" in source_m6
+
+
+def test_exact_m_source_covers_every_verify_tile() -> None:
+    # M2/M3/M5 compile as their own exact tiles instead of padding into M4/M6,
+    # so no zero-padded activation copy is materialized on those calls.
+    for m, tile_cols in ((2, 2), (3, 2), (5, 2), (3, 4), (5, 4)):
+        source = _fused_gate_up_q4_ksplit_source(
+            m=m,
+            group_size=64,
+            k_parts=2,
+            kconst=5120,
+            tile_cols=tile_cols,
+        )
+        n_acc = tile_cols * m
+        assert f"float gate_acc[{n_acc}];" in source
+        assert f"float up_acc[{n_acc}];" in source
+        assert f"threadgroup float gate_partials[K_PARTS * {n_acc}];" in source
+        assert f"int n0 = int(tg_n) * {tile_cols};" in source
+        # BN=2 M6 is the documented 24-accumulator ceiling; nothing exceeds it.
+        assert n_acc <= 24
+
+
+def test_eligibility_is_exact_m4_q4_affine_no_bias() -> None:
+    k, n = 512, 4096
+    gate = _q4_linear(k, n)
+    up = _q4_linear(k, n)
+    x4 = mx.zeros((4, k), dtype=mx.bfloat16)
+
+    for rows in range(2, 7):
+        assert is_qwen_gate_up_swiglu_vk_k_eligible(
+            mx.zeros((rows, k), dtype=mx.bfloat16),
+            gate,
+            up,
+        )
+    assert not is_qwen_gate_up_swiglu_vk_k_eligible(x4[:1], gate, up)
+    assert not is_qwen_gate_up_swiglu_vk_k_eligible(
+        mx.zeros((7, k), dtype=mx.bfloat16),
+        gate,
+        up,
+    )
+    assert not is_qwen_gate_up_swiglu_vk_k_eligible(
+        x4,
+        gate,
+        _q4_linear(k, n + 4),
+    )
+    assert not is_qwen_gate_up_swiglu_vk_k_eligible(
+        x4,
+        gate,
+        nn.QuantizedLinear(k, n, bias=False, group_size=64, bits=8),
+    )
+
+
+def test_fused_vk_k_matches_two_current_vk_k_projections() -> None:
+    from mlx_lm.models.qwen3_next import swiglu
+
+    from mtplx.verify_kernels import vk_qmm_m4_impl
+
+    k, n = 512, 4096
+    mx.random.seed(17)
+    gate = _q4_linear(k, n)
+    up = _q4_linear(k, n)
+    x = (mx.random.normal((4, k), dtype=mx.float32) * 0.25).astype(mx.bfloat16)
+    assert is_qwen_gate_up_swiglu_vk_k_eligible(x, gate, up)
+
+    reference = swiglu(
+        vk_qmm_m4_impl(
+            "vk_k",
+            x,
+            gate.weight,
+            gate.scales,
+            gate.biases,
+            bits=4,
+            group_size=64,
+        ),
+        vk_qmm_m4_impl(
+            "vk_k",
+            x,
+            up.weight,
+            up.scales,
+            up.biases,
+            bits=4,
+            group_size=64,
+        ),
+    )
+    for tile_cols in (2, 4):
+        candidate = qwen_gate_up_swiglu_vk_k(
+            x,
+            gate,
+            up,
+            tile_cols=tile_cols,
+        )
+        replay = qwen_gate_up_swiglu_vk_k(
+            x,
+            gate,
+            up,
+            tile_cols=tile_cols,
+        )
+        mx.eval(reference, candidate, replay)
+
+        dmax = float(
+            mx.abs(candidate.astype(mx.float32) - reference.astype(mx.float32)).max()
+        )
+        replay_dmax = float(
+            mx.abs(candidate.astype(mx.float32) - replay.astype(mx.float32)).max()
+        )
+        assert candidate.shape == (4, n)
+        assert dmax <= 0.25, f"fused BN={tile_cols} drift too large: {dmax}"
+        assert replay_dmax == 0.0
+
+
+def test_fused_bn2_matches_stock_for_every_speculative_verify_shape() -> None:
+    from mlx_lm.models.qwen3_next import swiglu
+
+    k, n = 512, 4096
+    mx.random.seed(23)
+    gate = _q4_linear(k, n)
+    up = _q4_linear(k, n)
+
+    for rows in range(2, 7):
+        x = (mx.random.normal((rows, k), dtype=mx.float32) * 0.25).astype(mx.bfloat16)
+        assert is_qwen_gate_up_swiglu_vk_k_eligible(x, gate, up)
+        reference = swiglu(gate(x), up(x))
+        candidate = qwen_gate_up_swiglu_vk_k(
+            x,
+            gate,
+            up,
+            tile_cols=2,
+        )
+        mx.eval(reference, candidate)
+        dmax = float(
+            mx.abs(candidate.astype(mx.float32) - reference.astype(mx.float32)).max()
+        )
+        assert candidate.shape == (rows, n)
+        assert dmax <= 0.25, f"M={rows} fused BN=2 drift too large: {dmax}"
+
+
+def test_exact_tile_is_bit_identical_to_padded_tile() -> None:
+    # Removing the zero-pad is a pure dispatch/compute-waste optimization: the
+    # exact M2/M3/M5 tile must reproduce the padded M4/M6 tile bit-for-bit on
+    # the live rows, so token trajectories are unchanged from the padded path.
+    k, n = 512, 4096
+    mx.random.seed(29)
+    gate = _q4_linear(k, n)
+    up = _q4_linear(k, n)
+
+    for rows, padded in ((2, 4), (3, 4), (5, 6)):
+        x = (mx.random.normal((rows, k), dtype=mx.float32) * 0.25).astype(mx.bfloat16)
+        pad = mx.concatenate(
+            [x, mx.zeros((padded - rows, k), dtype=mx.bfloat16)],
+            axis=0,
+        )
+        for tile_cols in (2, 4):
+            exact = qwen_gate_up_swiglu_vk_k(x, gate, up, tile_cols=tile_cols)
+            padded_rows = qwen_gate_up_swiglu_vk_k(
+                pad, gate, up, tile_cols=tile_cols
+            )[:rows, :]
+            mx.eval(exact, padded_rows)
+            drift = float(
+                mx.abs(
+                    exact.astype(mx.float32) - padded_rows.astype(mx.float32)
+                ).max()
+            )
+            assert exact.shape == (rows, n)
+            assert drift == 0.0, f"M{rows} BN={tile_cols} exact!=padded: {drift}"
+
+
+def test_internal_native_mlp_selector_accepts_fused_vk_k(monkeypatch) -> None:
+    from mtplx import native_mlp
+
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "fused-gateup-vk-k")
+    assert native_mlp._normalized_variant() == "fused_gateup_vk_k"
+    monkeypatch.setenv("MTPLX_MLP_CALL_VARIANT", "fused-gateup-vk-k-bn2")
+    assert native_mlp._normalized_variant() == "fused_gateup_vk_k_bn2"

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -30,6 +30,36 @@ def test_server_parser_accepts_native_app_launch_id():
     assert args.app_launch_id == "native-123"
 
 
+def test_server_parser_maps_qwen_experimental_flags_to_runtime_variants(
+    monkeypatch,
+):
+    monkeypatch.delenv("MTPLX_MLP_CALL_VARIANT", raising=False)
+    row = parse_args(
+        ["--warmup-tokens", "0", "--experimental-qwen-row-traversal"]
+    )
+    assert row.experimental_qwen_row_traversal is True
+    assert row.experimental_qwen_fast_sigmoid is False
+    assert os.environ["MTPLX_MLP_CALL_VARIANT"] == "fused_gateup_vk_k_bn2"
+
+    monkeypatch.delenv("MTPLX_MLP_CALL_VARIANT", raising=False)
+    fast = parse_args(
+        ["--warmup-tokens", "0", "--experimental-qwen-fast-sigmoid"]
+    )
+    assert fast.experimental_qwen_row_traversal is False
+    assert fast.experimental_qwen_fast_sigmoid is True
+    assert os.environ["MTPLX_MLP_CALL_VARIANT"] == "fast_sigmoid"
+
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "--warmup-tokens",
+                "0",
+                "--experimental-qwen-row-traversal",
+                "--experimental-qwen-fast-sigmoid",
+            ]
+        )
+
+
 def test_server_parser_resolves_api_key_file_before_env(monkeypatch, tmp_path):
     api_key_file = tmp_path / "api-key"
     api_key_file.write_text("file-secret\n", encoding="utf-8")


### PR DESCRIPTION
## What this ships

Experimental exact-M row-traversal verify kernels for Qwen3.6 under one default-off flag (`--experimental-qwen-row-traversal`, env `MTPLX_QWEN_ROW_TRAVERSAL`, qlinear half separately gated by `MTPLX_QWEN_ROW_TRAVERSAL_QLINEAR`):

1. **Fused gate/up + SwiGLU MLP tile compiled at the true verify row count** (M2-M6). Removes the two materialized MLP intermediates and the zero-padding waste of the fixed-M4/M8 tiles.
2. **Exact-M2/M3/M5 QuantizedLinear routing.** The turbo NAX patch covers M4-M16; below it, stock MLX `qmv` re-reads the full weight matrix once per output row at the depth-1/2 verify tiles, and M5 pays the padded-M6 route. Eligible non-prefill 4-bit calls now compile at M in {2,3,5}, with measured per-shape floors (tiny-N projections and M2 x lm_head stay stock).
3. Load-time selfcheck lanes (`qwen_rt_gateup`, `qwen_rt_qmm_m2/m3/m5`) with the same disable-on-mismatch contract as the shipped NAX lanes.

## Measured (M5 Max, Qwen3.6-27B Q4, greedy, 96 tok, fresh prefill per generation)

### Definitive end-to-end: total-quiet interleaved pairing

Protocol: exclusive GPU window (serving booted out), the only CPU-heavy cohabitant SIGSTOPped, no process >50% CPU, arms alternated in fresh processes (A,B,A,B,A,B), 3 repeats, control drift <=1.34%, engagement verified per arm.

**16K context:**

| K | control tok/s | fused tok/s | delta | verify-fwd | tokens |
| ---: | ---: | ---: | ---: | ---: | :--- |
| K0 | 28.06 | 27.75 | -1.08% | +1% | identical |
| K1 | 41.27 | 47.15 | **+14.25%** | **-7.7%** | fork (disclosed) |
| K2 | 44.25 | 57.91 | **+30.86%** | **-21.9%** | fork (disclosed) |
| K3 | 63.72 | 63.40 | -0.51% | ~0 | identical |
| K4 | 56.76 | 62.01 | **+9.23%** | **-10.3%** | identical |

**8K context (the cleanest statement of the win):**

| K | control | fused | delta | verify-fwd | tokens |
| ---: | ---: | ---: | ---: | ---: | :--- |
| K1 | 45.15 | 48.75 | **+7.95%** | -8.2% | **bitwise identical** |
| K2 | 47.73 | 59.66 | **+25.00%** | -22.5% | **bitwise identical** |

K4\@16K and both 8K cells are parity-clean end-to-end wins: identical tokens, identical acceptance, wall speed from kernel time alone. K1/K2\@16K combine the kernel-real verify-forward drop with a favorable acceptance-trajectory effect on the forked text (see numerics); both components are reported separately. K0/K3 price the Python dispatch wrappers (~0.5-1%) at depths where no new kernel engages — the flag is for K1/K2/K4-shaped serving, not the current K3 default.

### Kernel level (queued lane, real shapes and weights)

Exact-M QMM vs stock `qmv`: +8 to +45% across the live census shapes (peaks at M5, e.g. lm_head 2705->2134 us). Fused MLP tile vs stock projections+swiglu: +17 to +43% at M3-M6. Full tables in `docs/specs/2026-07-17-qwen-experimental-row-traversal.md`.

## Numerics

- **Bit-parity with the turbo baseline at M4/M5/M6 by construction** (gate-tested with `mx.array_equal` on real shapes: exact-M5 == NAX padded-M6, fused tile M4/M6 == turbo vk_k pair + compiled swiglu, dmax 0.0). K3/K4/K5 token parity in every window is structural.
- The **only** divergent tiles are M2/M3 vs stock MLX `qmv` (different association class). fp64 ladder: fused error 0.8-3.2 BF16 ULP, at or below stock's own 1.6-4.0; flat across 1000x magnitude; zero non-finite values. Measured forks are near-tie swaps (16K fork: 0.25-logit margin, fused picks stock's runner-up); stock replay is bit-deterministic; BN2/BN4 layouts are bit-identical.
- **Acceptance ratchet** (why forked cells post outsized tok/s): draft disagreements concentrate at the target's near-ties, so target-side tie-flips convert rejections to acceptances ~half the time and rarely break agreements. Measured +7.4 to +9.3pt acceptance in forked cells, jump anti-correlated with base acceptance, 0.0pt in all parity cells. Forked-cell tok/s is disclosed as workload throughput; verify-forward time is the kernel-real metric.
- **Bit-parity option prototyped:** stock-order kernels reproducing `qmv_fast`'s exact association while amortizing the weight read across rows — proven bitwise vs `mx.quantized_matmul` at M2/M3 (36/36 gates), at +9-16% over stock (vs vk_k's +26-45%). Documented as the follow-up path to a fully bit-identical flag.

## Method note

Two measurement failure modes were caught and are now protocol: (1) sequential arm blocks on a noisy box drifted controls 4-7% between windows — all end-to-end claims here come from same-window interleaved arms under the quiet protocol; (2) an in-process arm-toggle harness produced a convincing all-flat null because the fused path silently never engaged — every arm now carries an engagement signature (dispatch counters + the mechanical verify-forward drop).

Default off, no default-profile changes proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gca2cYpuyu1MC5UKKMs9dH
