### PR TITLE
fix(mtp): correct group_size inference for non-power-of-2 bit widths (5-bit MTP heads)

### DIFF
--- a/mtplx/mtp_patch.py
+++ b/mtplx/mtp_patch.py
@@ -433,7 +433,8 @@ def _heal_raw_delta_mtp_norms(weights: dict[str, Any]) -> dict[str, Any]:
 def _infer_prequantized_group_size(weights: dict[str, Any], bits: int | None) -> int | None:
     if bits is None or bits <= 0:
         return None
-    values_per_word = max(1, 32 // int(bits))
+    bits_int = int(bits)
+    values_per_word = max(1, 32 // bits_int)
     inferred: set[int] = set()
     for key, weight in weights.items():
         if not key.endswith(".weight"):
@@ -452,7 +453,13 @@ def _infer_prequantized_group_size(weights: dict[str, Any], bits: int | None) ->
         scale_groups = int(scales_shape[-1])
         if packed_cols <= 0 or scale_groups <= 0:
             continue
-        expanded_cols = packed_cols * values_per_word
+        if 32 % bits_int == 0:
+            expanded_cols = packed_cols * values_per_word
+        else:
+            total_bits = packed_cols * 32
+            if total_bits % bits_int != 0:
+                continue
+            expanded_cols = total_bits // bits_int
         if expanded_cols % scale_groups == 0:
             inferred.add(expanded_cols // scale_groups)
     if len(inferred) == 1:


### PR DESCRIPTION
Fixes #182.

## Problem

`_infer_prequantized_group_size` (`mtplx/mtp_patch.py`) expands packed uint32 columns back to a logical element count using integer-floor division:

```python
values_per_word = max(1, 32 // int(bits))
expanded_cols = packed_cols * values_per_word
```

For a 5-bit MTP head this undercounts. MLX packs `32 / 5 = 6.4` values per uint32 (640 uint32s hold exactly 4096 5-bit values: `640 * 32 / 5 = 4096`), but `32 // 5 = 6` gives `expanded_cols = 640 * 6 = 3840`, so the inferred `group_size = 3840 / 64 = 60` instead of `64`.

`60` does not divide common hidden dims (4096, 2048), so `nn.quantize(group_size=60, bits=5)` rejects the layer:

```
ValueError: [quantize] The last dimension of the matrix needs to be divisible by
the quantization group size 60. However the provided matrix has shape (2048,4096)
```

This blocks every MTPLX model whose MTP head is prequantized at a non-power-of-2 bit width (the Shiftedx `mxfp4-vision-mtplx` family), even though those models declare `mtp_quant_group_size: 64` in their `mtplx_runtime.json`.

## Fix

When `bits` does not evenly divide 32, derive `expanded_cols` from total bits instead of the floor-divided values-per-word:

```python
if 32 % bits_int == 0:
    expanded_cols = packed_cols * values_per_word
else:
    total_bits = packed_cols * 32
    if total_bits % bits_int != 0:
        continue
    expanded_cols = total_bits // bits_int
```

For the 5-bit case: `expanded_cols = (640 * 32) / 5 = 4096`, so `group_size = 4096 / 64 = 64`.

The `32 % bits_int == 0` branch keeps the original code path verbatim for power-of-2 widths (4, 8), so existing 4-bit models are unaffected.

## Verification

Before: loading `Shiftedx/ornith-1.0-35b-abliterated-mxfp4-vision-mtplx` on MTPLX 2.1.0 / MLX 0.31.2 raises the `group size 60` error.

After: the model loads. MTP gate resolves to 5-bit / group 64, matching the contract.

Regression: four 4-bit MTP models still load and run unchanged.

- `wang-yang/Ornith-1.0-35B-MTPLX`
- `Jonandrop/Ornith-1.0-35B-MTPLX-Vision`
- `Jonandrop/Qwen3.6-27B-MTPLX-Optimized-Speed-Vision`
- `Youssofal/Qwen3.6-27B-MTPLX-Optimized-Speed`

## Measured impact (post-fix)

`Shiftedx/ornith-1.0-35b-abliterated-mxfp4-vision-mtplx`, Apple M5 Pro 64GB, MTPLX 2.1.0, `mtp_history_policy=committed`, greedy draft, warm:

| Depth | tok/s (e2e) | speedup vs AR | acceptance pos1/2/3 |
|---|---|---|---|
| AR | 67.6 | 1.00x | - |
| 3 | 87.4 | 1.29x | 0.93 / 0.86 / 0.76 |

## Notes

No unit test added; I could not find an existing test for this function. A minimal repro is the model load above. I can add a test if you point me at the right module.
