### PR TITLE
Fix _infer_prequantized_group_size undercount for non-power-of-2 bit widths (fixes #182)

### DIFF
--- a/mtplx/mtp_patch.py
+++ b/mtplx/mtp_patch.py
@@ -433,7 +433,7 @@ def _heal_raw_delta_mtp_norms(weights: dict[str, Any]) -> dict[str, Any]:
 def _infer_prequantized_group_size(weights: dict[str, Any], bits: int | None) -> int | None:
     if bits is None or bits <= 0:
         return None
-    values_per_word = max(1, 32 // int(bits))
+    bits_int = int(bits)
     inferred: set[int] = set()
     for key, weight in weights.items():
         if not key.endswith(".weight"):
@@ -452,7 +452,13 @@ def _infer_prequantized_group_size(weights: dict[str, Any], bits: int | None) ->
         scale_groups = int(scales_shape[-1])
         if packed_cols <= 0 or scale_groups <= 0:
             continue
-        expanded_cols = packed_cols * values_per_word
+        # MLX packs quantized rows bit-contiguously: packed_cols * 32 == logical_cols * bits,
+        # even when bits does not divide 32 (e.g. 5-bit). Flooring 32 // bits per word
+        # undercounts logical columns for those widths.
+        total_bits = packed_cols * 32
+        if total_bits % bits_int != 0:
+            continue
+        expanded_cols = total_bits // bits_int
         if expanded_cols % scale_groups == 0:
             inferred.add(expanded_cols // scale_groups)
     if len(inferred) == 1:

--- a/tests/test_mtp_patch.py
+++ b/tests/test_mtp_patch.py
@@ -156,6 +156,52 @@ def test_prequantized_mtp_tensor_geometry_corrects_group_size() -> None:
     assert corrected.mtp_quant_group_size == 32
 
 
+def test_prequantized_mtp_tensor_geometry_handles_non_power_of_two_bits() -> None:
+    class FakeArray:
+        def __init__(self, shape: tuple[int, ...]):
+            self.shape = shape
+
+    contract = MTPContract(
+        mtp_quant_bits=5,
+        mtp_quant_group_size=32,
+        mtp_prequantized=True,
+    )
+    # 4096 logical columns at 5-bit pack into 4096 * 5 / 32 = 640 uint32 columns;
+    # 64 scale groups imply group_size 4096 / 64 = 64.
+    weights = {
+        "layers.0.self_attn.q_proj.weight": FakeArray((2048, 640)),
+        "layers.0.self_attn.q_proj.scales": FakeArray((2048, 64)),
+        "layers.0.self_attn.q_proj.biases": FakeArray((2048, 64)),
+    }
+
+    corrected = _contract_with_prequantized_tensor_geometry(contract, weights)
+
+    assert corrected.mtp_quant_group_size == 64
+
+
+def test_prequantized_mtp_tensor_geometry_skips_indivisible_bit_geometry() -> None:
+    class FakeArray:
+        def __init__(self, shape: tuple[int, ...]):
+            self.shape = shape
+
+    contract = MTPContract(
+        mtp_quant_bits=3,
+        mtp_quant_group_size=64,
+        mtp_prequantized=True,
+    )
+    # 256 packed columns * 32 bits is not divisible by 3, so no logical column
+    # count can be recovered and the declared group_size must stand.
+    weights = {
+        "layers.0.self_attn.q_proj.weight": FakeArray((2048, 256)),
+        "layers.0.self_attn.q_proj.scales": FakeArray((2048, 32)),
+        "layers.0.self_attn.q_proj.biases": FakeArray((2048, 32)),
+    }
+
+    corrected = _contract_with_prequantized_tensor_geometry(contract, weights)
+
+    assert corrected.mtp_quant_group_size == 64
+
+
 def test_prequantized_mtp_module_specs_read_mixed_quant_config() -> None:
     class FakeArray:
         def __init__(self, shape: tuple[int, ...]):


### PR DESCRIPTION
## Summary

`_infer_prequantized_group_size` expanded packed uint32 columns with floor division (`32 // bits` values per word), which undercounts logical columns for bit widths that don't divide 32. For a 5-bit MTP head with 4096 logical columns (640 packed uint32s) it produced 3840 columns and inferred `group_size = 60` instead of 64, and `nn.quantize` then rejected the layer at load — making 5-bit prequantized models (e.g. `Shiftedx/ornith-1.0-35b-abliterated-mxfp4-vision-mtplx`) unloadable.

Full credit to @Jonathangadeaharder for the diagnosis, proposed fix, and hardware verification in #182.

Fixes #182

## Fix

MLX packs quantized rows bit-contiguously (`packed_cols * 32 == logical_cols * bits`), so recover the logical column count as `packed_cols * 32 // bits`, and skip any layer whose packed bit count isn't divisible by the bit width (no logical column count is recoverable there, so the declared contract value stands). Power-of-2 widths are unaffected: both formulas agree whenever `bits` divides 32.

## Tests

- `test_prequantized_mtp_tensor_geometry_handles_non_power_of_two_bits` — the 5-bit geometry from the issue (640 packed cols, 64 scale groups → group_size 64). Fails with 60 on the old code.
- `test_prequantized_mtp_tensor_geometry_skips_indivisible_bit_geometry` — 3-bit geometry where `packed_cols * 32 % bits != 0`; the declared group_size must stand. Fails with 80 on the old code.

Both new tests verified to fail against the unfixed code and pass with the fix. Full suite: 1933 passed, 5 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdBYNdiLyQ6qkqPA1Z2MkP