### PR TITLE
Honor parallel_tool_calls instead of client-name sniffing

### DIFF
--- a/mtplx/server/omlx_bridge/adapter.py
+++ b/mtplx/server/omlx_bridge/adapter.py
@@ -65,6 +65,14 @@ def _content_to_text(content: Any) -> str:
 
 
 def _try_parse_json(value: Any) -> dict[str, Any]:
+    """Parse history tool-call arguments to a dict, or fail loudly.
+
+    The chat path strict-validates arguments before this adapter runs
+    (_template_tool_call), so malformed input here means a caller bypassed
+    that contract. This used to fall back to {} silently, which erased
+    tool-call arguments from rendered history with no trace (issue #170's
+    class of failure); an invariant violation must raise, not degrade.
+    """
     if isinstance(value, dict):
         return value
     if value in (None, ""):
@@ -72,10 +80,14 @@ def _try_parse_json(value: Any) -> dict[str, Any]:
     if isinstance(value, str):
         try:
             parsed = json.loads(value)
-        except (TypeError, ValueError):
-            return {}
-        return parsed if isinstance(parsed, dict) else {}
-    return {}
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "tool-call arguments in history are not valid JSON"
+            ) from exc
+        if isinstance(parsed, dict):
+            return parsed
+        raise ValueError("tool-call arguments in history are not a JSON object")
+    raise ValueError("tool-call arguments in history are not a JSON object")
 
 
 def _drop_void_assistant_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/mtplx/server/omlx_bridge/tool_calling.py
+++ b/mtplx/server/omlx_bridge/tool_calling.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 
@@ -25,23 +25,51 @@ class ToolCallExtraction:
     status: str = "no_tool"
     malformed_reason: str | None = None
     raw_tool_markup_suppressed: bool = False
+    # Arguments that reached the client as {} because the model's emission
+    # carried none / carried something unparseable. Historically this
+    # defaulting was silent, which made empty-arguments bugs (issue #170)
+    # impossible to localize: nobody could tell "model emitted {}" apart
+    # from "parser lost the arguments".
+    arguments_degraded: int = 0
+    arguments_degraded_reasons: tuple[str, ...] = ()
+    parser_exceptions: int = 0
 
 
-def _serialize_tool_call_arguments(arguments: Any) -> str:
+# Private marker attached by _tool_call and stripped (never serialized to
+# clients) by parse_tool_calls' finalize pass.
+_ARGS_DEGRADED_KEY = "_mtplx_arguments_degraded"
+
+
+def _serialize_tool_call_arguments(arguments: Any) -> tuple[str, str | None]:
+    """Serialize arguments for the wire; report why {} was substituted.
+
+    The second element is None for faithful serializations (including a
+    genuine empty object) and a reason string whenever {} replaced
+    something that was absent or could not be represented.
+    """
     if isinstance(arguments, dict):
