### PR TITLE
Structured output phase 1: response_format json_object/json_schema via llguidance token masks (#186)

### DIFF
--- a/mtplx/constrained.py
+++ b/mtplx/constrained.py
@@ -1,0 +1,242 @@
+"""Grammar-constrained decoding (structured output) for the serial AR path.
+
+Phase 1 of the plan in upstream issue #186: ``response_format`` of type
+``json_object`` / ``json_schema`` is enforced with llguidance token bitmasks
+applied to target logits before sampling, on the serial AR lane only.
+Constrained requests never ride the batched AR pump or the MTP lanes; the
+server pins them to ``generation_mode="ar"`` and bypasses the batch scheduler.
+
+llguidance is an optional dependency: requests that do not use
+``response_format`` never touch it, and requests that do get a clear 400 when
+it is missing instead of silent non-enforcement (which is what shipped before
+this module existed).
+
+The mask must hit the logits row before any shaping (temperature, top-p/k,
+penalties) so that both the greedy argmax branch and the sampled branch of
+``_sample_from_logits`` operate on the constrained distribution. Illegal
+tokens are set to -inf, which survives every downstream shaping step.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+try:  # pragma: no cover - exercised via LLGUIDANCE_AVAILABLE branches
+    import llguidance as _llg
+    import llguidance.hf as _llg_hf
+    import llguidance.mlx as _llg_mlx
+
+    LLGUIDANCE_AVAILABLE = True
+    LLGUIDANCE_VERSION = str(_llg.get_version())
+except Exception:  # pragma: no cover
+    _llg = None
+    _llg_hf = None
+    _llg_mlx = None
+    LLGUIDANCE_AVAILABLE = False
+    LLGUIDANCE_VERSION = None
+
+SUPPORTED_RESPONSE_FORMAT_TYPES = ("text", "json_object", "json_schema")
+
+# ``json_object`` promises a JSON object (OpenAI semantics), not merely any
+# JSON value, so the generic grammar pins the top-level type.
+_JSON_OBJECT_SCHEMA = '{"type": "object"}'
+
+
+class ResponseFormatError(ValueError):
+    """Invalid or unsupported ``response_format``; message is client-safe."""
+
+
+@dataclass(frozen=True)
+class ConstraintSpec:
+    """A validated, tokenizer-independent grammar for one request.
+
+    Built once at request-validation time (so bad schemas 400 before any
+    model work) and bound to the runtime tokenizer lazily via ``build`` —
+    once per generation attempt, because matcher state is consumed by a
+    generation and blank-retry attempts must start fresh.
+    """
+
+    grammar: str
+    source_type: str
+
+    def build(self, tokenizer: Any) -> "GrammarConstraint":
+        return GrammarConstraint(self.grammar, tokenizer)
+
+
+def constraint_spec_from_response_format(
+    response_format: Any,
+) -> ConstraintSpec | None:
+    """Parse/validate a request's ``response_format`` into a ConstraintSpec.
+
+    Returns None when no constraint applies (absent or ``type: text``).
+    Raises ResponseFormatError for anything the server cannot honestly
+    enforce — the caller turns that into a 400.
+    """
+    if response_format is None:
+        return None
+    if not isinstance(response_format, dict):
+        raise ResponseFormatError(
+            "response_format must be an object with a 'type' field"
+        )
+    format_type = response_format.get("type")
+    if format_type not in SUPPORTED_RESPONSE_FORMAT_TYPES:
+        raise ResponseFormatError(
+            "unsupported response_format type "
+            f"{format_type!r}; supported: {', '.join(SUPPORTED_RESPONSE_FORMAT_TYPES)}"
+        )
+    if format_type == "text":
+        return None
+    if not LLGUIDANCE_AVAILABLE:
+        raise ResponseFormatError(
+            f"response_format type {format_type!r} requires the optional "
+            "llguidance dependency (pip install llguidance); refusing to "
+            "silently return unconstrained output"
+        )
+    if format_type == "json_object":
+        schema_json = _JSON_OBJECT_SCHEMA
+    else:
+        wrapper = response_format.get("json_schema")
+        if wrapper is None and isinstance(response_format.get("schema"), dict):
+            # Lenient shape some clients send: {"type": "json_schema",
+            # "schema": {...}} without the OpenAI wrapper object.
+            schema = response_format["schema"]
+        elif isinstance(wrapper, dict):
+            schema = wrapper.get("schema")
+        else:
+            schema = None
+        if not isinstance(schema, dict):
+            raise ResponseFormatError(
+                "response_format type 'json_schema' requires json_schema.schema "
+                "to be a JSON Schema object"
+            )
+        schema_json = _canonical_schema_json(schema)
+    grammar = _cached_grammar_for_schema(schema_json)
+    return ConstraintSpec(grammar=grammar, source_type=str(format_type))
+
+
+class GrammarConstraint:
+    """Per-generation matcher state: mask logits rows, advance per token.
+
+    The llguidance tokenizer wrap needs the model's logits width (which can
+    exceed the tokenizer vocab on padded lm_heads), so binding is deferred to
+    the first ``mask_logits_row`` call, where the row's shape provides it.
+    Tokens beyond the tokenizer vocab are always masked out.
+    """
+
+    def __init__(self, grammar: str, tokenizer: Any):
+        self._grammar = grammar
+        self._tokenizer = tokenizer
+        self._matcher: Any | None = None
+        self._bitmask: Any | None = None
+        self.masked_steps = 0
+        self.mask_time_s = 0.0
+
+    def _bind(self, n_vocab: int) -> None:
+        ll_tokenizer = _cached_ll_tokenizer(self._tokenizer, n_vocab)
+        matcher = _llg.LLMatcher(ll_tokenizer, self._grammar)
+        err = matcher.get_error()
+        if err:
+            raise ResponseFormatError(f"response_format grammar rejected: {err}")
+        self._matcher = matcher
+        self._bitmask = _llg_mlx.allocate_token_bitmask(1, n_vocab)
+
+    def mask_logits_row(self, row: Any) -> Any:
+        """Apply the current-step token mask to a 1-D logits row (mx.array)."""
+        if self._matcher is None:
+            self._bind(int(row.shape[-1]))
+        if self._matcher.is_stopped():
+            return row
+        started = time.perf_counter()
+        _llg_mlx.fill_next_token_bitmask(self._matcher, self._bitmask)
+        masked = _llg_mlx.apply_token_bitmask(row.reshape(1, -1), self._bitmask)
+        self.mask_time_s += time.perf_counter() - started
+        self.masked_steps += 1
+        return masked.reshape(row.shape)
+
+    def advance(self, token_id: int) -> None:
+        if self._matcher is not None and not self._matcher.is_stopped():
+            self._matcher.consume_token(int(token_id))
+
+    @property
+    def stopped(self) -> bool:
+        return self._matcher is not None and bool(self._matcher.is_stopped())
+
+    @property
+    def completed(self) -> bool:
+        """True when the emitted text is a complete document per the grammar."""
+        if self._matcher is None:
+            return False
+        return bool(self._matcher.is_accepting() or self._matcher.is_stopped())
+
+
+# --- caches ---------------------------------------------------------------
+#
+# A compiled grammar is schema- and engine-version-specific; the LLTokenizer
+# wrap is tokenizer-object- and vocab-width-specific. Both caches hold strong
+# references (the server keeps one tokenizer for its lifetime) and are
+# bounded, so id() reuse after GC cannot alias a live entry.
+
+_GRAMMAR_CACHE: OrderedDict[str, str] = OrderedDict()
+_GRAMMAR_CACHE_MAX = 64
+_TOKENIZER_CACHE: dict[tuple[int, int], tuple[Any, Any]] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _canonical_schema_json(schema: dict[str, Any]) -> str:
+    return json.dumps(schema, sort_keys=True, separators=(",", ":"))
+
+
+def _cached_grammar_for_schema(schema_json: str) -> str:
+    key = f"{LLGUIDANCE_VERSION}:{schema_json}"
+    with _CACHE_LOCK:
+        cached = _GRAMMAR_CACHE.get(key)
+        if cached is not None:
+            _GRAMMAR_CACHE.move_to_end(key)
+            return cached
+    try:
+        grammar = _llg.LLMatcher.grammar_from_json_schema(schema_json)
+    except Exception as exc:
+        raise ResponseFormatError(f"unsupported JSON Schema: {exc}") from exc
+    err = _llg.LLMatcher.validate_grammar(grammar)
+    if err:
+        raise ResponseFormatError(f"unsupported JSON Schema: {err}")
+    with _CACHE_LOCK:
+        _GRAMMAR_CACHE[key] = grammar
+        while len(_GRAMMAR_CACHE) > _GRAMMAR_CACHE_MAX:
+            _GRAMMAR_CACHE.popitem(last=False)
+    return grammar
+
+
+def _unwrap_hf_tokenizer(tokenizer: Any) -> Any:
+    """Return the underlying fast tokenizer llguidance requires.
+
+    The runtime hands us mlx_lm's TokenizerWrapper, which delegates
+    attribute access to the fast tokenizer it holds but fails llguidance's
+    strict isinstance check; unwrap it when present.
+    """
+    import transformers
+
+    if isinstance(tokenizer, transformers.PreTrainedTokenizerFast):
+        return tokenizer
+    inner = getattr(tokenizer, "_tokenizer", None)
+    if inner is not None and isinstance(inner, transformers.PreTrainedTokenizerFast):
+        return inner
+    return tokenizer
+
+
+def _cached_ll_tokenizer(tokenizer: Any, n_vocab: int) -> Any:
+    tokenizer = _unwrap_hf_tokenizer(tokenizer)
+    key = (id(tokenizer), int(n_vocab))
+    with _CACHE_LOCK:
+        entry = _TOKENIZER_CACHE.get(key)
+        if entry is not None and entry[0] is tokenizer:
+            return entry[1]
+    ll_tokenizer = _llg_hf.from_tokenizer(tokenizer, n_vocab=int(n_vocab))
+    with _CACHE_LOCK:
+        _TOKENIZER_CACHE[key] = (tokenizer, ll_tokenizer)
+    return ll_tokenizer

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1581,6 +1581,14 @@ class GenerationStats:
     context_copy_suspended: bool = False
     context_copy_backoff_tokens: int = 0
     context_copy_disabled_reason: str | None = None
+    # Grammar-constrained decoding (response_format). constraint_completed is
+    # None when no constraint was active, False when generation ended before
+    # the grammar reached a complete document (truncation is never passed off
+    # as valid output).
+    constraint_active: bool = False
+    constraint_completed: bool | None = None
+    constraint_masked_steps: int = 0
+    constraint_mask_time_s: float = 0.0
     graphbank: dict[str, object] = field(default_factory=dict)
     reject_path_counts: dict[str, int] = field(default_factory=dict)
     repair_time_by_reject_depth_s: dict[str, float] = field(default_factory=dict)
@@ -4409,8 +4417,13 @@ def generate_ar(
     prefill_callback: Callable[[dict[str, Any]], None] | None = None,
     repetition_stop: bool = False,
     loop_guard: bool = False,
+    constraint: Any | None = None,
 ) -> GenerationOutput:
     if getattr(rt, "backend_id", None) == "gemma4_assistant":
+        if constraint is not None:
+            raise ValueError(
+                "constrained decoding is not supported on the gemma4_assistant backend"
+            )
         from .backends.gemma4_assistant import generate_gemma4_ar
 
         return generate_gemma4_ar(
@@ -4595,8 +4608,14 @@ def generate_ar(
                         },
                     }
                 )
+        logits_row = logits[0]
+        if constraint is not None:
+            # Masking precedes every shaping step in _sample_from_logits, so
+            # both the greedy and sampled branches draw from the constrained
+            # distribution (-inf survives temperature/top-p/penalties).
+            logits_row = constraint.mask_logits_row(logits_row)
         token, _ = _sample_from_logits(
-            logits[0],
+            logits_row,
             sampler,
             rng,
             token_counts=Counter(tokens)
@@ -4611,6 +4630,13 @@ def generate_ar(
         tokens.append(token)
         emit_token(token)
         events.append({"step": step, "token": token})
+        if constraint is not None:
+            constraint.advance(token)
+            if constraint.stopped and not _is_stop(token, stop_token_ids):
+                # The grammar reached its terminal without the model emitting
+                # a stop token; end here rather than decode past the document.
+                events.append({"step": step, "constraint_stop": True})
+                break
         repetition_result = _trim_repeated_suffix(tokens, repetition_config)
         if repetition_result is not None:
             events.append(
@@ -4701,6 +4727,14 @@ def generate_ar(
         loop_guard=(_loop_guard.summary() if _loop_guard is not None else {}),
         decode_trace_path=str(trace.path) if trace.path is not None else None,
         decode_trace_run_id=trace.run_id if trace.enabled else None,
+        constraint_active=constraint is not None,
+        constraint_completed=(constraint.completed if constraint is not None else None),
+        constraint_masked_steps=(
+            constraint.masked_steps if constraint is not None else 0
+        ),
+        constraint_mask_time_s=(
+            constraint.mask_time_s if constraint is not None else 0.0
+        ),
         events=events,
     )
     _attach_runtime_diagnostics(

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -77,6 +77,10 @@ from mtplx.backends.descriptors import (
 from mtplx.backends.registry import load_runtime_contract
 from mtplx.batching import BatchSchedulerConfig, SchedulerMode, SchedulerPreset
 from mtplx.chat_encoding import encode_chat_messages, is_gemma4_tokenizer
+from mtplx.constrained import (
+    ResponseFormatError,
+    constraint_spec_from_response_format,
+)
 from mtplx.gemma4_pair import (
     GEMMA4_BACKEND,
     gemma4_pair_sampler_defaults,
@@ -12784,6 +12788,11 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "context_copy_suspended",
     "context_copy_backoff_tokens",
     "context_copy_disabled_reason",
+    # Grammar-constrained decoding (response_format) counters.
+    "constraint_active",
+    "constraint_completed",
+    "constraint_masked_steps",
+    "constraint_mask_time_s",
     "verify_time_s",
     "draft_time_s",
     "accept_time_s",
@@ -15140,7 +15149,16 @@ def _run_generation_dispatched(
     history_bypass_reason = _ar_batch_history_bypass_reason(
         request_observability_for_lane
     )
-    if history_bypass_reason is not None:
+    if kwargs.get("constraint_spec") is not None:
+        # Grammar masks only exist on the serial AR path; the batched AR
+        # pump's per-job samplers carry no matcher state (issue #186 phase 1).
+        use_ar_batch = False
+        mtp_disabled_reason = "constrained_decoding"
+        request_observability_for_lane["scheduler_lane"] = "solo_constrained"
+        request_observability_for_lane["ar_batch_bypass_reason"] = (
+            "constrained_decoding"
+        )
+    elif history_bypass_reason is not None:
         use_ar_batch = False
         mtp_disabled_reason = None
         request_observability_for_lane["scheduler_lane"] = (
@@ -15292,6 +15310,7 @@ def _run_generation(
     cancel_event: Event | None = None,
     streaming_response: bool | None = None,
     vision_splice: Any | None = None,
+    constraint_spec: Any | None = None,
 ) -> dict[str, Any]:
     response_max, sampler, generation_limits = _generation_params(
         state,
@@ -15312,6 +15331,10 @@ def _run_generation(
         generation_mode,
         default=getattr(state.args, "generation_mode", "mtp"),
     )
+    if constraint_spec is not None:
+        # Grammar masks are wired into generate_ar only; never let a
+        # constrained request fall through to an unmasked lane.
+        effective_mode = "ar"
     requested_depth = (
         0
         if effective_mode == "ar"
@@ -15404,6 +15427,11 @@ def _run_generation(
                 dynamic_kv_reservation["env"]
             ), prefill_chunk_size_override(prefill_chunk_tokens):
                 if effective_mode == "ar":
+                    constraint = (
+                        constraint_spec.build(state.runtime.tokenizer)
+                        if constraint_spec is not None
+                        else None
+                    )
                     out = generate_ar(
                         state.runtime,
                         prompt_ids,
@@ -15414,8 +15442,16 @@ def _run_generation(
                         trace_label=trace_label,
                         trace_metadata=trace_metadata,
                         prefill_callback=prefill_callback,
-                        repetition_stop=uncapped_repetition_stop,
+                        # The repetition trimmer retracts already-committed
+                        # tokens, which would desync the grammar matcher;
+                        # constrained output is schema-shaped, not freeform.
+                        repetition_stop=(
+                            False
+                            if constraint is not None
+                            else uncapped_repetition_stop
+                        ),
                         loop_guard=_loop_guard_enabled(),
+                        constraint=constraint,
                     )
                 else:
                     adaptive_policy = _make_adaptive_policy(
@@ -15750,7 +15786,12 @@ def _run_generation(
             "end_to_end_tok_s": server_tok_s,
             "_final_state": final_state,
             "finish_reason": (
-                out.final_state.finish_reason if out.final_state is not None else "stop"
+                out.final_state.finish_reason
+                if out.final_state is not None
+                # The serial AR lane has no final_state; its GenerationOutput
+                # still reports length-vs-stop correctly — don't flatten a
+                # max_tokens truncation into "stop".
+                else (getattr(out, "finish_reason", None) or "stop")
             ),
         }
         if seed_is_explicit or out.text.strip():
@@ -16232,6 +16273,15 @@ def _stats_footer_text(state: ServerState, generated: dict[str, Any]) -> str:
     if not state.args.stats_footer:
         return ""
     stats = generated["stats"]
+    constraint_active = (
+        stats.get("constraint_active")
+        if isinstance(stats, dict)
+        else getattr(stats, "constraint_active", False)
+    )
+    if constraint_active:
+        # response_format promised machine-parseable output; a prose footer
+        # appended to the content would corrupt it for every JSON client.
+        return ""
     tok_s, decode_elapsed_s = _decode_timing(stats)
     completion_tokens = int(generated.get("completion_tokens") or 0)
     footer = f"**{tok_s:.1f} tok/s** · {completion_tokens} tokens · {decode_elapsed_s:.2f}s decode"
@@ -17080,6 +17130,8 @@ def _display_text(
     if not state.args.stats_footer:
         return text
     footer = _stats_footer_text(state, generated)
+    if not footer:
+        return text
     separator = "\n\n" if text.endswith("\n") else "\n\n"
     return f"{text}{separator}{footer}"
 
@@ -20545,6 +20597,25 @@ def create_app(state: ServerState) -> FastAPI:
             request,
             allow_client_controls=client_controls_allowed,
         )
+        try:
+            constraint_spec = constraint_spec_from_response_format(
+                request.response_format
+            )
+        except ResponseFormatError as constraint_error:
+            raise HTTPException(status_code=400, detail=str(constraint_error))
+        if constraint_spec is not None:
+            if getattr(state.runtime, "backend_id", None) == "gemma4_assistant":
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "response_format constrained decoding is not supported "
+                        "on the gemma4_assistant backend"
+                    ),
+                )
+            # Phase 1 pins constrained requests to the serial AR lane; the
+            # MTP verify paths and the batched AR pump do not apply grammar
+            # masks yet (see upstream issue #186 for the composition plan).
+            request_generation_mode = "ar"
         request_depth = _request_depth_for_generation(
             state,
             request,
@@ -20699,6 +20770,10 @@ def create_app(state: ServerState) -> FastAPI:
             request_generation_mode=request_generation_mode,
             request_depth=request_depth,
         )
+        if constraint_spec is not None:
+            request_observability["constrained_decoding"] = (
+                constraint_spec.source_type
+            )
         if vision_splice is not None:
             request_observability["request_vision_images"] = len(vision_images)
             request_observability["request_vision_rows"] = vision_splice.total_rows
@@ -21208,6 +21283,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=request.seed,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         session_id=session_id,
@@ -21246,6 +21322,7 @@ def create_app(state: ServerState) -> FastAPI:
                     seed=request.seed,
                     draft_sampler=request_draft_sampler,
                     generation_mode=request_generation_mode,
+                    constraint_spec=constraint_spec,
                     depth=request_depth,
                     resolved_mtp_depth=effective_request_depth,
                     session_id=session_id,
@@ -21605,6 +21682,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -21729,6 +21807,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -21869,6 +21948,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22044,6 +22124,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22204,6 +22285,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22283,6 +22365,7 @@ def create_app(state: ServerState) -> FastAPI:
                                 seed=request.seed,
                                 draft_sampler=request_draft_sampler,
                                 generation_mode=request_generation_mode,
+                                constraint_spec=constraint_spec,
                                 depth=request_depth,
                                 resolved_mtp_depth=effective_request_depth,
                                 token_callback=on_tokens,
@@ -22333,6 +22416,7 @@ def create_app(state: ServerState) -> FastAPI:
                                     seed=request.seed,
                                     draft_sampler=request_draft_sampler,
                                     generation_mode=request_generation_mode,
+                                    constraint_spec=constraint_spec,
                                     depth=request_depth,
                                     resolved_mtp_depth=effective_request_depth,
                                     token_callback=on_tokens,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ competitors = [
 ]
 server = [
   "fastapi>=0.136",
+  "llguidance>=1.7",
   "pillow>=10",
   "uvicorn>=0.46",
 ]

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1,0 +1,300 @@
+"""Grammar-constrained decoding (response_format), issue #186 phase 1.
+
+Covers: the request-validation surface (bad shapes 400 instead of silent
+non-enforcement), the generate_ar wiring (mask before sampling, advance per
+token, grammar-terminal early stop, stats counters), end-to-end schema
+enforcement against adversarial logits with a tiny single-byte tokenizer,
+and public-envelope exposure of the constraint counters.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mtplx.constrained import (
+    ResponseFormatError,
+    constraint_spec_from_response_format,
+)
+from mtplx.generation import generate_ar
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+from mtplx.sampling import SamplerConfig
+
+
+# --- response_format validation surface (no llguidance required) ----------
+
+
+def test_absent_and_text_response_formats_apply_no_constraint():
+    assert constraint_spec_from_response_format(None) is None
+    assert constraint_spec_from_response_format({"type": "text"}) is None
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        "json",
+        ["json_object"],
+        {},
+        {"type": "json"},
+        {"type": "grammar"},
+    ],
+)
+def test_invalid_response_formats_are_rejected(response_format):
+    with pytest.raises(ResponseFormatError):
+        constraint_spec_from_response_format(response_format)
+
+
+# --- generate_ar wiring (scripted model, fake constraint) ------------------
+
+
+class _Tokenizer:
+    def decode(self, tokens, **_kwargs):
+        return "".join(f"<{int(token)}>" for token in tokens)
+
+
+class _RampModel:
+    """Unconstrained argmax always walks t -> t+1 over an 8-token vocab."""
+
+    vocab = 8
+
+    def __init__(self):
+        self.mtp = SimpleNamespace(_mtplx_lora_targets=[])
+
+    def make_cache(self):
+        return []
+
+    def __call__(
+        self,
+        input_ids,
+        *,
+        cache=None,
+        return_hidden: bool = False,
+        hidden_variant: str | None = None,
+        emit_logits: bool = True,
+        logits_keep: int | None = None,
+    ):
+        tokens = [int(token) for token in np.asarray(input_ids).reshape(-1)]
+        row = [0.0] * self.vocab
+        row[(tokens[-1] + 1) % self.vocab] = 10.0
+        logits = mx.array([[row]], dtype=mx.float32)
+        hidden = mx.zeros((1, len(tokens), 2), dtype=mx.float32)
+        if return_hidden:
+            return logits, hidden
+        return logits
+
+
+class _ForcingConstraint:
+    """Duck-typed constraint that forces a scripted token path, then stops."""
+
+    def __init__(self, forced: list[int]):
+        self.forced = list(forced)
+        self.advanced: list[int] = []
+        self.masked_steps = 0
+        self.mask_time_s = 0.0
+
+    def mask_logits_row(self, row):
+        self.masked_steps += 1
+        wanted = self.forced[len(self.advanced)]
+        mask = mx.full(row.shape, -np.inf, dtype=row.dtype)
+        return mx.where(
+            mx.arange(row.shape[-1]) == wanted, mx.array(100.0, dtype=row.dtype), mask
+        )
+
+    def advance(self, token_id: int) -> None:
+        self.advanced.append(int(token_id))
+
+    @property
+    def stopped(self) -> bool:
+        return len(self.advanced) >= len(self.forced)
+
+    @property
+    def completed(self) -> bool:
+        return self.stopped
+
+
+def _runtime(model, backend_id: str | None = None) -> MTPLXRuntime:
+    rt = MTPLXRuntime(
+        model=model,
+        tokenizer=_Tokenizer(),
+        model_path=Path("tiny-constrained"),
+        mtp_enabled=False,
+        contract=MTPContract(),
+    )
+    if backend_id is not None:
+        rt.backend_id = backend_id
+    return rt
+
+
+def test_generate_ar_constraint_overrides_model_preference():
+    constraint = _ForcingConstraint([5, 2, 7])
+    out = generate_ar(
+        _runtime(_RampModel()),
+        [1, 2],
+        max_tokens=10,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=0,
+        stop_token_ids=set(),
+        constraint=constraint,
+    )
+    # The ramp model wants 3,4,5...; the mask forces the scripted path, and
+    # generation halts at the grammar terminal instead of running to
+    # max_tokens.
+    assert out.tokens == [5, 2, 7]
+    assert constraint.advanced == [5, 2, 7]
+    assert constraint.masked_steps == 3
+    assert out.finish_reason == "stop"
+    assert out.stats.constraint_active is True
+    assert out.stats.constraint_completed is True
+    assert out.stats.constraint_masked_steps == 3
+    assert any("constraint_stop" in event for event in out.stats.events)
+
+
+def test_generate_ar_without_constraint_reports_inactive():
+    out = generate_ar(
+        _runtime(_RampModel()),
+        [1],
+        max_tokens=3,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=0,
+        stop_token_ids=set(),
+    )
+    assert out.stats.constraint_active is False
+    assert out.stats.constraint_completed is None
+
+
+def test_generate_ar_rejects_constraint_on_gemma4_assistant_backend():
+    with pytest.raises(ValueError, match="gemma4_assistant"):
+        generate_ar(
+            _runtime(_RampModel(), backend_id="gemma4_assistant"),
+            [1],
+            max_tokens=3,
+            sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+            seed=0,
+            stop_token_ids=set(),
+            constraint=_ForcingConstraint([1]),
+        )
+
+
+# --- end-to-end with llguidance (tiny single-byte tokenizer) ---------------
+
+llguidance = pytest.importorskip("llguidance")
+
+
+def _tiny_hf_tokenizer():
+    from tokenizers import Tokenizer, decoders, models
+    from transformers import PreTrainedTokenizerFast
+
+    # No space token: raw space is not its own symbol in the byte-level
+    # alphabet (it's 'Ġ'), and JSON for the test schema needs no whitespace.
+    vocab = {chr(i): i - 32 for i in range(33, 127)}
+    vocab["<eos>"] = 0
+    # Merge-free BPE tokenizes any byte string char-by-char, which llguidance
+    # needs to canonically tokenize forced-byte runs like '"age"' (WordLevel
+    # would return UNK for multi-char lookups and break the mask).
+    backend = Tokenizer(models.BPE(vocab=vocab, merges=[], unk_token="<eos>"))
+    # llguidance derives token byte representations from the decoder type;
+    # ByteLevel is one it recognizes, and every remaining printable-ASCII
+    # token maps to itself under the byte-level alphabet.
+    backend.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(tokenizer_object=backend, eos_token="<eos>"), {
+        v: k for k, v in vocab.items()
+    }
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "age": {"type": "integer", "minimum": 0},
+        "tag": {"type": "string", "enum": ["a", "b"]},
+    },
+    "required": ["age", "tag"],
+    "additionalProperties": False,
+}
+
+
+def test_grammar_forces_schema_valid_json_under_adversarial_logits():
+    hf_tok, id_to_text = _tiny_hf_tokenizer()
+    spec = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"name": "t", "schema": _SCHEMA}}
+    )
+    assert spec is not None
+    constraint = spec.build(hf_tok)
+
+    # Logits width deliberately exceeds the tokenizer vocab (padded lm_head).
+    # The unmasked argmax is always a padding token, and among legal tokens
+    # the driver prefers the lowest id — never what the schema wants next —
+    # so any schema-valid output is purely the mask's doing.
+    n_vocab = 128
+    tokens: list[int] = []
+    for _ in range(200):
+        if constraint.stopped:
+            break
+        row = -mx.arange(n_vocab, dtype=mx.float32)
+        masked = constraint.mask_logits_row(row)
+        arr = np.array(masked)
+        assert np.all(arr[95:] < -1e30), "mask leaked padding/out-of-vocab tokens"
+        token = int(mx.argmax(masked).item())
+        constraint.advance(token)
+        tokens.append(token)
+
+    text = "".join(id_to_text[t] for t in tokens if id_to_text[t] != "<eos>")
+    assert constraint.completed, f"grammar never completed: {text!r}"
+    parsed = json.loads(text)
+    assert set(parsed) == {"age", "tag"}
+    assert isinstance(parsed["age"], int) and parsed["age"] >= 0
+    assert parsed["tag"] in {"a", "b"}
+    assert constraint.masked_steps == len(tokens)
+
+
+def test_json_object_and_lenient_schema_shapes_accepted():
+    assert (
+        constraint_spec_from_response_format({"type": "json_object"}).source_type
+        == "json_object"
+    )
+    lenient = constraint_spec_from_response_format(
+        {"type": "json_schema", "schema": {"type": "object"}}
+    )
+    assert lenient is not None and lenient.source_type == "json_schema"
+    with pytest.raises(ResponseFormatError, match="json_schema.schema"):
+        constraint_spec_from_response_format({"type": "json_schema"})
+
+
+def test_grammar_cache_canonicalizes_key_order():
+    from mtplx import constrained as mod
+
+    a = {"type": "object", "properties": {"x": {"type": "integer"}}}
+    b = {"properties": {"x": {"type": "integer"}}, "type": "object"}
+    before = len(mod._GRAMMAR_CACHE)
+    spec_a = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"schema": a}}
+    )
+    grown = len(mod._GRAMMAR_CACHE)
+    spec_b = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"schema": b}}
+    )
+    assert spec_a.grammar == spec_b.grammar
+    assert len(mod._GRAMMAR_CACHE) == grown >= before
+
+
+# --- public envelope --------------------------------------------------------
+
+
+def test_public_mtplx_stats_expose_constraint_counters():
+    from mtplx.server.openai import PUBLIC_MTPLX_STATS_KEYS, _public_mtplx_stats
+
+    keys = {
+        "constraint_active",
+        "constraint_completed",
+        "constraint_masked_steps",
+        "constraint_mask_time_s",
+    }
+    assert keys <= set(PUBLIC_MTPLX_STATS_KEYS)
+    generated = {"stats": {key: 1 for key in keys}}
+    public = _public_mtplx_stats(generated)
+    assert keys <= set(public)


