### PR TITLE
Pack Qwen MoE gate/up projections at load time (default off)

### DIFF
--- a/mtplx/moe_packed_projections.py
+++ b/mtplx/moe_packed_projections.py
@@ -1,0 +1,361 @@
+"""Construction-time gate/up projection packing for Qwen MoE blocks.
+
+Qwen's sparse MoE block runs the gate and up projections as two separate
+matmuls in both halves of the block::
+
+    routed experts (SwitchGLU): gather_qmm(gate), gather_qmm(up), gather_qmm(down)
+    shared expert  (MLP):       qmm(gate),        qmm(up),        qmm(down)
+
+Each pair reads the same activation and differs only in which output rows of
+a weight matrix it consumes, so the two matrices can be concatenated along
+their output-feature axis once at load time and evaluated as a single matmul
+whose result is split in two.
+
+Affine quantization groups run along the *input* axis, so concatenating
+output rows leaves every group intact: no requantization happens, and each
+output element is still produced by exactly the dot product that produced it
+before.  ``tests/test_moe_packed_projections.py`` asserts that bitwise on the
+CPU backend for both the plain and the gathered (routed-expert) form.
+
+The win here is dispatch count, not arithmetic.  A 35B-A3B decode forward
+touches roughly 1.4 GB of active weights but issues several hundred kernel
+launches to do it, which leaves it far below the memory-bandwidth roofline
+and makes per-launch and Python graph-construction cost the dominant term.
+Packing removes two matmul dispatches -- and the graph nodes that build them
+-- from every MoE layer, on both the trunk and the MTP draft block.
+
+Nothing in this module is a custom Metal kernel.  The packed forward is
+ordinary MLX ops, so unlike a ``mx.fast.metal_kernel`` lane it still composes
+with ``mx.compile`` and the graphbank verify paths.
+
+Interaction with the other optional lanes, since packing changes the *type*
+of the two projections it replaces:
+
+- the packed shared expert is no longer a ``Qwen3NextMLP``, so the
+  ``MTPLX_MLP_CALL_VARIANT`` lane in :mod:`mtplx.native_mlp` no longer sees
+  it (that lane targets the dense-model MLP and is inactive at M=1 anyway);
+- the packed projections call ``mx.quantized_matmul``/``mx.gather_qmm``
+  directly rather than through ``nn.QuantizedLinear``, so the NAX verify
+  patch in :mod:`mtplx.nax_verify` does not route them.
+
+Neither lane is on by default, and the routed-expert ``down_proj`` and the
+router itself are untouched either way.
+
+Default off.  Enable with ``MTPLX_QWEN_MOE_PACK_GATE_UP=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+PACK_GATE_UP_ENV = "MTPLX_QWEN_MOE_PACK_GATE_UP"
+
+_STATS: dict[str, Any] = {
+    "enabled": False,
+    "packed_switch_mlp": 0,
+    "packed_shared_expert": 0,
+    "skipped_blocks": 0,
+    "skip_reasons": [],
+}
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def moe_pack_gate_up_enabled() -> bool:
+    """Whether construction-time MoE gate/up packing is requested."""
+
+    return _env_enabled(PACK_GATE_UP_ENV)
+
+
+def moe_packed_projection_stats() -> dict[str, Any]:
+    """Snapshot of what the last :func:`configure_moe_packed_projections` did."""
+
+    stats = dict(_STATS)
+    stats["skip_reasons"] = list(_STATS["skip_reasons"])
+    return stats
+
+
+class _PackedQuantizedProjection(nn.Module):
+    """One affine-quantized projection holding two stacked source matrices."""
+
+    def __init__(
+        self,
+        weight: mx.array,
+        scales: mx.array,
+        biases: mx.array | None,
+        *,
+        group_size: int,
+        bits: int,
+        mode: str,
+    ):
+        super().__init__()
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        self.group_size = int(group_size)
+        self.bits = int(bits)
+        self.mode = str(mode)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.quantized_matmul(
+            x,
+            self["weight"],
+            scales=self["scales"],
+            biases=self.get("biases"),
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def gather(self, x: mx.array, indices: mx.array, sorted_indices: bool) -> mx.array:
+        return mx.gather_qmm(
+            x,
+            self["weight"],
+            self["scales"],
+            self.get("biases"),
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=sorted_indices,
+        )
+
+
+class _PackedDenseProjection(nn.Module):
+    """One unquantized projection holding two stacked source matrices."""
+
+    def __init__(self, weight: mx.array):
+        super().__init__()
+        self.weight = weight
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self["weight"].swapaxes(-1, -2)
+
+    def gather(self, x: mx.array, indices: mx.array, sorted_indices: bool) -> mx.array:
+        return mx.gather_mm(
+            x,
+            self["weight"].swapaxes(-1, -2),
+            rhs_indices=indices,
+            sorted_indices=sorted_indices,
+        )
+
+
+class PackedSwitchGLU(nn.Module):
+    """SwitchGLU with gate/up packed into a single gathered projection.
+
+    Reproduces :class:`mlx_lm.models.switch_layers.SwitchGLU` call for call,
+    including the token-sorting path, with the two expert matmuls replaced by
+    one over the packed weight.
+    """
+
+    def __init__(self, gate_up_proj: nn.Module, down_proj: Any, activation: Any, split_at: int):
+        super().__init__()
+        self.gate_up_proj = gate_up_proj
+        self.down_proj = down_proj
+        self.activation = activation
+        self._split_at = int(split_at)
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        from mlx_lm.models.switch_layers import _gather_sort, _scatter_unsort
+
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+
+        packed = self.gate_up_proj.gather(x, idx, do_sort)
+        x_gate, x_up = mx.split(packed, [self._split_at], axis=-1)
+
+        x = self.down_proj(
+            self.activation(x_up, x_gate),
+            idx,
+            sorted_indices=do_sort,
+        )
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)
+
+
+class PackedGateUpMLP(nn.Module):
+    """Shared-expert MLP with gate/up packed into a single projection.
+
+    Reproduces :class:`mlx_lm.models.qwen3_next.Qwen3NextMLP` with the two
+    projection matmuls replaced by one over the packed weight.
+    """
+
+    def __init__(self, gate_up_proj: nn.Module, down_proj: Any, split_at: int):
+        super().__init__()
+        self.gate_up_proj = gate_up_proj
+        self.down_proj = down_proj
+        self._split_at = int(split_at)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        from mlx_lm.models.qwen3_next import swiglu
+
+        packed = self.gate_up_proj(x)
+        gate, up = mx.split(packed, [self._split_at], axis=-1)
+        return self.down_proj(swiglu(gate, up))
+
+
+def _quant_metadata(module: Any) -> tuple[int, int, str] | None:
+    """Return (group_size, bits, mode) when the module is quantized."""
+
+    if "scales" not in module:
+        return None
+    return (
+        int(getattr(module, "group_size", 64)),
+        int(getattr(module, "bits", 4)),
+        str(getattr(module, "mode", "affine")),
+    )
+
+
+def _pack_pair(gate: Any, up: Any, axis: int) -> tuple[nn.Module, int] | str:
+    """Concatenate a gate/up pair along ``axis``, or return a skip reason.
+
+    ``axis`` is the output-feature axis: 0 for a plain ``[out, in]`` linear,
+    1 for a switch ``[experts, out, in]`` linear.
+    """
+
+    if "bias" in gate or "bias" in up:
+        return "projection carries an additive bias"
+
+    gate_quant = _quant_metadata(gate)
+    up_quant = _quant_metadata(up)
+    if gate_quant != up_quant:
+        return "gate and up quantization differ"
+
+    gate_weight = gate["weight"]
+    up_weight = up["weight"]
+    if gate_weight.ndim != up_weight.ndim or gate_weight.ndim != axis + 2:
+        return "unexpected weight rank"
+    if gate_weight.shape[axis] != up_weight.shape[axis]:
+        return "gate and up output widths differ"
+    if gate_weight.shape[:axis] != up_weight.shape[:axis]:
+        return "gate and up expert counts differ"
+    if gate_weight.shape[axis + 1 :] != up_weight.shape[axis + 1 :]:
+        return "gate and up input widths differ"
+    if gate_weight.dtype != up_weight.dtype:
+        return "gate and up weight dtypes differ"
+
+    split_at = int(gate_weight.shape[axis])
+
+    if gate_quant is None:
+        packed = _PackedDenseProjection(mx.concatenate([gate_weight, up_weight], axis=axis))
+        mx.eval(packed["weight"])
+        return packed, split_at
+
+    group_size, bits, mode = gate_quant
+    if gate["scales"].shape != up["scales"].shape:
+        return "gate and up scale shapes differ"
+    has_gate_bias = gate.get("biases") is not None
+    has_up_bias = up.get("biases") is not None
+    if has_gate_bias != has_up_bias:
+        return "only one of gate/up carries quantization biases"
+
+    weight = mx.concatenate([gate_weight, up_weight], axis=axis)
+    scales = mx.concatenate([gate["scales"], up["scales"]], axis=axis)
+    biases = None
+    if has_gate_bias:
+        biases = mx.concatenate([gate["biases"], up["biases"]], axis=axis)
+
+    packed = _PackedQuantizedProjection(
+        weight,
+        scales,
+        biases,
+        group_size=group_size,
+        bits=bits,
+        mode=mode,
+    )
+    mx.eval(packed["weight"], packed["scales"])
+    if biases is not None:
+        mx.eval(biases)
+    return packed, split_at
+
+
+def _pack_block(block: Any) -> tuple[int, int, list[str]]:
+    """Pack one sparse MoE block in place. Returns (switch, shared, reasons)."""
+
+    switch_packed = 0
+    shared_packed = 0
+    reasons: list[str] = []
+
+    switch_mlp = getattr(block, "switch_mlp", None)
+    if switch_mlp is not None and hasattr(switch_mlp, "gate_proj"):
+        result = _pack_pair(switch_mlp.gate_proj, switch_mlp.up_proj, axis=1)
+        if isinstance(result, str):
+            reasons.append(f"switch_mlp: {result}")
+        else:
+            packed, split_at = result
+            block.switch_mlp = PackedSwitchGLU(
+                packed,
+                switch_mlp.down_proj,
+                switch_mlp.activation,
+                split_at,
+            )
+            switch_packed = 1
+
+    shared = getattr(block, "shared_expert", None)
+    if shared is not None and hasattr(shared, "gate_proj"):
+        result = _pack_pair(shared.gate_proj, shared.up_proj, axis=0)
+        if isinstance(result, str):
+            reasons.append(f"shared_expert: {result}")
+        else:
+            packed, split_at = result
+            block.shared_expert = PackedGateUpMLP(packed, shared.down_proj, split_at)
+            shared_packed = 1
+
+    return switch_packed, shared_packed, reasons
+
+
+def configure_moe_packed_projections(model: Any | None = None) -> dict[str, Any]:
+    """Pack gate/up projections in every Qwen sparse MoE block of ``model``.
+
+    No-op unless ``MTPLX_QWEN_MOE_PACK_GATE_UP`` is set.  Safe to call on a
+    model without MoE blocks, and idempotent: an already-packed block exposes
+    no ``gate_proj`` to pack a second time.
+    """
+
+    _STATS["enabled"] = moe_pack_gate_up_enabled()
+    _STATS["packed_switch_mlp"] = 0
+    _STATS["packed_shared_expert"] = 0
+    _STATS["skipped_blocks"] = 0
+    _STATS["skip_reasons"] = []
+
+    if not _STATS["enabled"] or model is None:
+        return moe_packed_projection_stats()
+
+    try:
+        from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+    except ImportError:
+        _STATS["skip_reasons"] = ["mlx_lm Qwen MoE block unavailable"]
+        return moe_packed_projection_stats()
+
+    for _, module in model.named_modules():
+        if not isinstance(module, Qwen3NextSparseMoeBlock):
+            continue
+        switch_packed, shared_packed, reasons = _pack_block(module)
+        _STATS["packed_switch_mlp"] += switch_packed
+        _STATS["packed_shared_expert"] += shared_packed
+        if reasons:
+            _STATS["skipped_blocks"] += 1
+            for reason in reasons:
+                if reason not in _STATS["skip_reasons"]:
+                    _STATS["skip_reasons"].append(reason)
+
+    return moe_packed_projection_stats()

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -406,10 +406,21 @@ def load(
         if not mtp_enabled or not validate_mtp_support(model):
             raise RuntimeError(f"MTP injection failed for {path}")
     from .attention_split import configure_split_full_attention
+    from .moe_packed_projections import (
+        configure_moe_packed_projections,
+        moe_pack_gate_up_enabled,
+    )
     from .native_mlp import configure_native_mlp
 
     configure_split_full_attention(model)
     configure_native_mlp(model)
+    # Construction-time only: replaces the MoE gate/up projections with one
+    # packed matmul each. Must run after MTP injection so the draft block's
+    # MoE layer is packed too, and after load-coverage validation so the
+    # packed parameter tree is never compared against checkpoint keys.
+    if moe_pack_gate_up_enabled():
+        pack_report = configure_moe_packed_projections(model)
+        logger.info("[moe-pack] %s", pack_report)
     from .nax_verify import install_nax_qlinear_patch, nax_env_enabled
 
     if nax_env_enabled():

--- a/tests/test_moe_packed_projections.py
+++ b/tests/test_moe_packed_projections.py
@@ -1,0 +1,353 @@
+"""Parity tests for construction-time MoE gate/up packing.
+
+Everything here runs on the CPU stream: the packing itself is weight surgery
+and the parity claim is about which dot products produce which outputs, so it
+does not need Metal.  A GPU parity run on a real Qwen MoE artifact is tracked
+separately.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mtplx.moe_packed_projections import (
+    PACK_GATE_UP_ENV,
+    PackedGateUpMLP,
+    PackedSwitchGLU,
+    _pack_pair,
+    configure_moe_packed_projections,
+    moe_pack_gate_up_enabled,
+    moe_packed_projection_stats,
+)
+
+pytest.importorskip("mlx_lm.models.qwen3_next")
+
+HIDDEN = 128
+MOE_INTERMEDIATE = 64
+SHARED_INTERMEDIATE = 64
+NUM_EXPERTS = 8
+TOP_K = 4
+GROUP_SIZE = 64
+BITS = 4
+
+
+@pytest.fixture(autouse=True)
+def _cpu_stream():
+    """Keep every op in these tests off the Metal device."""
+    with mx.stream(mx.cpu):
+        yield
+
+
+def _moe_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        hidden_size=HIDDEN,
+        moe_intermediate_size=MOE_INTERMEDIATE,
+        shared_expert_intermediate_size=SHARED_INTERMEDIATE,
+        norm_topk_prob=True,
+        num_experts=NUM_EXPERTS,
+        num_experts_per_tok=TOP_K,
+    )
+
+
+def _make_block(quantized: bool = True):
+    from mlx_lm.models.qwen3_next import Qwen3NextSparseMoeBlock
+
+    mx.random.seed(1234)
+    block = Qwen3NextSparseMoeBlock(_moe_args())
+    if quantized:
+        nn.quantize(block, group_size=GROUP_SIZE, bits=BITS)
+    mx.eval(block.parameters())
+    return block
+
+
+class _Wrapper(nn.Module):
+    """Minimal model-shaped container so named_modules() finds the block."""
+
+    def __init__(self, block):
+        super().__init__()
+        self.block = block
+
+
+# --------------------------------------------------------------------------
+# The core claim: concatenating output rows preserves every dot product.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("quantized", [True, False])
+def test_packed_linear_pair_is_bitwise_exact(quantized: bool):
+    mx.random.seed(7)
+    gate = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=False)
+    up = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=False)
+    if quantized:
+        gate = nn.QuantizedLinear.from_linear(gate, group_size=GROUP_SIZE, bits=BITS)
+        up = nn.QuantizedLinear.from_linear(up, group_size=GROUP_SIZE, bits=BITS)
+    mx.eval(gate.parameters(), up.parameters())
+
+    x = mx.random.normal((5, HIDDEN))
+    stock_gate, stock_up = gate(x), up(x)
+
+    result = _pack_pair(gate, up, axis=0)
+    assert not isinstance(result, str), result
+    packed, split_at = result
+    assert split_at == SHARED_INTERMEDIATE
+
+    fused = packed(x)
+    got_gate, got_up = mx.split(fused, [split_at], axis=-1)
+
+    assert mx.array_equal(got_gate, stock_gate)
+    assert mx.array_equal(got_up, stock_up)
+
+
+@pytest.mark.parametrize("quantized", [True, False])
+def test_packed_switch_pair_is_bitwise_exact(quantized: bool):
+    from mlx_lm.models.switch_layers import SwitchLinear
+
+    mx.random.seed(11)
+    gate = SwitchLinear(HIDDEN, MOE_INTERMEDIATE, NUM_EXPERTS, bias=False)
+    up = SwitchLinear(HIDDEN, MOE_INTERMEDIATE, NUM_EXPERTS, bias=False)
+    if quantized:
+        gate = gate.to_quantized(group_size=GROUP_SIZE, bits=BITS)
+        up = up.to_quantized(group_size=GROUP_SIZE, bits=BITS)
+    mx.eval(gate.parameters(), up.parameters())
+
+    x = mx.random.normal((3, 1, 1, HIDDEN))
+    indices = mx.array([[0, 5], [2, 7], [1, 3]])
+    stock_gate = gate(x, indices)
+    stock_up = up(x, indices)
+
+    result = _pack_pair(gate, up, axis=1)
+    assert not isinstance(result, str), result
+    packed, split_at = result
+    assert split_at == MOE_INTERMEDIATE
+
+    fused = packed.gather(x, indices, False)
+    got_gate, got_up = mx.split(fused, [split_at], axis=-1)
+
+    assert mx.array_equal(got_gate, stock_gate)
+    assert mx.array_equal(got_up, stock_up)
+
+
+# --------------------------------------------------------------------------
+# Module-level parity, including SwitchGLU's token-sorting path.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tokens", [1, 3, 20])
+@pytest.mark.parametrize("quantized", [True, False])
+def test_packed_switch_glu_matches_stock(tokens: int, quantized: bool):
+    block = _make_block(quantized=quantized)
+    switch_mlp = block.switch_mlp
+
+    mx.random.seed(21)
+    x = mx.random.normal((tokens, HIDDEN))
+    indices = mx.broadcast_to(mx.arange(TOP_K), (tokens, TOP_K))
+    stock = switch_mlp(x, indices)
+
+    # tokens=20 crosses SwitchGLU's indices.size >= 64 sorting threshold.
+    assert (indices.size >= 64) is (tokens == 20)
+
+    result = _pack_pair(switch_mlp.gate_proj, switch_mlp.up_proj, axis=1)
+    assert not isinstance(result, str), result
+    packed, split_at = result
+    fused = PackedSwitchGLU(
+        packed, switch_mlp.down_proj, switch_mlp.activation, split_at
+    )
+
+    assert mx.array_equal(fused(x, indices), stock)
+
+
+@pytest.mark.parametrize("quantized", [True, False])
+def test_packed_shared_expert_matches_stock(quantized: bool):
+    block = _make_block(quantized=quantized)
+    shared = block.shared_expert
+
+    mx.random.seed(31)
+    x = mx.random.normal((4, HIDDEN))
+    stock = shared(x)
+
+    result = _pack_pair(shared.gate_proj, shared.up_proj, axis=0)
+    assert not isinstance(result, str), result
+    packed, split_at = result
+    fused = PackedGateUpMLP(packed, shared.down_proj, split_at)
+
+    assert mx.array_equal(fused(x), stock)
+
+
+# --------------------------------------------------------------------------
+# configure_moe_packed_projections wiring.
+# --------------------------------------------------------------------------
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv(PACK_GATE_UP_ENV, raising=False)
+    assert moe_pack_gate_up_enabled() is False
+
+    model = _Wrapper(_make_block())
+    stats = configure_moe_packed_projections(model)
+
+    assert stats["enabled"] is False
+    assert stats["packed_switch_mlp"] == 0
+    assert stats["packed_shared_expert"] == 0
+    # The block is untouched: stock projections still present.
+    assert hasattr(model.block.switch_mlp, "gate_proj")
+    assert hasattr(model.block.shared_expert, "gate_proj")
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "on", "yes"])
+def test_flag_parsing(monkeypatch, flag: str):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, flag)
+    assert moe_pack_gate_up_enabled() is True
+
+
+def test_configure_packs_block_and_preserves_output(monkeypatch):
+    model = _Wrapper(_make_block())
+
+    mx.random.seed(41)
+    x = mx.random.normal((6, HIDDEN))
+    stock = model.block(x)
+
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    stats = configure_moe_packed_projections(model)
+
+    assert stats["enabled"] is True
+    assert stats["packed_switch_mlp"] == 1
+    assert stats["packed_shared_expert"] == 1
+    assert stats["skip_reasons"] == []
+    assert isinstance(model.block.switch_mlp, PackedSwitchGLU)
+    assert isinstance(model.block.shared_expert, PackedGateUpMLP)
+
+    assert mx.array_equal(model.block(x), stock)
+
+
+def test_configure_reaches_blocks_nested_in_layer_lists(monkeypatch):
+    """The real model holds its MoE blocks in a list attribute, not directly."""
+
+    class _Layer(nn.Module):
+        def __init__(self, block):
+            super().__init__()
+            self.mlp = block
+
+    class _Model(nn.Module):
+        def __init__(self, blocks):
+            super().__init__()
+            self.layers = [_Layer(block) for block in blocks]
+
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    model = _Model([_make_block() for _ in range(3)])
+
+    mx.random.seed(61)
+    x = mx.random.normal((2, HIDDEN))
+    stock = [layer.mlp(x) for layer in model.layers]
+
+    stats = configure_moe_packed_projections(model)
+
+    assert stats["packed_switch_mlp"] == 3
+    assert stats["packed_shared_expert"] == 3
+    for layer, expected in zip(model.layers, stock):
+        assert isinstance(layer.mlp.switch_mlp, PackedSwitchGLU)
+        assert isinstance(layer.mlp.shared_expert, PackedGateUpMLP)
+        assert mx.array_equal(layer.mlp(x), expected)
+
+
+def test_configure_is_idempotent(monkeypatch):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    model = _Wrapper(_make_block())
+
+    mx.random.seed(51)
+    x = mx.random.normal((2, HIDDEN))
+
+    configure_moe_packed_projections(model)
+    once = model.block(x)
+
+    second = configure_moe_packed_projections(model)
+    assert second["packed_switch_mlp"] == 0
+    assert second["packed_shared_expert"] == 0
+    assert mx.array_equal(model.block(x), once)
+
+
+def test_configure_without_moe_blocks_is_noop(monkeypatch):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+
+    class _Dense(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = nn.Linear(HIDDEN, HIDDEN, bias=False)
+
+    stats = configure_moe_packed_projections(_Dense())
+    assert stats["packed_switch_mlp"] == 0
+    assert stats["packed_shared_expert"] == 0
+    assert stats["skipped_blocks"] == 0
+
+
+def test_configure_handles_none_model(monkeypatch):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    stats = configure_moe_packed_projections(None)
+    assert stats["packed_switch_mlp"] == 0
+
+
+# --------------------------------------------------------------------------
+# Guard rails: a pair that cannot be packed is skipped, never mispacked.
+# --------------------------------------------------------------------------
+
+
+def test_mismatched_output_widths_are_skipped():
+    gate = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=False)
+    up = nn.Linear(HIDDEN, SHARED_INTERMEDIATE * 2, bias=False)
+    mx.eval(gate.parameters(), up.parameters())
+
+    reason = _pack_pair(gate, up, axis=0)
+    assert isinstance(reason, str)
+    assert "output widths" in reason
+
+
+def test_mismatched_quantization_is_skipped():
+    gate = nn.QuantizedLinear.from_linear(
+        nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=False),
+        group_size=GROUP_SIZE,
+        bits=BITS,
+    )
+    up = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=False)
+    mx.eval(gate.parameters(), up.parameters())
+
+    reason = _pack_pair(gate, up, axis=0)
+    assert isinstance(reason, str)
+    assert "quantization" in reason
+
+
+def test_additive_bias_is_skipped():
+    gate = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=True)
+    up = nn.Linear(HIDDEN, SHARED_INTERMEDIATE, bias=True)
+    mx.eval(gate.parameters(), up.parameters())
+
+    reason = _pack_pair(gate, up, axis=0)
+    assert isinstance(reason, str)
+    assert "bias" in reason
+
+
+def test_skip_reason_surfaces_in_stats(monkeypatch):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    model = _Wrapper(_make_block(quantized=False))
+    # Make the shared expert unpackable without touching the routed experts.
+    model.block.shared_expert.up_proj = nn.Linear(
+        HIDDEN, SHARED_INTERMEDIATE * 2, bias=False
+    )
+    mx.eval(model.block.shared_expert.parameters())
+
+    stats = configure_moe_packed_projections(model)
+
+    assert stats["packed_switch_mlp"] == 1
+    assert stats["packed_shared_expert"] == 0
+    assert stats["skipped_blocks"] == 1
+    assert any("shared_expert" in reason for reason in stats["skip_reasons"])
+
+
+def test_stats_snapshot_is_a_copy(monkeypatch):
+    monkeypatch.setenv(PACK_GATE_UP_ENV, "1")
+    configure_moe_packed_projections(_Wrapper(_make_block()))
+    snapshot = moe_packed_projection_stats()
+    snapshot["skip_reasons"].append("mutation")
+    assert "mutation" not in moe_packed_projection_stats()["skip_reasons"]


