### PR TITLE
Treat mtp_depth_max as a ceiling, not the default MTP depth

### DIFF
--- a/benchmarks/repro_a3b_depth_default.py
+++ b/benchmarks/repro_a3b_depth_default.py
@@ -1,0 +1,47 @@
+"""Repro: A3B MTP speculative depth defaults to the contract CEILING (mtp_depth_max=3).
+
+Authors' published Qwen3.6-35B-A3B benchmark:
+    AR baseline   94.46 tok/s
+    D1           138.39 tok/s   <-- best mode
+    D2           135.66 tok/s
+    D3           107.67 tok/s   <-- what MTPLX selects as the default
+
+Run:
+    PYTHONPATH=. python repro_depth_pin.py
+"""
+import json
+import sys
+from pathlib import Path
+
+from mtplx.commands.public import _model_contract_depth
+
+MODEL = Path("/Users/davidtai/.mtplx/models/Youssofal--Qwen3.6-35B-A3B-MTPLX-Optimized-Speed")
+contract = json.loads((MODEL / "mtplx_runtime.json").read_text())
+
+
+class Profile:
+    """Stand-in for the resolved runtime profile; A3B recommends 'sustained'."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+print("contract mtp_depth_max   :", contract["mtp_depth_max"], "  (a CEILING)")
+print("contract recommended     :", contract["recommended_profile"])
+
+inspection = {"compatibility": {"runtime_contract": contract}}
+profile = Profile(contract["recommended_profile"])
+
+# fallback=1 makes the pin unambiguous: any 3 below comes from the contract,
+# not from the caller's default.
+resolved = _model_contract_depth(inspection, profile=profile, fallback=1)
+print("resolved default depth   :", resolved)
+print()
+
+if resolved == contract["mtp_depth_max"] == 3:
+    print("STUCK AT 3: the ceiling is returned as the default depth.")
+    print("Authors' data: D3 107.67 vs D1 138.39  ->  -22.2% throughput out of the box.")
+    sys.exit(0)
+
+print("not pinned; resolved", resolved)
+sys.exit(1)

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -795,6 +795,22 @@ def _model_draft_sampler_spec(
         return fallback
 
 
+# Artifacts whose fastest published mode is shallower than their sidecar
+# ceiling. Same shape as _TURBO_DEFAULT_PUBLIC_MODEL_IDS below: measured-win
+# only, keyed by public model id. Artifacts that declare ``mtp_depth_default``
+# in their runtime contract take precedence over this table.
+#
+# Qwen3.6-35B-A3B (published depth sweep, greedy):
+#     AR 94.46 | D1 138.39 | D2 135.66 | D3 107.67 tok/s
+# Per-level acceptance decays steeply on this MoE (D3: 0.829 / 0.541 / 0.278),
+# so verify cost outruns the extra accepted tokens past D1. Running the D3
+# ceiling as the default costs -22.2% against D1.
+_MODEL_CONTRACT_DEPTH_DEFAULTS: dict[str, int] = {
+    QWEN36_35B_OPTIMIZED_SPEED_PUBLIC_MODEL_ID: 1,
+    QWEN36_35B_OPTIMIZED_BALANCE_PUBLIC_MODEL_ID: 1,
+}
+
+
 def _model_contract_depth(
     inspection: dict[str, Any],
     *,
@@ -805,9 +821,23 @@ def _model_contract_depth(
     if not isinstance(contract, dict):
         return int(fallback)
     try:
-        depth = int(contract.get("mtp_depth_max", fallback))
+        depth_max = int(contract.get("mtp_depth_max", fallback))
     except (TypeError, ValueError):
         return int(fallback)
+    # ``mtp_depth_max`` is a CEILING (the deepest sidecar the artifact supports),
+    # not a recommendation. Artifacts whose fastest mode is shallower than that
+    # ceiling declare it via ``mtp_depth_default``; the ceiling then only bounds
+    # it. Without this split every artifact runs at its maximum depth, which is
+    # a measured loss whenever per-level acceptance decays quickly (Qwen3.6-35B-A3B:
+    # published D1 138.39 tok/s vs D3 107.67 tok/s, so the ceiling costs -22%).
+    measured_default = _MODEL_CONTRACT_DEPTH_DEFAULTS.get(
+        str(contract.get("public_model_id") or "").strip()
+    )
+    try:
+        depth = int(contract.get("mtp_depth_default", measured_default or depth_max))
+    except (TypeError, ValueError):
+        depth = measured_default or depth_max
+    depth = min(depth, depth_max)
     depth_ceiling = (
         MAX_GEMMA4_SPECULATIVE_DEPTH
         if _inspection_is_gemma4_assistant(inspection)

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -7126,3 +7126,54 @@ def test_quickstart_dashboard_handoff_does_not_crash(capsys):
     out = capsys.readouterr().out
     assert "Loading model: ~/.mtplx/models/demo" in out
     assert "Dashboard URL:" in out
+
+
+def test_model_contract_depth_uses_ceiling_when_no_default_declared():
+    """``mtp_depth_max`` alone still selects the ceiling (unchanged behaviour)."""
+    contract = {
+        "public_model_id": "some-third-party-artifact",
+        "mtp_depth_max": 3,
+    }
+    inspection = {"compatibility": {"runtime_contract": contract}}
+    sustained = public.get_profile("sustained")
+
+    assert public._model_contract_depth(inspection, profile=sustained, fallback=1) == 3
+
+
+def test_model_contract_depth_prefers_declared_default_over_ceiling():
+    """An artifact may declare a shallower default than its sidecar ceiling."""
+    contract = {
+        "public_model_id": "some-third-party-artifact",
+        "mtp_depth_max": 3,
+        "mtp_depth_default": 1,
+    }
+    inspection = {"compatibility": {"runtime_contract": contract}}
+    sustained = public.get_profile("sustained")
+
+    assert public._model_contract_depth(inspection, profile=sustained, fallback=3) == 1
+
+
+def test_model_contract_depth_clamps_declared_default_to_ceiling():
+    """A declared default never exceeds the artifact's supported depth."""
+    contract = {
+        "public_model_id": "some-third-party-artifact",
+        "mtp_depth_max": 2,
+        "mtp_depth_default": 5,
+    }
+    inspection = {"compatibility": {"runtime_contract": contract}}
+    sustained = public.get_profile("sustained")
+
+    assert public._model_contract_depth(inspection, profile=sustained, fallback=3) == 2
+
+
+def test_qwen36_35b_a3b_defaults_to_measured_best_depth():
+    """A3B's published sweep peaks at D1 (138.39 tok/s) vs its D3 ceiling (107.67)."""
+    contract = {
+        "public_model_id": public.QWEN36_35B_OPTIMIZED_SPEED_PUBLIC_MODEL_ID,
+        "recommended_profile": "sustained",
+        "mtp_depth_max": 3,
+    }
+    inspection = {"compatibility": {"runtime_contract": contract}}
+    sustained = public.get_profile("sustained")
+
+    assert public._model_contract_depth(inspection, profile=sustained, fallback=3) == 1


