### PR TITLE
Structured output phases 2+3: strict tool-call grammars + composition with the MTP verify loop (#186)

### DIFF
--- a/mtplx/constrained.py
+++ b/mtplx/constrained.py
@@ -20,6 +20,7 @@ tokens are set to -inf, which survives every downstream shaping step.
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 from collections import OrderedDict
@@ -46,6 +47,24 @@ SUPPORTED_RESPONSE_FORMAT_TYPES = ("text", "json_object", "json_schema")
 # JSON value, so the generic grammar pins the top-level type.
 _JSON_OBJECT_SCHEMA = '{"type": "object"}'
 
+# Strict tool-call constraint markers. These are the Qwen/Hermes-family
+# native tool-call and thinking tokens; strict mode only activates when the
+# runtime tokenizer encodes each marker as a single (special) token, so the
+# grammar can reference it as a hard boundary rather than bytes.
+TOOL_CALL_START = "<tool_call>"
+TOOL_CALL_END = "</tool_call>"
+THINK_START = "<think>"
+THINK_END = "</think>"
+
+
+def tool_call_strict_enabled() -> bool:
+    """Opt-in via MTPLX_TOOL_CALL_STRICT=1/true/on. Default off."""
+    return (os.environ.get("MTPLX_TOOL_CALL_STRICT") or "").strip().lower() in {
+        "1",
+        "true",
+        "on",
+    }
+
 
 class ResponseFormatError(ValueError):
     """Invalid or unsupported ``response_format``; message is client-safe."""
@@ -70,12 +89,18 @@ class ConstraintSpec:
 
 def constraint_spec_from_response_format(
     response_format: Any,
+    tokenizer: Any | None = None,
 ) -> ConstraintSpec | None:
     """Parse/validate a request's ``response_format`` into a ConstraintSpec.
 
     Returns None when no constraint applies (absent or ``type: text``).
     Raises ResponseFormatError for anything the server cannot honestly
     enforce — the caller turns that into a 400.
+
+    When a tokenizer is provided and its template family uses native
+    thinking markers, the grammar accepts an optional leading thinking
+    close (chat templates open ``<think>`` inside the generation prompt, so
+    the model's reasoning must be allowed to finish before the document).
     """
     if response_format is None:
         return None
@@ -115,8 +140,157 @@ def constraint_spec_from_response_format(
                 "to be a JSON Schema object"
             )
         schema_json = _canonical_schema_json(schema)
-    grammar = _cached_grammar_for_schema(schema_json)
+    think_prelude = tokenizer is not None and (
+        _single_token_id(tokenizer, THINK_START) is not None
+        and _single_token_id(tokenizer, THINK_END) is not None
+    )
+    grammar = _cached_grammar_for_schema(schema_json, think_prelude=think_prelude)
     return ConstraintSpec(grammar=grammar, source_type=str(format_type))
+
+
+def tool_call_constraint_spec(
+    tools: Any,
+    tool_choice: Any,
+    tokenizer: Any,
+) -> ConstraintSpec | None:
+    """Build a strict tool-call ConstraintSpec from a request's tools.
+
+    The grammar allows free text (and native thinking blocks) but forces any
+    tool-call envelope the model opens to carry a declared tool name and
+    schema-valid arguments. Returns None when no constraint applies
+    (tool_choice "none", or no function tools declared). Raises
+    ResponseFormatError for shapes strict mode cannot honestly enforce.
+    """
+    if isinstance(tool_choice, str) and tool_choice == "none":
+        return None
+    functions = _function_tools(tools)
+    if not functions:
+        return None
+    if tool_choice is not None and tool_choice != "auto":
+        raise ResponseFormatError(
+            "strict tool calls support tool_choice 'auto' or 'none' only; "
+            f"got {tool_choice!r}"
+        )
+    if not LLGUIDANCE_AVAILABLE:
+        raise ResponseFormatError(
+            "strict tool calls require the optional llguidance dependency "
+            "(pip install llguidance)"
+        )
+    if (
+        _single_token_id(tokenizer, TOOL_CALL_START) is None
+        or _single_token_id(tokenizer, TOOL_CALL_END) is None
+    ):
+        raise ResponseFormatError(
+            "strict tool calls require the chat template's tool-call markers "
+            f"({TOOL_CALL_START} / {TOOL_CALL_END}) to be single special "
+            "tokens; this model's template is not supported yet"
+        )
+    include_think = (
+        _single_token_id(tokenizer, THINK_START) is not None
+        and _single_token_id(tokenizer, THINK_END) is not None
+    )
+    cache_key = "structtool:" + json.dumps(
+        {
+            "functions": [[name, schema] for name, schema in functions],
+            "think": include_think,
+            "llg": LLGUIDANCE_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    with _CACHE_LOCK:
+        cached = _GRAMMAR_CACHE.get(cache_key)
+        if cached is not None:
+            _GRAMMAR_CACHE.move_to_end(cache_key)
+            return ConstraintSpec(grammar=cached, source_type="tool_call_strict")
+    grammar = _tool_call_lark_grammar(functions, include_think=include_think)
+    err = _llg.LLMatcher.validate_grammar(grammar)
+    if err:
+        raise ResponseFormatError(f"unsupported tool schema: {err}")
+    with _CACHE_LOCK:
+        _GRAMMAR_CACHE[cache_key] = grammar
+        while len(_GRAMMAR_CACHE) > _GRAMMAR_CACHE_MAX:
+            _GRAMMAR_CACHE.popitem(last=False)
+    return ConstraintSpec(grammar=grammar, source_type="tool_call_strict")
+
+
+def _function_tools(tools: Any) -> list[tuple[str, dict[str, Any]]]:
+    if not isinstance(tools, list):
+        return []
+    functions: list[tuple[str, dict[str, Any]]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise ResponseFormatError("each tool must be an object")
+        function = tool.get("function") if tool.get("type") == "function" else None
+        if function is None and "name" in tool:
+            function = tool
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise ResponseFormatError("each function tool must declare a name")
+        parameters = function.get("parameters")
+        if parameters is None:
+            parameters = {"type": "object"}
+        if not isinstance(parameters, dict):
+            raise ResponseFormatError(
+                f"tool {name!r} parameters must be a JSON Schema object"
+            )
+        functions.append((name, parameters))
+    return functions
+
+
+def _lark_string(text: str) -> str:
+    """A lark string literal; JSON escaping is a valid subset."""
+    return json.dumps(text)
+
+
+def _tool_call_lark_grammar(
+    functions: list[tuple[str, dict[str, Any]]],
+    *,
+    include_think: bool,
+) -> str:
+    """Free text + forced tool-call envelopes as a lark grammar.
+
+    Special tokens must appear at the rule level (llguidance rejects them
+    inside terminals), and the closing marker must be a bare special-token
+    reference — inside a quoted string it would match bytes the special
+    token never produces.
+    """
+    alternatives = []
+    for name, schema in functions:
+        name_inner = json.dumps(name)[1:-1]
+        head = f'\n{{"name": "{name_inner}", "arguments": '
+        alternatives.append(
+            f"TAG_TEXT <tool_call> {_lark_string(head)} %json "
+            f"{json.dumps(schema)} {_lark_string('}')} {_lark_string(chr(10))} "
+            "</tool_call>"
+        )
+    if include_think:
+        alternatives.append("TAG_TEXT <think> TAG_TEXT </think>")
+    seg = "seg: " + "\n   | ".join(alternatives)
+    # The optional prelude closes a thinking block the chat template opened
+    # inside the generation prompt (Qwen renders `<|im_start|>assistant\n
+    # <think>\n`, so generation begins mid-think and must be allowed out).
+    prelude = "prelude: TAG_TEXT </think>\n" if include_think else ""
+    start = "start: prelude? (seg)* tail\n" if include_think else "start: (seg)* tail\n"
+    return (
+        "%llguidance {}\n"
+        f"{start}"
+        f"{prelude}"
+        "tail: TAG_TEXT\n"
+        "TAG_TEXT: /(.|\\n)*/\n"
+        f"{seg}\n"
+    )
+
+
+def _single_token_id(tokenizer: Any, text: str) -> int | None:
+    unwrapped = _unwrap_hf_tokenizer(tokenizer)
+    try:
+        ids = unwrapped.encode(text, add_special_tokens=False)
+    except Exception:
+        return None
+    return int(ids[0]) if len(ids) == 1 else None
 
 
 class GrammarConstraint:
@@ -159,8 +333,33 @@ class GrammarConstraint:
         return masked.reshape(row.shape)
 
     def advance(self, token_id: int) -> None:
-        if self._matcher is not None and not self._matcher.is_stopped():
-            self._matcher.consume_token(int(token_id))
+        if self._matcher is None or self._matcher.is_stopped():
+            return
+        self._matcher.consume_token(int(token_id))
+        err = self._matcher.get_error()
+        if err:
+            # A committed token the grammar rejects means the decode loop
+            # desynced from the matcher — fail loudly rather than stream
+            # unconstrained output labeled as completed.
+            raise RuntimeError(
+                f"constrained decoding desync on token {int(token_id)}: {err}"
+            )
+
+    def advance_many(self, token_ids: list[int]) -> None:
+        for token_id in token_ids:
+            self.advance(token_id)
+
+    def validate_prefix(self, token_ids: list[int]) -> int:
+        """How many of token_ids extend the current state legally (no mutation).
+
+        Speculative windows get clamped to this prefix; the matcher itself
+        only ever advances through tokens that were actually committed.
+        """
+        if not token_ids:
+            return 0
+        if self._matcher is None or self._matcher.is_stopped():
+            return 0
+        return int(self._matcher.validate_tokens([int(t) for t in token_ids]))
 
     @property
     def stopped(self) -> bool:
@@ -169,7 +368,7 @@ class GrammarConstraint:
     @property
     def completed(self) -> bool:
         """True when the emitted text is a complete document per the grammar."""
-        if self._matcher is None:
+        if self._matcher is None or self._matcher.get_error():
             return False
         return bool(self._matcher.is_accepting() or self._matcher.is_stopped())
 
@@ -191,15 +390,24 @@ def _canonical_schema_json(schema: dict[str, Any]) -> str:
     return json.dumps(schema, sort_keys=True, separators=(",", ":"))
 
 
-def _cached_grammar_for_schema(schema_json: str) -> str:
-    key = f"{LLGUIDANCE_VERSION}:{schema_json}"
+def _cached_grammar_for_schema(schema_json: str, *, think_prelude: bool = False) -> str:
+    key = f"{LLGUIDANCE_VERSION}:think={int(think_prelude)}:{schema_json}"
     with _CACHE_LOCK:
         cached = _GRAMMAR_CACHE.get(key)
         if cached is not None:
             _GRAMMAR_CACHE.move_to_end(key)
             return cached
     try:
-        grammar = _llg.LLMatcher.grammar_from_json_schema(schema_json)
+        if think_prelude:
+            grammar = (
+                "%llguidance {}\n"
+                "start: prelude? doc\n"
+                "prelude: TAG_TEXT </think>\n"
+                "TAG_TEXT: /(.|\\n)*/\n"
+                f"doc: %json {schema_json}\n"
+            )
+        else:
+            grammar = _llg.LLMatcher.grammar_from_json_schema(schema_json)
     except Exception as exc:
         raise ResponseFormatError(f"unsupported JSON Schema: {exc}") from exc
     err = _llg.LLMatcher.validate_grammar(grammar)

--- a/mtplx/constrained.py
+++ b/mtplx/constrained.py
@@ -78,13 +78,45 @@ class ConstraintSpec:
     model work) and bound to the runtime tokenizer lazily via ``build`` —
     once per generation attempt, because matcher state is consumed by a
     generation and blank-retry attempts must start fresh.
+
+    ``grammar_with_prelude`` exists for response_format grammars on
+    thinking templates: it accepts a leading ``TEXT </think>`` so the model
+    can close reasoning the chat template opened inside the prompt. It is
+    selected only when the prompt actually ends inside an open think block —
+    otherwise the prelude's free-text rule would let the model write prose
+    forever without ever starting the document.
     """
 
     grammar: str
     source_type: str
+    grammar_with_prelude: str | None = None
+    think_start_id: int | None = None
+    think_end_id: int | None = None
 
-    def build(self, tokenizer: Any) -> "GrammarConstraint":
-        return GrammarConstraint(self.grammar, tokenizer)
+    def build(
+        self, tokenizer: Any, prompt_ids: list[int] | None = None
+    ) -> "GrammarConstraint":
+        grammar = self.grammar
+        if self.grammar_with_prelude is not None and _prompt_ends_inside_think(
+            prompt_ids, self.think_start_id, self.think_end_id
+        ):
+            grammar = self.grammar_with_prelude
+        return GrammarConstraint(grammar, tokenizer)
+
+
+def _prompt_ends_inside_think(
+    prompt_ids: list[int] | None,
+    think_start_id: int | None,
+    think_end_id: int | None,
+) -> bool:
+    if not prompt_ids or think_start_id is None:
+        return False
+    for token in reversed(prompt_ids):
+        if token == think_start_id:
+            return True
+        if think_end_id is not None and token == think_end_id:
+            return False
+    return False
 
 
 def constraint_spec_from_response_format(
@@ -140,12 +172,25 @@ def constraint_spec_from_response_format(
                 "to be a JSON Schema object"
             )
         schema_json = _canonical_schema_json(schema)
-    think_prelude = tokenizer is not None and (
-        _single_token_id(tokenizer, THINK_START) is not None
-        and _single_token_id(tokenizer, THINK_END) is not None
+    grammar = _cached_grammar_for_schema(schema_json, think_prelude=False)
+    think_start_id = (
+        _single_token_id(tokenizer, THINK_START) if tokenizer is not None else None
     )
-    grammar = _cached_grammar_for_schema(schema_json, think_prelude=think_prelude)
-    return ConstraintSpec(grammar=grammar, source_type=str(format_type))
+    think_end_id = (
+        _single_token_id(tokenizer, THINK_END) if tokenizer is not None else None
+    )
+    grammar_with_prelude = (
+        _cached_grammar_for_schema(schema_json, think_prelude=True)
+        if think_start_id is not None and think_end_id is not None
+        else None
+    )
+    return ConstraintSpec(
+        grammar=grammar,
+        source_type=str(format_type),
+        grammar_with_prelude=grammar_with_prelude,
+        think_start_id=think_start_id,
+        think_end_id=think_end_id,
+    )
 
 
 def tool_call_constraint_spec(

--- a/mtplx/constrained.py
+++ b/mtplx/constrained.py
@@ -1,0 +1,242 @@
+"""Grammar-constrained decoding (structured output) for the serial AR path.
+
+Phase 1 of the plan in upstream issue #186: ``response_format`` of type
+``json_object`` / ``json_schema`` is enforced with llguidance token bitmasks
+applied to target logits before sampling, on the serial AR lane only.
+Constrained requests never ride the batched AR pump or the MTP lanes; the
+server pins them to ``generation_mode="ar"`` and bypasses the batch scheduler.
+
+llguidance is an optional dependency: requests that do not use
+``response_format`` never touch it, and requests that do get a clear 400 when
+it is missing instead of silent non-enforcement (which is what shipped before
+this module existed).
+
+The mask must hit the logits row before any shaping (temperature, top-p/k,
+penalties) so that both the greedy argmax branch and the sampled branch of
+``_sample_from_logits`` operate on the constrained distribution. Illegal
+tokens are set to -inf, which survives every downstream shaping step.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+try:  # pragma: no cover - exercised via LLGUIDANCE_AVAILABLE branches
+    import llguidance as _llg
+    import llguidance.hf as _llg_hf
+    import llguidance.mlx as _llg_mlx
+
+    LLGUIDANCE_AVAILABLE = True
+    LLGUIDANCE_VERSION = str(_llg.get_version())
+except Exception:  # pragma: no cover
+    _llg = None
+    _llg_hf = None
+    _llg_mlx = None
+    LLGUIDANCE_AVAILABLE = False
+    LLGUIDANCE_VERSION = None
+
+SUPPORTED_RESPONSE_FORMAT_TYPES = ("text", "json_object", "json_schema")
+
+# ``json_object`` promises a JSON object (OpenAI semantics), not merely any
+# JSON value, so the generic grammar pins the top-level type.
+_JSON_OBJECT_SCHEMA = '{"type": "object"}'
+
+
+class ResponseFormatError(ValueError):
+    """Invalid or unsupported ``response_format``; message is client-safe."""
+
+
+@dataclass(frozen=True)
+class ConstraintSpec:
+    """A validated, tokenizer-independent grammar for one request.
+
+    Built once at request-validation time (so bad schemas 400 before any
+    model work) and bound to the runtime tokenizer lazily via ``build`` —
+    once per generation attempt, because matcher state is consumed by a
+    generation and blank-retry attempts must start fresh.
+    """
+
+    grammar: str
+    source_type: str
+
+    def build(self, tokenizer: Any) -> "GrammarConstraint":
+        return GrammarConstraint(self.grammar, tokenizer)
+
+
+def constraint_spec_from_response_format(
+    response_format: Any,
+) -> ConstraintSpec | None:
+    """Parse/validate a request's ``response_format`` into a ConstraintSpec.
+
+    Returns None when no constraint applies (absent or ``type: text``).
+    Raises ResponseFormatError for anything the server cannot honestly
+    enforce — the caller turns that into a 400.
+    """
+    if response_format is None:
+        return None
+    if not isinstance(response_format, dict):
+        raise ResponseFormatError(
+            "response_format must be an object with a 'type' field"
+        )
+    format_type = response_format.get("type")
+    if format_type not in SUPPORTED_RESPONSE_FORMAT_TYPES:
+        raise ResponseFormatError(
+            "unsupported response_format type "
+            f"{format_type!r}; supported: {', '.join(SUPPORTED_RESPONSE_FORMAT_TYPES)}"
+        )
+    if format_type == "text":
+        return None
+    if not LLGUIDANCE_AVAILABLE:
+        raise ResponseFormatError(
+            f"response_format type {format_type!r} requires the optional "
+            "llguidance dependency (pip install llguidance); refusing to "
+            "silently return unconstrained output"
+        )
+    if format_type == "json_object":
+        schema_json = _JSON_OBJECT_SCHEMA
+    else:
+        wrapper = response_format.get("json_schema")
+        if wrapper is None and isinstance(response_format.get("schema"), dict):
+            # Lenient shape some clients send: {"type": "json_schema",
+            # "schema": {...}} without the OpenAI wrapper object.
+            schema = response_format["schema"]
+        elif isinstance(wrapper, dict):
+            schema = wrapper.get("schema")
+        else:
+            schema = None
+        if not isinstance(schema, dict):
+            raise ResponseFormatError(
+                "response_format type 'json_schema' requires json_schema.schema "
+                "to be a JSON Schema object"
+            )
+        schema_json = _canonical_schema_json(schema)
+    grammar = _cached_grammar_for_schema(schema_json)
+    return ConstraintSpec(grammar=grammar, source_type=str(format_type))
+
+
+class GrammarConstraint:
+    """Per-generation matcher state: mask logits rows, advance per token.
+
+    The llguidance tokenizer wrap needs the model's logits width (which can
+    exceed the tokenizer vocab on padded lm_heads), so binding is deferred to
+    the first ``mask_logits_row`` call, where the row's shape provides it.
+    Tokens beyond the tokenizer vocab are always masked out.
+    """
+
+    def __init__(self, grammar: str, tokenizer: Any):
+        self._grammar = grammar
+        self._tokenizer = tokenizer
+        self._matcher: Any | None = None
+        self._bitmask: Any | None = None
+        self.masked_steps = 0
+        self.mask_time_s = 0.0
+
+    def _bind(self, n_vocab: int) -> None:
+        ll_tokenizer = _cached_ll_tokenizer(self._tokenizer, n_vocab)
+        matcher = _llg.LLMatcher(ll_tokenizer, self._grammar)
+        err = matcher.get_error()
+        if err:
+            raise ResponseFormatError(f"response_format grammar rejected: {err}")
+        self._matcher = matcher
+        self._bitmask = _llg_mlx.allocate_token_bitmask(1, n_vocab)
+
+    def mask_logits_row(self, row: Any) -> Any:
+        """Apply the current-step token mask to a 1-D logits row (mx.array)."""
+        if self._matcher is None:
+            self._bind(int(row.shape[-1]))
+        if self._matcher.is_stopped():
+            return row
+        started = time.perf_counter()
+        _llg_mlx.fill_next_token_bitmask(self._matcher, self._bitmask)
+        masked = _llg_mlx.apply_token_bitmask(row.reshape(1, -1), self._bitmask)
+        self.mask_time_s += time.perf_counter() - started
+        self.masked_steps += 1
+        return masked.reshape(row.shape)
+
+    def advance(self, token_id: int) -> None:
+        if self._matcher is not None and not self._matcher.is_stopped():
+            self._matcher.consume_token(int(token_id))
+
+    @property
+    def stopped(self) -> bool:
+        return self._matcher is not None and bool(self._matcher.is_stopped())
+
+    @property
+    def completed(self) -> bool:
+        """True when the emitted text is a complete document per the grammar."""
+        if self._matcher is None:
+            return False
+        return bool(self._matcher.is_accepting() or self._matcher.is_stopped())
+
+
+# --- caches ---------------------------------------------------------------
+#
+# A compiled grammar is schema- and engine-version-specific; the LLTokenizer
+# wrap is tokenizer-object- and vocab-width-specific. Both caches hold strong
+# references (the server keeps one tokenizer for its lifetime) and are
+# bounded, so id() reuse after GC cannot alias a live entry.
+
+_GRAMMAR_CACHE: OrderedDict[str, str] = OrderedDict()
+_GRAMMAR_CACHE_MAX = 64
+_TOKENIZER_CACHE: dict[tuple[int, int], tuple[Any, Any]] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _canonical_schema_json(schema: dict[str, Any]) -> str:
+    return json.dumps(schema, sort_keys=True, separators=(",", ":"))
+
+
+def _cached_grammar_for_schema(schema_json: str) -> str:
+    key = f"{LLGUIDANCE_VERSION}:{schema_json}"
+    with _CACHE_LOCK:
+        cached = _GRAMMAR_CACHE.get(key)
+        if cached is not None:
+            _GRAMMAR_CACHE.move_to_end(key)
+            return cached
+    try:
+        grammar = _llg.LLMatcher.grammar_from_json_schema(schema_json)
+    except Exception as exc:
+        raise ResponseFormatError(f"unsupported JSON Schema: {exc}") from exc
+    err = _llg.LLMatcher.validate_grammar(grammar)
+    if err:
+        raise ResponseFormatError(f"unsupported JSON Schema: {err}")
+    with _CACHE_LOCK:
+        _GRAMMAR_CACHE[key] = grammar
+        while len(_GRAMMAR_CACHE) > _GRAMMAR_CACHE_MAX:
+            _GRAMMAR_CACHE.popitem(last=False)
+    return grammar
+
+
+def _unwrap_hf_tokenizer(tokenizer: Any) -> Any:
+    """Return the underlying fast tokenizer llguidance requires.
+
+    The runtime hands us mlx_lm's TokenizerWrapper, which delegates
+    attribute access to the fast tokenizer it holds but fails llguidance's
+    strict isinstance check; unwrap it when present.
+    """
+    import transformers
+
+    if isinstance(tokenizer, transformers.PreTrainedTokenizerFast):
+        return tokenizer
+    inner = getattr(tokenizer, "_tokenizer", None)
+    if inner is not None and isinstance(inner, transformers.PreTrainedTokenizerFast):
+        return inner
+    return tokenizer
+
+
+def _cached_ll_tokenizer(tokenizer: Any, n_vocab: int) -> Any:
+    tokenizer = _unwrap_hf_tokenizer(tokenizer)
+    key = (id(tokenizer), int(n_vocab))
+    with _CACHE_LOCK:
+        entry = _TOKENIZER_CACHE.get(key)
+        if entry is not None and entry[0] is tokenizer:
+            return entry[1]
+    ll_tokenizer = _llg_hf.from_tokenizer(tokenizer, n_vocab=int(n_vocab))
+    with _CACHE_LOCK:
+        _TOKENIZER_CACHE[key] = (tokenizer, ll_tokenizer)
+    return ll_tokenizer

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -4501,6 +4501,10 @@ def generate_ar(
             pass
     tokens: list[int] = []
     events: list[dict] = []
+    if constraint is not None:
+        # The repetition trimmer retracts committed tokens, which would
+        # desync the grammar matcher; constrained output is schema-shaped.
+        repetition_stop = False
     repetition_config = _repetition_stop_config(bool(repetition_stop))
     repetition_result: RepetitionStopResult | None = None
     _loop_guard_config = loop_guard_config_from_env(
@@ -5479,6 +5483,7 @@ def generate_mtpk(
     repetition_stop: bool = False,
     loop_guard: bool = False,
     vision_splice: Any | None = None,
+    constraint: Any | None = None,
 ) -> GenerationOutput:
     """Generate with a fixed native-MTP depth.
 
@@ -5607,6 +5612,10 @@ def generate_mtpk(
         _default_stop_tokens(rt.tokenizer) if stop_token_ids is None else stop_token_ids
     )
     started_all = time.perf_counter()
+    if constraint is not None:
+        # The repetition trimmer retracts committed tokens, which would
+        # desync the grammar matcher; constrained output is schema-shaped.
+        repetition_stop = False
     repetition_config = _repetition_stop_config(bool(repetition_stop))
     repetition_result: RepetitionStopResult | None = None
     draft_time = verify_time = 0.0
@@ -5758,6 +5767,11 @@ def generate_mtpk(
     bonus_time = 0.0
     online_hidden_corrector_time = 0.0
     tokens: list[int] = []
+    # Grammar-constrained decoding (#186 phase 3): the matcher advances only
+    # through committed tokens (synced once per cycle after the primary);
+    # speculative windows are clamped to the matcher's legal prefix before
+    # commit, so drafts stay unmasked and correctness is target-side only.
+    constraint_synced_tokens = 0
     # OpenAI-style presence/frequency penalties. When active, each token is
     # penalized by the counts of the completion-so-far (prompt excluded), and
     # every verified MTP position by its growing in-block prefix (per-position /
@@ -6473,10 +6487,30 @@ def generate_mtpk(
                     }
                 )
         _guard_armed = _loop_guard is not None and _loop_guard.armed
+        if constraint is not None:
+            # Sync the matcher through the previous cycle's committed window
+            # BEFORE masking this cycle's primary — a stale matcher would
+            # compute the mask at the wrong grammar position.
+            constraint.advance_many(tokens[constraint_synced_tokens:])
+            constraint_synced_tokens = len(tokens)
+            if (
+                constraint.stopped
+                and tokens
+                and not _is_stop(tokens[-1], stop_token_ids)
+            ):
+                append_event({"step": len(tokens), "constraint_stop": True})
+                break
         primary_already_emitted = pending_primary is not None
         if pending_primary is None:
+            primary_row = logits[0]
+            if constraint is not None:
+                # The one guaranteed-progress mask site: every cycle's fresh
+                # position samples from the constrained target distribution.
+                # Speculative windows are handled by the legality clamp below
+                # instead of per-row masks (see #186 phase 3).
+                primary_row = constraint.mask_logits_row(primary_row)
             primary, _ = _sample_from_logits(
-                logits[0],
+                primary_row,
                 sampler,
                 rng,
                 token_counts=Counter(tokens) if _penalties_active else None,
@@ -6486,6 +6520,12 @@ def generate_mtpk(
             )
             tokens.append(primary)
             emit_new_tokens()
+            if constraint is not None:
+                # Everything later this cycle (copy-block truncation, the
+                # accept-loop clamp, bonus checks) validates windows that
+                # FOLLOW the primary, so consume it now.
+                constraint.advance_many(tokens[constraint_synced_tokens:])
+                constraint_synced_tokens = len(tokens)
         else:
             primary = pending_primary
             pending_primary = None
@@ -6585,10 +6625,18 @@ def generate_mtpk(
             _cc_hist = prompt_ids + tokens
             ccopy_probes += 1
             _cc_pos, _cc_ext = ccopy_index.find(_cc_hist)
+            _cc_block: list[int] = []
             if _cc_pos is not None and _cc_ext >= ccopy_min_ext:
                 _cc_klen = block_for_ext(_cc_ext, ccopy_k)
                 _cc_block = [int(t) for t in _cc_hist[_cc_pos:_cc_pos + _cc_klen]]
                 _cc_block = _cc_block[: max(1, max_tokens - len(tokens))]
+                if constraint is not None:
+                    # Truncate the copy proposal at the first grammar-illegal
+                    # token so masked rejections stay rare instead of
+                    # systematic; an empty result falls through to the normal
+                    # MTP round (#186 phase 3).
+                    _cc_block = _cc_block[: constraint.validate_prefix(_cc_block)]
+            if _cc_block:
                 _cc_T = 1 + len(_cc_block)
                 _cc_before = None
                 if not _env_truthy("MTPLX_SKIP_VERIFY_SNAPSHOT"):
@@ -6700,6 +6748,14 @@ def generate_mtpk(
                     _cc_acc = _cc_acc[:_cc_stop_idx + 1]
                 tokens.extend(_cc_acc)
                 _cc_finished = _cc_stop_idx is not None
+                if constraint is not None and _cc_correction is not None and (
+                    constraint.validate_prefix([*_cc_acc, int(_cc_correction)])
+                    != len(_cc_acc) + 1
+                ):
+                    # Grammar-illegal residual: drop it; the next cycle's
+                    # masked primary resamples the position, which preserves
+                    # the masked target law exactly.
+                    _cc_correction = None
                 if _cc_correction is not None and not _cc_finished:
                     # Exactness requires the rejected position's token to be
                     # the residual sample drawn above, not a fresh draw from
@@ -7596,6 +7652,15 @@ def generate_mtpk(
             # the target_prefix pre-sample above already carried the overlay
             # (and its lane has no draft distributions to fall back on).
             target_distribution_batch = None
+        # Grammar clamp (#186 phase 3): drafts are proposed unmasked, so the
+        # committed window must stop at the grammar's legal prefix. One
+        # stateless validate call per cycle; the matcher itself only advances
+        # through committed tokens at the top-of-cycle sync.
+        constraint_legal_prefix = (
+            constraint.validate_prefix(list(draft_tokens))
+            if constraint is not None
+            else None
+        )
         for depth_index, draft_token in enumerate(draft_tokens):
             target_logits_for_draft = verify_logits[:, depth_index, :]
             if _guard_armed:
@@ -7710,6 +7775,19 @@ def generate_mtpk(
                     )
                 )
 
+            if (
+                constraint_legal_prefix is not None
+                and accepted_now
+                and depth_index >= constraint_legal_prefix
+            ):
+                # The model accepted a draft the grammar forbids here; reject
+                # it and let the next cycle's masked primary resample the
+                # position from the constrained distribution (which keeps the
+                # output law exactly the masked target law).
+                accepted_now = False
+                accept_prob = 0.0
+                event["drafts"][depth_index]["constraint_clamped"] = True
+
             event["drafts"][depth_index]["accepted"] = accepted_now
             event["drafts"][depth_index]["accept_probability"] = float(accept_prob)
             event["drafts"][depth_index]["correction"] = int(correction)
@@ -7746,7 +7824,15 @@ def generate_mtpk(
                 event["drafts"][depth_index]["online_correction_cache"][
                     "stored_token"
                 ] = cached_target
-            if sampler.temperature > 0:
+            if sampler.temperature > 0 and (
+                constraint is None
+                or constraint.validate_prefix(
+                    [*draft_tokens[:depth_index], int(correction)]
+                )
+                == depth_index + 1
+            ):
+                # A grammar-illegal residual correction is dropped, not
+                # committed; the masked primary resamples the position.
                 rejection_correction = int(correction)
             break
         elapsed_accept = max(
@@ -7984,6 +8070,20 @@ def generate_mtpk(
                 )
                 bonus_time += elapsed_bonus
                 _add_timing(event, "bonus_sample", elapsed_bonus)
+                if constraint is not None and (
+                    constraint.validate_prefix([*draft_tokens, int(bonus)])
+                    != len(draft_tokens) + 1
+                ):
+                    # Grammar-illegal bonus: skip it (same control path as
+                    # omit_speculative_bonus). `logits` already holds the
+                    # bonus-position row, so the next cycle's masked primary
+                    # resamples this exact position from the constrained
+                    # distribution.
+                    event["bonus_token_constraint_skipped"] = True
+                    maybe_eval_state_roots(event, len(tokens))
+                    append_event(event)
+                    emit_trace()
+                    continue
                 tokens.append(bonus)
                 pending_primary = bonus
                 bonus_tokens += 1
@@ -8232,10 +8332,17 @@ def generate_mtpk(
         # other downstream cache consumer must never see promoted
         # tensor-offset adapters.
         compiled_verify_bank.demote(cache)
+    if constraint is not None:
+        # Final sync so `completed` reflects every committed token (the loop
+        # may exit between the per-cycle sync and the last commit).
+        constraint.advance_many(tokens[constraint_synced_tokens:])
+        constraint_synced_tokens = len(tokens)
     finish_reason = (
         "stop"
         if repetition_result is not None
         or any(_is_stop(token, stop_token_ids) for token in tokens)
+        # A grammar-terminal exit is a completed document, not truncation.
+        or (constraint is not None and constraint.stopped)
         else "length"
     )
     if capture_final_state:
@@ -8254,6 +8361,16 @@ def generate_mtpk(
     reject_path_counts, repair_time_by_reject_depth = _reject_repair_breakdown(events)
     stats = GenerationStats(
         mode="mtpk",
+        constraint_active=constraint is not None,
+        constraint_completed=(
+            constraint.completed if constraint is not None else None
+        ),
+        constraint_masked_steps=(
+            constraint.masked_steps if constraint is not None else 0
+        ),
+        constraint_mask_time_s=(
+            constraint.mask_time_s if constraint is not None else 0.0
+        ),
         generated_tokens=len(tokens),
         elapsed_s=elapsed,
         **_generation_rate_fields(

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1581,6 +1581,14 @@ class GenerationStats:
     context_copy_suspended: bool = False
     context_copy_backoff_tokens: int = 0
     context_copy_disabled_reason: str | None = None
+    # Grammar-constrained decoding (response_format). constraint_completed is
+    # None when no constraint was active, False when generation ended before
+    # the grammar reached a complete document (truncation is never passed off
+    # as valid output).
+    constraint_active: bool = False
+    constraint_completed: bool | None = None
+    constraint_masked_steps: int = 0
+    constraint_mask_time_s: float = 0.0
     graphbank: dict[str, object] = field(default_factory=dict)
     reject_path_counts: dict[str, int] = field(default_factory=dict)
     repair_time_by_reject_depth_s: dict[str, float] = field(default_factory=dict)
@@ -4409,8 +4417,13 @@ def generate_ar(
     prefill_callback: Callable[[dict[str, Any]], None] | None = None,
     repetition_stop: bool = False,
     loop_guard: bool = False,
+    constraint: Any | None = None,
 ) -> GenerationOutput:
     if getattr(rt, "backend_id", None) == "gemma4_assistant":
+        if constraint is not None:
+            raise ValueError(
+                "constrained decoding is not supported on the gemma4_assistant backend"
+            )
         from .backends.gemma4_assistant import generate_gemma4_ar
 
         return generate_gemma4_ar(
@@ -4595,8 +4608,14 @@ def generate_ar(
                         },
                     }
                 )
+        logits_row = logits[0]
+        if constraint is not None:
+            # Masking precedes every shaping step in _sample_from_logits, so
+            # both the greedy and sampled branches draw from the constrained
+            # distribution (-inf survives temperature/top-p/penalties).
+            logits_row = constraint.mask_logits_row(logits_row)
         token, _ = _sample_from_logits(
-            logits[0],
+            logits_row,
             sampler,
             rng,
             token_counts=Counter(tokens)
@@ -4611,6 +4630,13 @@ def generate_ar(
         tokens.append(token)
         emit_token(token)
         events.append({"step": step, "token": token})
+        if constraint is not None:
+            constraint.advance(token)
+            if constraint.stopped and not _is_stop(token, stop_token_ids):
+                # The grammar reached its terminal without the model emitting
+                # a stop token; end here rather than decode past the document.
+                events.append({"step": step, "constraint_stop": True})
+                break
         repetition_result = _trim_repeated_suffix(tokens, repetition_config)
         if repetition_result is not None:
             events.append(
@@ -4701,6 +4727,14 @@ def generate_ar(
         loop_guard=(_loop_guard.summary() if _loop_guard is not None else {}),
         decode_trace_path=str(trace.path) if trace.path is not None else None,
         decode_trace_run_id=trace.run_id if trace.enabled else None,
+        constraint_active=constraint is not None,
+        constraint_completed=(constraint.completed if constraint is not None else None),
+        constraint_masked_steps=(
+            constraint.masked_steps if constraint is not None else 0
+        ),
+        constraint_mask_time_s=(
+            constraint.mask_time_s if constraint is not None else 0.0
+        ),
         events=events,
     )
     _attach_runtime_diagnostics(

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -77,6 +77,10 @@ from mtplx.backends.descriptors import (
 from mtplx.backends.registry import load_runtime_contract
 from mtplx.batching import BatchSchedulerConfig, SchedulerMode, SchedulerPreset
 from mtplx.chat_encoding import encode_chat_messages, is_gemma4_tokenizer
+from mtplx.constrained import (
+    ResponseFormatError,
+    constraint_spec_from_response_format,
+)
 from mtplx.gemma4_pair import (
     GEMMA4_BACKEND,
     gemma4_pair_sampler_defaults,
@@ -12784,6 +12788,11 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "context_copy_suspended",
     "context_copy_backoff_tokens",
     "context_copy_disabled_reason",
+    # Grammar-constrained decoding (response_format) counters.
+    "constraint_active",
+    "constraint_completed",
+    "constraint_masked_steps",
+    "constraint_mask_time_s",
     "verify_time_s",
     "draft_time_s",
     "accept_time_s",
@@ -15140,7 +15149,16 @@ def _run_generation_dispatched(
     history_bypass_reason = _ar_batch_history_bypass_reason(
         request_observability_for_lane
     )
-    if history_bypass_reason is not None:
+    if kwargs.get("constraint_spec") is not None:
+        # Grammar masks only exist on the serial AR path; the batched AR
+        # pump's per-job samplers carry no matcher state (issue #186 phase 1).
+        use_ar_batch = False
+        mtp_disabled_reason = "constrained_decoding"
+        request_observability_for_lane["scheduler_lane"] = "solo_constrained"
+        request_observability_for_lane["ar_batch_bypass_reason"] = (
+            "constrained_decoding"
+        )
+    elif history_bypass_reason is not None:
         use_ar_batch = False
         mtp_disabled_reason = None
         request_observability_for_lane["scheduler_lane"] = (
@@ -15292,6 +15310,7 @@ def _run_generation(
     cancel_event: Event | None = None,
     streaming_response: bool | None = None,
     vision_splice: Any | None = None,
+    constraint_spec: Any | None = None,
 ) -> dict[str, Any]:
     response_max, sampler, generation_limits = _generation_params(
         state,
@@ -15312,6 +15331,10 @@ def _run_generation(
         generation_mode,
         default=getattr(state.args, "generation_mode", "mtp"),
     )
+    if constraint_spec is not None:
+        # Grammar masks are wired into generate_ar only; never let a
+        # constrained request fall through to an unmasked lane.
+        effective_mode = "ar"
     requested_depth = (
         0
         if effective_mode == "ar"
@@ -15404,6 +15427,11 @@ def _run_generation(
                 dynamic_kv_reservation["env"]
             ), prefill_chunk_size_override(prefill_chunk_tokens):
                 if effective_mode == "ar":
+                    constraint = (
+                        constraint_spec.build(state.runtime.tokenizer)
+                        if constraint_spec is not None
+                        else None
+                    )
                     out = generate_ar(
                         state.runtime,
                         prompt_ids,
@@ -15414,8 +15442,16 @@ def _run_generation(
                         trace_label=trace_label,
                         trace_metadata=trace_metadata,
                         prefill_callback=prefill_callback,
-                        repetition_stop=uncapped_repetition_stop,
+                        # The repetition trimmer retracts already-committed
+                        # tokens, which would desync the grammar matcher;
+                        # constrained output is schema-shaped, not freeform.
+                        repetition_stop=(
+                            False
+                            if constraint is not None
+                            else uncapped_repetition_stop
+                        ),
                         loop_guard=_loop_guard_enabled(),
+                        constraint=constraint,
                     )
                 else:
                     adaptive_policy = _make_adaptive_policy(
@@ -15750,7 +15786,12 @@ def _run_generation(
             "end_to_end_tok_s": server_tok_s,
             "_final_state": final_state,
             "finish_reason": (
-                out.final_state.finish_reason if out.final_state is not None else "stop"
+                out.final_state.finish_reason
+                if out.final_state is not None
+                # The serial AR lane has no final_state; its GenerationOutput
+                # still reports length-vs-stop correctly — don't flatten a
+                # max_tokens truncation into "stop".
+                else (getattr(out, "finish_reason", None) or "stop")
             ),
         }
         if seed_is_explicit or out.text.strip():
@@ -16232,6 +16273,15 @@ def _stats_footer_text(state: ServerState, generated: dict[str, Any]) -> str:
     if not state.args.stats_footer:
         return ""
     stats = generated["stats"]
+    constraint_active = (
+        stats.get("constraint_active")
+        if isinstance(stats, dict)
+        else getattr(stats, "constraint_active", False)
+    )
+    if constraint_active:
+        # response_format promised machine-parseable output; a prose footer
+        # appended to the content would corrupt it for every JSON client.
+        return ""
     tok_s, decode_elapsed_s = _decode_timing(stats)
     completion_tokens = int(generated.get("completion_tokens") or 0)
     footer = f"**{tok_s:.1f} tok/s** · {completion_tokens} tokens · {decode_elapsed_s:.2f}s decode"
@@ -17080,6 +17130,8 @@ def _display_text(
     if not state.args.stats_footer:
         return text
     footer = _stats_footer_text(state, generated)
+    if not footer:
+        return text
     separator = "\n\n" if text.endswith("\n") else "\n\n"
     return f"{text}{separator}{footer}"
 
@@ -20545,6 +20597,25 @@ def create_app(state: ServerState) -> FastAPI:
             request,
             allow_client_controls=client_controls_allowed,
         )
+        try:
+            constraint_spec = constraint_spec_from_response_format(
+                request.response_format
+            )
+        except ResponseFormatError as constraint_error:
+            raise HTTPException(status_code=400, detail=str(constraint_error))
+        if constraint_spec is not None:
+            if getattr(state.runtime, "backend_id", None) == "gemma4_assistant":
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "response_format constrained decoding is not supported "
+                        "on the gemma4_assistant backend"
+                    ),
+                )
+            # Phase 1 pins constrained requests to the serial AR lane; the
+            # MTP verify paths and the batched AR pump do not apply grammar
+            # masks yet (see upstream issue #186 for the composition plan).
+            request_generation_mode = "ar"
         request_depth = _request_depth_for_generation(
             state,
             request,
@@ -20699,6 +20770,10 @@ def create_app(state: ServerState) -> FastAPI:
             request_generation_mode=request_generation_mode,
             request_depth=request_depth,
         )
+        if constraint_spec is not None:
+            request_observability["constrained_decoding"] = (
+                constraint_spec.source_type
+            )
         if vision_splice is not None:
             request_observability["request_vision_images"] = len(vision_images)
             request_observability["request_vision_rows"] = vision_splice.total_rows
@@ -21208,6 +21283,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=request.seed,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         session_id=session_id,
@@ -21246,6 +21322,7 @@ def create_app(state: ServerState) -> FastAPI:
                     seed=request.seed,
                     draft_sampler=request_draft_sampler,
                     generation_mode=request_generation_mode,
+                    constraint_spec=constraint_spec,
                     depth=request_depth,
                     resolved_mtp_depth=effective_request_depth,
                     session_id=session_id,
@@ -21605,6 +21682,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -21729,6 +21807,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -21869,6 +21948,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22044,6 +22124,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22204,6 +22285,7 @@ def create_app(state: ServerState) -> FastAPI:
                         seed=None,
                         draft_sampler=request_draft_sampler,
                         generation_mode=request_generation_mode,
+                        constraint_spec=constraint_spec,
                         depth=request_depth,
                         resolved_mtp_depth=effective_request_depth,
                         token_callback=on_tokens,
@@ -22283,6 +22365,7 @@ def create_app(state: ServerState) -> FastAPI:
                                 seed=request.seed,
                                 draft_sampler=request_draft_sampler,
                                 generation_mode=request_generation_mode,
+                                constraint_spec=constraint_spec,
                                 depth=request_depth,
                                 resolved_mtp_depth=effective_request_depth,
                                 token_callback=on_tokens,
@@ -22333,6 +22416,7 @@ def create_app(state: ServerState) -> FastAPI:
                                     seed=request.seed,
                                     draft_sampler=request_draft_sampler,
                                     generation_mode=request_generation_mode,
+                                    constraint_spec=constraint_spec,
                                     depth=request_depth,
                                     resolved_mtp_depth=effective_request_depth,
                                     token_callback=on_tokens,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -80,6 +80,8 @@ from mtplx.chat_encoding import encode_chat_messages, is_gemma4_tokenizer
 from mtplx.constrained import (
     ResponseFormatError,
     constraint_spec_from_response_format,
+    tool_call_constraint_spec,
+    tool_call_strict_enabled,
 )
 from mtplx.gemma4_pair import (
     GEMMA4_BACKEND,
@@ -15331,10 +15333,6 @@ def _run_generation(
         generation_mode,
         default=getattr(state.args, "generation_mode", "mtp"),
     )
-    if constraint_spec is not None:
-        # Grammar masks are wired into generate_ar only; never let a
-        # constrained request fall through to an unmasked lane.
-        effective_mode = "ar"
     requested_depth = (
         0
         if effective_mode == "ar"
@@ -15426,12 +15424,12 @@ def _run_generation(
             with _temporary_env(
                 dynamic_kv_reservation["env"]
             ), prefill_chunk_size_override(prefill_chunk_tokens):
+                constraint = (
+                    constraint_spec.build(state.runtime.tokenizer)
+                    if constraint_spec is not None
+                    else None
+                )
                 if effective_mode == "ar":
-                    constraint = (
-                        constraint_spec.build(state.runtime.tokenizer)
-                        if constraint_spec is not None
-                        else None
-                    )
                     out = generate_ar(
                         state.runtime,
                         prompt_ids,
@@ -15464,6 +15462,7 @@ def _run_generation(
                     out = generate_mtpk(
                         state.runtime,
                         prompt_ids,
+                        constraint=constraint,
                         vision_splice=vision_splice,
                         abort_check=(
                             (lambda: bool(cancel_event.is_set()))
@@ -20599,23 +20598,39 @@ def create_app(state: ServerState) -> FastAPI:
         )
         try:
             constraint_spec = constraint_spec_from_response_format(
-                request.response_format
+                request.response_format,
+                tokenizer=state.runtime.tokenizer,
             )
         except ResponseFormatError as constraint_error:
             raise HTTPException(status_code=400, detail=str(constraint_error))
+        if request.tools and tool_call_strict_enabled():
+            if constraint_spec is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "response_format constrained decoding cannot be "
+                        "combined with strict tool calls"
+                    ),
+                )
+            try:
+                constraint_spec = tool_call_constraint_spec(
+                    request.tools,
+                    request.tool_choice,
+                    state.runtime.tokenizer,
+                )
+            except ResponseFormatError as constraint_error:
+                raise HTTPException(status_code=400, detail=str(constraint_error))
         if constraint_spec is not None:
             if getattr(state.runtime, "backend_id", None) == "gemma4_assistant":
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        "response_format constrained decoding is not supported "
-                        "on the gemma4_assistant backend"
+                        "constrained decoding is not supported on the "
+                        "gemma4_assistant backend"
                     ),
                 )
-            # Phase 1 pins constrained requests to the serial AR lane; the
-            # MTP verify paths and the batched AR pump do not apply grammar
-            # masks yet (see upstream issue #186 for the composition plan).
-            request_generation_mode = "ar"
+            # Constrained requests ride the serial lanes (MTP included since
+            # #186 phase 3); only the batched AR pump is bypassed.
         request_depth = _request_depth_for_generation(
             state,
             request,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -15425,7 +15425,9 @@ def _run_generation(
                 dynamic_kv_reservation["env"]
             ), prefill_chunk_size_override(prefill_chunk_tokens):
                 constraint = (
-                    constraint_spec.build(state.runtime.tokenizer)
+                    constraint_spec.build(
+                        state.runtime.tokenizer, prompt_ids=prompt_ids
+                    )
                     if constraint_spec is not None
                     else None
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ competitors = [
 ]
 server = [
   "fastapi>=0.136",
+  "llguidance>=1.7",
   "pillow>=10",
   "uvicorn>=0.46",
 ]

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -181,6 +181,186 @@ def test_generate_ar_rejects_constraint_on_gemma4_assistant_backend():
         )
 
 
+# --- generate_mtpk composition (#186 phase 3): scripted model, fake grammar -
+
+
+class _EvensOnlyConstraint:
+    """Duck-typed grammar allowing only even token ids, stopping after `limit`.
+
+    The scripted ramp model always prefers odd successors, so every even
+    committed token is the mask's or the clamp's doing.
+    """
+
+    def __init__(self, limit: int = 6):
+        self.limit = limit
+        self.advanced: list[int] = []
+        self.masked_steps = 0
+        self.mask_time_s = 0.0
+
+    def _legal(self, token_id: int) -> bool:
+        return token_id % 2 == 0 and len(self.advanced) < self.limit
+
+    def mask_logits_row(self, row):
+        self.masked_steps += 1
+        ids = mx.arange(row.shape[-1])
+        legal = (ids % 2) == 0
+        return mx.where(legal, row, mx.array(-np.inf, dtype=row.dtype))
+
+    def validate_prefix(self, token_ids):
+        count = 0
+        pos = len(self.advanced)
+        for token in token_ids:
+            if pos + count >= self.limit or int(token) % 2 != 0:
+                break
+            count += 1
+        return count
+
+    def advance(self, token_id: int) -> None:
+        self.advanced.append(int(token_id))
+
+    def advance_many(self, token_ids) -> None:
+        for token in token_ids:
+            self.advance(token)
+
+    @property
+    def stopped(self) -> bool:
+        return len(self.advanced) >= self.limit
+
+    @property
+    def completed(self) -> bool:
+        return self.stopped
+
+
+class _MTPScriptedModel:
+    """Deterministic mtpk stub: after token t, both trunk and MTP head want
+    t+1 (mod vocab) — always odd successors from even tokens and vice versa."""
+
+    def __init__(self, vocab: int = 8):
+        self.vocab = vocab
+        self.mtp = SimpleNamespace(_mtplx_lora_targets=[])
+
+    def make_cache(self):
+        return []
+
+    def make_mtp_cache(self):
+        return []
+
+    def mtp_update_cache(self, hidden_states, next_token_ids, **_kwargs):
+        return hidden_states
+
+    def _logits_for(self, last_tokens):
+        rows = []
+        for token in last_tokens:
+            row = [0.0] * self.vocab
+            row[(int(token) + 1) % self.vocab] = 10.0
+            rows.append(row)
+        return mx.array([rows], dtype=mx.float32)
+
+    def __call__(
+        self,
+        input_ids,
+        *,
+        cache=None,
+        return_hidden: bool = False,
+        hidden_variant: str | None = None,
+        emit_logits: bool = True,
+        logits_keep: int | None = None,
+    ):
+        toks = [int(t) for t in np.asarray(input_ids).reshape(-1)]
+        keep = len(toks) if logits_keep is None else min(len(toks), max(1, int(logits_keep)))
+        logits = self._logits_for(toks[-keep:]) if emit_logits else None
+        hidden = mx.zeros((1, len(toks), 2), dtype=mx.float32)
+        if not emit_logits:
+            return (None, hidden) if return_hidden else None
+        return (logits, hidden) if return_hidden else logits
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        *,
+        mtp_cache=None,
+        concat_order=None,
+        return_hidden: bool = False,
+        mtp_hidden_variant: str | None = None,
+        position_offset=None,
+    ):
+        toks = [int(t) for t in np.asarray(next_token_ids).reshape(-1)]
+        logits = self._logits_for(toks)
+        hidden = mx.zeros((1, len(toks), 2), dtype=mx.float32)
+        return (logits, hidden) if return_hidden else logits
+
+
+def _mtpk_constrained(constraint, *, max_tokens: int = 12, depth: int = 2):
+    from mtplx.generation import generate_mtpk
+
+    rt = MTPLXRuntime(
+        model=_MTPScriptedModel(),
+        tokenizer=_Tokenizer(),
+        model_path=Path("tiny-constrained-mtpk"),
+        mtp_enabled=True,
+        contract=MTPContract(),
+    )
+    return generate_mtpk(
+        rt,
+        [0, 1, 2, 3],
+        max_tokens=max_tokens,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        speculative_depth=depth,
+        seed=0,
+        stop_token_ids=set(),
+        verify_strategy="capture_commit",
+        constraint=constraint,
+    )
+
+
+def test_generate_mtpk_masks_and_clamps_to_grammar(monkeypatch):
+    monkeypatch.delenv("MTPLX_CONTEXT_COPY", raising=False)
+    constraint = _EvensOnlyConstraint(limit=6)
+    out = _mtpk_constrained(constraint)
+    # The ramp model always wants odd successors; only the mask (primary) and
+    # the legality clamp (draft window / bonus) can keep the stream even.
+    assert out.tokens, "no tokens generated"
+    assert all(t % 2 == 0 for t in out.tokens), out.tokens
+    # The matcher advanced through exactly the committed stream, in order.
+    assert constraint.advanced == out.tokens
+    assert out.stats.constraint_active is True
+    assert out.stats.constraint_completed is True
+    assert out.stats.constraint_masked_steps >= 1
+
+
+def test_generate_mtpk_stops_at_grammar_terminal(monkeypatch):
+    monkeypatch.delenv("MTPLX_CONTEXT_COPY", raising=False)
+    constraint = _EvensOnlyConstraint(limit=3)
+    out = _mtpk_constrained(constraint, max_tokens=20)
+    assert len(out.tokens) == 3, out.tokens
+    assert out.finish_reason == "stop"
+    assert out.stats.constraint_completed is True
+
+
+def test_generate_mtpk_unconstrained_reports_inactive(monkeypatch):
+    monkeypatch.delenv("MTPLX_CONTEXT_COPY", raising=False)
+    out = _mtpk_constrained(None, max_tokens=6)
+    assert out.stats.constraint_active is False
+    assert out.stats.constraint_completed is None
+
+
+# --- strict tool-call constraint spec (phase 2) -----------------------------
+
+
+def test_tool_call_spec_paths_without_llguidance_dependency():
+    from mtplx.constrained import tool_call_constraint_spec
+
+    assert tool_call_constraint_spec(None, None, object()) is None
+    assert tool_call_constraint_spec([], "auto", object()) is None
+    assert (
+        tool_call_constraint_spec(
+            [{"type": "function", "function": {"name": "f"}}], "none", object()
+        )
+        is None
+    )
+
+
 # --- end-to-end with llguidance (tiny single-byte tokenizer) ---------------
 
 llguidance = pytest.importorskip("llguidance")

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -548,6 +548,38 @@ def test_strict_tool_call_grammar_end_to_end():
     assert fresh.validate_prefix(bad) < len(bad)
 
 
+def test_json_prelude_gated_on_open_think_block():
+    hf_tok = _tiny_tool_tokenizer()
+    spec = constraint_spec_from_response_format(
+        {"type": "json_object"}, tokenizer=hf_tok
+    )
+    assert spec.grammar_with_prelude is not None
+    think_open = hf_tok.encode("<think>", add_special_tokens=False)[0]
+    think_close = hf_tok.encode("</think>", add_special_tokens=False)[0]
+    n_vocab = 160
+    prose = hf_tok.encode("hello", add_special_tokens=False)
+
+    # Prompt ends inside an open think block -> prelude grammar: reasoning
+    # text is legal before the document.
+    inside = spec.build(hf_tok, prompt_ids=[5, think_open])
+    inside.mask_logits_row(mx.zeros((n_vocab,)))
+    assert inside.validate_prefix(prose) == len(prose)
+
+    # Think block already closed -> plain grammar: prose is illegal, the
+    # document must start immediately (the prelude would otherwise allow
+    # unbounded free text on non-thinking runs).
+    closed = spec.build(hf_tok, prompt_ids=[5, think_open, 6, think_close])
+    closed.mask_logits_row(mx.zeros((n_vocab,)))
+    assert closed.validate_prefix(prose) == 0
+    brace = hf_tok.encode("{", add_special_tokens=False)
+    assert closed.validate_prefix(brace) == 1
+
+    # No prompt information -> conservative plain grammar.
+    unknown = spec.build(hf_tok)
+    unknown.mask_logits_row(mx.zeros((n_vocab,)))
+    assert unknown.validate_prefix(prose) == 0
+
+
 def test_grammar_cache_canonicalizes_key_order():
     from mtplx import constrained as mod
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1,0 +1,300 @@
+"""Grammar-constrained decoding (response_format), issue #186 phase 1.
+
+Covers: the request-validation surface (bad shapes 400 instead of silent
+non-enforcement), the generate_ar wiring (mask before sampling, advance per
+token, grammar-terminal early stop, stats counters), end-to-end schema
+enforcement against adversarial logits with a tiny single-byte tokenizer,
+and public-envelope exposure of the constraint counters.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mtplx.constrained import (
+    ResponseFormatError,
+    constraint_spec_from_response_format,
+)
+from mtplx.generation import generate_ar
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+from mtplx.sampling import SamplerConfig
+
+
+# --- response_format validation surface (no llguidance required) ----------
+
+
+def test_absent_and_text_response_formats_apply_no_constraint():
+    assert constraint_spec_from_response_format(None) is None
+    assert constraint_spec_from_response_format({"type": "text"}) is None
+
+
+@pytest.mark.parametrize(
+    "response_format",
+    [
+        "json",
+        ["json_object"],
+        {},
+        {"type": "json"},
+        {"type": "grammar"},
+    ],
+)
+def test_invalid_response_formats_are_rejected(response_format):
+    with pytest.raises(ResponseFormatError):
+        constraint_spec_from_response_format(response_format)
+
+
+# --- generate_ar wiring (scripted model, fake constraint) ------------------
+
+
+class _Tokenizer:
+    def decode(self, tokens, **_kwargs):
+        return "".join(f"<{int(token)}>" for token in tokens)
+
+
+class _RampModel:
+    """Unconstrained argmax always walks t -> t+1 over an 8-token vocab."""
+
+    vocab = 8
+
+    def __init__(self):
+        self.mtp = SimpleNamespace(_mtplx_lora_targets=[])
+
+    def make_cache(self):
+        return []
+
+    def __call__(
+        self,
+        input_ids,
+        *,
+        cache=None,
+        return_hidden: bool = False,
+        hidden_variant: str | None = None,
+        emit_logits: bool = True,
+        logits_keep: int | None = None,
+    ):
+        tokens = [int(token) for token in np.asarray(input_ids).reshape(-1)]
+        row = [0.0] * self.vocab
+        row[(tokens[-1] + 1) % self.vocab] = 10.0
+        logits = mx.array([[row]], dtype=mx.float32)
+        hidden = mx.zeros((1, len(tokens), 2), dtype=mx.float32)
+        if return_hidden:
+            return logits, hidden
+        return logits
+
+
+class _ForcingConstraint:
+    """Duck-typed constraint that forces a scripted token path, then stops."""
+
+    def __init__(self, forced: list[int]):
+        self.forced = list(forced)
+        self.advanced: list[int] = []
+        self.masked_steps = 0
+        self.mask_time_s = 0.0
+
+    def mask_logits_row(self, row):
+        self.masked_steps += 1
+        wanted = self.forced[len(self.advanced)]
+        mask = mx.full(row.shape, -np.inf, dtype=row.dtype)
+        return mx.where(
+            mx.arange(row.shape[-1]) == wanted, mx.array(100.0, dtype=row.dtype), mask
+        )
+
+    def advance(self, token_id: int) -> None:
+        self.advanced.append(int(token_id))
+
+    @property
+    def stopped(self) -> bool:
+        return len(self.advanced) >= len(self.forced)
+
+    @property
+    def completed(self) -> bool:
+        return self.stopped
+
+
+def _runtime(model, backend_id: str | None = None) -> MTPLXRuntime:
+    rt = MTPLXRuntime(
+        model=model,
+        tokenizer=_Tokenizer(),
+        model_path=Path("tiny-constrained"),
+        mtp_enabled=False,
+        contract=MTPContract(),
+    )
+    if backend_id is not None:
+        rt.backend_id = backend_id
+    return rt
+
+
+def test_generate_ar_constraint_overrides_model_preference():
+    constraint = _ForcingConstraint([5, 2, 7])
+    out = generate_ar(
+        _runtime(_RampModel()),
+        [1, 2],
+        max_tokens=10,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=0,
+        stop_token_ids=set(),
+        constraint=constraint,
+    )
+    # The ramp model wants 3,4,5...; the mask forces the scripted path, and
+    # generation halts at the grammar terminal instead of running to
+    # max_tokens.
+    assert out.tokens == [5, 2, 7]
+    assert constraint.advanced == [5, 2, 7]
+    assert constraint.masked_steps == 3
+    assert out.finish_reason == "stop"
+    assert out.stats.constraint_active is True
+    assert out.stats.constraint_completed is True
+    assert out.stats.constraint_masked_steps == 3
+    assert any("constraint_stop" in event for event in out.stats.events)
+
+
+def test_generate_ar_without_constraint_reports_inactive():
+    out = generate_ar(
+        _runtime(_RampModel()),
+        [1],
+        max_tokens=3,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        seed=0,
+        stop_token_ids=set(),
+    )
+    assert out.stats.constraint_active is False
+    assert out.stats.constraint_completed is None
+
+
+def test_generate_ar_rejects_constraint_on_gemma4_assistant_backend():
+    with pytest.raises(ValueError, match="gemma4_assistant"):
+        generate_ar(
+            _runtime(_RampModel(), backend_id="gemma4_assistant"),
+            [1],
+            max_tokens=3,
+            sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+            seed=0,
+            stop_token_ids=set(),
+            constraint=_ForcingConstraint([1]),
+        )
+
+
+# --- end-to-end with llguidance (tiny single-byte tokenizer) ---------------
+
+llguidance = pytest.importorskip("llguidance")
+
+
+def _tiny_hf_tokenizer():
+    from tokenizers import Tokenizer, decoders, models
+    from transformers import PreTrainedTokenizerFast
+
+    # No space token: raw space is not its own symbol in the byte-level
+    # alphabet (it's 'Ġ'), and JSON for the test schema needs no whitespace.
+    vocab = {chr(i): i - 32 for i in range(33, 127)}
+    vocab["<eos>"] = 0
+    # Merge-free BPE tokenizes any byte string char-by-char, which llguidance
+    # needs to canonically tokenize forced-byte runs like '"age"' (WordLevel
+    # would return UNK for multi-char lookups and break the mask).
+    backend = Tokenizer(models.BPE(vocab=vocab, merges=[], unk_token="<eos>"))
+    # llguidance derives token byte representations from the decoder type;
+    # ByteLevel is one it recognizes, and every remaining printable-ASCII
+    # token maps to itself under the byte-level alphabet.
+    backend.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(tokenizer_object=backend, eos_token="<eos>"), {
+        v: k for k, v in vocab.items()
+    }
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "age": {"type": "integer", "minimum": 0},
+        "tag": {"type": "string", "enum": ["a", "b"]},
+    },
+    "required": ["age", "tag"],
+    "additionalProperties": False,
+}
+
+
+def test_grammar_forces_schema_valid_json_under_adversarial_logits():
+    hf_tok, id_to_text = _tiny_hf_tokenizer()
+    spec = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"name": "t", "schema": _SCHEMA}}
+    )
+    assert spec is not None
+    constraint = spec.build(hf_tok)
+
+    # Logits width deliberately exceeds the tokenizer vocab (padded lm_head).
+    # The unmasked argmax is always a padding token, and among legal tokens
+    # the driver prefers the lowest id — never what the schema wants next —
+    # so any schema-valid output is purely the mask's doing.
+    n_vocab = 128
+    tokens: list[int] = []
+    for _ in range(200):
+        if constraint.stopped:
+            break
+        row = -mx.arange(n_vocab, dtype=mx.float32)
+        masked = constraint.mask_logits_row(row)
+        arr = np.array(masked)
+        assert np.all(arr[95:] < -1e30), "mask leaked padding/out-of-vocab tokens"
+        token = int(mx.argmax(masked).item())
+        constraint.advance(token)
+        tokens.append(token)
+
+    text = "".join(id_to_text[t] for t in tokens if id_to_text[t] != "<eos>")
+    assert constraint.completed, f"grammar never completed: {text!r}"
+    parsed = json.loads(text)
+    assert set(parsed) == {"age", "tag"}
+    assert isinstance(parsed["age"], int) and parsed["age"] >= 0
+    assert parsed["tag"] in {"a", "b"}
+    assert constraint.masked_steps == len(tokens)
+
+
+def test_json_object_and_lenient_schema_shapes_accepted():
+    assert (
+        constraint_spec_from_response_format({"type": "json_object"}).source_type
+        == "json_object"
+    )
+    lenient = constraint_spec_from_response_format(
+        {"type": "json_schema", "schema": {"type": "object"}}
+    )
+    assert lenient is not None and lenient.source_type == "json_schema"
+    with pytest.raises(ResponseFormatError, match="json_schema.schema"):
+        constraint_spec_from_response_format({"type": "json_schema"})
+
+
+def test_grammar_cache_canonicalizes_key_order():
+    from mtplx import constrained as mod
+
+    a = {"type": "object", "properties": {"x": {"type": "integer"}}}
+    b = {"properties": {"x": {"type": "integer"}}, "type": "object"}
+    before = len(mod._GRAMMAR_CACHE)
+    spec_a = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"schema": a}}
+    )
+    grown = len(mod._GRAMMAR_CACHE)
+    spec_b = constraint_spec_from_response_format(
+        {"type": "json_schema", "json_schema": {"schema": b}}
+    )
+    assert spec_a.grammar == spec_b.grammar
+    assert len(mod._GRAMMAR_CACHE) == grown >= before
+
+
+# --- public envelope --------------------------------------------------------
+
+
+def test_public_mtplx_stats_expose_constraint_counters():
+    from mtplx.server.openai import PUBLIC_MTPLX_STATS_KEYS, _public_mtplx_stats
+
+    keys = {
+        "constraint_active",
+        "constraint_completed",
+        "constraint_masked_steps",
+        "constraint_mask_time_s",
+    }
+    assert keys <= set(PUBLIC_MTPLX_STATS_KEYS)
+    generated = {"stats": {key: 1 for key in keys}}
+    public = _public_mtplx_stats(generated)
+    assert keys <= set(public)

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -445,6 +445,109 @@ def test_json_object_and_lenient_schema_shapes_accepted():
         constraint_spec_from_response_format({"type": "json_schema"})
 
 