### PR DESCRIPTION
Implements phase 1 of #186: honest `response_format` handling with grammar-constrained decoding on the serial AR lane.

## What this does

- **`response_format` is enforced instead of silently ignored.** `json_object` and `json_schema` requests decode under an llguidance token bitmask applied to target logits *before* any shaping (temperature/top-p/top-k/penalties), so both the greedy and sampled branches draw from the constrained distribution. Unsupported shapes get a clear 400 — previously a client sending `{"type": "json_schema", ...}` received unconstrained text with no warning.
- **Constrained requests pin to the serial AR lane** (`generation_mode=ar`, batched-AR pump bypassed, `scheduler_lane=solo_constrained`) exactly as proposed in #186. The MTP verify paths and context-copy are untouched; composition is phase 3.
- **Truncation is never passed off as valid output**: `mtplx_stats.constraint_completed` is `false` when generation ended before the grammar reached a complete document, alongside the usual `finish_reason`.
- **llguidance is optional** (`server` extra): requests without `response_format` never import it; requests that need it 400 with an install hint when it's missing.
- New `mtplx_stats` counters: `constraint_active`, `constraint_completed`, `constraint_masked_steps`, `constraint_mask_time_s`.

## Two adjacent fixes this surfaced

- **Stats footer suppressed for constrained responses.** The `⚡ MTPLX TPS` footer appended to message content corrupts the promised JSON for every machine client — first live test caught it.
- **Pre-existing serial-AR `finish_reason` bug.** The AR payload took `finish_reason` from `final_state` (always `None` on that lane) and flattened everything to `"stop"`, so `max_tokens` truncations were mislabeled. Now falls back to the GenerationOutput's own length/stop determination. (Existing AR users see correct `"length"` on truncation after this.)