### PR DESCRIPTION
## Problem

`_model_contract_depth` returns an artifact's **`mtp_depth_max`** as the **default** speculative depth. That field is a *ceiling* — the deepest MTP sidecar the artifact ships — so every model runs at its maximum depth regardless of whether that depth is its fastest mode.

For **Qwen3.6-35B-A3B** this is a measured regression. Published depth sweep (greedy):

| mode | tok/s | acceptance |
|---|---|---|
| AR baseline | 94.46 | — |
| **D1** | **138.39** | 0.8858 |
| D2 | 135.66 | 0.8701, 0.6409 |
| D3 | 107.67 | 0.8291, 0.5414, 0.2783 |

Per-level acceptance decays steeply on this MoE (0.829 / 0.541 / 0.278), so verify cost outruns the extra accepted tokens past D1. The artifact declares `mtp_depth_max: 3`, so MTPLX selects D3 — **−22.2% against D1, out of the box.**

## Repro

`benchmarks/repro_a3b_depth_default.py`, against a local A3B artifact:

```
$ PYTHONPATH=. python benchmarks/repro_a3b_depth_default.py
contract mtp_depth_max   : 3   (a CEILING)
contract recommended     : sustained
resolved default depth   : 3

STUCK AT 3: the ceiling is returned as the default depth.
Authors' data: D3 107.67 vs D1 138.39  ->  -22.2% throughput out of the box.
```

It passes `fallback=1`, so the `3` can only originate from the contract ceiling — not from a caller default. After this change the same script reports `resolved default depth : 1`.

Note the contract is profile-scoped: A3B declares `recommended_profile: sustained`, and the pin only reproduces under the matching profile.

## Fix

Separate the two concepts that `mtp_depth_max` was conflating:

1. Artifacts may declare **`mtp_depth_default`** in their runtime contract; `mtp_depth_max` then only *bounds* it.
2. `_MODEL_CONTRACT_DEPTH_DEFAULTS` carries measured defaults for already-published artifacts that predate the field — same measured-win-only shape as the existing `_TURBO_DEFAULT_PUBLIC_MODEL_IDS` list.
3. Artifacts declaring neither keep the previous ceiling behaviour, so nothing else changes.

Explicit `--depth` / `--speculative-depth` still wins, unchanged.

## Tests

Four new cases in `tests/test_public_cli.py`: ceiling-only behaviour preserved, declared default honoured, declared default clamped to the ceiling, and A3B resolving to its measured D1.

`tests/test_public_cli.py`, `tests/test_artifacts.py`, `tests/test_forge_cli.py` all pass (exit 0).