### PR DESCRIPTION
## What

Concatenates the gate and up projections of Qwen's sparse MoE block into a single projection once at load time, so each half of the block runs one matmul instead of two:

| | before | after |
|---|---|---|
| routed experts (`SwitchGLU`) | `gather_qmm(gate)`, `gather_qmm(up)`, `gather_qmm(down)` | `gather_qmm(gate_up)`, `gather_qmm(down)` |
| shared expert (`Qwen3NextMLP`) | `qmm(gate)`, `qmm(up)`, `qmm(down)` | `qmm(gate_up)`, `qmm(down)` |

Both pairs read the same activation and differ only in which output rows of a weight matrix they consume, so the two matrices can be stacked along their output-feature axis and the fused result split in two.

Default off behind `MTPLX_QWEN_MOE_PACK_GATE_UP=1`.

## Why this is exact

Affine quantization groups run along the **input** axis, so concatenating output rows keeps every group intact. Nothing is requantized, and each output element is still produced by exactly the dot product that produced it before.

`tests/test_moe_packed_projections.py` asserts that bitwise (`mx.array_equal`, not a tolerance) on the CPU backend for:

- the plain `quantized_matmul` form and the gathered `gather_qmm` form, quantized and unquantized;
- `SwitchGLU` both below and above its `indices.size >= 64` token-sorting threshold;
- the shared expert MLP;
- the whole MoE block before vs. after packing, including blocks nested in a layer list.

