### PR TITLE
67.6tps Laguna S-2.1 AR support (mlx-community oQ4e)

### DIFF
--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -716,11 +716,12 @@ def load(
             adapter_merge_report = merge_installed_mtp_lora_adapters(model)
     elif merge_mtp_adapter:
         raise RuntimeError("merge_mtp_adapter requires mtp_adapter")
+    fused_report: list[dict[str, Any]] = []
     if _is_laguna_s_2_1_mlx_4bit_config(config):
         # Env-gated fused decode paths (MTPLX_LAGUNA_*): with no switches set
         # this returns an empty report and changes nothing, so default serving
         # behavior is untouched; a serving wrapper that exports the measured
-        # stack gets it engaged at load, visible in this log line.
+        # stack gets it engaged at load.
         from .models.laguna_fused import install_from_env as _laguna_install_fused
 
         fused_report = _laguna_install_fused(model)
@@ -759,6 +760,9 @@ def load(
         )
         runtime.a3b_whole_moe_installed = True
         logger.info("[a3b-whole-moe] %s", whole_moe_report)
+    # The server prints this as its startup engagement receipt; logger.info
+    # alone is invisible under `python -m mtplx.server.openai` (no handler).
+    runtime.laguna_fused_report = fused_report
     return runtime
 
 

--- a/mtplx/server/omlx_bridge/tool_calling.py
+++ b/mtplx/server/omlx_bridge/tool_calling.py
@@ -474,8 +474,10 @@ def parse_tool_calls(
         cleaned, calls, malformed = _parse_xml_tool_calls(cleaned_text)
         filtered_calls = _filter_known_tools(calls, tools)
         if calls and not filtered_calls and tools:
-            first_name = calls[0].get("function", {}).get("name", "unknown")
-            malformed = f"unknown tool '{first_name}'"
+            # OpenAI passes unknown-named calls through; the client owns the
+            # rejection (and answers the model, letting it self-correct).
+            # Degrading the whole turn to prose costs the agent a strike.
+            filtered_calls = calls
         if filtered_calls:
             return ToolCallExtraction(
                 cleaned_text=cleaned,

--- a/mtplx/server/omlx_bridge/tool_calling.py
+++ b/mtplx/server/omlx_bridge/tool_calling.py
@@ -243,6 +243,47 @@ def _parse_xml_tool_calls(text: str) -> tuple[str, list[dict[str, Any]] | None, 
                 break
             calls.append(_tool_call(name, params))
             continue
+        # Poolside dialect: `name<arg_key>k</arg_key><arg_value>v</arg_value>...`
+        # (the Laguna family's native emission; same contract as the strict
+        # parser in openai.py — every non-pair byte after the name is residue
+        # and marks the call malformed rather than silently dropping args).
+        poolside_match = re.match(r"\s*([A-Za-z_][\w.-]*)", content)
+        if poolside_match:
+            poolside_name = poolside_match.group(1)
+            body = content[poolside_match.end():]
+            pairs = list(
+                re.finditer(
+                    r"<arg_key>\s*(.*?)\s*</arg_key>\s*<arg_value>\s*(.*?)\s*</arg_value>",
+                    body,
+                    re.DOTALL,
+                )
+            )
+            if pairs:
+                params = {}
+                residue_parts = []
+                cursor = 0
+                valid = True
+                for pair in pairs:
+                    key = pair.group(1).strip()
+                    if not key or key in params:
+                        valid = False
+                        break
+                    value = pair.group(2).strip()
+                    try:
+                        params[key] = json.loads(value)
+                    except (TypeError, ValueError):
+                        params[key] = value
+                    residue_parts.append(body[cursor:pair.start()])
+                    cursor = pair.end()
+                residue_parts.append(body[cursor:])
+                if valid and not "".join(residue_parts).strip():
+                    calls.append(_tool_call(poolside_name, params))
+                    continue
+                malformed_reason = (
+                    f"tool '{poolside_name}' contains malformed Poolside arguments"
+                )
+                calls = []
+                break
         malformed_reason = "unrecognized <tool_call> payload"
     if not calls:
         return text, None, malformed_reason

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6360,6 +6360,69 @@ def _parse_poolside_tool_call(block: str) -> tuple[str, Any] | None:
     return name, arguments
 
 
+def _scan_bracket_tool_call(
+    text: str,
+    start: int,
+) -> tuple[int, str, Any] | None:
+    """Balanced-scan one `[Calling tool: name({...})]` block at `start`.
+
+    The JSON object is walked with string/escape awareness, so `}` or `)]`
+    sequences inside argument strings (a JS file body, a task_progress
+    checklist) cannot end the block early — the failure mode of the
+    non-greedy regex this replaces. Returns (end_exclusive, name, arguments)
+    for a complete block, or None when no complete well-formed block starts
+    at `start`.
+    """
+    match = re.compile(
+        r"\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)\s*\(",
+        re.IGNORECASE,
+    ).match(text, start)
+    if match is None:
+        return None
+    name = match.group(1)
+    i = match.end()
+    tail = re.compile(r"\s*\)\s*\]").match(text, i)
+    if tail is not None:
+        return tail.end(), name, {}
+    if i >= len(text) or text[i] != "{":
+        return None
+    depth = 0
+    in_string = False
+    escaped = False
+    j = i
+    while j < len(text):
+        ch = text[j]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                j += 1
+                break
+        j += 1
+    if depth != 0:
+        return None
+    close = re.compile(r"\s*\)\s*\]").match(text, j)
+    if close is None:
+        return None
+    try:
+        arguments = json.loads(text[i:j])
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(arguments, dict):
+        return None
+    return close.end(), name, arguments
+
+
 def _tool_marker_pairs_from_tokenizer(tokenizer: Any | None) -> list[tuple[str, str]]:
     if tokenizer is None:
         return []
@@ -6391,19 +6454,33 @@ def _iter_generated_tool_call_envelopes(
         )
         for match in pattern.finditer(text):
             envelopes.append((match.start(), match.end(), match.group(1).strip(), None))
-    for match in _BRACKET_TOOL_CALL_RE.finditer(text):
-        name = match.group(1).strip()
-        raw_args = (match.group(2) or "").strip()
-        if raw_args:
-            try:
-                arguments: Any = json.loads(raw_args)
-            except json.JSONDecodeError as exc:
-                raise _tool_protocol_error(
-                    f"bracket tool_call '{name}' arguments are not valid JSON"
-                ) from exc
-        else:
-            arguments = {}
-        envelopes.append((match.start(), match.end(), "", (name, arguments)))
+    # Bracket dialect (`[Calling tool: name({...})]`) via the balanced scanner:
+    # the old non-greedy regex ended the block at the first `})]`, which any
+    # code-file argument contains inside a string, so large bracket calls
+    # always failed JSON decode and fell back to prose.
+    search_from = 0
+    lowered_text = text.lower()
+    while True:
+        candidates = [
+            idx
+            for idx in (
+                lowered_text.find(prefix.lower(), search_from)
+                for prefix in _BRACKET_TOOL_PREFIXES
+            )
+            if idx >= 0
+        ]
+        if not candidates:
+            break
+        found = min(candidates)
+        scanned = _scan_bracket_tool_call(text, found)
+        if scanned is None:
+            # Unterminated or malformed: not an envelope — the text stays
+            # visible content, same terminal state as the old decode error.
+            search_from = found + 1
+            continue
+        end, name, arguments = scanned
+        envelopes.append((found, end, "", (name, arguments)))
+        search_from = end
     envelopes.sort(key=lambda item: item[0])
     for previous, current in zip(envelopes, envelopes[1:]):
         if current[0] < previous[1]:

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -305,8 +305,15 @@ STREAM_SILENCE_WARN_INTERVAL_S = 60.0
 STREAM_STALL_DEADLINE_S = float(
     os.environ.get("MTPLX_STREAM_STALL_DEADLINE_S") or 300.0
 )
-STREAM_HIDDEN_TOOL_GUARD_TOKENS = 2048
-STREAM_HIDDEN_TOOL_GUARD_S = 30.0
+# Runaway-hidden-generation backstop. Native-tool agent workloads stream
+# multi-thousand-token arguments (whole files) as legitimate hidden text, so
+# the ceilings are env-tunable; the defaults keep the original chat-UX guard.
+STREAM_HIDDEN_TOOL_GUARD_TOKENS = int(
+    os.environ.get("MTPLX_STREAM_HIDDEN_TOOL_GUARD_TOKENS", "2048")
+)
+STREAM_HIDDEN_TOOL_GUARD_S = float(
+    os.environ.get("MTPLX_STREAM_HIDDEN_TOOL_GUARD_S", "30")
+)
 STREAM_TOOL_CALL_FINISH_GRACE_S = 0.05
 TOOL_PROTOCOL_BOUNDARY_GRACE_S = 0.05
 _REASONING_DETAILS_RE = re.compile(

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1082,6 +1082,15 @@ def _startup_line(text: str = "") -> None:
     _safe_stdout_print(text)
 
 
+def _laguna_fused_startup_line(runtime: Any) -> str | None:
+    """Engagement receipt for the env-gated fused stack (grep: [laguna-fused])."""
+
+    report = getattr(runtime, "laguna_fused_report", None)
+    if not report:
+        return None
+    return "[5/6] [laguna-fused] " + json.dumps(report, ensure_ascii=False)
+
+
 def _startup_server_url(args: argparse.Namespace) -> str:
     return local_url_for_bind(
         str(getattr(args, "host", "127.0.0.1")),
@@ -1765,6 +1774,9 @@ class ServerState:
             _startup_line(
                 f"[5/6] {self.backend_descriptor.display_name} drafter is active"
             )
+        fused_line = _laguna_fused_startup_line(self.runtime)
+        if fused_line:
+            _startup_line(fused_line)
         if self.backend_descriptor.uses_draft_lm_head and self.runtime.mtp_enabled:
             self.draft_lm_head = self.model_scheduler.submit_foreground(
                 _install_draft_lm_head,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6423,6 +6423,74 @@ def _scan_bracket_tool_call(
     return close.end(), name, arguments
 
 
+def _classify_bracket_tool_call(text: str, start: int) -> str:
+    """Classify the bracket block starting at `start` (which sits on a full
+    `[Calling tool:`/`[Tool call:` prefix).
+
+    'complete'   — a well-formed call the scanner can extract now.
+    'incomplete' — the available text ends inside a structurally consistent
+                   block; more chunks may complete it (streaming: buffer).
+    'invalid'    — the structure is already broken with text to spare (e.g. a
+                   dangling prefix in prose); never a call, leave it to the
+                   content path and its prefix sanitizer.
+    """
+    if _scan_bracket_tool_call(text, start) is not None:
+        return "complete"
+    tail = text[start:]
+    head = re.match(
+        r"\[(?:Calling tool|Tool call):\s*[A-Za-z_][\w.-]*\s*\(",
+        tail,
+        re.IGNORECASE,
+    )
+    if head is None:
+        after_prefix = re.sub(
+            r"^\[(?:Calling tool|Tool call):",
+            "",
+            tail,
+            flags=re.IGNORECASE,
+        )
+        if re.fullmatch(r"\s*(?:[A-Za-z_][\w.-]*)?\s*\(?", after_prefix):
+            return "incomplete"
+        return "invalid"
+    i = start + head.end()
+    if i >= len(text):
+        return "incomplete"
+    if text[i] != "{":
+        return (
+            "incomplete"
+            if re.fullmatch(r"\s*\)?\s*\]?", text[i:])
+            else "invalid"
+        )
+    depth = 0
+    in_string = False
+    escaped = False
+    j = i
+    while j < len(text):
+        ch = text[j]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                j += 1
+                break
+        j += 1
+    if depth != 0:
+        return "incomplete"
+    # Object closed but the scanner rejected it: either the `)]` close is
+    # still arriving, or the payload is truly malformed.
+    return "incomplete" if re.fullmatch(r"\s*\)?\s*", text[j:]) else "invalid"
+
+
 def _tool_marker_pairs_from_tokenizer(tokenizer: Any | None) -> list[tuple[str, str]]:
     if tokenizer is None:
         return []
@@ -7360,12 +7428,16 @@ class _ToolAwareContentStreamTranslator:
         for prefix in _BRACKET_TOOL_PREFIXES:
             bracket_idx = lowered.find(prefix.lower())
             while bracket_idx >= 0:
-                candidate = text[bracket_idx:]
-                if _BRACKET_TOOL_CALL_RE.match(candidate):
+                # The old gate demanded a complete regex match mid-stream and
+                # skipped ahead on any early `]` (present in every
+                # task_progress checklist), so bracket-call text streamed to
+                # the client as content AND the finish-time rescue emitted the
+                # same call — a double delivery that also taught the model its
+                # drift dialect was accepted. Buffer on complete AND
+                # still-completing blocks; only structurally-dead prefixes
+                # stay on the content path for the prefix sanitizer.
+                if _classify_bracket_tool_call(text, bracket_idx) != "invalid":
                     candidates.append(bracket_idx)
-                    break
-                close_idx = candidate.find("]")
-                if close_idx < 0:
                     break
                 bracket_idx = lowered.find(prefix.lower(), bracket_idx + 1)
         for start_marker, _end_marker in self._marker_pairs:

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -6515,23 +6515,28 @@ def _parse_generated_tool_calls(
             raise _tool_protocol_error("unsupported tool_call payload format")
         name, arguments = parsed
         canonical_name = _canonical_tool_name_for_model_output(name, tools)
-        if canonical_name is None:
-            raise _tool_protocol_error(f"unknown tool '{name}'")
         arguments_value = _json_object_value(
             arguments,
             context=f"tool_call[{index}]",
         )
-        arguments_value = _normalize_tool_arguments_for_schema(
-            tool_name=canonical_name,
-            arguments=arguments_value,
-            tools=tools,
-        )
-        _validate_tool_arguments_for_schema(
-            tool_name=canonical_name,
-            arguments=arguments_value,
-            tools=tools,
-            context=f"tool_call[{index}]",
-        )
+        if canonical_name is None:
+            # OpenAI-compatible pass-through: surface the call under its raw
+            # name and let the client own the unknown-tool rejection (the
+            # client answers the model, which self-corrects). There is no
+            # schema to normalize or validate against.
+            canonical_name = str(name)
+        else:
+            arguments_value = _normalize_tool_arguments_for_schema(
+                tool_name=canonical_name,
+                arguments=arguments_value,
+                tools=tools,
+            )
+            _validate_tool_arguments_for_schema(
+                tool_name=canonical_name,
+                arguments=arguments_value,
+                tools=tools,
+                context=f"tool_call[{index}]",
+            )
         calls.append(
             {
                 "id": f"call_{uuid.uuid4().hex[:24]}",
@@ -6841,8 +6846,8 @@ class _QwenXMLToolCallStreamParser(_ToolCallStreamParser):
                     self._tools,
                 )
                 if canonical_name is None:
-                    self._fallback_reason = f"unknown tool '{name}'"
-                    return deltas
+                    # Pass-through: the client owns unknown-tool rejection.
+                    canonical_name = name
                 self._name = canonical_name
                 self._started = True
                 self._buf = self._buf[function_end + 1 :]

--- a/tests/test_bracket_tool_rescue.py
+++ b/tests/test_bracket_tool_rescue.py
@@ -1,0 +1,69 @@
+"""Bracket-dialect tool calls (`[Calling tool: name({...})]`) parse via the
+balanced scanner.
+
+Laguna drifts into this textual dialect on large writes (observed live on a
+game.js apply_patch, 2026-07-25). The old non-greedy regex ended the block at
+the first `})]`, which any code-file argument contains inside a string, so
+every large bracket call failed JSON decode and fell back to prose — burning
+a Cline mistake strike.
+"""
+
+import json
+
+from mtplx.server.openai import (
+    _parse_generated_tool_calls,
+    _scan_bracket_tool_call,
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "apply_patch",
+            "parameters": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+            },
+        },
+    }
+]
+
+
+def test_bracket_call_with_close_sequence_inside_string_parses():
+    # The argument string contains the literal "})]"; the old regex ended the
+    # envelope there and the decode failed.
+    payload = {"input": "const f = (x) => ({y: x});\ncall(f(1))]... })] tail"}
+    text = "Prose before. [Calling tool: apply_patch(" + json.dumps(payload) + ")]"
+    calls = _parse_generated_tool_calls(text, tools=TOOLS, tokenizer=None)
+    assert calls is not None and len(calls) == 1
+    assert calls[0]["function"]["name"] == "apply_patch"
+    assert json.loads(calls[0]["function"]["arguments"]) == payload
+
+
+def test_bracket_call_with_checklist_brackets_parses():
+    payload = {
+        "input": "*** Begin Patch\n+code\n*** End Patch",
+        "task_progress": "- [x] step one\n- [ ] step two",
+    }
+    text = "[Calling tool: apply_patch(" + json.dumps(payload) + ")]"
+    calls = _parse_generated_tool_calls(text, tools=TOOLS, tokenizer=None)
+    assert calls is not None
+    assert json.loads(calls[0]["function"]["arguments"]) == payload
+
+
+def test_unterminated_bracket_call_is_not_an_envelope():
+    import pytest
+    from fastapi.exceptions import HTTPException
+
+    text = '[Calling tool: apply_patch({"input": "never closed'
+    assert _scan_bracket_tool_call(text, 0) is None
+    # The parser classifies it as an unclosed block; the catch layer above
+    # turns that into visible content plus a logged fallback reason.
+    with pytest.raises(HTTPException):
+        _parse_generated_tool_calls(text, tools=TOOLS, tokenizer=None)
+
+
+def test_zero_argument_bracket_call_parses():
+    end, name, arguments = _scan_bracket_tool_call("[Calling tool: noop()]", 0)
+    assert (name, arguments) == ("noop", {})
+    assert end == len("[Calling tool: noop()]")

--- a/tests/test_laguna_model.py
+++ b/tests/test_laguna_model.py
@@ -1086,3 +1086,37 @@ def test_batched_decode_rows_are_independent() -> None:
 
     assert mixed_rows[0] == duplicated_rows[0]
     assert duplicated_rows[0] == duplicated_rows[1]
+
+
+def test_laguna_load_attaches_the_fused_install_report(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The server's [laguna-fused] startup receipt reads this attribute."""
+
+    from mtplx import runtime
+    from mtplx.models import laguna_fused
+
+    target_config = _target_laguna_config()
+    fused_report = [{"path": "fused_gate_up", "layers_converted": 47}]
+
+    class _StubLagunaRuntime:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(runtime, "load_config", lambda path: target_config)
+    monkeypatch.setattr(
+        runtime, "_preflight_laguna_system_memory", lambda config: None
+    )
+    monkeypatch.setattr(
+        runtime, "_load_base_model", lambda path, config: (object(), object())
+    )
+    monkeypatch.setattr(runtime, "_load_runtime_metadata", lambda path: None)
+    monkeypatch.setattr(
+        laguna_fused, "install_from_env", lambda model: list(fused_report)
+    )
+    monkeypatch.setattr(runtime, "LagunaARRuntime", _StubLagunaRuntime)
+
+    loaded = runtime.load(tmp_path, mtp=False)
+
+    assert isinstance(loaded, _StubLagunaRuntime)
+    assert loaded.laguna_fused_report == fused_report

--- a/tests/test_omlx_bridge.py
+++ b/tests/test_omlx_bridge.py
@@ -290,3 +290,33 @@ def test_omlx_native_branch_keeps_blank_body_no_arg_call():
     )
     assert extraction.status == "parsed"
     assert json.loads(extraction.tool_calls[0]["function"]["arguments"]) == {}
+
+
+def test_omlx_tool_parser_accepts_poolside_arg_pairs():
+    extraction = parse_tool_calls(
+        "I'll list the files.<tool_call>list_files"
+        "<arg_key>path</arg_key><arg_value>src</arg_value></tool_call>",
+        tokenizer=None,
+        tools=[{"type": "function", "function": {"name": "list_files"}}],
+    )
+
+    assert extraction.status == "parsed"
+    assert json.loads(extraction.tool_calls[0]["function"]["arguments"]) == {
+        "path": "src"
+    }
+    assert extraction.cleaned_text == "I'll list the files."
+
+
+def test_omlx_tool_parser_poolside_residue_stays_content():
+    text = (
+        "<tool_call>foo<arg_key>k</arg_key><arg_value>v</arg_value>"
+        "garbage</tool_call>"
+    )
+    extraction = parse_tool_calls(
+        text,
+        tokenizer=None,
+        tools=[{"type": "function", "function": {"name": "foo"}}],
+    )
+
+    assert extraction.status == "malformed_as_content"
+    assert extraction.tool_calls is None

--- a/tests/test_omlx_bridge.py
+++ b/tests/test_omlx_bridge.py
@@ -320,3 +320,15 @@ def test_omlx_tool_parser_poolside_residue_stays_content():
 
     assert extraction.status == "malformed_as_content"
     assert extraction.tool_calls is None
+
+
+def test_omlx_tool_parser_passes_unknown_tool_name_through():
+    extraction = parse_tool_calls(
+        "<tool_call>task_progress<arg_key>steps</arg_key>"
+        "<arg_value>plan</arg_value></tool_call>",
+        tokenizer=None,
+        tools=[{"type": "function", "function": {"name": "list_files"}}],
+    )
+
+    assert extraction.status == "parsed"
+    assert extraction.tool_calls[0]["function"]["name"] == "task_progress"

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -10102,7 +10102,7 @@ def test_chat_tools_malformed_tool_call_drops_punctuation_only_visible_fallback(
     assert stats["raw_tool_markup_suppressed"] is True
 
 
-def test_chat_tools_unknown_generated_tool_falls_back_to_content(monkeypatch):
+def test_chat_tools_unknown_generated_tool_passes_through(monkeypatch):
     state = _fake_state()
     state.args.stats_footer = False
     client = TestClient(create_app(state))
@@ -10129,18 +10129,25 @@ def test_chat_tools_unknown_generated_tool_falls_back_to_content(monkeypatch):
         },
     )
 
+    # A name outside the request's tools list is still delivered as a real tool call:
+    # the OpenAI surface leaves the rejection to the client, which answers the model and
+    # lets it self-correct. Degrading the turn to prose instead makes agent clients count
+    # a consecutive-mistake strike (three fails the task), so this must NOT fall back.
     assert response.status_code == 200
     choice = response.json()["choices"][0]
-    assert choice["finish_reason"] == "stop"
-    assert choice["message"]["content"] == ""
-    assert "tool_calls" not in choice["message"]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["content"] is None
+    calls = choice["message"]["tool_calls"]
+    assert [c["function"]["name"] for c in calls] == ["Agent"]
+    assert json.loads(calls[0]["function"]["arguments"]) == {"description": "List files"}
     stats = response.json()["mtplx_stats"]
-    assert stats["tool_parse_fallback"] is True
-    assert stats["tool_parse_fallback_kind"] == "unknown_tool_name"
-    assert "unknown tool 'Agent'" in stats["tool_parse_fallback_reason"]
+    assert stats["tool_parse_status"] == "parsed"
+    assert stats["tool_calls_emitted"] == 1
+    assert stats["raw_tool_markup_suppressed"] is True
+    assert "tool_parse_fallback_kind" not in stats
 
 
-def test_chat_stream_unknown_generated_tool_falls_back_to_content(monkeypatch):
+def test_chat_stream_unknown_generated_tool_passes_through(monkeypatch):
     state = _fake_state()
     state.args.stream_interval = 1
     state.args.stats_footer = False
@@ -10170,15 +10177,27 @@ def test_chat_stream_unknown_generated_tool_falls_back_to_content(monkeypatch):
     streamed_content = "".join(
         payload["choices"][0]["delta"].get("content", "") for payload in payloads
     )
+    # Streaming carries the same contract as the buffered path: an unknown name is
+    # delivered as incremental tool_calls deltas, never degraded to prose (see the
+    # non-stream sibling for why the fallback would cost the client a mistake strike).
     assert streamed_content == ""
-    assert not any(
-        payload["choices"][0]["delta"].get("tool_calls") for payload in payloads
+    deltas = [
+        payload["choices"][0]["delta"]["tool_calls"]
+        for payload in payloads
+        if payload["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert deltas, "unknown tool must still stream as tool_calls"
+    assert deltas[0][0]["function"]["name"] == "task"
+    streamed_args = "".join(
+        chunk[0]["function"].get("arguments", "") for chunk in deltas
     )
+    assert json.loads(streamed_args) == {"description": "List files"}
     final = [payload for payload in payloads if payload["choices"][0]["finish_reason"]]
-    assert final[-1]["choices"][0]["finish_reason"] == "stop"
+    assert final[-1]["choices"][0]["finish_reason"] == "tool_calls"
     stats = final[-1]["mtplx_stats"]
-    assert stats["tool_parse_fallback"] is True
-    assert stats["tool_parse_fallback_kind"] == "unknown_tool_name"
+    assert stats["tool_calls_emitted"] == 1
+    assert stats["raw_tool_markup_suppressed"] is True
+    assert "tool_parse_fallback_kind" not in stats
     assert "data: [DONE]" in response.text
 
 

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -348,6 +348,26 @@ def test_startup_urls_distinguish_wildcard_bind_from_local_url():
     assert openai._startup_openai_base_url(args) == "http://127.0.0.1:8000/v1"
 
 
+def test_laguna_fused_startup_line_carries_the_engagement_receipt():
+    runtime = SimpleNamespace(
+        laguna_fused_report=[{"path": "fused_gate_up", "layers_converted": 47}]
+    )
+
+    line = openai._laguna_fused_startup_line(runtime)
+
+    assert line is not None
+    assert "[laguna-fused]" in line
+    assert json.loads(line.split("[laguna-fused] ", 1)[1]) == runtime.laguna_fused_report
+
+
+def test_laguna_fused_startup_line_stays_silent_without_a_report():
+    assert openai._laguna_fused_startup_line(SimpleNamespace()) is None
+    assert (
+        openai._laguna_fused_startup_line(SimpleNamespace(laguna_fused_report=[]))
+        is None
+    )
+
+
 def test_chat_request_accepts_ai_sdk_camel_sampler_aliases():
     request = openai.ChatCompletionRequest.model_validate(
         {

--- a/tests/test_stream_guard_env.py
+++ b/tests/test_stream_guard_env.py
@@ -1,0 +1,50 @@
+"""The hidden-tool stream guard ceilings honor their env overrides.
+
+The ceilings gate how much buffered tool-call text may stream before the
+runaway backstop cancels generation (f8440e7). A typo in the env names would
+silently fall back to the chat-UX defaults and re-break whole-file tool calls,
+so the names and defaults are pinned here via a fresh interpreter (the values
+are read once at import).
+"""
+
+import os
+import subprocess
+import sys
+
+_SNIPPET = (
+    "from mtplx.server.openai import "
+    "STREAM_HIDDEN_TOOL_GUARD_TOKENS, STREAM_HIDDEN_TOOL_GUARD_S; "
+    "print(STREAM_HIDDEN_TOOL_GUARD_TOKENS, STREAM_HIDDEN_TOOL_GUARD_S)"
+)
+
+
+def _read_ceilings(extra_env: dict[str, str]) -> tuple[int, float]:
+    env = dict(os.environ)
+    env.pop("MTPLX_STREAM_HIDDEN_TOOL_GUARD_TOKENS", None)
+    env.pop("MTPLX_STREAM_HIDDEN_TOOL_GUARD_S", None)
+    env.update(extra_env)
+    out = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    ).stdout.split()
+    return int(out[0]), float(out[1])
+
+
+def test_stream_guard_ceilings_default_to_chat_ux_values():
+    tokens, seconds = _read_ceilings({})
+    assert tokens == 2048
+    assert seconds == 30.0
+
+
+def test_stream_guard_ceilings_honor_env_overrides():
+    tokens, seconds = _read_ceilings(
+        {
+            "MTPLX_STREAM_HIDDEN_TOOL_GUARD_TOKENS": "16384",
+            "MTPLX_STREAM_HIDDEN_TOOL_GUARD_S": "600",
+        }
+    )
+    assert tokens == 16384
+    assert seconds == 600.0

--- a/tests/test_tool_aware_stream_translator.py
+++ b/tests/test_tool_aware_stream_translator.py
@@ -361,7 +361,11 @@ def test_leading_whitespace_before_marker_still_dropped():
     assert any("tool_calls" in d for d in (out + finish_deltas))
 
 
-def test_unknown_tool_name_suppresses_raw_tool_markup():
+def test_unknown_tool_name_passes_through_as_tool_call():
+    # OpenAI-compatible contract: an unknown-named call is surfaced to the
+    # client, which owns the rejection (and answers the model so it can
+    # self-correct). Suppressing it degraded the whole turn to prose and cost
+    # agent clients (Cline) a consecutive-mistake strike per occurrence.
     t = _make()
     text = (
         "<tool_call>\n<function=Agent>\n"
@@ -369,9 +373,17 @@ def test_unknown_tool_name_suppresses_raw_tool_markup():
         "</function>\n</tool_call>"
     )
     out = t.feed("content", text)
-    assert t.finish() == []
-    assert t.has_tool_calls is False
-    assert t.fallback_reason == "unknown tool 'Agent'"
+    finish_deltas = t.finish()
+    assert t.has_tool_calls is True
+    assert t.fallback_reason is None
+    named = [
+        d for d in (out + finish_deltas)
+        if any(
+            (c.get("function") or {}).get("name") == "Agent"
+            for c in (d.get("tool_calls") or [])
+        )
+    ]
+    assert named, "unknown-named call should stream as a tool_call delta"
     assert _content_text(out) == ""
 
 

--- a/tests/test_tool_aware_stream_translator.py
+++ b/tests/test_tool_aware_stream_translator.py
@@ -863,3 +863,60 @@ def test_schema_type_mismatch_suppresses_raw_tool_markup():
     assert t.has_tool_calls is False
     assert "timeout must be number" in (t.fallback_reason or "")
     assert _content_text(out) == ""
+
+
+def test_bracket_call_streams_as_tool_call_not_content():
+    # Live shape 2026-07-25: prose, then a complete [Calling tool: ...] block
+    # whose arguments contain `]` (task_progress checklist) and `})]` inside
+    # strings. The old start detector skipped the prefix on the early `]`,
+    # so the block streamed as content AND the finish-time rescue emitted the
+    # same call — a double delivery.
+    payload = {
+        "input": "*** Begin Patch\n+const f = (x) => ({y: x});\ncall(f(1))]\n*** End Patch",
+        "task_progress": "- [x] one\n- [ ] two",
+    }
+    text = (
+        "Let me start with the math utilities: [Calling tool: apply_patch("
+        + json.dumps(payload)
+        + ")]"
+    )
+    t = _make(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "apply_patch",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"input": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+    )
+    out = []
+    for i in range(0, len(text), 7):  # simulate streaming in small chunks
+        out += t.feed("content", text[i : i + 7])
+    out += t.finish()
+    assert t.has_tool_calls is True, t.fallback_reason
+    contents = _content_text(out)
+    assert "[Calling tool:" not in contents
+    assert "Begin Patch" not in contents
+    args = _argument_text(out)
+    assert json.loads(args) == payload
+
+
+def test_unterminated_bracket_call_suppresses_like_unclosed_markup():
+    # Same contract as test_unclosed_tool_call_suppresses_raw_tool_markup:
+    # a never-completing block is suppressed with a recorded reason, keeping
+    # the drift dialect out of the visible transcript (and the model's
+    # conversation history).
+    text = 'And now: [Calling tool: apply_patch({"input": "never closed'
+    t = _make()
+    out = []
+    for i in range(0, len(text), 9):
+        out += t.feed("content", text[i : i + 9])
+    out += t.finish()
+    assert t.has_tool_calls is False
+    assert t.fallback_reason
+    assert _content_text(out) == "And now: "


### PR DESCRIPTION
## What changed

Adds target-only AR support for the exact `mlx-community/Laguna-S-2.1-oQ4e` checkpoint at revision `8e3f5cad513746264940c1c4195de48d7ea345a5`. The earlier `pipenetwork/Laguna-S-2.1-MLX-4bit` pin is now rejected like any other unadmitted variant.

- bundles the Apache-2.0 Laguna MLX model implementation with construction-time geometry checks
- pins the Hugging Face revision and verifies all 13 shard sizes plus exact config, index, tokenizer, generation config, special tokens map, and Poolside template hashes (7 sidecar sha256s)
- installs a dedicated `laguna_ar` runtime with native Laguna KV caches, cache-only prefill, final-logit slicing, and no Qwen optimization hooks or hot-path fallback
- rejects MTP before weight loading because this checkpoint has no native MTP head
- owns Laguna sampler, reasoning, Poolside native tool protocol, 32K context/response defaults, integration budgets, and memory/disk preflights through the backend descriptor
- updates CLI/server inspection, docs, dashboard parser controls, and tracked dashboard assets
- handles the oQ4e export layout specifically: every tensor sits under a `language_model.` prefix, which the runtime strips from both weights and the quantization map so the vendored module tree (no such wrapper) matches by path; the BF16 router lives in a `gate.proj` submodule with the load-balancing bias parked under `gate`
- quantization is a mixed-precision imatrix map read directly from the checkpoint's config: 4-bit/gs128 base (MoE experts), 8-bit `lm_head` and embeddings at gs64, 5/6-bit layer-0 dense MLP at gs64, per-layer self-attention overrides (mostly 5-bit with several layers promoted to 8-bit), and unquantized BF16 routers
- `Model.sanitize()` folds the `language_model.` layout onto the module tree, and the runtime feeds the prefix-stripped quant dict through `load_model(model_config=...)` so mlx-lm's config-driven quantizer addresses module paths directly; the old hard-coded 8-bit-router `quant_predicate` was dead code under mlx-lm 0.31.3 and is removed
- `generation_config.json` and `chat_template.jinja` are byte-identical to the previous pin, so reasoning/tool defaults carry over unchanged

- ports the batched AR decode lane (ragged-KV batched driver) and opens `decode_mode="ar"` to target-only runtimes: neither prefill nor the AR loop requests hidden states, and no MTP head is required
- fixes batched single-token rope: `mx.fast.rope`'s single-step fast path writes only batch row 0 when `T==1` and the offset is scalar, so every batched decode row past the first came back as uninitialized buffer; a per-row offset vector routes the call to the general kernel (this hits the 36 sliding-window layers, whose caches keep scalar offsets whenever context exceeds the window)
- adds seven env-gated fused decode paths, all default-off, with the per-path measurements in the "Decode kernel stack" section below and CPU contracts in `tests/test_laguna_fused.py`

- adds a compile-able single-token decode step (`mtplx/laguna_compiled_step.py`): the B=1 step re-expressed as a pure function over explicit tensor cache leaves so `mx.compile` traces it once and replays it from the C++ runtime — measurements in the "Compiled decode step" subsection below

## Why

The checkpoint is not loadable through the current pinned `mlx-lm` model registry, and MTPLX previously treated runnable models as MTP-only. Laguna also has different attention-head geometry, RoPE, router, cache, and Poolside tool-protocol requirements, so it needs an exact target-owned route rather than a topology transplant or silent stock fallback.

The admitted artifact moved from the uniform-4bit `pipenetwork` build to the `mlx-community` oQ4e mixed-precision imatrix export because the export layout differs mechanically — the `language_model.` prefix and the per-path quantization dict cannot be expressed by a hard-coded predicate — so the runtime now reads the checkpoint's own quantization config instead of assuming a fixed bit-width scheme.

## How to verify

```bash
PYTHONPATH="$PWD" python -m pytest \
  tests/test_laguna_model.py tests/test_artifacts.py tests/test_hf_loader.py \
  tests/test_metal_memory_caps.py tests/test_reasoning_stream_split.py \
  tests/test_generation_sustained.py tests/test_public_cli.py \
  tests/test_server_openai.py -q

ruff check mtplx tests/test_laguna_model.py tests/test_artifacts.py \
  tests/test_hf_loader.py tests/test_metal_memory_caps.py \
  tests/test_public_cli.py tests/test_reasoning_stream_split.py \
  tests/test_server_openai.py tests/test_generation_sustained.py

cd dashboard
npm run typecheck
npm run build
```

CI runs the no-mlx-installed lane as a single pytest invocation; the affected files are all in that list:

```bash
python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py \
  tests/test_runtime_kpis.py tests/test_server_openai.py \
  tests/test_openai_bridge.py tests/test_thermal.py tests/test_cache_state.py
```

Pinned artifact validation:

```bash
mtplx pull mlx-community/Laguna-S-2.1-oQ4e --progress-json
mtplx inspect mlx-community/Laguna-S-2.1-oQ4e --json
```

Guarded real-checkpoint hosting and generation completed against the oQ4e pin; see Benchmarks below.

## Benchmarks

Measured 2026-07-22 on an M5 Max (128 GiB unified, 614 GB/s) inside an exclusive guarded window (no other model processes). Server benchmarks ran against `mtplx serve --no-mtp` on localhost via the OpenAI-compatible endpoint, serial requests, `temperature 0`; decode rates use two-point timing (`max_tokens 1` vs `max_tokens N` on the identical prompt) so prefill and connection overhead cancel out.

| Measurement | Prompt tokens | Generated | Result |
|---|---|---|---|
| Prefill (server) | 690 | — | 513.8 tok/s |
| Prefill (server) | 14,872 | — | 698.9 tok/s |
| Decode (server) | 690 | 780 (natural EOS before the 1024 cap) | **52.3 tok/s** |
| Decode at ~15K context (server) | 14,872 | 256 | 47.3 tok/s |
| Decode (`mtplx run --json` runtime receipt) | short prompt | 291 | 55.3 tok/s |

Speculative-decoding stats in every receipt are structurally zero — `generation_mode="ar"`, `mtp_depth 0`, `verify_calls 0`, `accepted_by_depth []` — confirming the target-only AR route: one token per forward pass, no draft/verify cycle exists for this checkpoint.

Two caveats frame these numbers. First, they predate the decode kernel stack below: `laguna_ar` runs stock kernels by default (no tuned kernel routes, no prefill-layout work; `tune_policy` is disabled for this backend by design). Second, the checkpoint ships no MTP head, so the decode figures above are the plain-AR floor — speculative decoding, MTPLX's primary decode lever, is unavailable until an MTP-equipped Laguna export exists. Both are properties of the artifact and the deliberately exact-scope route, not measurement conditions.

## Decode kernel stack (env-gated, measured)

Added 2026-07-24 on top of the AR route above. All paths are opt-in via environment variables; default behavior is unchanged unless a flag is set. Each path ran as an arm inside a guarded GPU window (M5 Max, ctx 1024, greedy, 96 decode steps) against an in-window stock arm, with a repeated stock cell in the same window bounding drift. Greedy-token identity between fused and stock arms was gated at B=1.

| Path (env var) | What it fuses | Exactness | B=1 solo | B=2 solo |
|---|---|---|---|---|
| `MTPLX_LAGUNA_KERNEL_ATTN_GATE` | Per-head attention gate: softplus + broadcast-multiply chain in one Metal kernel | Bit-exact | +1.68% | +0.46% |
| `MTPLX_LAGUNA_KERNEL_ROUTER` | MoE router epilogue: sigmoid → bias → top-k → normalize → scale in one kernel, row-gated to ≤4 rows | Identical expert set; weight reassociation bounded at ~1e-8 | +2.25% | +2.51% |
| `MTPLX_LAGUNA_FUSED_GATE_UP` | Expert gate/up projections concatenated into one gather matmul | Bit-exact (quantization groups run along the input dim, so concatenating output rows preserves per-row scales/biases) | +1.94% | +1.18% |
| `MTPLX_LAGUNA_KERNEL_QK_ROPE` | q/k RMSNorm + transpose + rope (YaRN partial-rotary on full-attention layers, plain rope on sliding layers) for q and k in one dispatch per layer | Bit-exact (reproduces the stock kernels' exact lane layout, rounding order, and angle math) | -0.23% | +1.11% |
| `MTPLX_LAGUNA_KERNEL_COMBINE` | MoE weighted expert combine + shared-expert add in one dispatch, eliminating the `[rows, top_k, hidden]` intermediate | Bit-exact (reproduces the strided-reduction accumulation order) | +0.03% | +2.03% |
| `MTPLX_LAGUNA_FUSED_SHARED_GATE_UP` | Gate/up concatenation applied to the shared experts and the dense layer-0 MLP | Bit-exact | -0.01% | +0.15% |
| `MTPLX_LAGUNA_CACHED_LHS` | Cached gather `lhs_indices` + constant router-bias cast, removing ~190 dispatches/step | Value-identical inputs; the explicit index array can select a different gather kernel tiling at prefill, which was observed to flip greedy near-ties | neutral eager; ~-0.2 ms inside the compiled lane | neutral |
| `MTPLX_LAGUNA_FUSED_QKVG` | q/k/v/gate projections concatenated into one quantized matmul per attention block | Projection outputs bit-exact; the wider matmul changes prefill kernel selection, which was observed to flip greedy near-ties when composed with the full stack | neutral (the four projections already execute concurrently) | neutral |
| `MTPLX_LAGUNA_KERNEL_ROUTER_GEMV` | The router's BF16 gemv folded into the routing path: a simdgroup-per-expert logits kernel feeding the fused top-k kernel — two dispatches replace gemv + cast + eleven-op epilogue | Logits within one bf16 ulp of the stock gemv (~1 in 12k values); zero selection flips observed; kept the stock token stream in the exact composition's measured windows | -0.5 ms inside the compiled lane (neutral eager) | untested |

*Solo figures come from two windows: Window A (stock B=1 18.18 ms/step; repeated-stock drift −0.4% at B=1, −0.32% at B=2) covers `KERNEL_ATTN_GATE`, `KERNEL_ROUTER`, `FUSED_GATE_UP`. Window B (stock B=1 17.92 ms/step; drift +1.0% at B=1, −0.68% at B=2) covers `KERNEL_QK_ROPE`, `KERNEL_COMBINE`, `FUSED_SHARED_GATE_UP`, `CACHED_LHS`.*

**Stacked**

Two stacked configurations were measured in Window B against the same in-window stock arm. The all-reversible stack combines `KERNEL_ROUTER` + `KERNEL_ATTN_GATE` + `KERNEL_QK_ROPE` + `KERNEL_COMBINE`. The candidate-best stack adds `FUSED_GATE_UP` + `FUSED_SHARED_GATE_UP` on top of that set. Both produce token sequences identical to stock at B=1.

Per cell: speedup vs in-window stock, ms/step, then per-prompt and raw (aggregate) throughput.

| Stack | B=1 | B=2 | B=4 |
|---|---|---|---|
| stock (baseline) | 17.92 ms — 55.8 per-prompt / 55.8 raw tok/s | 25.52 ms — 39.2 per-prompt / 78.4 raw | 37.13 ms — 26.9 per-prompt / 107.7 raw |
| all-reversible | +4.78% — 17.07 ms — 58.6 per-prompt / 58.6 raw | +5.50% — 24.12 ms — 41.5 per-prompt / 82.9 raw | +5.55% — 35.07 ms — 28.5 per-prompt / 114.1 raw |
| candidate-best | +7.44% — 16.59 ms — **60.3 per-prompt** / 60.3 raw | +7.24% — 23.67 ms — **42.3 per-prompt** / 84.5 raw | +5.04% — 35.26 ms — 28.4 per-prompt / 113.4 raw |

A second confirmation window anchored candidate-best B=1 in the 16.55–16.73 ms range.

Solo deltas at B=1 sit inside the launch-overlap shadow of the large kernels, so small-kernel dispatch removal only registers once several paths run in combination — the stack total exceeds the sum of the solo deltas. A residual+norm fusion path also exists but stays off by default: a single fused custom-kernel launch costs more host-side than the two stock ops it replaces.

### Compiled decode step (tensor-leaf caches)

`mtplx/laguna_compiled_step.py` re-expresses the B=1 decode step as a pure function over explicit tensor state leaves: fixed-capacity full-attention KV written at a traced offset with an in-graph additive mask, and the sliding windows as ring buffers written at a traced slot index — unmasked at steady state, since every slot is live once context exceeds the window and softmax is permutation-invariant over the ring. That makes the whole step `mx.compile`-able: the graph is traced once and replayed from the C++ runtime, removing the per-token python graph reconstruction (~1,600 op builds/step). The lane seeds from the eager caches after a normal prefill; the supported regime is context ≥ sliding window.

One guarded window (M5 Max, ctx 1024, greedy, 96 measured steps, B=1; stock anchors 18.07/18.13 ms bracketing the arms):

| Configuration | ms/step | tok/s (per-prompt = raw at B=1) |
|---|---|---|
| stock python-cache lane | 18.00 | 55.6 |
| tensor-leaf lane, eager | 17.82 | 56.1 |
| tensor-leaf lane, compiled | 16.12 | 62.0 |
| stock lane + kernel stack | 16.54 | 60.5 |
| compiled + kernel stack | **15.73** | **63.6** |

A second window reproduced the compiled + kernel stack cell at 15.55 ms (64.3 tok/s; anchors 17.79/18.09 ms), again with one shared token digest across every lane. The fused q/k norm+rope kernel also runs inside the compiled graph (traced position input) — token-safe, measured speed-neutral there: the dispatches it removes were already inexpensive inside the compiled graph.

**Choosing a configuration.** Two vetted stacks, differing only in whether the greedy token stream is identical to stock:

| Configuration | Env on top of the compiled lane | ms/step | tok/s (B=1) | Output contract |
|---|---|---|---|---|
| exact | GATE_UP + SHARED_GATE_UP + KERNEL_ROUTER + KERNEL_ATTN_GATE + KERNEL_QK_ROPE + KERNEL_COMBINE + KERNEL_ROUTER_GEMV | **14.84** | **67.4** | Greedy tokens identical to stock in every measured window (in-window stock reference; the router kernels' bounded reassociations are present but altered no token) |
| inexact | exact + CACHED_LHS + FUSED_QKVG | **14.83** | **67.4** | Value-safe: identical arithmetic inputs, but different prefill kernel selection flips occasional greedy near-ties; within-configuration stock/eager/compiled lanes agree exactly |

Without the router-gemv fold the same stacks measure 15.53 / 15.18 ms; the exact figure includes the strided-GLU activation kernel on the dense gate/up paths (bit-exact, source-matched rounding). Sizing the compiled lane's full-attention capacity to the workload (constructor argument; 1152 for this 1024+decode shape instead of the default 2048) measures 14.80 ms / 67.6 tok/s with the same stock-identical digest. A packed k/v leaf layout was also built and measured ~0.07 ms slower than unpacked in-model, so it ships default-off. This exact configuration is the shipped result of the optimization pass: 17.9-18.2 ms stock to 14.84-14.80 ms, +21.6%, greedy tokens identical to stock in every measured window. The fold's token-stream preservation in the exact stack is a measured property of its rounding contract (the dot is rounded to bf16 before the sigmoid, matching the stock gemv's own output precision), not a bitwise guarantee — a logit within one bf16 ulp of a routing tie could still flip; none did across the measured windows.

Both configurations pass every within-arm identity gate (python-cache, eager tensor-leaf, and compiled lanes produce one shared digest). The inexact stack's divergence from stock is the same benign class as batched-vs-solo non-invariance: equally valid float reassociation, not a precision change.

Greedy tokens were identical across every lane and configuration in the window — one shared digest, including compiled-vs-stock. Inside the compiled lane the router, attention-gate, and combine kernels plus both gate/up concatenations engage; the q/k norm+rope fusion is bypassed because the compiled step's own attention covers that chain (compile fuses it). CPU contracts live in `tests/test_laguna_compiled_step.py` (18 tests: ring-write equivalence against `RotatingKVCache` across wraps, snapshot aliasing, compiled-vs-eager equality, quantized/YaRN/tied-embedding variants).

## Notable decisions

- Support is deliberately exact-checkpoint-only. Other Laguna variants remain blocked, including the earlier `pipenetwork` build, which is now rejected the same way any unadmitted variant is.
- MTP is rejected explicitly; there is no enabled-lane fallback.
- The 32K default is a resource-safe operating default, while the model maximum remains 1,048,576 and larger server contexts must pass the active Metal-memory budget.
- Weights are 64,122,027,323 bytes (59.72 GiB); the full pinned snapshot is 64,129,728,868 bytes (64.13 GB). The resident floor at the 32K default context is 74,398,072,123 bytes (~69.3 GiB), plus a 16 GiB system reserve; the docs round this up to the practical tier: at least 96 GiB unified memory, 128 GiB recommended.
- The test-env isolation fix (turned CI green): the laguna one-shot defaults test drives `_generate_one_shot_public` with the sustained profile, which writes roughly three dozen `MTPLX_*` keys into process env. Under CI's single-process pytest invocation those keys leaked into later tests, and leftover `MTPLX_VLLM_METAL_PAGED_*` keys flipped env-driven cache selection and failed `test_cache_state.py`. The test now snapshots and restores `os.environ` around itself so the profile application stays observable but process-local state doesn't leak.