-        return json.dumps(
-            _order_tool_arguments_for_client_display("", arguments),
-            ensure_ascii=False,
-            separators=(",", ":"),
+        return (
+            json.dumps(
+                _order_tool_arguments_for_client_display("", arguments),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            None,
         )
+    if arguments is None:
+        return "{}", "missing_arguments"
     if isinstance(arguments, str):
         try:
             parsed = json.loads(arguments)
         except (TypeError, ValueError):
-            parsed = None
+            return "{}", "unparseable_arguments"
         if isinstance(parsed, dict):
-            return json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
-    return "{}"
+            return (
+                json.dumps(parsed, ensure_ascii=False, separators=(",", ":")),
+                None,
+            )
+        return "{}", "non_object_arguments"
+    return "{}", "non_object_arguments"
 
 
 _TOOL_ARGUMENT_PRIMARY_ORDER: dict[str, tuple[str, ...]] = {
@@ -87,14 +115,18 @@ def _order_tool_arguments_for_client_display(
 def _tool_call(name: str, arguments: Any) -> dict[str, Any]:
     if isinstance(arguments, dict):
         arguments = _order_tool_arguments_for_client_display(str(name), arguments)
-    return {
+    serialized, degraded_reason = _serialize_tool_call_arguments(arguments)
+    call: dict[str, Any] = {
         "id": f"call_{uuid.uuid4().hex[:8]}",
         "type": "function",
         "function": {
             "name": str(name),
-            "arguments": _serialize_tool_call_arguments(arguments),
+            "arguments": serialized,
         },
     }
+    if degraded_reason is not None:
+        call[_ARGS_DEGRADED_KEY] = degraded_reason
+    return call
 
 
 def _coerce_json_tool_payload(parsed: Any) -> dict[str, Any] | None:
@@ -112,7 +144,9 @@ def _coerce_json_tool_payload(parsed: Any) -> dict[str, Any] | None:
         arguments = (
             function.get("arguments")
             if "arguments" in function
-            else function.get("args", function.get("parameters", {}))
+            # A missing key stays None so the {} substitution is recorded,
+            # not silent (issue #170).
+            else function.get("args", function.get("parameters"))
         )
         if name:
             return _tool_call(str(name), arguments)
@@ -124,7 +158,7 @@ def _coerce_json_tool_payload(parsed: Any) -> dict[str, Any] | None:
     )
     if not name:
         return None
-    arguments = parsed.get("arguments", parsed.get("args", parsed.get("parameters", {})))
+    arguments = parsed.get("arguments", parsed.get("args", parsed.get("parameters")))
     return _tool_call(str(name), arguments)
 
 
@@ -257,7 +291,8 @@ def _parse_bracket_tool_calls(text: str) -> tuple[str, list[dict[str, Any]] | No
             try:
                 arguments = json.loads(args_text)
             except (TypeError, ValueError):
-                arguments = {}
+                # Recorded as degraded downstream instead of silently {}.
+                arguments = args_text
         calls.append(_tool_call(name, arguments))
     if not calls:
         return text, None
@@ -295,6 +330,28 @@ def parse_tool_calls(
     tokenizer: Any | None,
     tools: list[dict[str, Any]] | None = None,
 ) -> ToolCallExtraction:
+    result = _parse_tool_calls_impl(text, tokenizer, tools)
+    if not result.tool_calls:
+        return result
+    reasons = tuple(
+        reason
+        for call in result.tool_calls
+        if (reason := call.pop(_ARGS_DEGRADED_KEY, None)) is not None
+    )
+    if not reasons:
+        return result
+    return replace(
+        result,
+        arguments_degraded=len(reasons),
+        arguments_degraded_reasons=reasons,
+    )
+
+
+def _parse_tool_calls_impl(
+    text: str,
+    tokenizer: Any | None,
+    tools: list[dict[str, Any]] | None = None,
+) -> ToolCallExtraction:
     cleaned_text = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL)
     raw_markup = any(
         marker in (text or "")
@@ -320,11 +377,15 @@ def parse_tool_calls(
                     if part.strip()
                 ]
             calls: list[dict[str, Any]] = []
+            native_parser_exceptions = 0
             for match in matches:
                 try:
                     parsed = parser(match.strip(), tools)
                 except Exception:
+                    # A swallowed parser exception used to drop the call with
+                    # no trace; the count now surfaces in mtplx_stats.
                     parsed = None
+                    native_parser_exceptions += 1
                 items = parsed if isinstance(parsed, list) else [parsed]
                 for item in items:
                     if not isinstance(item, dict):
@@ -332,7 +393,7 @@ def parse_tool_calls(
                     name = item.get("name")
                     if not name:
                         continue
-                    calls.append(_tool_call(str(name), item.get("arguments", {})))
+                    calls.append(_tool_call(str(name), item.get("arguments")))
             calls = _filter_known_tools(calls, tools) or []
             if calls:
                 if end:
@@ -351,6 +412,7 @@ def parse_tool_calls(
                     parser_source="native",
                     status="parsed",
                     raw_tool_markup_suppressed=raw_markup,
+                    parser_exceptions=native_parser_exceptions,
                 )
 
     if "<tool_call" in cleaned_text:
@@ -433,12 +495,14 @@ def extract_tool_calls_with_thinking(
     status = result.status
     source = result.parser_source
     malformed = result.malformed_reason
+    degradation_source = result
     if not calls and thinking_content:
         thinking_result = parse_tool_calls(thinking_content, tokenizer, tools)
         if thinking_result.tool_calls and not regular_content.strip():
             calls = thinking_result.tool_calls
             source = thinking_result.parser_source
             status = thinking_result.status
+            degradation_source = thinking_result
         elif thinking_result.status == "malformed_as_content" and status == "no_tool":
             status = thinking_result.status
             malformed = thinking_result.malformed_reason
@@ -453,6 +517,9 @@ def extract_tool_calls_with_thinking(
         raw_tool_markup_suppressed=(
             result.raw_tool_markup_suppressed or cleaned_thinking != thinking_content
         ),
+        arguments_degraded=degradation_source.arguments_degraded,
+        arguments_degraded_reasons=degradation_source.arguments_degraded_reasons,
+        parser_exceptions=degradation_source.parser_exceptions,
     )
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -5549,6 +5549,36 @@ def _request_explicit_single_tool_then_answer(messages: list[ChatMessage]) -> bo
     return bool(_EXPLICIT_SINGLE_TOOL_THEN_ANSWER_RE.search(_last_user_text(messages)))
 
 
+def _request_parallel_tool_calls(request: Any) -> bool | None:
+    """The client's explicit parallel_tool_calls preference, or None.
+
+    Only genuine booleans count; anything else means the client expressed
+    no preference and the legacy client-hint heuristics apply.
+    """
+    value = getattr(request, "parallel_tool_calls", None)
+    return value if isinstance(value, bool) else None
+
+
+def _single_tool_call_stream_policy(
+    *,
+    parallel_tool_calls: bool | None,
+    client_hint: str,
+    explicit_single_tool: bool,
+) -> bool:
+    """Whether streaming should stop after the first complete tool call.
+
+    The request's declared ``parallel_tool_calls`` is authoritative when
+    present — previously this was decided purely by sniffing the client
+    name, and the declared field was accepted but never consulted. The
+    hint-based behavior is preserved as the fallback for clients that do
+    not send the field.
+    """
+    if parallel_tool_calls is not None:
+        return not parallel_tool_calls
+    hint = (client_hint or "").lower()
+    return "pi" in hint or ("opencode" in hint and explicit_single_tool)
+
+
 def _request_should_force_answer_for_read_only_inspection(
     messages: list[ChatMessage],
 ) -> bool:
@@ -12969,6 +12999,7 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "tool_arguments_degraded",
     "tool_arguments_degraded_reasons",
     "tool_parser_exceptions",
+    "tool_calls_truncated_parallel_disabled",
     "raw_tool_markup_suppressed",
     "legacy_bridge_used",
     "hidden_generation_repair_used",
@@ -21511,14 +21542,12 @@ def create_app(state: ServerState) -> FastAPI:
                 stream_client_hint = str(
                     request_observability.get("request_client_hint") or ""
                 ).lower()
-                single_tool_call_stream = (
-                    "pi" in stream_client_hint
-                    or (
-                        "opencode" in stream_client_hint
-                        and _request_explicit_single_tool_then_answer(
-                            messages_for_generation
-                        )
-                    )
+                single_tool_call_stream = _single_tool_call_stream_policy(
+                    parallel_tool_calls=_request_parallel_tool_calls(request),
+                    client_hint=stream_client_hint,
+                    explicit_single_tool=_request_explicit_single_tool_then_answer(
+                        messages_for_generation
+                    ),
                 )
                 orphan_stream_guard_enabled = bool(
                     tools_active and tool_result_history_present
@@ -23955,6 +23984,15 @@ def create_app(state: ServerState) -> FastAPI:
                 tool_specs,
             )
             tool_calls = extraction.tool_calls
+            if (
+                tool_calls
+                and len(tool_calls) > 1
+                and _request_parallel_tool_calls(request) is False
+            ):
+                # The client declared parallel_tool_calls=false; honor the
+                # OpenAI contract of at most one call per turn.
+                tool_calls = tool_calls[:1]
+                generated["stats"]["tool_calls_truncated_parallel_disabled"] = True
             generated["stats"]["tool_parser_source"] = extraction.parser_source
             generated["stats"]["tool_parse_status"] = extraction.status
             generated["stats"]["tool_calls_emitted"] = len(tool_calls or [])

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -12966,6 +12966,9 @@ PUBLIC_MTPLX_STATS_KEYS = (
     "tool_parser_source",
     "tool_parse_status",
     "tool_calls_emitted",
+    "tool_arguments_degraded",
+    "tool_arguments_degraded_reasons",
+    "tool_parser_exceptions",
     "raw_tool_markup_suppressed",
     "legacy_bridge_used",
     "hidden_generation_repair_used",
@@ -13114,6 +13117,9 @@ def _merge_final_bridge_stats_into_latest_metrics(
         "tool_parser_source",
         "tool_parse_status",
         "tool_calls_emitted",
+        "tool_arguments_degraded",
+        "tool_arguments_degraded_reasons",
+        "tool_parser_exceptions",
         "tool_parse_success",
         "tool_parse_fallback",
         "tool_parse_fallback_reason",
@@ -23364,6 +23370,26 @@ def create_app(state: ServerState) -> FastAPI:
                                 stats["tool_calls_emitted"] = len(
                                     assistant_tool_calls or []
                                 )
+                                if getattr(extraction, "arguments_degraded", 0):
+                                    stats["tool_arguments_degraded"] = int(
+                                        extraction.arguments_degraded
+                                    )
+                                    stats["tool_arguments_degraded_reasons"] = list(
+                                        extraction.arguments_degraded_reasons
+                                    )
+                                    LOGGER.warning(
+                                        "tool-call arguments degraded to {} during parse",
+                                        extra={
+                                            "request_id": response_id,
+                                            "reasons": list(
+                                                extraction.arguments_degraded_reasons
+                                            ),
+                                        },
+                                    )
+                                if getattr(extraction, "parser_exceptions", 0):
+                                    stats["tool_parser_exceptions"] = int(
+                                        extraction.parser_exceptions
+                                    )
                                 stats["raw_tool_markup_suppressed"] = bool(
                                     extraction.raw_tool_markup_suppressed
                                     or streamed_tool_deltas_emitted
@@ -23935,6 +23961,24 @@ def create_app(state: ServerState) -> FastAPI:
             generated["stats"]["raw_tool_markup_suppressed"] = bool(
                 extraction.raw_tool_markup_suppressed
             )
+            if getattr(extraction, "arguments_degraded", 0):
+                generated["stats"]["tool_arguments_degraded"] = int(
+                    extraction.arguments_degraded
+                )
+                generated["stats"]["tool_arguments_degraded_reasons"] = list(
+                    extraction.arguments_degraded_reasons
+                )
+                LOGGER.warning(
+                    "tool-call arguments degraded to {} during parse",
+                    extra={
+                        "request_id": response_id,
+                        "reasons": list(extraction.arguments_degraded_reasons),
+                    },
+                )
+            if getattr(extraction, "parser_exceptions", 0):
+                generated["stats"]["tool_parser_exceptions"] = int(
+                    extraction.parser_exceptions
+                )
         else:
             tool_calls = None
             extraction = None

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -10722,3 +10722,93 @@ def test_completions_nonstream_stop_aborts_generation_early(monkeypatch):
     assert body["choices"][0]["finish_reason"] == "stop"
     assert body["usage"]["completion_tokens"] == len("Hello ") + len("STOP\n")
     assert body["mtplx_stats"]["stop_sequence_hit"] is True
+
+
+# --- parallel_tool_calls wiring ---------------------------------------------
+
+
+def _two_call_extraction(*_args, **_kwargs):
+    def _call(name):
+        return {
+            "id": f"call_{name}",
+            "type": "function",
+            "function": {"name": name, "arguments": "{\"q\": 1}"},
+        }
+
+    return SimpleNamespace(
+        cleaned_text="",
+        cleaned_thinking="",
+        tool_calls=[_call("session_status"), _call("session_status")],
+        parser_source="native",
+        status="parsed",
+        malformed_reason=None,
+        raw_tool_markup_suppressed=True,
+    )
+
+
+def test_parallel_tool_calls_false_truncates_nonstream_tool_calls(monkeypatch):
+    state = _fake_state()
+    state.runtime.tokenizer = CaptureTokenizer()
+    monkeypatch.setattr(openai, "_run_generation", lambda *a, **k: _fake_generation("x"))
+    monkeypatch.setattr(
+        openai, "omlx_extract_tool_calls_with_thinking", _two_call_extraction
+    )
+    client = TestClient(create_app(state))
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"x-mtplx-cache-mode": "bypass"},
+        json={
+            "messages": [{"role": "user", "content": "status twice"}],
+            "tools": [_tool_schema()],
+            "parallel_tool_calls": False,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["choices"][0]["message"]["tool_calls"]) == 1
+    assert body["mtplx_stats"]["tool_calls_emitted"] == 1
+
+
+def test_parallel_tool_calls_unset_keeps_all_nonstream_tool_calls(monkeypatch):
+    state = _fake_state()
+    state.runtime.tokenizer = CaptureTokenizer()
+    monkeypatch.setattr(openai, "_run_generation", lambda *a, **k: _fake_generation("x"))
+    monkeypatch.setattr(
+        openai, "omlx_extract_tool_calls_with_thinking", _two_call_extraction
+    )
+    client = TestClient(create_app(state))
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"x-mtplx-cache-mode": "bypass"},
+        json={
+            "messages": [{"role": "user", "content": "status twice"}],
+            "tools": [_tool_schema()],
+        },
+    )
+    assert response.status_code == 200
+    assert len(response.json()["choices"][0]["message"]["tool_calls"]) == 2
+
+
+def test_single_tool_call_stream_policy_declared_field_wins():
+    policy = openai._single_tool_call_stream_policy
+    # Declared field is authoritative in both directions.
+    assert policy(parallel_tool_calls=False, client_hint="", explicit_single_tool=False)
+    assert not policy(
+        parallel_tool_calls=True, client_hint="pi", explicit_single_tool=True
+    )
+    # Unset falls back to the legacy client-hint heuristics.
+    assert policy(parallel_tool_calls=None, client_hint="pi", explicit_single_tool=False)
+    assert policy(
+        parallel_tool_calls=None, client_hint="opencode", explicit_single_tool=True
+    )
+    assert not policy(
+        parallel_tool_calls=None, client_hint="opencode", explicit_single_tool=False
+    )
+    assert not policy(parallel_tool_calls=None, client_hint="", explicit_single_tool=False)
+
+
+def test_request_parallel_tool_calls_only_honors_booleans():
+    assert openai._request_parallel_tool_calls(SimpleNamespace(parallel_tool_calls=True)) is True
+    assert openai._request_parallel_tool_calls(SimpleNamespace(parallel_tool_calls=False)) is False
+    assert openai._request_parallel_tool_calls(SimpleNamespace(parallel_tool_calls="yes")) is None
+    assert openai._request_parallel_tool_calls(SimpleNamespace()) is None

--- a/tests/test_tool_call_degradation.py
+++ b/tests/test_tool_call_degradation.py
@@ -1,0 +1,149 @@
+"""Silent tool-argument loss is now visible (issue #170's failure class).
+
+Covers: faithful roundtrip of nested edit-style arguments through the output
+parser, degradation counters when the model's emission carries no/unusable
+arguments, the private marker never leaking to clients, the adapter tripwire
+for history arguments, and the strict input path staying strict.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mtplx.server.omlx_bridge.adapter import _tool_call_for_template
+from mtplx.server.omlx_bridge.tool_calling import (
+    extract_tool_calls_with_thinking,
+    parse_tool_calls,
+)
+
+EDIT_ARGS = {
+    "filePath": "a.py",
+    "edits": [
+        {"search": "def f(x):", "replace": "def f(x, y):"},
+        {"search": "return x", "replace": "return x + y"},
+    ],
+}
+
+
+def _xml(payload: dict) -> str:
+    return f"<tool_call>\n{json.dumps(payload)}\n</tool_call>"
+
+
+def test_nested_arguments_roundtrip_unmangled():
+    text = "I'll fix that.\n" + _xml({"name": "edit", "arguments": EDIT_ARGS})
+    extraction = parse_tool_calls(text, None, None)
+    assert extraction.tool_calls and len(extraction.tool_calls) == 1
+    call = extraction.tool_calls[0]
+    assert json.loads(call["function"]["arguments"]) == EDIT_ARGS
+    assert extraction.arguments_degraded == 0
+    assert extraction.arguments_degraded_reasons == ()
+
+
+def test_missing_arguments_flagged_not_silent():
+    extraction = parse_tool_calls(_xml({"name": "edit"}), None, None)
+    call = extraction.tool_calls[0]
+    assert call["function"]["arguments"] == "{}"
+    assert extraction.arguments_degraded == 1
+    assert extraction.arguments_degraded_reasons == ("missing_arguments",)
+    # The private degradation marker never reaches the client payload.
+    assert all(not key.startswith("_mtplx") for key in call)
+
+
+def test_explicit_empty_arguments_are_not_degraded():
+    extraction = parse_tool_calls(
+        _xml({"name": "edit", "arguments": {}}), None, None
+    )
+    assert extraction.tool_calls[0]["function"]["arguments"] == "{}"
+    assert extraction.arguments_degraded == 0
+
+
+def test_unparseable_bracket_arguments_flagged():
+    extraction = parse_tool_calls(
+        "[Calling tool: edit({not valid json})]", None, None
+    )
+    call = extraction.tool_calls[0]
+    assert call["function"]["arguments"] == "{}"
+    assert extraction.arguments_degraded == 1
+    assert extraction.arguments_degraded_reasons == ("unparseable_arguments",)
+
+
+def test_native_parser_exception_counted():
+    calls_payload = [
+        {"name": "edit", "arguments": EDIT_ARGS},
+        None,  # second envelope makes the parser raise
+    ]
+
+    def parser(match: str, _tools):
+        payload = calls_payload.pop(0)
+        if payload is None:
+            raise ValueError("boom")
+        return payload
+
+    tokenizer = SimpleNamespace(
+        has_tool_calling=True,
+        tool_call_start="<tool_call>",
+        tool_call_end="</tool_call>",
+        tool_parser=parser,
+    )
+    text = (
+        "<tool_call>one</tool_call><tool_call>two</tool_call>"
+    )
+    extraction = parse_tool_calls(text, tokenizer, None)
+    assert extraction.parser_source == "native"
+    assert len(extraction.tool_calls) == 1
+    assert extraction.parser_exceptions == 1
+    assert json.loads(
+        extraction.tool_calls[0]["function"]["arguments"]
+    ) == EDIT_ARGS
+
+
+def test_extract_with_thinking_carries_degradation():
+    extraction = extract_tool_calls_with_thinking(
+        "some reasoning",
+        _xml({"name": "edit"}),
+        None,
+        None,
+    )
+    assert extraction.arguments_degraded == 1
+    assert extraction.arguments_degraded_reasons == ("missing_arguments",)
+
+
+# --- history (input) side ---------------------------------------------------
+
+
+def test_adapter_roundtrips_valid_history_arguments():
+    for arguments in (EDIT_ARGS, json.dumps(EDIT_ARGS)):
+        call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "edit", "arguments": arguments},
+        }
+        normalized = _tool_call_for_template(call)
+        assert normalized["function"]["arguments"] == EDIT_ARGS
+
+
+def test_adapter_treats_absent_arguments_as_empty():
+    call = {"function": {"name": "edit", "arguments": None}}
+    assert _tool_call_for_template(call)["function"]["arguments"] == {}
+    call = {"function": {"name": "edit", "arguments": ""}}
+    assert _tool_call_for_template(call)["function"]["arguments"] == {}
+
+
+@pytest.mark.parametrize("bad", ["{broken", "[1, 2]", '"a string"', 42])
+def test_adapter_raises_on_malformed_history_arguments(bad):
+    call = {"function": {"name": "edit", "arguments": bad}}
+    with pytest.raises(ValueError):
+        _tool_call_for_template(call)
+
+
+def test_strict_input_path_rejects_malformed_arguments():
+    from mtplx.server.openai import _template_tool_call
+
+    with pytest.raises(Exception) as excinfo:
+        _template_tool_call(
+            {"function": {"name": "edit", "arguments": "{broken"}}
+        )
+    assert "arguments" in str(getattr(excinfo.value, "detail", excinfo.value))


### PR DESCRIPTION
`parallel_tool_calls` is declared on the request model and logged in observability, but the actual single-vs-parallel tool-call behavior was decided by sniffing the client name (`"pi"`, `"opencode"` + a prompt-text heuristic). A client that explicitly declared `parallel_tool_calls: true/false` was ignored in both directions.

- New `_single_tool_call_stream_policy`: the declared boolean is authoritative — `false` stops the stream after the first complete call, `true` disables truncation even for hint-matched clients. The existing hint heuristics are untouched as the fallback when the field is absent (no behavior change for current clients that don't send it). Non-boolean values are treated as absent.
- Nonstream responses honor `parallel_tool_calls: false` by truncating to the first call per the OpenAI contract, with a `tool_calls_truncated_parallel_disabled` stats marker so the truncation is visible.

Four regression tests: declared-field-wins in both directions, heuristic fallback preserved, nonstream truncation, non-boolean coercion. Full suite: 1935 passed, 5 skipped; ruff clean. Independent branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9i9E2rXWXMFRAEsUqDeGP