### PR TITLE
thermal: restore fans via the ThermalForge daemon socket, not the app-killing CLI

### DIFF
--- a/mtplx/thermal.py
+++ b/mtplx/thermal.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import threading
@@ -67,6 +68,37 @@ def _run_probe(command: list[str], *, timeout_s: float = 3.0) -> dict[str, Any]:
         "stdout": proc.stdout.strip(),
         "stderr": proc.stderr.strip(),
         "ok": proc.returncode == 0,
+    }
+
+
+# Unix socket the ThermalForge privileged daemon listens on (matches
+# ThermalForgeDaemon.socketPath). Reaching it resets fans as root without sudo
+# and, unlike the `thermalforge auto` CLI, without quitting the menu bar app.
+THERMALFORGE_DAEMON_SOCKET = "/tmp/thermalforge.sock"
+
+
+def _daemon_socket_send(command: str, *, timeout_s: float = 3.0) -> dict[str, Any] | None:
+    """Send one newline-terminated command to the ThermalForge daemon socket.
+
+    Returns None when no daemon is reachable, so callers fall back to the CLI;
+    otherwise ``{"ok": bool, "response": str, "command": [...]}``. The daemon
+    speaks "auto" / "max" / "set <rpm>" / "status" and replies "ok", JSON, or
+    "error: ...".
+    """
+    if not os.path.exists(THERMALFORGE_DAEMON_SOCKET):
+        return None
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout_s)
+            sock.connect(THERMALFORGE_DAEMON_SOCKET)
+            sock.sendall((command + "\n").encode())
+            response = sock.recv(8192).decode(errors="replace").strip()
+    except OSError:
+        return None
+    return {
+        "ok": bool(response) and not response.lower().startswith("error"),
+        "response": response,
+        "command": ["<thermalforge-daemon-socket>", command],
     }
 
 
@@ -1569,7 +1601,26 @@ def set_thermal_profile(profile: str, *, dry_run: bool = False) -> dict[str, Any
             "command": commands[0] if commands else None,
             "attempts": [],
         }
-    attempts = []
+    attempts: list[dict[str, Any]] = []
+
+    # ThermalForge exposes a privileged daemon socket that resets fans as root
+    # (no sudo) and, unlike the `auto` CLI, never quits the menu bar app. Prefer
+    # it for the fan reset so restoring fans can't take down a running app; the
+    # CLI candidates below stay the fallback when no daemon is reachable.
+    if profile == "silent" and str(selected.get("kind")) == "thermalforge":
+        reset = _daemon_socket_send("auto")
+        if reset is not None:
+            attempts.append(reset)
+            if reset["ok"]:
+                return {
+                    "ok": True,
+                    "profile": profile,
+                    "dry_run": False,
+                    "detection": detection,
+                    "command": reset["command"],
+                    "attempts": attempts,
+                }
+
     for command in commands:
         result = _run_probe(command, timeout_s=15.0)
         attempts.append(result)

--- a/mtplx/thermal_sidecar.py
+++ b/mtplx/thermal_sidecar.py
@@ -31,6 +31,8 @@ import subprocess
 import sys
 import time
 
+from mtplx.thermal import _daemon_socket_send
+
 
 def _detach_from_terminal() -> None:
     """Best-effort detach from the controlling terminal.
@@ -79,13 +81,18 @@ def _parent_alive(pid: int) -> bool:
 
 
 def _restore_fans(binary: str) -> int:
-    """Run ``sudo -n <binary> auto``. Returns the subprocess exit code.
+    """Restore Apple-auto fans and return an exit code.
 
-    ``sudo -n`` never prompts for a password, so this either succeeds
-    immediately (NOPASSWD rule active) or fails fast with a non-zero
-    exit code. Either way the sidecar exits — there's no point staying
-    alive once the parent is gone and we've made our attempt.
+    Prefer the ThermalForge daemon socket: it resets fans as root without sudo
+    and, unlike ``thermalforge auto``, never quits the menu bar app. Fall back
+    to ``sudo -n <binary> auto`` when no daemon is reachable. ``sudo -n`` never
+    prompts, so it succeeds immediately (NOPASSWD active) or fails fast — either
+    way the sidecar exits, having made its attempt.
     """