Guard rails are tested too: a pair with mismatched output widths, mismatched quantization, or an additive bias is skipped with a reason recorded in the stats rather than mispacked.

## Why it should help

This targets **dispatch count**, not arithmetic or bytes. A 35B-A3B decode forward touches roughly 1.4 GB of active weights but issues several hundred kernel launches to do it, which puts it far below the memory-bandwidth roofline and makes per-launch and Python graph-construction cost the dominant term. Packing removes two matmul dispatches — and the graph nodes that build them — from every MoE layer, on the trunk and the MTP draft block alike. The arithmetic is unchanged.

## Compatibility

The packed forward is ordinary MLX ops, **not** a custom Metal kernel, so unlike a `mx.fast.metal_kernel` lane it still composes with `mx.compile` and the graphbank verify paths.

Because packing changes the *type* of the two projections it replaces, two optional lanes stop seeing them (both documented in the module docstring, both default-off, and neither touches the routed `down_proj` or the router):

- the packed shared expert is no longer a `Qwen3NextMLP`, so the `MTPLX_MLP_CALL_VARIANT` lane in `native_mlp` skips it — that lane targets the dense-model MLP and is inactive at M=1 anyway;
- the packed projections call `mx.quantized_matmul`/`mx.gather_qmm` directly rather than through `nn.QuantizedLinear`, so the NAX verify patch does not route them.

## Status

Correctness-gated, **performance pending**. The parity tests above run on the CPU backend and pass; I have not yet measured decode throughput on a Qwen MoE artifact, so there is no tok/s claim here. Follow-ups I'd want before this comes out of draft:

1. GPU parity on a real Qwen3.6-35B-A3B artifact (the group-preservation argument is backend-independent, but Metal parity should be confirmed rather than assumed);
2. an A/B decode measurement to size the dispatch saving;
3. optionally, packing the router `gate` with `shared_expert_gate` — same mechanism, one more dispatch per layer — which I left out to keep this reviewable.

## Test

```
$ python -m pytest tests/test_moe_packed_projections.py tests/test_attention_split.py -q
.............................                                            [100%]
$ echo $?
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHUiWXTFYuksrafoFWoPbB
