### PR TITLE
cleanup: remove unused variables and imports

### DIFF
--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -811,7 +811,6 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
             config = dict(target_config)
             config["assistant_pair_bundle"] = pair_manifest
             config["mtplx_pair.json"] = True
-            config_path = target_path
             config_error = None
     if config is None:
         raise RuntimeError(

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2025,7 +2025,6 @@ def cmd_stop_public(args: Any) -> int:
     """Stop a running MTPLX server via its health-reported pid."""
 
     from mtplx.daemon_client import (
-        DAEMON_PROBE_PORTS,
         probe_running_daemons,
         stop_daemon,
     )
@@ -10280,7 +10279,6 @@ def _quickstart_openwebui_payload(
     port = int(getattr(args, "port", 8000))
     model_id = _public_model_id_for_args(args, str(getattr(args, "model", "")))
     base = f"http://{_connect_host_for_bind(host)}:{port}"
-    profile = str(getattr(args, "profile", None) or DEFAULT_PROFILE_NAME)
     context_window = _inspection_context_window(inspection)
     return {
         "integration": "openwebui",

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1772,7 +1772,6 @@ def _session_bank_cold_tier_from_args(args: argparse.Namespace) -> Any | None:
         return None
     from mtplx.cache_bank import (
         DEFAULT_COLD_TIER_DIR,
-        DEFAULT_COLD_TIER_MAX_BYTES,
         DEFAULT_COLD_TIER_MIN_PREFIX_TOKENS,
         SessionBankColdTier,
         parse_size_bytes,


### PR DESCRIPTION
Four dead symbols flagged by ruff, all pure deletions with no behavior change:

- `mtplx/artifacts.py`: `config_path` assigned but never read in the assistant-pair branch of `_inspect_hf_model`
- `mtplx/commands/public.py`: unused `DAEMON_PROBE_PORTS` import in `cmd_stop_public`; `profile` assigned but never read in `_quickstart_openwebui_payload`
- `mtplx/server/openai.py`: unused `DEFAULT_COLD_TIER_MAX_BYTES` import in `_session_bank_cold_tier_from_args`

Verification: `ruff check` passes on all three files; no orphaned imports left behind (remaining references checked for every removed symbol — e.g. `DEFAULT_PROFILE_NAME` retains its other uses in `public.py`). Deletion-only diff, −4 lines.