## Implementation notes

- Grammar compilation cached on (canonicalized schema, llguidance version); the tokenizer wrap is cached on (tokenizer, logits width) and bound lazily from the first logits row, so padded lm_heads (model logits wider than tokenizer vocab) mask their padding tokens — no vocab-width plumbing through the server.
- The runtime's mlx_lm `TokenizerWrapper` is unwrapped to the fast tokenizer llguidance requires.
- Constrained requests disable the token-retracting repetition trimmer (it would desync the matcher; constrained output is schema-shaped, not freeform degeneration territory).
- `mask -> sample -> advance` per token, with a grammar-terminal early stop so decode never runs past the completed document; llguidance's forced-EOS behavior makes that a rare safety net in practice.

## Verification

- 13 new tests in `tests/test_constrained.py`: validation surface, generate_ar wiring via a scripted model + forcing constraint, an end-to-end test where a merge-free single-byte tokenizer decodes under adversarial logits (unmasked argmax is always a padding token; every legal choice is the lowest id, never what the schema wants) and still yields schema-valid JSON, cache canonicalization, and public-envelope exposure. Full suite: **1944 passed, 5 skipped**; ruff clean on touched files.
- **Hardware-verified** (Apple Silicon, `Youssofal/Qwen3.6-35B-A3B-MTPLX-Optimized-Speed`):
  - Prompt "Introduce yourself in flowing prose. Do not use JSON." + a 3-field schema with integer bounds → `{"name": "Qwen", "specialty": "Large Language Model", "years_experience": 3}`, `constraint_completed: true`.
  - Bad `response_format` shapes → 400 with actionable messages; requests without `response_format` ride the MTP lane unchanged (footer intact).
  - Streaming constrained requests produce valid JSON end-to-end; deliberate `max_tokens` truncation reports `finish_reason: "length"` + `constraint_completed: false`.
  - **Overhead ~1–2% at matched output length** (plain AR 91–96 tok/s vs constrained 92–94 tok/s over 3 warmed runs; mask fill ~0.12ms/step on the 248k vocab).

## Not in this PR (per the #186 phasing)

Strict tool-call argument enforcement (phase 2) and grammar-mask composition with the MTP verify path / context-copy (phase 3). The `llguidance.numpy` module already ships draft-token bitmask helpers (`fill_next_token_bitmask_par_with_draft_tokens`), which looks promising for phase 3.

Note: `uv.lock` was intentionally left untouched (it currently pins mtplx 2.1.0 while pyproject says 2.2.0 upstream — re-locking would drag unrelated churn into this PR).

Closes nothing on its own; tracked by #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdBYNdiLyQ6qkqPA1Z2MkP