### PR TITLE
pull: stop reporting an interrupted download as a complete model

### DIFF
--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -7,6 +7,7 @@ import errno
 import importlib
 import json
 import os
+import re
 import shutil
 import time
 from dataclasses import dataclass
@@ -162,14 +163,44 @@ def _complete_indexed_weights(path: Path, index_name: str) -> bool:
     return True
 
 
+_SHARD_FILENAME_RE = re.compile(r"-\d+-of-\d+", re.IGNORECASE)
+
+
+def _has_incomplete_transfers(path: Path) -> bool:
+    """``snapshot_download`` stages in-flight files as ``*.incomplete``.
+
+    Markers inside the hub's ``.cache`` bookkeeping tree are ignored: they
+    can outlive a successful resume, and the weight checks verify the final
+    files directly. A marker next to the weights, however, means the final
+    file never landed.
+    """
+
+    try:
+        for marker in path.rglob("*.incomplete"):
+            if ".cache" in marker.relative_to(path).parts:
+                continue
+            return True
+    except OSError:
+        pass
+    return False
+
+
 def _complete_unindexed_weights(path: Path) -> bool:
     for pattern in ("*.safetensors", "*.bin", "*.gguf"):
         for candidate in path.glob(pattern):
             try:
-                if candidate.is_file() and candidate.stat().st_size > 0:
-                    return True
+                if not candidate.is_file() or candidate.stat().st_size <= 0:
+                    continue
             except OSError:
                 continue
+            # A shard-named file implies a weight index the download has not
+            # reached yet; shard names can sort before the index (e.g.
+            # "model.safetensors-00001-of-00039.safetensors" precedes
+            # "model.safetensors.index.json"), so treat the copy as partial
+            # rather than as a complete single-file model.
+            if _SHARD_FILENAME_RE.search(candidate.name):
+                return False
+            return True
     return False
 
 
@@ -182,6 +213,8 @@ def cached_model_is_complete(path: Path) -> bool:
     """
 
     if not path.is_dir():
+        return False
+    if _has_incomplete_transfers(path):
         return False
     # Assistant-pair bundles (Gemma 4) have no top-level config.json — the
     # weights live under target/ and assistant/ with an mtplx_pair.json

--- a/tests/test_hf_loader.py
+++ b/tests/test_hf_loader.py
@@ -183,6 +183,40 @@ def test_cached_model_is_complete_rejects_partial_index_even_with_one_shard(
     assert cached_model_is_complete(cached) is False
 
 
+def test_cached_model_is_complete_rejects_incomplete_transfer_marker(tmp_path: Path):
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors").write_bytes(b"weights")
+    (cached / "model.safetensors.incomplete").write_bytes(b"partial")
+
+    assert cached_model_is_complete(cached) is False
+
+
+def test_cached_model_is_complete_rejects_shards_that_sort_before_index(
+    tmp_path: Path,
+):
+    # Interrupted pull of Qwen/Qwen3.5-122B-A10B: shard names like
+    # "model.safetensors-00001-of-00039.safetensors" download before
+    # "model.safetensors.index.json", so a cancel leaves complete shards,
+    # no index, and no .incomplete marker.
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors-00001-of-00039.safetensors").write_bytes(b"weights")
+
+    assert cached_model_is_complete(cached) is False
+
+
+def test_cached_model_is_complete_accepts_single_file_model(tmp_path: Path):
+    cached = tmp_path / "mtplx--example"
+    cached.mkdir()
+    (cached / "config.json").write_text("{}\n", encoding="utf-8")
+    (cached / "model.safetensors").write_bytes(b"weights")
+
+    assert cached_model_is_complete(cached) is True
+
+
 def test_pull_model_reuses_complete_destination_without_redownload(
     tmp_path: Path, monkeypatch
 ):


### PR DESCRIPTION
## Problem

A cancelled first `mtplx pull` can leave a cache directory that every later `pull`, `forge`, and `serve` treats as complete. Two gates fail together:

1. `cached_model_is_complete` assumes the weight index arrives early in a download. For repos whose shard files sort lexicographically *before* the index file — e.g. `model.safetensors-00001-of-00039.safetensors` < `model.safetensors.index.json`, as shipped by `Qwen/Qwen3.5-122B-A10B` — all shards download first. A cancel mid-shard leaves N complete shards and **no index**, so the check falls through to the unindexed single-file path, sees one healthy `.safetensors`, and reports complete.
2. `_local_matches_remote_index` returns `True` vacuously when there is no local index, so the freshness check can't save it.

Net effect (reproduced): a pull cancelled at shard 2/39 (12.7 GB of 245 GB) is "reused" by every subsequent pull with no resume, and would be handed to forge/serve as a runnable model.

## Change

- `cached_model_is_complete` rejects any directory containing a `*.incomplete` transfer marker next to the weights — unambiguous evidence of an interrupted transfer. Markers inside the hub's `.cache/` bookkeeping tree are exempt: they can legitimately outlive a successful resume, and the final files are verified directly.
- `_complete_unindexed_weights` no longer accepts shard-named files (`*-NNNNN-of-NNNNN*`) as a complete single-file model: a shard implies an index, and a missing index means the download never got there.

Either signal alone catches the reproduced case; together they also cover the marker-less variant (cancel exactly between shard completion and index download).

## Tests

Three regression tests in `tests/test_hf_loader.py`: the shards-before-index cancel, a top-level `.incomplete` marker, and a guard that legitimate single-file models still pass. Full file suite 24/24; adjacent download/forge/default-model suites also pass.