+def _tiny_tool_tokenizer():
+    """Tiny char tokenizer plus the Qwen-family special markers, so the
+    strict tool-call grammar is exercisable in CI without model weights."""
+    from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+    from transformers import PreTrainedTokenizerFast
+
+    vocab = {chr(i): i - 32 for i in range(33, 127)}
+    vocab["<eos>"] = 0
+    # Space and newline via their byte-level alphabet symbols (raw space is
+    # not its own symbol there); the forced envelope head needs both.
+    vocab["Ġ"] = 95
+    vocab["Ċ"] = 96
+    backend = Tokenizer(models.BPE(vocab=vocab, merges=[], unk_token="<eos>"))
+    # The ByteLevel pre-tokenizer makes encode() map raw bytes to the
+    # byte-level symbols — llguidance canonically tokenizes forced-byte runs
+    # through the tokenizer, so "\n" must encode to Ċ, not UNK.
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False, use_regex=False)
+    backend.decoder = decoders.ByteLevel()
+    hf_tok = PreTrainedTokenizerFast(tokenizer_object=backend, eos_token="<eos>")
+    hf_tok.add_special_tokens(
+        {
+            "additional_special_tokens": [
+                "<tool_call>",
+                "</tool_call>",
+                "<think>",
+                "</think>",
+            ]
+        }
+    )
+    return hf_tok
+
+
+def test_strict_tool_call_grammar_end_to_end():
+    from mtplx.constrained import tool_call_constraint_spec
+
+    hf_tok = _tiny_tool_tokenizer()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "pick",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "n": {"type": "integer", "minimum": 0, "maximum": 9}
+                    },
+                    "required": ["n"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+    spec = tool_call_constraint_spec(tools, "auto", hf_tok)
+    assert spec is not None and spec.source_type == "tool_call_strict"
+
+    n_vocab = 128
+    constraint = spec.build(hf_tok)
+    constraint.mask_logits_row(mx.zeros((n_vocab,)))  # bind
+
+    def ids(text):
+        return hf_tok.encode(text, add_special_tokens=False)
+
+    # Free text is unconstrained; a lone </think> is legal (the chat template
+    # opens the think block inside the generation prompt).
+    assert constraint.validate_prefix(ids("hello.")) == len(ids("hello."))
+    prelude = ids("reasoning...") + ids("</think>") + ids("ok.")
+    assert constraint.validate_prefix(prelude) == len(prelude)
+
+    # Inside the envelope everything is forced: walk the adversarial argmax
+    # (unmasked argmax is always a padding token; among legal tokens the
+    # lowest id wins, never what the schema wants).
+    constraint.advance_many(prelude)
+    trigger = ids("<tool_call>")
+    assert len(trigger) == 1
+    constraint.advance_many(trigger)
+    out = []
+    for _ in range(80):
+        if constraint.stopped or constraint.completed and out and out[-1] == trigger[0]:
+            break
+        row = -mx.arange(n_vocab, dtype=mx.float32)
+        masked = constraint.mask_logits_row(row)
+        token = int(mx.argmax(masked).item())
+        constraint.advance(token)
+        out.append(token)
+        if token == ids("</tool_call>")[0]:
+            break
+    text = hf_tok.decode(out).replace("</tool_call>", "")
+    payload = json.loads(text)
+    assert payload["name"] == "pick"
+    assert isinstance(payload["arguments"]["n"], int)
+    assert 0 <= payload["arguments"]["n"] <= 9
+    # Back in free text after the envelope closes.
+    assert constraint.completed
+    assert constraint.validate_prefix(ids("done.")) == len(ids("done."))
+
+    # A tool the request never declared is unreachable.
+    fresh = spec.build(hf_tok)
+    fresh.mask_logits_row(mx.zeros((n_vocab,)))
+    fresh.advance_many(trigger)
+    bad = ids('\n{"name": "rm_rf"')
+    assert fresh.validate_prefix(bad) < len(bad)
+
+
 def test_grammar_cache_canonicalizes_key_order():
     from mtplx import constrained as mod
 


### PR DESCRIPTION
Stacked on #187 (this branch contains its commit — review/merge #187 first; this PR's own change is the single top commit).

Implements phases 2 and 3 of #186.

## Phase 2 — strict tool-call arguments (opt-in `MTPLX_TOOL_CALL_STRICT=1`)

When a request declares `tools`, the decode grammar allows free text and native thinking blocks, but any tool-call envelope the model opens is forced to carry a declared tool name and schema-valid arguments — malformed calls (wrong name, missing required keys, out-of-range values, truncated JSON like #170's `{}` collapses) become unsamplable rather than parse-time failures.

- Grammars are hand-rolled lark rather than llguidance `StructTag`: the sugar only specializes the *trigger* into a special-token terminal, so a closing `</tool_call>` inside its `end` string stays bytes and never matches the token Qwen actually emits. Closing markers are referenced at rule level.
- Activates only when the template's tool-call markers are single special tokens (Qwen/Hermes family); other templates 400 with a clear message. `tool_choice` auto/none supported; `required`/pinned-function 400s for now.
- Env-gated and default-off, following how context-copy shipped.

## Phase 3 — grammar constraint composed with the MTP speculative loop

Constrained requests now ride `generate_mtpk` instead of pinning to serial AR. The composition is **target-side only** — no draft-core, reranker, or ensemble surgery:

- The cycle **primary** is sampled under the grammar mask (the guaranteed-progress site).
- **Draft windows stay unmasked**; the accept loop clamps acceptance at the grammar-legal prefix (one stateless `validate_tokens` per cycle).
- Grammar-illegal rejection corrections, bonus tokens, and context-copy residuals are dropped; copy blocks are truncated at the first illegal token.
- The matcher mutates only at the cycle-top sync (before masking, so the mask is computed at the true grammar position), after the primary append, and once post-loop.

Correctness: sample-unmasked → discard-illegal → masked-resample yields exactly the masked target distribution per position (P(x) = p(x) + (1−p(legal))·p_masked(x) = p_masked(x)), so clamping is not an approximation.

**Measured (Qwen3.6-35B-A3B-Optimized-Speed, alternating warmed runs):** constrained MTP at parity with unconstrained — 124.6–129.7 vs 124.2–126.5 tok/s, 82–86% draft acceptance with the constraint active, every output schema-valid. That's ~+37% over the phase-1 AR pin (~92 tok/s): **constrained decoding now keeps the MTP speedup**.

## The template-opens-think discovery (affects phase 1 users too)

Qwen templates end the generation prompt with `<|im_start|>assistant\n<think>\n` — generation starts *inside* a thinking block. A grammar that only accepts paired `<think>…</think>` makes the lone closing tag illegal; in testing, the model (unable to exit reasoning) emitted identical tool calls until the token cap. Both grammar families now accept an optional leading `TEXT </think>` prelude. Side effect: `response_format` requests get their thinking back (phase 1 silently suppressed it); truncation honesty (`constraint_completed: false`) covers reasoning that overruns `max_tokens`.

## Fail-loud hardening

`GrammarConstraint.advance` now raises on matcher error. During development, a mask computed at a stale grammar position produced `{"name": "Qwen", "specialtyty` **labeled `constraint_completed: true`** — the matcher had errored, its stopped-state guard silently disabled masking, and "stopped" read as "completed". A decode/matcher desync is an internal invariant violation; it now crashes the request instead of streaming corrupt output marked valid.

## Verification

- 17 tests in `tests/test_constrained.py` (4 new for the mtpk composition: a scripted-model harness with an evens-only fake grammar where the model always prefers illegal tokens — committed output stays legal purely via mask+clamp; grammar-terminal stop; inactive-stats control). Full suite: **1948 passed, 5 skipped**; ruff clean.
- Hardware: strict tool call → one schema-valid call (integer bounds + enum enforced), `finish_reason: tool_calls`, thinking preserved, greedy + sampled + streaming; `json_schema` at temp 0/0.8 across seeds → schema-valid with 800+ token reasoning preludes; bad shapes and unsupported combos → 400s; unconstrained traffic byte-identical behavior.

## Not in this PR

Draft-side masking (phase 3b — only worth it if acceptance inside constrained spans measures low on adversarial schemas; at 82–86% it doesn't yet), `tool_choice: required`/pinned grammars, and batch-pump integration (constrained requests still bypass the batched AR lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdBYNdiLyQ6qkqPA1Z2MkP