+
+    reset = _daemon_socket_send("auto")
+    if reset is not None and reset["ok"]:
+        return 0
 
     try:
         proc = subprocess.run(

--- a/tests/test_thermal.py
+++ b/tests/test_thermal.py
@@ -1,6 +1,16 @@
 from mtplx import thermal
 import subprocess
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_no_daemon_socket(monkeypatch):
+    """Default every test to "no ThermalForge daemon socket" so the suite never
+    touches a real daemon on the dev machine. Socket-path tests opt back in by
+    re-patching ``_daemon_socket_send``."""
+    monkeypatch.setattr(thermal, "_daemon_socket_send", lambda *a, **k: None)
+
 
 def test_detect_thermal_control_reports_none_without_tools(monkeypatch):
     thermal.detect_thermal_control.cache_clear()
@@ -30,6 +40,57 @@ def test_set_thermal_profile_without_tool_is_actionable(monkeypatch):
     assert result["profile"] == "performance"
     assert "mtplx max --install" in result["message"]
     thermal.detect_thermal_control.cache_clear()
+
+
+_FAKE_THERMALFORGE_DETECTION = {
+    "available": True,
+    "selected": {"kind": "thermalforge", "path": "/usr/local/bin/thermalforge"},
+    "instructions": "",
+}
+
+
+def test_set_thermal_profile_silent_prefers_daemon_socket(monkeypatch):
+    """The fan reset goes through the daemon socket (no sudo, no app-kill) and
+    does not fall back to the `auto` CLI when the socket accepts it."""
+    monkeypatch.setattr(thermal, "detect_thermal_control", lambda: _FAKE_THERMALFORGE_DETECTION)
+
+    sent: list[str] = []
+
+    def fake_socket(command, *, timeout_s=3.0):
+        sent.append(command)
+        return {"ok": True, "response": "ok", "command": ["<thermalforge-daemon-socket>", command]}
+
+    monkeypatch.setattr(thermal, "_daemon_socket_send", fake_socket)
+
+    def no_cli(command, *, timeout_s=None, cwd=None):
+        raise AssertionError(f"CLI should not run when the socket handles it: {command}")
+
+    monkeypatch.setattr(thermal, "_run_probe", no_cli)
+
+    result = thermal.set_thermal_profile("silent")
+
+    assert result["ok"] is True
+    assert sent == ["auto"]
+    assert result["command"] == ["<thermalforge-daemon-socket>", "auto"]
+
+
+def test_set_thermal_profile_silent_falls_back_to_cli_without_daemon(monkeypatch):
+    """With no daemon socket reachable (the autouse default), the reset uses the
+    `auto` CLI candidates."""
+    monkeypatch.setattr(thermal, "detect_thermal_control", lambda: _FAKE_THERMALFORGE_DETECTION)
+
+    ran: list[list[str]] = []
+
+    def fake_run(command, *, timeout_s=None, cwd=None):
+        ran.append(command)
+        return {"command": command, "returncode": 0, "ok": True, "stdout": "", "stderr": ""}
+
+    monkeypatch.setattr(thermal, "_run_probe", fake_run)
+
+    result = thermal.set_thermal_profile("silent")
+
+    assert result["ok"] is True
+    assert ran and ran[0][-1] == "auto"
 
 
 _RAMPED_SUMMARY = {

--- a/tests/test_thermal_sidecar.py
+++ b/tests/test_thermal_sidecar.py
@@ -13,11 +13,36 @@ import os
 import subprocess
 import time
 
+import pytest
+
 from mtplx import thermal_sidecar
+
+
+@pytest.fixture(autouse=True)
+def _default_no_daemon_socket(monkeypatch):
+    """Default every test to "no ThermalForge daemon socket" so the suite never
+    touches a real daemon on the dev machine. The socket-path test opts in."""
+    monkeypatch.setattr(thermal_sidecar, "_daemon_socket_send", lambda *a, **k: None)
 
 
 def test_parent_alive_returns_true_for_self():
     assert thermal_sidecar._parent_alive(os.getpid()) is True
+
+
+def test_restore_fans_prefers_daemon_socket(monkeypatch):
+    """When the daemon socket answers, restore through it and never shell out
+    to sudo (which needs a password and would run the app-killing CLI)."""
+    monkeypatch.setattr(
+        thermal_sidecar,
+        "_daemon_socket_send",
+        lambda *a, **k: {"ok": True, "response": "ok", "command": ["<sock>", "auto"]},
+    )
+
+    def boom(*a, **k):
+        raise AssertionError("must not shell out when the daemon socket handles it")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert thermal_sidecar._restore_fans("/path/to/thermalforge") == 0
 
 
 def test_parent_alive_returns_false_for_dead_pid():


### PR DESCRIPTION
## Problem

MTPLX restores fans by shelling out to `thermalforge auto`, which has two side effects the restore path never wanted:

- the CLI runs `killall ThermalForgeApp`, so **every** fan restore — MaxSession cleanup, the atexit/signal hooks, and the detached sidecar — silently quits the user's running menu bar app;
- the direct-SMC write path requires root, so the sidecar's `sudo -n` restore fails on machines without a NOPASSWD rule, leaving fans pinned after the parent exits.

## Change

ThermalForge's privileged daemon exposes a Unix socket (`/tmp/thermalforge.sock`) whose `auto` command resets fans **as root, without sudo, and without touching the app**. This PR prefers that socket for the silent→auto reset in `set_thermal_profile` and in the sidecar's `_restore_fans`, falling back to the existing CLI candidates whenever no daemon is reachable — behavior on daemon-less installs is unchanged.

The daemon's `auto` verb ships in ThermalForge today; no ThermalForge change is required. (Companion upstream PR making the CLI's app-kill opt-in: ProducerGuy/ThermalForge#29.)

Adds a `_daemon_socket_send` seam with a documented protocol (`auto` / `max` / `set <rpm>` / `status`, newline-terminated, `ok`/JSON/`error:` replies). Tests default the seam to "no daemon" via an autouse fixture, so the suite never touches a real socket; new tests cover the daemon-preferred path, the fallback ordering, and the sidecar restore.

## Tests

`tests/test_thermal.py` + `tests/test_thermal_sidecar.py`: 47/47 on top of current main.