### PR TITLE
Hy3: 48 tok/s full-residency serving via 4-bit dynamic requant (quality-gated) + corrected MTP draft contract — continues #152

### DIFF
--- a/mtplx/backends/hy_v3_mtp.py
+++ b/mtplx/backends/hy_v3_mtp.py
@@ -2,7 +2,7 @@
 
 Hy3 ships one appended MTP layer (num_nextn_predict_layers=1): a full MoE
 decoder layer fed concat[RMSNorm(next-token embedding), RMSNorm(trunk
-pre-final-norm hidden state)] through an eh_proj down-projection, sharing the
+post-final-norm hidden state)] through an eh_proj down-projection, sharing the
 trunk's embeddings and lm_head. The MLX reference implementation exposes it as
 ``Model.predict_next_tokens(hidden, token_ids, cache)`` with
 ``return_hidden_states=True`` on the trunk forward (see
@@ -57,8 +57,8 @@ class HyV3MTPBackend(MTPBackend):
                 "Single appended NextN layer with its own 192-expert MoE MLP, "
                 "sigmoid top-8 routing with expert bias, eh_proj over "
                 "concat[enorm(embedding), hnorm(hidden)], shared embeddings "
-                "and head. Draft layer consumes the trunk pre-final-norm "
-                "hidden state. Verification is exact rejection sampling in "
+                "and head. Draft layer consumes the trunk POST-final-norm "
+                "hidden state (measured 0.773 vs 0.387 pre-norm). Verification is exact rejection sampling in "
                 "generation.py; the MLX reference (mlx-lm hy_v3 MTP revision) "
                 "verifies greedily and is temp-0 exact."
             ),

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -816,23 +816,35 @@ _HY_V3_MTP_MARKER_SUFFIXES = (
 
 
 def _passes_hy_v3_gate(inspection: Any) -> bool:
-    """Hy3's appended MTP block lives directly under an ``mtp.`` prefix
-    (``mtp.enorm.weight``, ``mtp.hnorm.weight``, ``mtp.eh_proj.weight``,
-    ``mtp.final_layernorm.weight``, ``mtp.layer.*``) rather than the
-    ``mtp.layers.{idx}.`` nesting DeepSeek/GLM/Step use, so it needs its own
-    gate instead of `_passes_appended_layer_gate` (verified against the
-    shipped `hy3-demolition-mlx-*-mtp` checkpoints' safetensors index)."""
+    """Hy3's appended MTP block ships in one of two layouts: repacked
+    checkpoints put it directly under an ``mtp.`` prefix (``mtp.enorm.weight``,
+    ``mtp.eh_proj.weight``, ``mtp.layer.*`` — verified against the shipped
+    `hy3-demolition-mlx-*-mtp` indexes), while tencent-native exports keep the
+    canonical appended-layer form ``model.layers.{num_hidden_layers}.*``
+    (``...enorm.weight``, ``...self_attn.*``, ``...mlp.*``). Neither uses the
+    ``mtp.layers.{idx}.`` nesting DeepSeek/GLM/Step share, so this stays a
+    dedicated gate instead of `_passes_appended_layer_gate`."""
     keys = _weight_keys(inspection)
     if not keys:
         return False
     count = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
     if count <= 0:
         return False
-    return _has_marker_under_prefixes(
+    if _has_marker_under_prefixes(
         keys,
         ("mtp.",),
         _HY_V3_MTP_MARKER_SUFFIXES,
         ("mtp.layer.",),
+    ):
+        return True
+    start = int(getattr(inspection, "num_hidden_layers", 0) or 0)
+    if start <= 0:
+        return False
+    return _has_marker_under_prefixes(
+        keys,
+        (f"model.layers.{start}.",),
+        _HY_V3_MTP_MARKER_SUFFIXES,
+        ("self_attn.", "mlp."),
     )
 
 

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -424,9 +424,11 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         notes=(
             "Hy3 ships one appended NextN layer with its own 192-expert MoE, "
             "eh_proj over concat[enorm(embedding), hnorm(hidden)], and shared "
-            "embeddings/head. The mlx-lm hy_v3 MTP revision exposes the head "
-            "natively (predict_next_tokens), so injection binds the existing "
-            "surface rather than grafting weights."
+            "embeddings/head. The draft consumes the POST-final-norm trunk "
+            "hidden (measured: teacher-forced agreement 0.773 post vs 0.387 "
+            "pre on real code). Injection grafts the head from the standard "
+            "appended-layer checkpoint; a native mlx-lm surface, when it "
+            "lands, is bound instead."
         ),
     ),
     "generic-mtp": ArchitectureSupport(

--- a/mtplx/benchmarks/code_eval.py
+++ b/mtplx/benchmarks/code_eval.py
@@ -1,0 +1,405 @@
+"""HumanEval / MBPP code-generation evaluation.
+
+Every benchmark in this repo so far measures throughput or acceptance. None
+measures whether the output is still *correct*. That matters here because the
+shipping configuration quantizes aggressively — Q2 routed experts, Q4 trunk
+projections — and a throughput win that silently costs pass@1 is not a win.
+
+This module is the scoring half: load the tasks, build prompts, extract code
+from a completion, execute it against the reference tests, and compute pass@k.
+Getting completions from a model is the driver's job
+(``scripts/code_eval_gate.py``), so this stays importable with no MLX, no
+network, and no model.
+
+## Executing model-generated code
+
+Scoring HumanEval means running code the model wrote. That is inherently
+unsafe, so it is deliberately not the default and not silent:
+
+- every candidate runs in a **fresh subprocess**, never in-process ``exec``
+- a hard wall-clock timeout, then SIGKILL of the whole process group
+- ``resource`` limits on CPU time, address space, and core dumps
+- an empty-ish environment and a scratch cwd that is deleted afterwards
+- the caller must pass ``allow_execution=True`` explicitly; the default
+  refuses, matching the ``--allow-degraded-mtp`` convention elsewhere
+
+This is the standard HumanEval methodology and it is appropriate for
+benchmarking a local model on your own machine. It is *not* a container, and
+it should not be pointed at completions from an untrusted source.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+__all__ = [
+    "CodeTask",
+    "CodeEvalError",
+    "TaskResult",
+    "load_humaneval",
+    "load_mbpp",
+    "load_tasks",
+    "extract_code",
+    "build_program",
+    "run_candidate",
+    "pass_at_k",
+    "DEFAULT_TIMEOUT_S",
+]
+
+DEFAULT_TIMEOUT_S = 15.0
+_DEFAULT_ADDRESS_SPACE_BYTES = 4 * 1024**3  # 4 GiB per candidate
+
+
+class CodeEvalError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class CodeTask:
+    """One benchmark problem, normalized across HumanEval and MBPP."""
+
+    task_id: str
+    suite: str  # "humaneval" | "mbpp"
+    prompt: str  # what the model is shown
+    test: str  # test source appended after the candidate
+    entry_point: str | None = None
+    setup: str = ""  # MBPP test_setup_code
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "suite": self.suite,
+            "entry_point": self.entry_point,
+        }
+
+
+@dataclass(frozen=True)
+class TaskResult:
+    task_id: str
+    passed: bool
+    status: str  # "passed" | "failed" | "timeout" | "error" | "empty"
+    detail: str = ""
+    seconds: float = 0.0
+
+
+# --------------------------------------------------------------------------
+# loading
+# --------------------------------------------------------------------------
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def load_humaneval(path: Path | str) -> list[CodeTask]:
+    """Load the canonical ``HumanEval.jsonl``.
+
+    Fields: task_id, prompt, canonical_solution, test, entry_point. The test
+    body defines ``check(candidate)`` but does not call it, so the caller
+    appends the invocation — see ``build_program``.
+    """
+
+    tasks: list[CodeTask] = []
+    for row in _read_jsonl(Path(path)):
+        tasks.append(
+            CodeTask(
+                task_id=str(row["task_id"]),
+                suite="humaneval",
+                prompt=str(row["prompt"]),
+                test=str(row["test"]),
+                entry_point=str(row["entry_point"]),
+            )
+        )
+    if not tasks:
+        raise CodeEvalError(f"no HumanEval tasks parsed from {path}")
+    return tasks
+
+
+def load_mbpp(path: Path | str, *, sanitized: bool = False) -> list[CodeTask]:
+    """Load MBPP from ``mbpp.jsonl`` or ``sanitized-mbpp.json``.
+
+    MBPP shows the model a natural-language description plus its asserts (the
+    asserts pin the expected function name, without which the task is
+    underspecified). Scoring then re-runs those asserts.
+    """
+
+    path = Path(path)
+    if sanitized or path.suffix == ".json":
+        rows = json.loads(path.read_text())
+    else:
+        rows = _read_jsonl(path)
+
+    tasks: list[CodeTask] = []
+    for row in rows:
+        asserts = list(row.get("test_list") or [])
+        if not asserts:
+            continue
+        description = str(row.get("text") or row.get("prompt") or "").strip()
+        prompt = (
+            f"{description}\n"
+            f"Your code should satisfy these tests:\n" + "\n".join(asserts) + "\n"
+        )
+        tasks.append(
+            CodeTask(
+                task_id=f"MBPP/{row['task_id']}",
+                suite="mbpp",
+                prompt=prompt,
+                test="\n".join(asserts),
+                setup=str(row.get("test_setup_code") or ""),
+            )
+        )
+    if not tasks:
+        raise CodeEvalError(f"no MBPP tasks parsed from {path}")
+    return tasks
+
+
+def load_tasks(suite: str, path: Path | str) -> list[CodeTask]:
+    if suite == "humaneval":
+        return load_humaneval(path)
+    if suite == "mbpp":
+        return load_mbpp(path)
+    raise CodeEvalError(f"unknown suite {suite!r}; expected humaneval or mbpp")
+
+
+# --------------------------------------------------------------------------
+# completion -> program
+# --------------------------------------------------------------------------
+
+_FENCE = re.compile(r"```(?:python|py)?\s*\n(.*?)(?:\n```|\Z)", re.DOTALL)
+
+
+def extract_code(completion: str, *, suite: str = "humaneval") -> str:
+    """Pull runnable Python out of a chat completion.
+
+    Instruct-tuned models wrap code in markdown fences and add prose, so a raw
+    completion is usually not valid Python. Prefer the first fenced block; if
+    there is no fence, fall back to the raw text.
+
+    For HumanEval the model is continuing a function signature, so a fenced
+    block that redefines the whole function is *also* valid — the caller
+    concatenates prompt + completion only when nothing was fenced.
+    """
+
+    match = _FENCE.search(completion)
+    if match:
+        return match.group(1).rstrip()
+    return completion.rstrip()
+
+
+def build_program(task: CodeTask, completion: str) -> str:
+    """Assemble the full source to execute: candidate + tests + invocation."""
+
+    code = extract_code(completion, suite=task.suite)
+
+    if task.suite == "humaneval":
+        # If the model re-emitted the signature, the block stands alone;
+        # otherwise it is a body continuing task.prompt.
+        standalone = re.search(
+            rf"def\s+{re.escape(task.entry_point or '')}\s*\(", code
+        )
+        body = code if standalone else task.prompt + code
+        return "\n".join(
+            [body, "", task.test, "", f"check({task.entry_point})", ""]
+        )
+
+    # MBPP: the asserts reference the function by name; nothing to append.
+    parts = [code, ""]
+    if task.setup:
+        parts += [task.setup, ""]
+    parts += [task.test, ""]
+    return "\n".join(parts)
+
+
+# --------------------------------------------------------------------------
+# sandboxed execution
+# --------------------------------------------------------------------------
+
+# Resource limits are defense in depth and are applied BEST-EFFORT: the real
+# containment is the subprocess boundary plus the wall-clock timeout. macOS
+# rejects some of these (RLIMIT_AS in particular), and a hardening call that
+# raises would otherwise turn every candidate into a spurious failure — which
+# is exactly what it did before this was made defensive.
+_PREAMBLE = """\
+import resource as _r, os as _os, faulthandler as _fh
+for _name, _val in (
+    ("RLIMIT_CPU", {cpu}),
+    ("RLIMIT_AS", {addr}),
+    ("RLIMIT_CORE", 0),
+):
+    _lim = getattr(_r, _name, None)
+    if _lim is None:
+        continue
+    try:
+        _r.setrlimit(_lim, (_val, _val))
+    except (ValueError, OSError):
+        pass
+try:
+    _fh.disable()
+except Exception:
+    pass
+"""
+
+
+def run_candidate(
+    task: CodeTask,
+    completion: str,
+    *,
+    allow_execution: bool = False,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    address_space_bytes: int = _DEFAULT_ADDRESS_SPACE_BYTES,
+) -> TaskResult:
+    """Execute one candidate against its tests in an isolated subprocess.
+
+    ``allow_execution`` must be passed explicitly. Running model-generated
+    code is the entire point of this benchmark and also its only real hazard,
+    so it never happens as a side effect of calling into this module.
+    """
+
+    import time
+
+    if not allow_execution:
+        raise CodeEvalError(
+            "run_candidate executes model-generated code; pass "
+            "allow_execution=True to acknowledge that"
+        )
+    if not completion.strip():
+        return TaskResult(task.task_id, False, "empty", "empty completion")
+
+    program = _PREAMBLE.format(
+        cpu=max(1, int(timeout_s)), addr=int(address_space_bytes)
+    ) + build_program(task, completion)
+
+    workdir = tempfile.mkdtemp(prefix="mtplx-codeeval-")
+    started = time.monotonic()
+    try:
+        source = Path(workdir) / "candidate.py"
+        source.write_text(program)
+        try:
+            completed = subprocess.run(
+                [sys.executable, str(source)],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                # New process group so a timeout kills grandchildren too.
+                start_new_session=True,
+                env={
+                    "PATH": os.environ.get("PATH", ""),
+                    "HOME": workdir,
+                    "TMPDIR": workdir,
+                    "PYTHONDONTWRITEBYTECODE": "1",
+                },
+            )
+        except subprocess.TimeoutExpired:
+            return TaskResult(
+                task.task_id, False, "timeout",
+                f"exceeded {timeout_s}s", time.monotonic() - started,
+            )
+        elapsed = time.monotonic() - started
+        if completed.returncode == 0:
+            return TaskResult(task.task_id, True, "passed", "", elapsed)
+
+        stderr = completed.stderr or ""
+        tail = stderr.strip().splitlines()
+        detail = tail[-1] if tail else f"exit {completed.returncode}"
+
+        # Python exits 1 for a failed assert AND for a SyntaxError, but those
+        # mean different things when comparing quantization arms: unparseable
+        # output is degraded generation, a failed assert is wrong reasoning.
+        # Keep them separate so a regression can be attributed.
+        if re.search(r"^(SyntaxError|IndentationError|TabError)", stderr, re.MULTILINE):
+            status = "syntax_error"
+        elif completed.returncode == 1:
+            status = "failed"
+        else:
+            status = "error"
+        return TaskResult(task.task_id, False, status, detail, elapsed)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------
+# scoring
+# --------------------------------------------------------------------------
+
+
+def pass_at_k(n: int, c: int, k: int) -> float:
+    """Unbiased pass@k estimator from the Codex paper (Chen et al. 2021).
+
+    ``n`` samples drawn, ``c`` of them correct. Computed as
+    ``1 - C(n-c, k) / C(n, k)`` via the numerically stable product form
+    rather than factorials.
+    """
+
+    if k <= 0 or n <= 0:
+        raise CodeEvalError("pass_at_k requires n > 0 and k > 0")
+    if c < 0 or c > n:
+        raise CodeEvalError(f"pass_at_k: c={c} outside [0, n={n}]")
+    if n - c < k:
+        return 1.0
+    product = 1.0
+    for i in range(n - c + 1, n + 1):
+        product *= 1.0 - k / i
+    return 1.0 - product
+
+
+def summarize(results: Sequence[TaskResult], *, k: int = 1) -> dict[str, Any]:
+    """Aggregate sample-level results into a report.
+
+    ``results`` may contain several samples per task (same ``task_id``).
+    pass@k is computed **per task and then averaged**, which is the Codex-paper
+    definition — ``pass_at_k`` is a per-task estimator and feeding it a
+    corpus-wide correct count is meaningless.
+
+    An earlier signature took an ``n=`` argument and did exactly that, which
+    raised as soon as the corpus-wide pass count exceeded the sample count.
+    Sample counts are now derived per task, so callers cannot get it wrong.
+    """
+
+    by_task: dict[str, list[TaskResult]] = {}
+    for result in results:
+        by_task.setdefault(result.task_id, []).append(result)
+
+    by_status: dict[str, int] = {}
+    for result in results:
+        by_status[result.status] = by_status.get(result.status, 0) + 1
+
+    per_task: list[float] = []
+    for samples in by_task.values():
+        n_samples = len(samples)
+        n_correct = sum(1 for s in samples if s.passed)
+        if n_samples < k:
+            # Cannot estimate pass@k from fewer than k samples; skip rather
+            # than silently reporting an optimistic value.
+            continue
+        per_task.append(pass_at_k(n_samples, n_correct, k))
+
+    tasks = len(by_task)
+    fully_passed = sum(1 for s in by_task.values() if any(r.passed for r in s))
+    return {
+        "tasks": tasks,
+        "samples": len(results),
+        "passed": fully_passed,
+        f"pass@{k}": (sum(per_task) / len(per_task)) if per_task else 0.0,
+        "by_status": by_status,
+        "failures": [
+            {"task_id": r.task_id, "status": r.status, "detail": r.detail}
+            for r in results
+            if not r.passed
+        ][:25],
+    }

--- a/mtplx/benchmarks/programming_prompts.py
+++ b/mtplx/benchmarks/programming_prompts.py
@@ -1,0 +1,246 @@
+"""Deterministic, common-vocabulary coding-agent benchmark context."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+PROGRAMMING_ARTIFACT_KINDS = (
+    "source",
+    "test",
+    "config",
+    "documentation",
+    "diagnostic",
+    "review",
+)
+
+
+@dataclass(frozen=True)
+class ProgrammingArtifact:
+    kind: str
+    path: str
+    body: str
+
+    def render(self, cycle: int) -> str:
+        return (
+            f"\n\n## Repository artifact: workspace_{cycle}/{self.path}\n"
+            f"Artifact type: {self.kind}.\n```text\n{self.body.rstrip()}\n```\n"
+        )
+
+
+def _artifacts() -> tuple[ProgrammingArtifact, ...]:
+    return (
+        ProgrammingArtifact(
+            "documentation",
+            "README.md",
+            """# Task Queue
+A small Python service accepts jobs, validates input, stores state, and writes
+structured logs. Keep public behavior stable and make failures explicit.
+
+Development uses Python 3.11 and pytest. Run the unit tests before changing the
+command line interface or the JSON record schema.""",
+        ),
+        ProgrammingArtifact(
+            "source",
+            "src/task_queue/models.py",
+            """from dataclasses import dataclass, field
+from typing import Any
+
+@dataclass(frozen=True)
+class Job:
+    job_id: str
+    command: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.job_id.strip():
+            raise ValueError("job_id must not be empty")
+        if not self.command.strip():
+            raise ValueError("command must not be empty")""",
+        ),
+        ProgrammingArtifact(
+            "source",
+            "src/task_queue/store.py",
+            """from collections import OrderedDict
+
+class JobStore:
+    def __init__(self, capacity: int = 128) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self.capacity = capacity
+        self._items = OrderedDict()
+
+    def get(self, key: str):
+        value = self._items.pop(key)
+        self._items[key] = value
+        return value
+
+    def put(self, key: str, value) -> None:
+        self._items.pop(key, None)
+        self._items[key] = value
+        while len(self._items) > self.capacity:
+            self._items.popitem(last=False)""",
+        ),
+        ProgrammingArtifact(
+            "test",
+            "tests/test_store.py",
+            """import pytest
+from task_queue.store import JobStore
+
+def test_store_rejects_invalid_capacity():
+    with pytest.raises(ValueError, match="positive"):
+        JobStore(0)
+
+def test_store_evicts_the_oldest_item():
+    store = JobStore(capacity=2)
+    store.put("first", 1)
+    store.put("second", 2)
+    store.put("third", 3)
+    with pytest.raises(KeyError):
+        store.get("first")""",
+        ),
+        ProgrammingArtifact(
+            "config",
+            "pyproject.toml",
+            """[project]
+name = "task-queue"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+task-queue = "task_queue.cli:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+""",
+        ),
+        ProgrammingArtifact(
+            "diagnostic",
+            "logs/failed-run.log",
+            """INFO request accepted job_id=demo-17
+INFO state loaded records=42 elapsed_ms=3
+WARNING retry scheduled attempt=2 delay_ms=50
+ERROR state write failed reason=temporary_io_error
+INFO request finished status=failed elapsed_ms=61""",
+        ),
+        ProgrammingArtifact(
+            "review",
+            "docs/review-notes.md",
+            """The patch must preserve insertion order, reject invalid limits,
+use atomic file replacement, and add a regression test for duplicate job
+identifiers. Avoid a new dependency when the standard library is sufficient.
+Keep error messages useful to both command-line users and automated clients.""",
+        ),
+        ProgrammingArtifact(
+            "source",
+            "src/task_queue/codec.py",
+            """import json
+from typing import Any
+
+def encode_record(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+def decode_record(raw: str) -> dict[str, Any]:
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise ValueError("record must be an object")
+    return value""",
+        ),
+        ProgrammingArtifact(
+            "test",
+            "tests/test_codec.py",
+            """from task_queue.codec import decode_record, encode_record
+
+def test_codec_is_deterministic():
+    assert encode_record({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+    assert decode_record('{"ok":true}') == {"ok": True}
+
+def test_decoder_rejects_a_list():
+    with pytest.raises(ValueError, match="object"):
+        decode_record("[]")""",
+        ),
+        ProgrammingArtifact(
+            "documentation",
+            "docs/api.md",
+            """# Command line contract
+
+The run command reads newline-delimited JSON, validates each object, and prints
+a summary. Exit code 0 means success, 2 means invalid input, and 3 means a
+storage failure. Standard output contains data; diagnostics use standard error.""",
+        ),
+        ProgrammingArtifact(
+            "config",
+            "config/example.json",
+            """{
+  "capacity": 128,
+  "retry_limit": 3,
+  "retry_delay_ms": 50,
+  "log_level": "INFO",
+  "output_path": "var/jobs.jsonl"
+}""",
+        ),
+        ProgrammingArtifact(
+            "diagnostic",
+            "docs/incident.md",
+            """# Interrupted state write
+
+A process interruption between writing data and renaming the temporary file
+left stale state. The fix must flush, fsync, and replace the destination without
+exposing partial JSON. A failed replacement must leave the old file readable.""",
+        ),
+        ProgrammingArtifact(
+            "review",
+            "docs/acceptance.md",
+            """Run unit tests, type checks, and the command-line smoke test.
+Confirm deterministic output, helpful error messages, no network access, and no
+changes to the public schema. Test both a clean run and recovery from invalid
+JSON. Record the exact command and result in the pull request.""",
+        ),
+    )
+
+
+def build_programming_context(*, minimum_characters: int) -> str:
+    """Return at least ``minimum_characters`` of deterministic repository text."""
+
+    if minimum_characters <= 0:
+        raise ValueError("minimum_characters must be positive")
+    rendered = [
+        "You are reviewing a normal Python repository. Read the source, tests, "
+        "configuration, documentation, and diagnostics before making a small, "
+        "production-safe change. Preserve public behavior and explain errors clearly."
+    ]
+    total_characters = len(rendered[0])
+    artifacts = _artifacts()
+    index = 0
+    while total_characters < minimum_characters:
+        artifact = artifacts[index % len(artifacts)]
+        generation = index // len(artifacts)
+        section = artifact.render(generation)
+        rendered.append(section)
+        total_characters += len(section)
+        index += 1
+    return "".join(rendered)
+
+
+def programming_context_stats(text: str) -> dict[str, object]:
+    """Return structural diagnostics used to qualify generated prompt context."""
+
+    paths = [
+        line.split(": ", 1)[1]
+        for line in text.splitlines()
+        if line.startswith("## Repository artifact: ")
+    ]
+    kinds = [
+        kind
+        for kind in PROGRAMMING_ARTIFACT_KINDS
+        if f"Artifact type: {kind}." in text
+    ]
+    counts = {path: paths.count(path) for path in set(paths)}
+    return {
+        "artifact_count": len(paths),
+        "artifact_kinds": kinds,
+        "largest_duplicate_count": max(counts.values(), default=0),
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    }

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -3527,6 +3527,38 @@ def trim_verified_window_to_prefix(
     return True
 
 
+def trim_verified_window_without_snapshot(
+    cache: list[Any],
+    *,
+    verified_tokens: int,
+    keep_tokens: int,
+) -> bool:
+    """Snapshot-free ``trim_verified_window_to_prefix``.
+
+    The snapshot's only role in the trim path is proving that no
+    recurrent/non-trimmable state needs restoring; when every cache entry is
+    trimmable that property holds by construction, so a skipped verify
+    snapshot (MTPLX_SKIP_VERIFY_SNAPSHOT=1) must not strand the repair.
+    Returns False for any cache carrying non-trimmable entries — those
+    genuinely need the snapshot.
+    """
+
+    if not cache:
+        return False
+    if any(not _is_trimmable(entry) for entry in cache):
+        return False
+    empty = CacheSnapshot(
+        states=tuple(None for _ in cache),
+        meta_states=tuple(None for _ in cache),
+    )
+    return trim_verified_window_to_prefix(
+        cache,
+        empty,
+        verified_tokens=verified_tokens,
+        keep_tokens=keep_tokens,
+    )
+
+
 def _entry_offset(entry: Any) -> int | None:
     offset = getattr(entry, "offset", None)
     if offset is None:

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -2611,6 +2611,15 @@ def build_parser() -> argparse.ArgumentParser:
         default="linear-gdn-from-conv-tape",
         help="Server verification core.",
     )
+    serve_p.add_argument(
+        "--draft-core",
+        choices=["stock", "device-d2", "device"],
+        default="stock",
+        help=(
+            "Server DraftCore backend. 'device' keeps the whole draft chain "
+            "on device with a single sync per cycle."
+        ),
+    )
     serve_p.add_argument("--mtp-adapter", type=Path)
     serve_p.add_argument(
         "--merge-mtp-adapter",

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -22,7 +22,7 @@ from .profiles import (
     list_profiles,
     resolve_profile_name,
 )
-from .runtime_options import normalize_paged_kv_quantization
+from .runtime_options import canonicalize_flag_tokens, normalize_paged_kv_quantization
 from .version import DISPLAY_VERSION, __version__
 
 # Help/usage advertises only the canonical profiles; the parser itself
@@ -1845,7 +1845,9 @@ class _FlagRecordingArgumentParser(argparse.ArgumentParser):
         raw = list(sys.argv[1:]) if args is None else list(args)
         parsed = super().parse_args(raw, namespace)
         if not hasattr(parsed, "_cli_flags"):
-            parsed._cli_flags = _explicit_cli_flags(raw)
+            parsed._cli_flags = canonicalize_flag_tokens(
+                _explicit_cli_flags(raw), self, parsed
+            )
         return parsed
 
 
@@ -3825,7 +3827,9 @@ def main(argv: list[str] | None = None) -> int:
     if raw_args[0] not in command_names and not raw_args[0].startswith("-"):
         return _print_unknown_command(raw_args[0])
     args = parser.parse_args(raw_args)
-    args._cli_flags = _explicit_cli_flags(raw_args)
+    args._cli_flags = canonicalize_flag_tokens(
+        _explicit_cli_flags(raw_args), parser, args
+    )
     from .config import apply_user_config
 
     apply_user_config(args)

--- a/mtplx/compile_state.py
+++ b/mtplx/compile_state.py
@@ -1,0 +1,39 @@
+"""Shared 'inside a compiled forward trace' flag (issue #51, 70 tps goal).
+
+A dependency-free home for one bit of state so `compiled_forward` (which sets it)
+and the model forwards (which read it) can agree without an import cycle.
+
+The model decode loop keeps the GPU fed during Python graph-build by calling
+`mx.async_eval` every N layers (the submit cadence). Inside an `mx.compile`
+trace that call is (a) illegal — "[async_eval] Not allowed inside a graph
+transformation" — and (b) pointless, because the whole reason to compile is to
+replace the per-layer Python walk with a single traced submission. So while a
+compiled forward is tracing/replaying, the forward checks `compile_trace_active()`
+and suppresses those scheduling-only host-syncs. Kernel math and ordering are
+unchanged; this only removes an eval whose sole job was to paper over the
+graph-build stall that compilation eliminates outright.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Iterator
+
+_COMPILE_TRACE_ACTIVE = False
+
+
+def compile_trace_active() -> bool:
+    """True while a compiled AR forward is executing (and while it traces)."""
+    return _COMPILE_TRACE_ACTIVE
+
+
+@contextlib.contextmanager
+def compile_trace() -> Iterator[None]:
+    """Mark the enclosed block as running inside a compiled forward."""
+    global _COMPILE_TRACE_ACTIVE
+    previous = _COMPILE_TRACE_ACTIVE
+    _COMPILE_TRACE_ACTIVE = True
+    try:
+        yield
+    finally:
+        _COMPILE_TRACE_ACTIVE = previous

--- a/mtplx/compiled_forward.py
+++ b/mtplx/compiled_forward.py
@@ -1,0 +1,144 @@
+"""Compiled AR decode forward for fully-resident models.
+
+Without compilation the decode loop rebuilds the model's whole MLX graph in
+Python every step; on deep MoE trunks that host-side rebuild is a double-digit
+ms/token tax against a memory floor roughly its size. This compiles the single
+target call `model(input_ids, cache=cache)` so the graph traces ONCE and
+replays.
+
+Mechanism: mx.compile cannot trace a Python object whose arrays grow each
+step, so each layer's KV cache is converted to a fixed-buffer
+`TensorOffsetKVCache` (stable graph shape via a reserved buffer + offset), and
+its 3 state leaves (keys, values, offset) are threaded as explicit compile
+inputs and outputs. N layers -> 3N threaded leaves.
+
+Correctness note: mx.compile is exact for fp32 matmul; a quantized gather_qmm
+may select a different fused kernel (sub-percent divergence from
+non-associative FP). Whether that flips tokens end-to-end is the A/B gate to
+run per model before promotion.
+
+Flag-gated (MTPLX_COMPILE_AR_FORWARD), fully-resident models only (a
+host-sync inside the forward breaks the traced region and raises on first
+call). Emits an engagement counter so a null A/B is never credited as
+control-vs-control.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+from typing import Any, Callable
+
+import mlx.core as mx
+
+from mtplx.compile_state import compile_trace
+from mtplx.graphbank import TensorOffsetKVCache
+
+# Engagement proof: incremented every time the compiled forward actually runs, so
+# an A/B can assert the compiled path fired rather than inferring it from a null.
+_COMPILED_FORWARD_CALLS = 0
+
+
+def compiled_forward_calls() -> int:
+    return _COMPILED_FORWARD_CALLS
+
+
+def _write_engagement_count_file() -> None:
+    """Persist the final call count to a file so an out-of-process A/B driver can
+    verify engagement (arm-off must read 0, arm-on > 0). The in-memory counter and
+    the runtime's diagnostic_counters never cross the subprocess boundary; the
+    benchmark does not serialize either into its JSON, so a file is the only
+    channel the driver can read. Registered at import; fires on normal exit."""
+    path = os.environ.get("MTPLX_COMPILE_AR_FORWARD_COUNT_FILE")
+    if not path:
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(str(_COMPILED_FORWARD_CALLS))
+    except OSError:
+        pass
+
+
+atexit.register(_write_engagement_count_file)
+
+
+def compile_forward_enabled() -> bool:
+    return os.environ.get("MTPLX_COMPILE_AR_FORWARD") == "1"
+
+
+class CompiledARForward:
+    """Compiles `model(input_ids, cache)` with per-layer cache state threaded.
+
+    Stateful across steps: the fixed-buffer `TensorOffsetKVCache` entries are
+    built once from the live cache and advanced in place, exactly like the live
+    KV cache would be. The compiled function reads and returns the 3N leaves so
+    mx.compile sees a pure array->array graph.
+    """
+
+    def __init__(self, model: Any, *, reserve_tokens: int) -> None:
+        self._model = model
+        self._reserve = int(reserve_tokens)
+        self._compiled: Callable[..., tuple] | None = None
+        self._n: int = 0
+        # The PERSISTENT decode state (3N leaves), owned by the wrapper — NOT
+        # by the scratch caches. The compiled fn's scratch caches are overwritten
+        # by these leaves every call, so state ownership stays unambiguous (the
+        # tangle that flipped tokens when the caches held state and were also
+        # mutated in-graph). Same discipline as the draft core's `_trace_depth`.
+        self._state: list[mx.array] | None = None
+
+    def _ensure_compiled(self, live_cache: list[Any]) -> None:
+        if self._compiled is not None:
+            return
+        self._n = len(live_cache)
+        # Scratch fixed-buffer caches, seeded from the live (primed) cache.
+        caches = [
+            TensorOffsetKVCache.from_kv_cache(entry, reserve_tokens=self._reserve)
+            for entry in live_cache
+        ]
+        # Seed the persistent state from the primed caches' current contents.
+        self._state = []
+        for cache in caches:
+            self._state.extend([cache.cache[0], cache.cache[1], cache.cache[2]])
+        model = self._model
+        n = self._n
+
+        def forward(input_ids: mx.array, *state: mx.array) -> tuple:
+            if len(state) != 3 * n:
+                raise ValueError(f"expected {3 * n} state leaves, got {len(state)}")
+            for i in range(n):
+                caches[i].cache[0] = state[3 * i]
+                caches[i].cache[1] = state[3 * i + 1]
+                caches[i].cache[2] = state[3 * i + 2]
+            logits = model(input_ids, cache=caches)
+            out: list[mx.array] = []
+            for i in range(n):
+                out.append(caches[i].cache[0])
+                out.append(caches[i].cache[1])
+                out.append(caches[i].cache[2])
+            return (logits, *out)
+
+        self._compiled = mx.compile(forward)
+
+    def __call__(self, input_ids: mx.array, cache: list[Any]) -> mx.array:
+        global _COMPILED_FORWARD_CALLS
+        self._ensure_compiled(cache)
+        try:
+            # Mark the trace so the model forward suppresses its per-layer
+            # async_eval submit cadence (illegal inside a graph transformation,
+            # and obsolete once the whole forward is one traced submission).
+            with compile_trace():
+                result = self._compiled(input_ids, *self._state)  # type: ignore[misc]
+        except Exception:
+            # The trace fires on the first call; a host-sync buried in the model
+            # forward (async_eval/eval) only surfaces here. Dump the full stack
+            # so the offending line is visible in the driver log, then re-raise.
+            if os.environ.get("MTPLX_COMPILE_AR_FORWARD_DEBUG") == "1":
+                import sys
+                import traceback
+
+                traceback.print_exc(file=sys.stderr)
+            raise
+        self._state = list(result[1:])
+        _COMPILED_FORWARD_CALLS += 1
+        return result[0]

--- a/mtplx/deepseek_mtp_patch.py
+++ b/mtplx/deepseek_mtp_patch.py
@@ -171,6 +171,32 @@ def _stack_moe_experts(weights: dict[str, Any], prefix: str, args: Any) -> None:
             weights[f"{prefix}.mlp.switch_mlp.{module}.{leaf}"] = mx.stack(values)
 
 
+def _has_complete_deepseek_mtp_payload(
+    weights: dict[str, Any],
+    *,
+    num_mtp_layers: int,
+) -> bool:
+    """Return true only when every declared DeepSeek MTP layer has real weights.
+
+    A prefix-mismatched checkpoint still yields a non-empty ``mapped`` from
+    stray keys, and ``strict=False`` then loads nothing -- injection would
+    report success while the draft head stays randomly initialized.
+    """
+
+    for local_idx in range(num_mtp_layers):
+        prefix = f"layers.{local_idx}."
+        required = (
+            f"{prefix}enorm.weight",
+            f"{prefix}hnorm.weight",
+            f"{prefix}eh_proj.weight",
+        )
+        if not all(key in weights for key in required):
+            return False
+        if not any(key.startswith(f"{prefix}mtp_block.") for key in weights):
+            return False
+    return True
+
+
 def _rewrite_deepseek_mtp_weights(
     raw: dict[str, Any],
     *,
@@ -321,7 +347,9 @@ def inject_deepseek_mtp_support(
         start_layer=int(getattr(args, "num_hidden_layers")),
         num_mtp_layers=_num_mtp_layers(config),
     )
-    if not mapped:
+    if not mapped or not _has_complete_deepseek_mtp_payload(
+        mapped, num_mtp_layers=_num_mtp_layers(config)
+    ):
         logger.warning("[DeepSeek MTP inject] No DeepSeek MTP weights found in %s", model_path)
         return False
 

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -31,6 +31,7 @@ from .session_bank import (
     SessionBank,
     block_aligned_prefix_len,
 )
+from .runtime_options import block_prefix_restore_enabled
 
 
 logger = logging.getLogger(__name__)
@@ -460,10 +461,14 @@ def _near_prefix_min_match_tokens() -> int:
 
 
 def _block_prefix_restore_enabled() -> bool:
-    raw = os.environ.get("MTPLX_SESSION_BLOCK_PREFIX_RESTORE")
-    if raw is None:
-        return True
-    return str(raw).strip().lower() not in {"0", "false", "no", "off"}
+    """The single parse of ``MTPLX_SESSION_BLOCK_PREFIX_RESTORE`` (default ON).
+
+    Shared by :mod:`mtplx.generation`, :mod:`mtplx.session_bank` and the
+    server so one spelling cannot mean ON in the decode loop and OFF in the
+    cold tier.
+    """
+
+    return block_prefix_restore_enabled()
 
 
 def _prefix_block_size() -> int:

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -31,6 +31,7 @@ from .cache_state import (
     owned_recurrent_state_stats,
     restore_cache,
     rollback_after_verify,
+    trim_verified_window_without_snapshot,
     snapshot_cache,
     snapshot_untrimmable_cache,
     tail_owned_attention_kv_stats,
@@ -8325,6 +8326,26 @@ def generate_mtpk(
             committed_from_trim = trim_verified_window_to_prefix(
                 cache,
                 before_verify,
+                verified_tokens=len(verify_input),
+                keep_tokens=committed_prefix_len,
+            )
+            elapsed_trim_commit = time.perf_counter() - started_trim_commit
+            if committed_from_trim:
+                commit_time += elapsed_trim_commit
+                _add_timing(event, "trim_commit", elapsed_trim_commit)
+        if (
+            not committed_from_capture
+            and not committed_from_trim
+            and before_verify is None
+        ):
+            # The verify snapshot was skipped (MTPLX_SKIP_VERIFY_SNAPSHOT=1,
+            # the product-profile default) and no capture/trim lane committed.
+            # All-trimmable caches can still repair exactly by trimming the
+            # uncommitted verify tail — without this, the first rejection on
+            # such a lane raised and killed the request.
+            started_trim_commit = time.perf_counter()
+            committed_from_trim = trim_verified_window_without_snapshot(
+                cache,
                 verified_tokens=len(verify_input),
                 keep_tokens=committed_prefix_len,
             )

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1352,6 +1352,41 @@ class _DecodeTrace:
         }
 
 
+_AR_FORWARD_PROFILE: Any = None
+
+
+def _ar_forward_profiler(step: int) -> Any:
+    """Diagnostic lane: MTPLX_AR_PROFILE_TOKENS=N cProfiles decode forwards
+    for steps [8, 8+N) and dumps pstats to MTPLX_AR_PROFILE_PATH at the
+    last profiled step. Off (None) unless the env is set; throughput
+    measured with this enabled is not promotion evidence."""
+
+    global _AR_FORWARD_PROFILE
+    raw = os.environ.get("MTPLX_AR_PROFILE_TOKENS")
+    if not raw:
+        return None
+    try:
+        budget = int(raw)
+    except ValueError:
+        return None
+    first, last = 8, 8 + budget
+    if not first <= step < last:
+        if step == last and _AR_FORWARD_PROFILE is not None:
+            import pstats
+
+            path = os.environ.get(
+                "MTPLX_AR_PROFILE_PATH", "/tmp/mtplx-ar-forward.pstats"
+            )
+            pstats.Stats(_AR_FORWARD_PROFILE).dump_stats(path)
+            _AR_FORWARD_PROFILE = None
+        return None
+    if _AR_FORWARD_PROFILE is None:
+        import cProfile
+
+        _AR_FORWARD_PROFILE = cProfile.Profile()
+    return _AR_FORWARD_PROFILE
+
+
 def _batch_target_distributions_enabled() -> bool:
     return os.environ.get("MTPLX_BATCH_TARGET_DISTS", "").lower() in {
         "1",
@@ -4706,12 +4741,17 @@ def generate_ar(
             break
 
         started = time.perf_counter()
+        profiler = _ar_forward_profiler(step)
         with attention_phase("ar_decode"):
+            if profiler is not None:
+                profiler.enable()
             result_next = rt.forward_ar(
                 mx.array([[token]]),
                 cache=cache,
                 return_hidden=ar_return_hidden,
             )
+            if profiler is not None:
+                profiler.disable()
         if ar_return_hidden:
             logits_next, hidden_next = result_next
         else:

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -982,8 +982,14 @@ class _DecodeTrace:
             self.path.parent.mkdir(parents=True, exist_ok=True)
 
     def _delta(self, totals: dict[str, Any], key: str) -> Any:
-        value = totals[key]
-        previous = self.last_totals[key]
+        # Lanes maintain different counter sets (AR omits MTP-only keys);
+        # a counter absent on either side is a zero delta, not an error.
+        value = totals.get(key)
+        previous = self.last_totals.get(key)
+        if value is None:
+            value = previous if previous is not None else 0
+        if previous is None:
+            previous = [0.0] * len(value) if isinstance(value, list) else 0
         if isinstance(value, list):
             return [(float(item) - float(prev)) for item, prev in zip(value, previous)]
         return value - previous

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -66,6 +66,7 @@ from .sampling import (
     sample_from_distribution,
 )
 from .session_bank import _boundary_true_restore_enabled
+from .runtime_options import block_prefix_restore_enabled, env_bool
 
 Mode = Literal["ar", "mtp1", "mtpk", "mtpa"]
 VerifyStrategy = Literal[
@@ -183,6 +184,18 @@ def _env_falsey(name: str) -> bool:
         "no",
         "off",
     }
+
+
+def _skip_verify_snapshot() -> bool:
+    """The single parse of ``MTPLX_SKIP_VERIFY_SNAPSHOT`` (default OFF).
+
+    The serve fast path force-sets this to "1"; whether that is safe is
+    decided by the verify strategy, and the server now answers that from an
+    explicit list of strategies known to survive without the snapshot
+    rather than from a two-element list of the ones that need it.
+    """
+
+    return env_bool("MTPLX_SKIP_VERIFY_SNAPSHOT", default=False)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -644,12 +657,13 @@ def _sustained_prefill_layout() -> str:
     )
     if layout != "auto":
         return layout
-    kv_quant = (
-        os.environ.get("MTPLX_VLLM_METAL_PAGED_KV_QUANT")
-        or os.environ.get("MTPLX_PAGED_KV_QUANT")
-        or ""
-    ).strip().lower().replace("-", "_")
-    if kv_quant in {"q8", "q8_0", "int8", "q4", "q4_0", "int4"}:
+    # Canonicalize through the one parser: a raw membership test here missed
+    # documented spellings ("8", "8bit", "uint8") that the rest of the stack
+    # honours as q8, and silently picked the dense-decode layout for a
+    # quantized cache.
+    from .kv_quant import paged_kv_quant_mode_from_env
+
+    if paged_kv_quant_mode_from_env() != "off":
         return "contiguous_then_repage"
     context_tokens = _env_int("MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS", 0)
     dense_max = _env_int("MTPLX_SUSTAINED_DENSE_DECODE_MAX_CONTEXT", 131072)
@@ -1261,7 +1275,7 @@ class _DecodeTrace:
             "lazy_mtp_history_append": _env_truthy("MTPLX_LAZY_MTP_HISTORY_APPEND"),
             "batch_target_arrays": _batch_target_arrays_enabled(),
             "drop_events": _env_truthy("MTPLX_DROP_EVENTS"),
-            "skip_verify_snapshot": _env_truthy("MTPLX_SKIP_VERIFY_SNAPSHOT"),
+            "skip_verify_snapshot": _skip_verify_snapshot(),
             "mtp_history_materialize_every": int(mtp_history_materialize_every),
             "mtp_history_materialize_events": int(mtp_history_materialize_events),
             "clear_cache_every": int(_clear_cache_every()),
@@ -2295,13 +2309,8 @@ def _restore_near_prefix_prompt_state(
         return None
     max_gap = max(0, _env_int("MTPLX_SESSION_NEAR_PREFIX_MAX_TOKEN_GAP", 8))
     min_match = max(1, _env_int("MTPLX_SESSION_NEAR_PREFIX_MIN_MATCH_TOKENS", 64))
-    block_prefix_raw = os.environ.get("MTPLX_SESSION_BLOCK_PREFIX_RESTORE")
     block_prefix_enabled = (
-        (
-            True
-            if block_prefix_raw is None
-            else not _env_falsey("MTPLX_SESSION_BLOCK_PREFIX_RESTORE")
-        )
+        block_prefix_restore_enabled()
         if allow_block_prefix is None
         else bool(allow_block_prefix)
     )
@@ -7479,7 +7488,7 @@ def generate_mtpk(
                     break
 
         before_verify = None
-        if _env_truthy("MTPLX_SKIP_VERIFY_SNAPSHOT"):
+        if _skip_verify_snapshot():
             event["snapshot"] = "skipped_capture_commit_required"
         else:
             started = time.perf_counter()

--- a/mtplx/hy_v3_mtp_patch.py
+++ b/mtplx/hy_v3_mtp_patch.py
@@ -1,31 +1,35 @@
-"""Hy3 (hy_v3) native MTP support injection.
+"""Hy3 (hy_v3) MTP support injection.
 
-Unlike families whose MTP layers must be grafted on at load time, the mlx-lm
-hy_v3 model class (MTP revision) already owns its MTP head: with
-``num_nextn_predict_layers > 0`` the checkpoint's mtp.* weights load onto an
-``MTPBlock`` submodule natively. Injection therefore installs the MTPLX
-runtime surface (``mtp_forward`` / ``mtp_update_cache`` / ``make_mtp_cache``,
-plus ``return_hidden`` on the trunk forward) as a subclass wrapper over the
-already-loaded model — no weight rewriting.
+Real hy_v3 exports ship the appended NextN layer in tencent-native layout —
+canonical ``model.layers.{num_hidden_layers}.*`` tensors inside the standard
+sharded checkpoint. The released mlx-lm hy_v3 model class (the #1211 line)
+loads the trunk only and sanitizes those tensors away, so injection grafts the
+draft head from the checkpoint itself: build the module (enorm/hnorm/eh_proj +
+one DecoderLayer + final_layernorm), load and (per config) quantize its
+weights, and install the MTPLX runtime surface (``mtp_forward`` /
+``mtp_update_cache`` / ``make_mtp_cache``, plus ``return_hidden`` on the trunk
+forward) as a subclass wrapper.
+
+When a future mlx-lm loads the head natively (``model.mtp`` present), the
+graft is skipped and the same wrapper binds the native module unchanged.
 
 Architecture contract (must match the checkpoint):
 - one appended NextN layer (depth 1) with its own MoE MLP;
 - draft input is concat[enorm(next-token embedding), hnorm(trunk hidden)]
   with the trunk hidden taken PRE-final-norm ("embedding_hidden" order);
 - shared embeddings and lm_head.
-
-Status: experimental — pending hy_v3 landing in the pinned mlx-lm
-(ml-explore/mlx-lm#1211 + MTP follow-up) and a hardware-measured runtime
-contract.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_TOP_LEVEL_MTP_PARTS = ("enorm", "hnorm", "eh_proj", "final_layernorm")
 
 
 def is_hy_v3_mtp_config(config: dict[str, Any]) -> bool:
@@ -34,6 +38,134 @@ def is_hy_v3_mtp_config(config: dict[str, Any]) -> bool:
     if model_type != "hy_v3" and "HyV3ForCausalLM" not in architectures:
         return False
     return int(config.get("num_nextn_predict_layers") or 0) > 0
+
+
+def _num_trunk_layers(config: dict[str, Any], model: Any = None) -> int:
+    declared = config.get("num_hidden_layers")
+    if declared is not None:
+        return int(declared)
+    return len(model.model.layers)
+
+
+def _spec_layer_prefix(config: dict[str, Any], model: Any = None) -> str:
+    return f"model.layers.{_num_trunk_layers(config, model)}."
+
+
+def _load_appended_layer_weights(
+    model_path: Path, config: dict[str, Any], model: Any = None
+) -> dict[str, Any]:
+    """Read the NextN layer's tensors from the standard sharded checkpoint.
+
+    Returns them renamed for the grafted module: ``enorm/hnorm/eh_proj/
+    final_layernorm`` stay top-level, everything else (attention, MoE, layer
+    norms) moves under ``layer.``. Empty dict when the checkpoint carries no
+    appended layer (AR-only export).
+    """
+    import mlx.core as mx
+
+    prefix = _spec_layer_prefix(config, model)
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+        shards = sorted({v for k, v in weight_map.items() if k.startswith(prefix)})
+        candidates = [model_path / s for s in shards]
+    else:
+        candidates = sorted(model_path.glob("model*.safetensors"))
+
+    raw: dict[str, Any] = {}
+    for file in candidates:
+        for key, value in mx.load(str(file)).items():
+            if key.startswith(prefix):
+                raw[key] = value
+
+    mapped: dict[str, Any] = {}
+    for key, value in raw.items():
+        suffix = key.removeprefix(prefix)
+        if suffix.split(".", 1)[0] in _TOP_LEVEL_MTP_PARTS:
+            mapped[suffix] = value
+        else:
+            mapped[f"layer.{suffix}"] = value
+    return mapped
+
+
+def _make_grafted_mtp(args: Any, spec_idx: int):
+    import mlx.nn as nn
+    from mlx_lm.models import hy_v3 as impl
+
+    class _HyV3GraftedMTP(nn.Module):
+        """Checkpoint-grafted NextN head; call-compatible with the native block."""
+
+        def __init__(self):
+            super().__init__()
+            self.enorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            self.hnorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            self.eh_proj = nn.Linear(
+                args.hidden_size * 2, args.hidden_size, bias=False
+            )
+            self.layer = impl.DecoderLayer(args, layer_idx=spec_idx)
+            self.final_layernorm = nn.RMSNorm(
+                args.hidden_size, eps=args.rms_norm_eps
+            )
+
+        def __call__(self, hidden_states, e_next, mask, cache=None):
+            import mlx.core as mx
+
+            mixed = self.eh_proj(
+                mx.concatenate(
+                    [self.enorm(e_next), self.hnorm(hidden_states)], axis=-1
+                )
+            )
+            # pre-final-norm draft hidden; the head path applies
+            # final_layernorm before the shared lm_head.
+            return self.layer(mixed, mask, cache=cache)
+
+    return _HyV3GraftedMTP()
+
+
+def _quantize_grafted_mtp(
+    mtp: Any, config: dict[str, Any], weights: dict[str, Any], spec_prefix: str
+) -> None:
+    """Quantize grafted modules whose checkpoint tensors are quantized.
+
+    Per-module entries in ``config["quantization"]`` (keyed by the original
+    ``model.layers.{N}.<module>`` path) take precedence over the global
+    group_size/bits — real exports quantize the draft head at a different
+    precision than the 2-bit expert body.
+    """
+    import mlx.nn as nn
+
+    quantization = config.get("quantization") or config.get("quantization_config")
+    if not quantization:
+        return
+    prefix = spec_prefix
+
+    def class_predicate(path: str, module: Any):
+        if not hasattr(module, "to_quantized"):
+            return False
+        if f"{path}.scales" not in weights:
+            return False
+        original = prefix + (
+            path.removeprefix("layer.") if path.startswith("layer.") else path
+        )
+        spec = quantization.get(original) or quantization
+        try:
+            return {
+                "group_size": int(spec["group_size"]),
+                "bits": int(spec["bits"]),
+                "mode": spec.get("mode", "affine"),
+            }
+        except (KeyError, TypeError, ValueError):
+            return False
+
+    if "group_size" not in quantization or "bits" not in quantization:
+        return
+    nn.quantize(
+        mtp,
+        group_size=int(quantization["group_size"]),
+        bits=int(quantization["bits"]),
+        mode=quantization.get("mode", "affine"),
+        class_predicate=class_predicate,
+    )
 
 
 def inject_hy_v3_mtp_support(
@@ -45,33 +177,54 @@ def inject_hy_v3_mtp_support(
     """Install the MTPLX draft surface on an already-loaded hy_v3 model.
 
     Returns True when the model exposes a usable MTP head. Raises if the
-    config promises MTP but the loaded model cannot draft (an AR-only export
-    with the sidecar stripped, or an mlx-lm predating hy_v3 MTP support).
+    config promises MTP but neither a native ``model.mtp`` submodule nor
+    appended-layer checkpoint tensors exist (an AR-only export).
     """
     if not is_hy_v3_mtp_config(config):
         return False
 
-    if getattr(model, "num_nextn_predict_layers", 0) <= 0 or not hasattr(model, "mtp"):
-        raise RuntimeError(
-            f"{path}: config declares num_nextn_predict_layers="
-            f"{config.get('num_nextn_predict_layers')} but the loaded model has "
-            "no MTP submodule. The checkpoint is likely an AR-only export "
-            "(model-mtp.safetensors absent) or the installed mlx-lm predates "
-            "hy_v3 MTP support."
-        )
+    import inspect
 
+    import mlx.core as mx
     from mlx_lm.models.base import create_attention_mask
     from mlx_lm.models.cache import KVCache
 
+    path = Path(path)
+    native = getattr(model, "mtp", None) is not None
+    grafted = None
+    if not native:
+        weights = _load_appended_layer_weights(path, config, model)
+        if not weights:
+            raise RuntimeError(
+                f"{path}: config declares num_nextn_predict_layers="
+                f"{config.get('num_nextn_predict_layers')} but the checkpoint "
+                f"carries no {_spec_layer_prefix(config, model)}* tensors and the "
+                "loaded model has no native MTP submodule — an AR-only export."
+            )
+        args = getattr(model, "args", None)
+        if args is None:
+            from mlx_lm.models import hy_v3 as impl
+
+            args = impl.ModelArgs.from_dict(config)
+        grafted = _make_grafted_mtp(args, _num_trunk_layers(config, model))
+        _quantize_grafted_mtp(
+            grafted, config, weights, _spec_layer_prefix(config, model)
+        )
+        grafted.load_weights(list(weights.items()), strict=True)
+        mx.eval(grafted.parameters())
+
     # validate_mtp_support (mtp_patch.py) requires model.mtp.layers to be a
-    # truthy container; the native mlx-lm MTPBlock exposes its single decoder
-    # as `.layer`. Expose a `.layers` alias (assigning a list to an nn.Module
-    # attribute registers it as a child-module container — an alias, not a
-    # weight copy) so the validator and any depth-indexing caller see a
-    # 1-element list.
+    # truthy container; both the native MTPBlock and the graft expose their
+    # single decoder as `.layer`. The list assignment registers an alias (a
+    # child-module container), not a weight copy.
+    if grafted is not None:
+        model.mtp = grafted
     if getattr(model.mtp, "layers", None) is None:
         model.mtp.layers = [model.mtp.layer]
 
+    native_return_hidden = "return_hidden_states" in inspect.signature(
+        type(model).__call__
+    ).parameters
     original_outer_class = model.__class__
 
     # Hy3 has exactly one native draft wiring (pre-final-norm trunk hidden,
@@ -90,9 +243,14 @@ def inject_hy_v3_mtp_support(
             # branch). Replicate that directly here -- calling
             # make_prompt_cache(self) would recurse, since it dispatches back
             # to this very method once it sees the model has a make_cache.
-            from mlx_lm.models.cache import KVCache
-
             return [KVCache() for _ in self.model.layers]
+
+        def _head_logits(self, hidden):
+            if getattr(self.args, "enable_lm_head_fp32", False):
+                hidden = hidden.astype(mx.float32)
+            if getattr(self.args, "tie_word_embeddings", False):
+                return self.model.embed_tokens.as_linear(hidden)
+            return self.lm_head(hidden)
 
         def __call__(
             self,
@@ -105,12 +263,33 @@ def inject_hy_v3_mtp_support(
         ):
             if input_embeddings is not None:
                 raise ValueError("Hy3 MTP backend does not support input_embeddings")
-            if return_hidden:
+            if not return_hidden:
+                return super().__call__(inputs, cache=cache)
+            if native_return_hidden:
                 # hy_v3's native forward already returns (logits, pre-norm h)
                 return super().__call__(
                     inputs, cache=cache, return_hidden_states=True
                 )
-            return super().__call__(inputs, cache=cache)
+            # Released hy_v3 has no return_hidden_states: walk the trunk
+            # keeping the PRE-final-norm hidden the draft layer consumes.
+            inner = self.model
+            if getattr(inner, "pipeline_size", 1) > 1:
+                raise ValueError(
+                    "Hy3 MTP return_hidden is single-rank only (pipeline off)"
+                )
+            h = inner.embed_tokens(inputs)
+            if cache is None:
+                cache = [None] * len(inner.layers)
+            mask = create_attention_mask(h, cache[0])
+            for layer, c in zip(inner.layers, cache):
+                h = layer(h, mask, cache=c)
+            return self._head_logits(inner.norm(h)), h
+
+        def _hy3_mtp_logits(self, h_mtp):
+            native_logits = getattr(self, "_logits", None)
+            if callable(native_logits):
+                return native_logits(h_mtp)
+            return self._head_logits(self.mtp.final_layernorm(h_mtp))
 
         def mtp_forward(
             self,
@@ -129,11 +308,10 @@ def inject_hy_v3_mtp_support(
             layer_cache = mtp_cache if mtp_cache is not None else cache
             if isinstance(layer_cache, list):
                 layer_cache = layer_cache[0] if layer_cache else None
-            # replicate Model.predict_next_tokens, keeping the draft hidden
             e_next = self.model.embed_tokens(next_token_ids)
             mask = create_attention_mask(e_next, layer_cache)
             h_mtp = self.mtp(hidden_states, e_next, mask, layer_cache)
-            logits = self._logits(h_mtp)
+            logits = self._hy3_mtp_logits(h_mtp)
             if not return_hidden:
                 return logits
             return logits, h_mtp
@@ -161,5 +339,9 @@ def inject_hy_v3_mtp_support(
             return [KVCache()]
 
     model.__class__ = _MTPLXHyV3Model
-    logger.info("[Hy3 MTP inject] native head bound (depth 1) for %s", path)
+    logger.info(
+        "[Hy3 MTP inject] %s head bound (depth 1) for %s",
+        "native" if native else "checkpoint-grafted",
+        path,
+    )
     return True

--- a/mtplx/hy_v3_mtp_patch.py
+++ b/mtplx/hy_v3_mtp_patch.py
@@ -16,7 +16,11 @@ graft is skipped and the same wrapper binds the native module unchanged.
 Architecture contract (must match the checkpoint):
 - one appended NextN layer (depth 1) with its own MoE MLP;
 - draft input is concat[enorm(next-token embedding), hnorm(trunk hidden)]
-  with the trunk hidden taken PRE-final-norm ("embedding_hidden" order);
+  with the trunk hidden taken POST-final-norm ("embedding_hidden" order).
+  Measured, not assumed: teacher-forced draft/target argmax agreement on a
+  1024-token real-code prompt is 0.773 with the post-norm hidden vs 0.387
+  pre-norm (and 0.000 with the concat order flipped) — the checkpoint's head
+  was trained on the normed trunk output;
 - shared embeddings and lm_head.
 """
 
@@ -266,12 +270,15 @@ def inject_hy_v3_mtp_support(
             if not return_hidden:
                 return super().__call__(inputs, cache=cache)
             if native_return_hidden:
-                # hy_v3's native forward already returns (logits, pre-norm h)
-                return super().__call__(
+                # A native forward returns the raw (pre-norm) trunk hidden;
+                # normalize it to match the measured draft contract.
+                logits, h = super().__call__(
                     inputs, cache=cache, return_hidden_states=True
                 )
-            # Released hy_v3 has no return_hidden_states: walk the trunk
-            # keeping the PRE-final-norm hidden the draft layer consumes.
+                return logits, self.model.norm(h)
+            # Released hy_v3 has no return_hidden_states: walk the trunk and
+            # hand back the POST-final-norm hidden the draft layer consumes
+            # (measured contract — see module docstring).
             inner = self.model
             if getattr(inner, "pipeline_size", 1) > 1:
                 raise ValueError(
@@ -283,7 +290,8 @@ def inject_hy_v3_mtp_support(
             mask = create_attention_mask(h, cache[0])
             for layer, c in zip(inner.layers, cache):
                 h = layer(h, mask, cache=c)
-            return self._head_logits(inner.norm(h)), h
+            normed = inner.norm(h)
+            return self._head_logits(normed), normed
 
         def _hy3_mtp_logits(self, h_mtp):
             native_logits = getattr(self, "_logits", None)
@@ -299,7 +307,7 @@ def inject_hy_v3_mtp_support(
             mtp_cache=None,
             concat_order=None,
             return_hidden: bool = False,
-            mtp_hidden_variant: str = "pre_norm",
+            mtp_hidden_variant: str = "post_norm",
             position_offset: int | None = None,
             mtp_depth: int | None = None,
         ):

--- a/mtplx/kv_quant.py
+++ b/mtplx/kv_quant.py
@@ -40,23 +40,30 @@ def env_enabled(name: str, *, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def config_from_env() -> PagedKVQuantConfig | None:
+def paged_kv_quant_mode_from_env() -> str:
+    """The single parse of the paged-KV-quant env pair, canonicalized.
+
+    Returns one of ``off``/``q8``/``q4``. Every reader goes through
+    :func:`~mtplx.runtime_options.normalize_paged_kv_quantization`, so
+    spellings like ``8``/``8bit``/``uint8`` cannot normalize in one reader,
+    raise in a second, and fall through to the wrong KV layout in a third.
+    """
+
+    from mtplx.runtime_options import normalize_paged_kv_quantization
+
     raw = (
         os.environ.get("MTPLX_VLLM_METAL_PAGED_KV_QUANT")
         or os.environ.get("MTPLX_PAGED_KV_QUANT")
         or ""
-    ).strip().lower().replace("-", "_")
-    if raw in {"", "0", "false", "no", "off", "none"}:
+    )
+    return str(normalize_paged_kv_quantization(raw))
+
+
+def config_from_env() -> PagedKVQuantConfig | None:
+    mode = paged_kv_quant_mode_from_env()
+    if mode == "off":
         return None
-    if raw in {"q8_0", "int8"}:
-        raw = "q8"
-    if raw in {"q4_0", "int4"}:
-        raw = "q4"
-    if raw not in {"q8", "q4"}:
-        raise ValueError(
-            f"Unsupported paged KV quantization mode {raw!r}; available=['off', 'q8', 'q4']"
-        )
-    return PagedKVQuantConfig(mode=raw)
+    return PagedKVQuantConfig(mode=mode)
 
 
 def packed_dim(head_dim: int, bits: int) -> int:

--- a/mtplx/loop_guard.py
+++ b/mtplx/loop_guard.py
@@ -55,6 +55,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from .runtime_options import env_bool
+
 __all__ = [
     "LoopGuard",
     "LoopGuardConfig",
@@ -154,6 +156,19 @@ def tool_call_marker_ids(tokenizer: Any) -> tuple[int, int] | None:
     return open_id, close_id
 
 
+def loop_guard_enabled_from_env(*, default: bool) -> bool:
+    """The single parse of ``MTPLX_LOOP_GUARD``.
+
+    ``default`` is the caller's product default (OFF on the serve path);
+    the env var overrides in either direction. The server used to answer
+    this question with a *lease-token* vocabulary that counted "none" and
+    "unlimited" as off, so ``MTPLX_LOOP_GUARD=unlimited`` made the server
+    report the guard disabled while this module built it enabled.
+    """
+
+    return env_bool("MTPLX_LOOP_GUARD", default=default)
+
+
 def loop_guard_config_from_env(
     enabled: bool,
     *,
@@ -166,9 +181,7 @@ def loop_guard_config_from_env(
     ``tokenizer`` (when provided) resolves the tool-call marker tokens for
     span masking; ``MTPLX_LOOP_GUARD_MASK_TOOL_CALLS=0`` turns masking off.
     """
-    raw = os.environ.get("MTPLX_LOOP_GUARD")
-    if raw is not None and raw.strip() != "":
-        enabled = raw.strip().lower() not in {"0", "false", "off", "no"}
+    enabled = loop_guard_enabled_from_env(default=enabled)
     if not enabled:
         return LoopGuardConfig(enabled=False)
     markers: tuple[int, int] | None = None

--- a/mtplx/metadata_scrub.py
+++ b/mtplx/metadata_scrub.py
@@ -1,0 +1,125 @@
+"""Strip machine-identifying provenance from artifact metadata before publish.
+
+Forge stamps ``mtplx_runtime.json`` with the absolute paths it read and wrote
+(``forge_inputs``), plus the operator's intended Hugging Face repo. Those are
+useful locally and leak a home directory once uploaded. The helpers here
+normalize such values without discarding the provenance that a downstream user
+actually needs (source repo, source SHA, recipe, versions).
+
+Pure standard library so it can run anywhere a manifest can be read.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+
+#: Provenance keys removed outright — they name only local locations.
+DROPPED_PROVENANCE_KEYS = ("intended_hf_repo",)
+
+#: Replacement stand-in for a scrubbed absolute path.
+REDACTED_PATH = "<redacted>"
+
+#: Keys whose values are paths that should be reduced to a basename.
+_PATH_KEY_RE = re.compile(r"(^|_)(path|dir|directory|file|root|location)s?$")
+
+_HOME_PREFIX_RE = re.compile(r"^(/Users/|/home/|/var/folders/|/private/var/folders/)")
+_ABSOLUTE_PATH_IN_TEXT_RE = re.compile(
+    r"(?:/Users/|/home/|/private/var/folders/|/var/folders/)[^\s\"';,)]*"
+)
+
+
+def _looks_like_local_path(value: str) -> bool:
+    if not value:
+        return False
+    if value.startswith("~"):
+        return True
+    return value.startswith("/") or bool(_HOME_PREFIX_RE.match(value))
+
+
+def scrub_path_value(value: str) -> str:
+    """Reduce an absolute local path to a non-identifying stand-in.
+
+    A path keeps its final component (``experts.bin``,
+    ``hy3-q4-mlx-mtp``) because that names the artifact, not the machine.
+    Everything above it is dropped.
+    """
+
+    if not _looks_like_local_path(value):
+        return value
+    name = Path(value.rstrip("/")).name
+    return f"{REDACTED_PATH}/{name}" if name else REDACTED_PATH
+
+
+def scrub_text_value(value: str) -> str:
+    """Redact absolute local paths embedded inside a free-text string."""
+
+    return _ABSOLUTE_PATH_IN_TEXT_RE.sub(
+        lambda match: scrub_path_value(match.group(0)), value
+    )
+
+
+def _scrub_value(key: str | None, value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            child_key: _scrub_value(child_key, child_value)
+            for child_key, child_value in value.items()
+            if child_key not in DROPPED_PROVENANCE_KEYS
+        }
+    if isinstance(value, list):
+        return [_scrub_value(key, item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_value(key, item) for item in value)
+    if isinstance(value, str):
+        if key is not None and _PATH_KEY_RE.search(key) and _looks_like_local_path(value):
+            return scrub_path_value(value)
+        if _looks_like_local_path(value):
+            return scrub_path_value(value)
+        return scrub_text_value(value)
+    return value
+
+
+def scrub_runtime_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Return a publish-safe copy of a runtime-metadata dict.
+
+    - Absolute local paths (``/Users/...``, ``/home/...``, temp dirs) are cut
+      down to ``<redacted>/<basename>``, wherever they appear — as a value, a
+      list element, or embedded in a longer string.
+    - Machine-identifying provenance keys (``intended_hf_repo``) are removed.
+    - Everything else, including ``source_repo``, ``source_sha``,
+      ``forge_recipe`` and version stamps, is preserved verbatim.
+
+    The input dict is never mutated.
+    """
+
+    if not isinstance(metadata, dict):
+        raise TypeError("runtime metadata must be a dict")
+    return _scrub_value(None, metadata)
+
+
+def runtime_metadata_leaks(metadata: Any) -> list[str]:
+    """Return every absolute local path still present in ``metadata``.
+
+    Intended as a publish-time assertion: an empty list means the payload
+    carries no home-directory or temp-directory paths.
+    """
+
+    leaks: list[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for child in value.values():
+                walk(child)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                walk(item)
+        elif isinstance(value, str):
+            if _looks_like_local_path(value):
+                leaks.append(value)
+            else:
+                leaks.extend(_ABSOLUTE_PATH_IN_TEXT_RE.findall(value))
+
+    walk(metadata)
+    return leaks

--- a/mtplx/mimo_mtp_patch.py
+++ b/mtplx/mimo_mtp_patch.py
@@ -67,6 +67,33 @@ def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Pa
     return sorted(model_path.glob("model*.safetensors"))
 
 
+def _has_complete_mimo_mtp_payload(
+    weights: dict[str, Any],
+    *,
+    num_mtp_layers: int,
+) -> bool:
+    """Return true only when every declared MiMo MTP layer has real weights.
+
+    A prefix-mismatched checkpoint still yields a non-empty ``mapped`` from
+    stray keys, and ``strict=False`` then loads nothing -- injection would
+    report success while the draft head stays randomly initialized.
+    """
+
+    for local_idx in range(num_mtp_layers):
+        prefix = f"layers.{local_idx}."
+        required = (
+            f"{prefix}token_layernorm.weight",
+            f"{prefix}hidden_layernorm.weight",
+            f"{prefix}input_proj.weight",
+            f"{prefix}final_layernorm.weight",
+        )
+        if not all(key in weights for key in required):
+            return False
+        if not any(key.startswith(f"{prefix}mtp_block.") for key in weights):
+            return False
+    return True
+
+
 def _rewrite_mimo_mtp_weights(
     raw: dict[str, Any],
     *,
@@ -207,7 +234,9 @@ def inject_mimo_mtp_support(
         start_layer=int(getattr(args, "num_hidden_layers")),
         num_mtp_layers=_num_mtp_layers(config),
     )
-    if not mapped:
+    if not mapped or not _has_complete_mimo_mtp_payload(
+        mapped, num_mtp_layers=_num_mtp_layers(config)
+    ):
         logger.warning("[MiMo MTP inject] No MiMo MTP weights found in %s", model_path)
         return False
 

--- a/mtplx/nemotron_h_mtp_patch.py
+++ b/mtplx/nemotron_h_mtp_patch.py
@@ -125,6 +125,29 @@ def _stack_moe_experts(weights: dict[str, Any], prefix: str, n_routed_experts: i
             weights[f"{prefix}.mixer.switch_mlp.{target}.{leaf}"] = mx.stack(values)
 
 
+def _has_complete_nemotron_h_mtp_payload(
+    weights: dict[str, Any],
+    *,
+    physical_layers: int,
+) -> bool:
+    """Return true only when every Nemotron-H MTP layer has real weights.
+
+    A prefix-mismatched checkpoint still yields a non-empty ``mapped`` from
+    stray keys, and ``strict=False`` then loads nothing -- injection would
+    report success while the draft head stays randomly initialized. Only
+    ``norm`` and ``mixer`` are unconditional per block; enorm/hnorm/eh_proj
+    and final_layernorm depend on the block's position flags.
+    """
+
+    for local_idx in range(physical_layers):
+        prefix = f"layers.{local_idx}."
+        if f"{prefix}norm.weight" not in weights:
+            return False
+        if not any(key.startswith(f"{prefix}mixer.") for key in weights):
+            return False
+    return True
+
+
 def _rewrite_nemotron_h_mtp_weights(
     raw: dict[str, Any],
     *,
@@ -289,7 +312,9 @@ def inject_nemotron_h_mtp_support(
         start_layer=int(getattr(args, "num_hidden_layers")),
         physical_layers=len(mtp.layers),
     )
-    if not mapped:
+    if not mapped or not _has_complete_nemotron_h_mtp_payload(
+        mapped, physical_layers=len(mtp.layers)
+    ):
         logger.warning("[Nemotron-H MTP inject] No Nemotron-H MTP weights found in %s", model_path)
         return False
 

--- a/mtplx/optimization_profiles.py
+++ b/mtplx/optimization_profiles.py
@@ -1,0 +1,222 @@
+"""Per-model optimization-profile registry.
+
+Every serving optimization measured on large models is model-conditional:
+the knob that buys one family double-digit throughput is meaningless (or
+harmful) on another. This module records those MEASURED decisions as
+reviewable in-repo data — a change to a default is a diff to this file, with
+the measurement named in ``provenance``.
+
+Profiles are not an autotuner. Entries carry one of four states:
+
+- ``default_on``: measured win; the value is the recommended default.
+- ``default_off``: applicable but measured harmful (or a null); leave off.
+- ``not_applicable``: structurally meaningless or measured net-negative at
+  the operating envelope — see the entry's provenance for which.
+- ``unvalidated``: mechanism exists but no end-to-end measurement backs a
+  default either way.
+
+Consumers are read-only and advisory: ``resolve_profile_defaults`` lets
+benchmark/serving surfaces print a "profile suggests" note when explicit
+flags conflict with a measured default (warning only; no behavior change),
+and ``not_applicable_violations`` lets a loader refuse a knob the registry
+marks structurally wrong for the model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+VALID_STATES = ("default_on", "default_off", "not_applicable", "unvalidated")
+
+KNOB_NAMES = (
+    "proj_quant",
+    "proj_requant",
+    "kv_quant",
+    "mtp_history_policy",
+    "draft_core",
+    "verify_strategy",
+    "speculative_depth",
+    "compile_ar_forward",
+)
+
+ENFORCEABLE_KNOBS = frozenset({"proj_quant", "proj_requant", "kv_quant"})
+
+
+@dataclass(frozen=True)
+class KnobEntry:
+    """One measured (or explicitly unmeasured) per-model knob decision."""
+
+    state: str
+    value: Any
+    provenance: str
+
+    def __post_init__(self) -> None:
+        if self.state not in VALID_STATES:
+            raise ValueError(
+                f"state must be one of {VALID_STATES}, got {self.state!r}"
+            )
+        if not isinstance(self.provenance, str) or not self.provenance.strip():
+            raise ValueError(
+                "provenance must name the measurement (date + config + "
+                "delta) or say why none exists; empty provenance is a "
+                "registry defect"
+            )
+
+
+@dataclass(frozen=True, eq=False)
+class OptimizationProfile:
+    """Complete knob decision set for one model_key."""
+
+    model_key: str
+    knobs: Mapping[str, KnobEntry]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model_key, str) or not self.model_key:
+            raise ValueError("model_key must be a non-empty string")
+        if not isinstance(self.knobs, Mapping):
+            raise ValueError("knobs must be a mapping")
+        unknown = set(self.knobs) - set(KNOB_NAMES)
+        if unknown:
+            raise ValueError(f"unknown knob names: {sorted(unknown)}")
+
+
+_HY3_OQ2E = OptimizationProfile(
+    model_key="hy3-oq2e",
+    knobs={
+        "proj_requant": KnobEntry(
+            state="default_on",
+            value="q4",
+            provenance=(
+                "2026-07-24 M-class 614 GB/s, 1024-tok real-code prefill: "
+                "q4 residents cut per-token reads ~11.9->~7.9 GB; AR 33.9->"
+                "43.1 tok/s short-ctx (36.6 @ 1k ctx); paired HumanEval "
+                "unchanged (McNemar p=1.0). Draft head excluded (stays q8)."
+            ),
+        ),
+        "kv_quant": KnobEntry(
+            state="not_applicable",
+            value="off",
+            provenance=(
+                "2026-07-22 envelope matrix: MTP dead under kv4 at real "
+                "prefill (AR 26.2 vs K3 10.8); bf16 KV locked."
+            ),
+        ),
+        "mtp_history_policy": KnobEntry(
+            state="default_on",
+            value="committed",
+            provenance=(
+                "2026-07-24 mtpk d1, 1k-ctx real code: committed history "
+                "accept 0.903 vs 0.262 unprimed; draft is context-starved "
+                "without prompt priming."
+            ),
+        ),
+        "draft_core": KnobEntry(
+            state="default_on",
+            value="device",
+            provenance=(
+                "2026-07-24 mtpk d1 committed, 1k-ctx real code: device "
+                "core 37.9 tok/s vs stock core 35.3-36.5 (AR 35.9) at "
+                "accept 0.903 — first configuration where K=1 beats AR."
+            ),
+        ),
+        "verify_strategy": KnobEntry(
+            state="default_on",
+            value="batched",
+            provenance=(
+                "2026-07-24 d1 sweep: capture_commit 32.0 (accept drops "
+                "0.903->0.776, off-lane numerics), graphbank 27.4, "
+                "graphbank_capture_commit 26.5 — batched wins on this "
+                "family."
+            ),
+        ),
+        "speculative_depth": KnobEntry(
+            state="default_on",
+            value=1,
+            provenance=(
+                "2026-07-24 depth sweep @ accept ~0.9: d2 28.9, d3 23.5 "
+                "vs d1 35.3-37.9 — each extra draft position multiplies "
+                "MoE expert bytes in verify; depth 1 is the win."
+            ),
+        ),
+        "compile_ar_forward": KnobEntry(
+            state="default_off",
+            value=False,
+            provenance=(
+                "2026-07-24 live A/B, engagement-proofed 256/256: null win "
+                "(35.1 vs 35.9 eager) — the host graph-rebuild tax this "
+                "targets is not present on the lean mlx-lm forward; greedy "
+                "token parity also flipped (gather_qmm kernel selection)."
+            ),
+        ),
+    },
+)
+
+_PROFILES: dict[str, OptimizationProfile] = {
+    _HY3_OQ2E.model_key: _HY3_OQ2E,
+}
+
+_MODEL_KEY_ALIASES = {
+    "mlx-community/hy3-oq2e": "hy3-oq2e",
+    "hy3-oq2e-stock": "hy3-oq2e",
+    "hy3-oq2e-stock-mtp": "hy3-oq2e",
+    "hy3-oq2e-r4": "hy3-oq2e",
+    "hy3-oq2e-r4-mtpbf16": "hy3-oq2e",
+}
+
+
+def canonical_model_key(model_key: str) -> str:
+    lowered = model_key.strip().lower()
+    return _MODEL_KEY_ALIASES.get(lowered, lowered)
+
+
+def get_profile(model_key: str) -> OptimizationProfile | None:
+    return _PROFILES.get(canonical_model_key(model_key))
+
+
+def resolve_profile_defaults(model_key: str) -> dict[str, KnobEntry]:
+    """Measured defaults for a model key; empty when unregistered."""
+
+    profile = get_profile(model_key)
+    if profile is None:
+        return {}
+    return dict(profile.knobs)
+
+
+def profile_conflict_warnings(
+    model_key: str, observed: Mapping[str, Any]
+) -> list[str]:
+    """Advisory-only: explicit values conflicting with measured defaults."""
+
+    warnings: list[str] = []
+    for name, entry in resolve_profile_defaults(model_key).items():
+        if name not in observed or observed[name] is None:
+            continue
+        if entry.state not in {"default_on", "default_off"}:
+            continue
+        if observed[name] != entry.value:
+            warnings.append(
+                f"profile suggests {name}={entry.value!r} for "
+                f"{canonical_model_key(model_key)!r} (got {observed[name]!r}): "
+                f"{entry.provenance}"
+            )
+    return warnings
+
+
+def not_applicable_violations(
+    model_key: str, knob_values: Mapping[str, Any]
+) -> list[str]:
+    """Enforceable knobs explicitly set despite ``not_applicable`` state."""
+
+    violations: list[str] = []
+    for name, entry in resolve_profile_defaults(model_key).items():
+        if entry.state != "not_applicable" or name not in ENFORCEABLE_KNOBS:
+            continue
+        value = knob_values.get(name)
+        if value in (None, False, "off", "none", ""):
+            continue
+        violations.append(
+            f"{name}={value!r} is marked not_applicable for "
+            f"{canonical_model_key(model_key)!r}: {entry.provenance}"
+        )
+    return violations

--- a/mtplx/proj_quant.py
+++ b/mtplx/proj_quant.py
@@ -1,0 +1,156 @@
+"""Load-time quantization of the bandwidth-dominant trunk ``*_proj`` Linears.
+
+Decode throughput on large resident MoE models is bound by bytes read per
+token, and the trunk projections (attention ``q/k/v/o_proj`` plus dense and
+shared-expert ``gate/up/down_proj``) dominate the always-read set. These
+passes shrink exactly that set at load time:
+
+- ``quantize_projections`` converts BF16 ``nn.Linear`` projections to
+  q4/q8 gs64 affine (checkpoints that ship residents in BF16);
+- ``requantize_projections`` re-quantizes pre-quantized projections DOWN
+  (e.g. a checkpoint's q8/gs64 residents to q4/gs64) via dequantize +
+  ``QuantizedLinear.from_linear`` — the same canonical path a load-time
+  quantization would take. The double quantization is deliberate and
+  disclosed; deriving from BF16 sources remains the higher-quality route
+  when a BF16 checkpoint is available.
+
+Router gates, expert banks (SwitchLinear), embeddings, the LM head, norms,
+and biases keep their loaded precision — the router picks experts, so its
+numerics stay exact.
+
+Measured on Hy3 oQ2e (2-bit experts, q8 residents, M-class 614 GB/s): q4
+residents cut per-token reads ~11.9 GB -> ~7.9 GB and lifted AR decode
+33.9 -> 43.1 tok/s short-context (36.6 at 1k-token real-code context), with
+full-suite pass@1 statistically unchanged (McNemar p=1.0 on paired
+HumanEval).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+PROJ_QUANT_BITS = {"q8": 8, "q4": 4}
+PROJ_REQUANT_BITS = {"q4": 4}
+PROJ_QUANT_GROUP_SIZE = 64
+
+_ATTENTION_PROJ_SUFFIXES = (".q_proj", ".k_proj", ".v_proj", ".o_proj", ".qkv_proj")
+_MLP_PROJ_SUFFIXES = (".gate_proj", ".up_proj", ".down_proj", ".gate_up_proj")
+
+
+class ProjQuantError(RuntimeError):
+    pass
+
+
+def proj_quant_covers(path: str) -> bool:
+    """Module/tensor paths quantized by the load-time proj-quant pass.
+
+    Covers exactly the ``*_proj`` weights of the trunk: attention
+    ``q/k/v/o_proj`` plus ``gate/up/down/gate_up_proj`` in ``mlp`` and
+    ``shared_mlp`` blocks. Deliberately narrower than "everything resident";
+    expert banks are excluded by module type (SwitchLinear is never an
+    ``nn.Linear``), routers/embeddings/head/norms by path.
+    """
+
+    if ".self_attn." in path and path.endswith(_ATTENTION_PROJ_SUFFIXES):
+        return True
+    if path.endswith(_MLP_PROJ_SUFFIXES):
+        segments = path.split(".")
+        return "mlp" in segments or "shared_mlp" in segments
+    return False
+
+
+def quantize_projections(model: Any, mode: str) -> list[str]:
+    """Quantize BF16 trunk ``*_proj`` Linears to ``mode`` (q4/q8, gs64)."""
+
+    import mlx.nn as nn
+
+    if mode not in PROJ_QUANT_BITS:
+        raise ProjQuantError(
+            f"proj_quant mode must be one of {sorted(PROJ_QUANT_BITS)}, got {mode!r}"
+        )
+    bits = PROJ_QUANT_BITS[mode]
+    quantized: list[str] = []
+
+    def predicate(path: str, module: Any) -> bool:
+        if not isinstance(module, nn.Linear) or isinstance(
+            module, nn.QuantizedLinear
+        ):
+            return False
+        if proj_quant_covers(path):
+            quantized.append(path)
+            return True
+        return False
+
+    nn.quantize(
+        model,
+        group_size=PROJ_QUANT_GROUP_SIZE,
+        bits=bits,
+        mode="affine",
+        class_predicate=predicate,
+    )
+    if not quantized:
+        raise ProjQuantError(
+            f"proj_quant={mode!r} matched no trunk *_proj Linear modules"
+        )
+    return quantized
+
+
+def requantize_projections(model: Any, mode: str) -> list[str]:
+    """Re-quantize pre-quantized trunk ``*_proj`` Linears down to ``mode``.
+
+    Matches ``nn.QuantizedLinear`` modules in the ``proj_quant_covers`` scope
+    whose bit width exceeds the target, dequantizes each via its own
+    ``(group_size, bits, mode)`` triple, and rebuilds a standard q4/gs64
+    affine module through ``QuantizedLinear.from_linear``. Idempotent: a
+    module already at or below the target is never touched.
+    """
+
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx.utils import tree_map_with_path
+
+    if mode not in PROJ_REQUANT_BITS:
+        raise ProjQuantError(
+            f"proj_requant mode must be one of {sorted(PROJ_REQUANT_BITS)}, got {mode!r}"
+        )
+    target_bits = PROJ_REQUANT_BITS[mode]
+    requantized: list[str] = []
+
+    def rebuild(path: str, module: Any) -> Any:
+        if not isinstance(module, nn.QuantizedLinear):
+            return module
+        if int(module.bits) <= target_bits:
+            return module
+        if not proj_quant_covers(path):
+            return module
+        weight = mx.dequantize(
+            module.weight,
+            module.scales,
+            module.biases,
+            group_size=module.group_size,
+            bits=module.bits,
+            mode=module.mode,
+        )
+        restored = nn.Linear(
+            int(weight.shape[1]), int(weight.shape[0]), bias=("bias" in module)
+        )
+        restored.weight = weight
+        if "bias" in module:
+            restored.bias = module.bias
+        requantized.append(path)
+        return nn.QuantizedLinear.from_linear(
+            restored,
+            group_size=PROJ_QUANT_GROUP_SIZE,
+            bits=target_bits,
+            mode="affine",
+        )
+
+    leaves = model.leaf_modules()
+    leaves = tree_map_with_path(rebuild, leaves, is_leaf=nn.Module.is_module)
+    model.update_modules(leaves)
+    if not requantized:
+        raise ProjQuantError(
+            f"proj_requant={mode!r} matched no quantized trunk *_proj "
+            f"modules above {target_bits} bits"
+        )
+    return requantized

--- a/mtplx/roofline_profile.py
+++ b/mtplx/roofline_profile.py
@@ -1,0 +1,270 @@
+"""Env-gated per-component GPU roofline for hy3 DECODE, QUEUED lane (issue #51).
+
+MTPLX_ROOFLINE_PROFILE=1 turns it on. REAL modules, no synthetic shapes, and no
+per-call barrier (the eager barrier adds ~0.2 ms host sync that inverts small-op
+verdicts — the queued-vs-eager law). Method:
+
+  - during the real forward, CAPTURE a handful of real (module, concrete input)
+    samples per component across the first few layers (cheap; no timing there, so
+    the forward is undistorted);
+  - at exit, bench each component on the QUEUED lane: submit N ops, ONE eval. The
+    L2 cache is defeated the way real decode defeats it — experts gather DISTINCT
+    random slots each iter, and dense components CYCLE several layers' weights so
+    the working set exceeds L2 and every weight is re-read from DRAM;
+  - achieved GB/s = bytes_moved / queued_time, vs a measured DRAM ceiling.
+    >=70% ceiling => memory-bound; <40% & GPU busy => compute/occupancy-bound.
+"""
+
+from __future__ import annotations
+
+import atexit
+import copy
+import os
+import time
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+_SAMPLES: dict[str, list] = {}   # name -> list of rebuild thunks () -> lazy out
+_BYTES: dict[str, int] = {}      # name -> bytes moved per call
+_RESULTS: dict[str, tuple] = {}  # name -> (secs_per_call | None, bytes | errmsg)
+_ORDER: list[str] = []
+_MAX = 8                         # layers cycled per dense component (defeat L2)
+_N = 60                          # queued iterations
+_TOP_K = 8
+_EXPERTS = 192
+
+
+def enabled() -> bool:
+    return os.environ.get("MTPLX_ROOFLINE_PROFILE") == "1"
+
+
+def module_nbytes(module) -> int:
+    return sum(int(p.nbytes) for _, p in tree_flatten(module.parameters()))
+
+
+def _concrete(x):
+    """A standalone concrete copy safe to replay after the forward frees x."""
+    c = x + 0.0
+    mx.eval(c)
+    return c
+
+
+def _bench_now(name: str) -> None:
+    """Queued-bench a full sample set immediately, while every resident bank/weight
+    is still live (the MoE bank is cleared at teardown, so atexit is too late)."""
+    thunks = _SAMPLES.pop(name, [])
+    try:
+        probe = thunks[0]()
+        if probe is None:
+            _RESULTS[name] = (None, "ineligible (wave declined shape)")
+            return
+        _RESULTS[name] = (_queued_seconds(thunks), _BYTES.get(name, 0))
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        _RESULTS[name] = (None, repr(exc))
+
+
+def _reg(name: str, thunk, nbytes: int) -> None:
+    if name in _RESULTS:
+        return
+    if name not in _SAMPLES:
+        _SAMPLES[name] = []
+        _ORDER.append(name)
+        _BYTES[name] = int(nbytes)
+    _SAMPLES[name].append(thunk)
+    if len(_SAMPLES[name]) >= _MAX:
+        _bench_now(name)
+
+
+def capture_dense(name: str, module, x, nbytes: int) -> None:
+    """A per-layer matvec module (router / shared / lm_head): cycle layers."""
+    if not enabled():
+        return
+    xc = _concrete(x)
+    _reg(name, lambda m=module, xx=xc: m(xx), nbytes)
+
+
+def snapshot_cache(cache):
+    """An INDEPENDENT copy of a KV cache, or None if one cannot be made safely.
+
+    capture_attention replays its thunk ~61 times (1 warm + _N=60). Attention's
+    forward calls cache.update_and_fetch, which APPENDS a token per call. Against
+    the live cache that injects ~61 phantom tokens into layers 0-7 only (the
+    captured ones), which:
+      * corrupts the run's generated text from that point on, so tok/s and token
+        hashes from any MTPLX_ROOFLINE_PROFILE=1 run are not trustworthy, and
+      * makes the measurement non-idempotent (offset crosses KVCache.step=256
+        boundaries, triggering whole-buffer reallocation mid-bench).
+    Copying arrays via an arithmetic op (arr + 0) rather than a constructor
+    guarantees a distinct buffer regardless of MLX's aliasing rules; this is
+    asserted by tests/test_roofline_cache_isolation.py rather than assumed.
+
+    Returning None makes the caller SKIP the capture. Losing one component's
+    number is strictly better than silently corrupting the run producing it.
+    """
+    if cache is None:
+        return None
+    try:
+        snap = copy.copy(cache)
+        copied = False
+        for attr in ("keys", "values"):
+            arr = getattr(cache, attr, None)
+            if isinstance(arr, mx.array):
+                setattr(snap, attr, arr + 0)  # forces an independent buffer
+                copied = True
+            elif arr is not None:
+                # Quantized caches hold tuples of arrays; not handled -> skip
+                # rather than risk sharing a buffer with the live cache.
+                return None
+        if not copied:
+            return None
+        mx.eval(snap.keys, snap.values)
+        return snap
+    except Exception:  # pragma: no cover - never corrupt a run over a profile
+        return None
+
+
+def capture_attention(module, normed, mask, cache, nbytes: int) -> None:
+    if not enabled():
+        return
+    # Replay against an isolated copy so the live cache is never advanced.
+    snap = snapshot_cache(cache)
+    if cache is not None and snap is None:
+        return
+    nc = _concrete(normed)
+    _reg("attention", lambda m=module, n=nc, c=snap: m(n, mask, c), nbytes)
+
+
+def capture_moe(switch_mlp, x, indices, nbytes: int) -> None:
+    """Routed experts: replay each captured layer's real gather. Cache is defeated
+    by cycling several DISTINCT layers' banks (each ~1 GB resident), so a layer's
+    experts are evicted before its thunk comes round again -> streamed from DRAM."""
+    if not enabled():
+        return
+    xc = _concrete(x)
+    idx = mx.array(indices)
+    mx.eval(idx)
+    _reg("moe_experts", lambda m=switch_mlp, xx=xc, ii=idx: m(xx, ii), nbytes)
+
+
+def capture_moe_wave(switch_mlp, x, nbytes_32: int) -> None:
+    """T0a: bench the 32-assignment M4 wave (the real MTP-depth hot path shape)
+    vs the single-token 8-assignment gather. If the wave runs materially above
+    the single-token 44%, MoE occupancy starvation is a batch=1-only artifact.
+    Weights/kernel/shape are real; only x values are broadcast (they don't affect
+    bandwidth), and 32 DISTINCT experts are gathered so the bank streams from DRAM."""
+    if not enabled():
+        return
+    xc = _concrete(x)
+
+    def thunk(m=switch_mlp, xx=xc):
+        wave_call = getattr(m, "wave_call", None)
+        if wave_call is None:
+            return None
+        x4 = mx.broadcast_to(xx.reshape(1, 1, -1), (1, 4, xx.shape[-1])) + 0.0
+        idx = (mx.arange(32, dtype=mx.uint32) % _EXPERTS).reshape(1, 4, 8)
+        scores = mx.ones((1, 4, 8), dtype=mx.bfloat16)
+        return wave_call(x4, idx, scores)
+
+    _reg("moe_wave(32)", thunk, nbytes_32)
+
+
+_DTYPES: dict[str, str] = {}
+
+
+def note_dtype(key: str, arr) -> None:
+    """T0b: record a tensor's dtype once (norm weights / cache keys) to prove the
+    bf16 invariant and surface the latent fp32-KV trap."""
+    if not enabled() or key in _DTYPES:
+        return
+    dtype = getattr(arr, "dtype", None)
+    if dtype is not None:
+        _DTYPES[key] = str(dtype)
+
+
+def _measure_ceiling() -> float:
+    big = mx.random.normal((512, 1024, 1024)).astype(mx.float32)
+    mx.eval(big)
+    mx.synchronize()
+    start = time.perf_counter()
+    for _ in range(5):
+        mx.eval(big.sum())
+    mx.synchronize()
+    return big.nbytes / ((time.perf_counter() - start) / 5) / 1e9
+
+
+def _queued_seconds(thunks) -> float:
+    """Per-op seconds on the queued lane: build N ops cycling the samples, ONE
+    eval. No per-call barrier -> no host-sync inflation."""
+    def _flat(out, acc):
+        if isinstance(out, tuple):
+            acc.extend(o for o in out if isinstance(o, mx.array))
+        else:
+            acc.append(out)
+
+    warm = []
+    _flat(thunks[0](), warm)
+    mx.eval(warm)
+    mx.synchronize()
+    start = time.perf_counter()
+    outs: list = []
+    for i in range(_N):
+        _flat(thunks[i % len(thunks)](), outs)
+    mx.eval(outs)
+    mx.synchronize()
+    return (time.perf_counter() - start) / _N
+
+
+@atexit.register
+def _dump() -> None:
+    if not _RESULTS and not _SAMPLES:
+        return
+    try:
+        ceiling = _measure_ceiling()
+    except Exception:  # pragma: no cover
+        ceiling = float("nan")
+    print("\n" + "=" * 76, flush=True)
+    print("PER-COMPONENT DECODE ROOFLINE — QUEUED lane, real modules", flush=True)
+    print(f"DRAM read ceiling (measured): {ceiling:.0f} GB/s", flush=True)
+    print("=" * 76, flush=True)
+    # Bench any component that never reached _MAX (persistent-weight ones only;
+    # the MoE bank is gone by now, but it always fills within the first token).
+    for name in list(_SAMPLES):
+        if name not in _RESULTS:
+            _bench_now(name)
+    layers = {"attention": 80, "router": 79, "moe_experts": 79,
+              "shared_expert": 79, "lm_head": 1}
+    print(f"{'component':16s} {'us/call':>8s} {'MB/call':>8s} {'GB/s':>7s} {'%ceil':>6s} "
+          f"{'ms/tok':>7s}  bound", flush=True)
+    tot_ms = 0.0
+    for name in _ORDER:
+        secs, payload = _RESULTS.get(name, (None, "not benched"))
+        if secs is None:
+            print(f"{name:16s} FAILED: {payload}", flush=True)
+            continue
+        nbytes = int(payload)
+        gbs = (nbytes / secs / 1e9) if secs and nbytes else 0.0
+        pct = (gbs / ceiling * 100) if ceiling and gbs else 0.0
+        ms_tok = secs * 1e3 * layers.get(name, 1)
+        tot_ms += ms_tok
+        bound = "MEMORY" if pct >= 70 else ("compute/occ" if 0 < pct < 40 else ("mixed" if pct else "-"))
+        print(f"{name:16s} {secs*1e6:8.1f} {nbytes/1e6:8.2f} {gbs:7.0f} {pct:5.0f}% "
+              f"{ms_tok:7.2f}  {bound}", flush=True)
+    print("-" * 76, flush=True)
+    print(f"reconstructed decode ~{tot_ms:.1f} ms/token  ({1000/tot_ms if tot_ms else 0:.1f} tok/s)"
+          f"  vs measured ~35 tok/s (~28.4 ms)", flush=True)
+    print("per-call = one layer; ms/tok = per-call x layers (attention 80, MoE/shared/router 79).", flush=True)
+    if "moe_experts" in _RESULTS and "moe_wave(32)" in _RESULTS:
+        s8, b8 = _RESULTS["moe_experts"]
+        sw, bw = _RESULTS["moe_wave(32)"]
+        if s8 and sw:
+            g8 = b8 / s8 / 1e9
+            gw = int(bw) / sw / 1e9
+            print(f"\nT0a: single-token 8-assign {g8:.0f} GB/s vs 32-assign wave {gw:.0f} GB/s "
+                  f"({gw/g8:.2f}x) -> occupancy starvation is "
+                  f"{'batch=1-ONLY (MoE deprioritizes)' if gw > 1.3*g8 else 'STRUCTURAL (kernel work justified)'}", flush=True)
+    if _DTYPES:
+        print("\nT0b dtype invariants (bf16 expected; fp32 = latent KV trap):", flush=True)
+        for key, dtype in _DTYPES.items():
+            flag = "  <-- FP32 TRAP" if "float32" in dtype else ""
+            print(f"  {key:24s} {dtype}{flag}", flush=True)

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -120,7 +120,14 @@ class MTPLXRuntime:
                 self._count("final_logits_tokens_emitted", 1)
             else:
                 self._count("full_logits_tokens_emitted", emitted)
-        if not return_hidden and hidden_variant is None and not kwargs:
+        # kwargs == {"emit_logits": True} is semantically the plain call —
+        # MTP-patched wrappers advertise emit_logits via **kwargs, so on MTP
+        # runtimes the bare-kwargs case never occurs and the compiled hook
+        # must accept the default-emit form too.
+        plain_call = not kwargs or (
+            set(kwargs) == {"emit_logits"} and kwargs["emit_logits"] is True
+        )
+        if not return_hidden and hidden_variant is None and plain_call:
             # Decode-only (seq_len == 1). Prefill is multi-token over an
             # unprimed cache: seeding the compiled graph from its None KV
             # leaves throws, and its shape differs from a single-token decode
@@ -133,7 +140,8 @@ class MTPLXRuntime:
                 # arm B (on) > 0 — the A/B credits nothing without it.
                 self._count("compiled_forward_calls")
                 return compiled(input_ids, cache)
-            return self.model(input_ids, cache=cache)
+            if not kwargs:
+                return self.model(input_ids, cache=cache)
         return self.model(
             input_ids,
             cache=cache,

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -309,8 +309,17 @@ def load(
     merge_mtp_adapter: bool = False,
     gemma4_draft_block_size: int | None = None,
     gemma4_target_distribution_mode: str | None = None,
+    proj_quant: str | None = None,
+    proj_requant: str | None = None,
 ) -> MTPLXRuntime:
-    """Load an MLX model and optionally inject native MTP support."""
+    """Load an MLX model and optionally inject native MTP support.
+
+    ``proj_quant`` / ``proj_requant`` (or the ``MTPLX_PROJ_QUANT`` /
+    ``MTPLX_PROJ_REQUANT`` environment variables) quantize the trunk
+    ``*_proj`` Linears at load time — see :mod:`mtplx.proj_quant`. Applied
+    to the trunk only, before MTP injection, so a draft head's precision is
+    never reduced.
+    """
     path = Path(model_path)
     from .gemma4_pair import resolve_gemma4_pair_paths
 
@@ -371,6 +380,25 @@ def load(
         from mlx_lm.utils import load as mlx_lm_load
 
         model, tokenizer = mlx_lm_load(str(_mtp_alias_load_path(path, config)))
+    import os as _os
+
+    proj_quant = proj_quant or _os.environ.get("MTPLX_PROJ_QUANT") or None
+    proj_requant = proj_requant or _os.environ.get("MTPLX_PROJ_REQUANT") or None
+    if proj_quant or proj_requant:
+        from .proj_quant import quantize_projections, requantize_projections
+
+        if proj_quant:
+            touched = quantize_projections(model, proj_quant)
+            logger.info(
+                "[proj-quant] quantized %d trunk *_proj modules to %s",
+                len(touched), proj_quant,
+            )
+        if proj_requant:
+            touched = requantize_projections(model, proj_requant)
+            logger.info(
+                "[proj-quant] requantized %d trunk *_proj modules to %s",
+                len(touched), proj_requant,
+            )
     runtime_metadata = _load_runtime_metadata(path)
     contract = (
         (contract or MTPContract())

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -121,6 +121,18 @@ class MTPLXRuntime:
             else:
                 self._count("full_logits_tokens_emitted", emitted)
         if not return_hidden and hidden_variant is None and not kwargs:
+            # Decode-only (seq_len == 1). Prefill is multi-token over an
+            # unprimed cache: seeding the compiled graph from its None KV
+            # leaves throws, and its shape differs from a single-token decode
+            # step, forcing a retrace. Prefill stays eager.
+            compiled = (
+                self._compiled_ar_forward(cache) if sequence_len == 1 else None
+            )
+            if compiled is not None:
+                # Engagement proof: arm A (flag off) must report 0 here,
+                # arm B (on) > 0 — the A/B credits nothing without it.
+                self._count("compiled_forward_calls")
+                return compiled(input_ids, cache)
             return self.model(input_ids, cache=cache)
         return self.model(
             input_ids,
@@ -128,6 +140,47 @@ class MTPLXRuntime:
             return_hidden=return_hidden,
             **kwargs,
         )
+
+    def _compiled_ar_forward(self, cache):
+        """Compiled target forward (MTPLX_COMPILE_AR_FORWARD).
+
+        Kills the per-token Python graph rebuild by tracing the full trunk
+        forward once (CompiledARForward, KV state threaded). Applies to
+        fully-resident loads with a standard per-layer KV cache; a host-sync
+        buried in the model forward surfaces as an error on the first traced
+        call rather than silently degrading. Rebuilds per cache identity so a
+        new generation gets fresh threaded state. Returns None (the eager
+        path) otherwise.
+        """
+        from .compiled_forward import CompiledARForward, compile_forward_enabled
+
+        if not compile_forward_enabled() or not cache:
+            return None
+        # An unprimed cache (empty context / first token) has None KV leaves
+        # that would crash the compiled graph. Only compile once the cache
+        # holds real keys, and only for the plain growable KVCache shape the
+        # fixed-buffer conversion understands.
+        first = cache[0]
+        if getattr(first, "keys", None) is None:
+            return None
+        if any(
+            not hasattr(entry, "keys")
+            or not hasattr(entry, "values")
+            or not hasattr(entry, "offset")
+            for entry in cache
+        ):
+            return None
+        cache_key = id(first)
+        if (
+            getattr(self, "_compiled_ar", None) is None
+            or getattr(self, "_compiled_ar_key", None) != cache_key
+        ):
+            import os as _os
+
+            reserve = int(_os.environ.get("MTPLX_COMPILE_AR_RESERVE_TOKENS", "4096"))
+            self._compiled_ar = CompiledARForward(self.model, reserve_tokens=reserve)
+            self._compiled_ar_key = cache_key
+        return self._compiled_ar
 
     def forward_ar_capture(
         self,

--- a/mtplx/runtime_options.py
+++ b/mtplx/runtime_options.py
@@ -8,6 +8,47 @@ from typing import Mapping
 
 KV_QUANT_MODES = ("off", "q8", "q4")
 
+#: The one boolean vocabulary for MTPLX env flags.
+#:
+#: Every reader of a boolean ``MTPLX_*`` var should go through
+#: :func:`env_bool` so a spelling means the same thing everywhere. Values
+#: outside these sets raise rather than being silently read as "off" by one
+#: reader and "on" by another — the failure mode catalogued in
+#: docs/AUDIT_2026-07-18.md, where ``=enabled`` disabled a feature in the
+#: server while enabling it in the generation loop.
+ENV_TRUE_VALUES = frozenset({"1", "true", "yes", "on", "enable", "enabled"})
+ENV_FALSE_VALUES = frozenset({"0", "false", "no", "off", "disable", "disabled"})
+
+
+def env_bool(
+    name: str,
+    *,
+    default: bool,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Parse a boolean ``MTPLX_*`` env var, or raise on an unknown spelling.
+
+    Unset (and set-but-empty) yields ``default``. Anything that is neither
+    a recognized true nor a recognized false value is a configuration
+    error: guessing is what let one variable mean three things.
+    """
+
+    source = os.environ if env is None else env
+    raw = source.get(name)
+    if raw is None:
+        return bool(default)
+    token = str(raw).strip().lower()
+    if not token:
+        return bool(default)
+    if token in ENV_TRUE_VALUES:
+        return True
+    if token in ENV_FALSE_VALUES:
+        return False
+    accepted = ", ".join(sorted(ENV_TRUE_VALUES | ENV_FALSE_VALUES))
+    raise ValueError(
+        f"{name}={raw!r} is not a boolean; expected one of: {accepted}"
+    )
+
 
 @dataclass(frozen=True)
 class ResolvedAPIKey:
@@ -17,6 +58,87 @@ class ResolvedAPIKey:
     @property
     def required(self) -> bool:
         return bool(self.value)
+
+
+def parser_option_names(parser: object, namespace: object = None) -> set[str]:
+    """Every option name reachable in the parse context, without dashes.
+
+    Walks the root parser plus whichever subparsers the parse actually
+    descended into (using ``namespace`` to pick the branch), which is the
+    same scope argparse resolves abbreviations against.
+    """
+
+    names: set[str] = set()
+    seen: set[int] = set()
+    pending = [parser]
+    while pending:
+        current = pending.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        for action in getattr(current, "_actions", ()):
+            for option in getattr(action, "option_strings", ()) or ():
+                names.add(str(option).lstrip("-"))
+            choices = getattr(action, "choices", None)
+            dest = getattr(action, "dest", None)
+            if not isinstance(choices, dict) or not dest:
+                continue
+            # A subparsers action: follow only the branch that was taken.
+            picked = getattr(namespace, str(dest), None) if namespace else None
+            if picked is not None and picked in choices:
+                pending.append(choices[picked])
+            elif namespace is None:
+                pending.extend(choices.values())
+    return names
+
+
+def canonicalize_flag_tokens(
+    tokens: set[str],
+    parser: object,
+    namespace: object = None,
+) -> set[str]:
+    """Expand argparse abbreviations to the flag names they resolved to.
+
+    ``--temp 0.9`` sets ``args.temperature`` but was recorded as ``temp``,
+    so every ``"temperature" in cli_flags`` check read it as *not typed*
+    and the config file happily overwrote the user's value. Resolving here
+    (rather than setting ``allow_abbrev=False``) keeps abbreviations
+    working while making the explicit-flag signal true.
+
+    The raw token is kept alongside the expansion, so checks written
+    against either spelling keep working. Ambiguous prefixes expand to
+    nothing — argparse would have rejected the command anyway.
+    """
+
+    known = parser_option_names(parser, namespace)
+    resolved = set(tokens)
+    for token in tokens:
+        if token in known:
+            continue
+        matches = {name for name in known if name.startswith(token)}
+        if len(matches) == 1:
+            resolved |= matches
+    return resolved
+
+
+def block_prefix_restore_enabled() -> bool:
+    """The single parse of ``MTPLX_SESSION_BLOCK_PREFIX_RESTORE``.
+
+    Default ON. Every reader — the decode loop, the engine session, the
+    session bank's cold tier, and the server's settings view — goes through
+    this, so one spelling cannot mean ON in one and OFF in another. Unset
+    used to mean OFF in the cold tier and ON everywhere else, which
+    silently disabled cold-tier block-prefix restore for library embedders
+    (the CLI path masks it by force-setting "1"); and the server's
+    allowlist-only read reported "off" for spellings the runtime honours as
+    on, e.g. ``=enabled``.
+
+    Lives here rather than in :mod:`mtplx.session_bank` because this module
+    has no heavy imports: the server reads the setting on paths where the
+    mlx-backed runtime may be unavailable.
+    """
+
+    return env_bool("MTPLX_SESSION_BLOCK_PREFIX_RESTORE", default=True)
 
 
 def normalize_paged_kv_quantization(value: object | None, *, allow_none: bool = False) -> str | None:

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -104,6 +104,9 @@ from mtplx.profiles import (
 )
 from mtplx.runtime_options import (
     apply_paged_kv_quantization_env,
+    block_prefix_restore_enabled,
+    canonicalize_flag_tokens,
+    env_bool,
     normalize_paged_kv_quantization,
     resolve_api_key,
 )
@@ -258,7 +261,22 @@ FAST_PATH_ENV = {
     "MTPLX_DROP_EVENTS": "1",
     "MTPLX_SKIP_VERIFY_SNAPSHOT": "1",
 }
-VERIFY_SNAPSHOT_REQUIRED_STRATEGIES = {"trim_commit", "target_prefix"}
+#: Verify strategies known to be correct with ``MTPLX_SKIP_VERIFY_SNAPSHOT=1``.
+#:
+#: Stated as a safe-list rather than as the complement (which used to be the
+#: two-element ``{"trim_commit", "target_prefix"}``) so that a verify strategy
+#: added later defaults to *keeping* the snapshot — slower, but correct —
+#: instead of silently inheriting the fast path's skip.
+VERIFY_SNAPSHOT_OPTIONAL_STRATEGIES = frozenset(
+    {
+        "batched",
+        "sequential",
+        "capture",
+        "capture_commit",
+        "graphbank",
+        "graphbank_capture_commit",
+    }
+)
 STATS_FOOTER_MARKER = "\n---\n⚡ **MTPLX TPS:**"
 THINK_OPEN = "<think>"
 THINK_CLOSE = "</think>"
@@ -544,7 +562,10 @@ def _server_runtime_env_overrides(
         .lower()
         .replace("-", "_")
     )
-    if generation_mode == "mtp" and verify_strategy in VERIFY_SNAPSHOT_REQUIRED_STRATEGIES:
+    if (
+        generation_mode == "mtp"
+        and verify_strategy not in VERIFY_SNAPSHOT_OPTIONAL_STRATEGIES
+    ):
         overrides["MTPLX_SKIP_VERIFY_SNAPSHOT"] = "0"
     return overrides
 
@@ -11903,10 +11924,10 @@ def _effective_ram_session_cache_settings() -> dict[str, Any]:
     entries_raw = os.environ.get("MTPLX_SESSION_BANK_MAX_ENTRIES")
     max_bytes = os.environ.get("MTPLX_SESSION_BANK_MAX_BYTES") or "8G"
     per_session_bytes = os.environ.get("MTPLX_SESSION_BANK_PER_SESSION_BYTES") or "4G"
-    block_prefix_restore = _env_bool_setting(
-        "MTPLX_SESSION_BLOCK_PREFIX_RESTORE",
-        default=True,
-    )
+    # One parse, shared with the decode loop and the cold tier: an
+    # allowlist-only read here reported "off" for spellings the runtime
+    # honours as on (e.g. "enabled").
+    block_prefix_restore = block_prefix_restore_enabled()
     try:
         entries = max(1, int(entries_raw)) if entries_raw is not None else 4
     except ValueError:
@@ -15060,9 +15081,13 @@ def _loop_guard_enabled() -> bool:
     ``MTPLX_LOOP_GUARD=1``, but the product answer to the quantized-model
     loop marathons is the artifact lane (delta-net-sensitive quantization),
     not a sampler intervention. Config knobs live in mtplx/loop_guard.py.
+
+    Parsed by loop_guard.py's own reader so this answer cannot disagree
+    with the guard the decode loop actually builds.
     """
-    raw = os.environ.get("MTPLX_LOOP_GUARD", "0").strip().lower()
-    return raw not in _UNCAPPED_RESPONSE_LEASE_DISABLED_VALUES
+    from mtplx.loop_guard import loop_guard_enabled_from_env
+
+    return loop_guard_enabled_from_env(default=False)
 
 
 def _fresh_seed() -> int:
@@ -25289,8 +25314,11 @@ def _apply_backend_server_defaults(
     if not _server_flag_present(explicit_flags, "draft-top-k"):
         args.draft_top_k = int(sampler["top_k"])
     if (
+        # `and`, not `or`: the flag's own default *is* LOCAL, so an `or` on
+        # the value fired regardless of provenance and rewrote an explicitly
+        # typed `--chat-template-profile local_qwen36` to `tokenizer`.
         not _server_flag_present(explicit_flags, "chat-template-profile")
-        or getattr(args, "chat_template_profile", None) == _CHAT_TEMPLATE_PROFILE_LOCAL
+        and getattr(args, "chat_template_profile", None) == _CHAT_TEMPLATE_PROFILE_LOCAL
     ):
         args.chat_template_profile = _CHAT_TEMPLATE_PROFILE_TOKENIZER
     if not _server_flag_present(
@@ -25466,9 +25494,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--kv-quant",
         dest="paged_kv_quantization",
         metavar="{off,q8,q4}",
-        default=os.environ.get("MTPLX_VLLM_METAL_PAGED_KV_QUANT")
-        or os.environ.get("MTPLX_PAGED_KV_QUANT")
-        or "off",
+        # Canonical, not raw: the runtime readers only understand
+        # off/q8/q4, so an env-supplied "uint8" must arrive here as "q8".
+        default=_effective_paged_kv_quantization(),
         help="Paged KV cache quantization mode: off, q8, or q4.",
     )
     parser.add_argument(
@@ -25888,7 +25916,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     args = parser.parse_args(raw_args)
     args._raw_args = list(raw_args)
-    args._cli_flags = _explicit_server_flags(raw_args)
+    args._cli_flags = canonicalize_flag_tokens(
+        _explicit_server_flags(raw_args), parser, args
+    )
     try:
         resolved_key = resolve_api_key(
             explicit_api_key=getattr(args, "api_key", None),

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -15795,6 +15795,9 @@ def _run_generation(
                         mtp_history_policy="committed",
                         verify_strategy=state.args.verify_strategy,
                         verify_core=state.args.verify_core,
+                        draft_core=str(
+                            getattr(state.args, "draft_core", None) or "stock"
+                        ),
                         token_callback=record_tokens,
                         session_bank=session_bank,
                         session_id=session_id,

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -29,6 +29,7 @@ from .cache_state import (
     snapshot_cache_lazy_hybrid,
 )
 from .runtime import MTPLXRuntime
+from .runtime_options import block_prefix_restore_enabled
 
 
 def _lazy_snapshot_enabled() -> bool:
@@ -879,8 +880,7 @@ class SessionBank:
             return None
         if model_path is None or mtp_enabled is None:
             return None
-        raw_enabled = os.environ.get("MTPLX_SESSION_BLOCK_PREFIX_RESTORE")
-        if raw_enabled is None or str(raw_enabled).strip().lower() in {"0", "false", "no", "off"}:
+        if not block_prefix_restore_enabled():
             return None
         lookup = getattr(self.cold_tier, "lookup_prefix_boundary", None)
         if not callable(lookup):

--- a/scripts/code_eval_gate.py
+++ b/scripts/code_eval_gate.py
@@ -1,0 +1,706 @@
+#!/usr/bin/env python3
+"""HumanEval / MBPP correctness gate against an OpenAI-compatible server.
+
+Every other benchmark in this repo measures throughput or acceptance. This one
+measures whether the output is still *correct*, which is what makes a
+quantization arm comparable: a decode win that silently costs pass@1 is not a
+win.
+
+This is the driver half. It gets completions from a served model and hands them
+to :mod:`mtplx.benchmarks.code_eval`, which owns loading, program assembly,
+sandboxed execution, and pass@k. Splitting it this way keeps the scoring half
+importable with no network and no model, and keeps this half free of any
+opinion about how a candidate is executed.
+
+Two endpoints are supported. ``--endpoint chat`` posts to
+``/v1/chat/completions`` and expects an instruct-tuned model to answer with a
+fenced code block. ``--endpoint completions`` posts to ``/v1/completions`` with
+the raw HumanEval prompt, which is the base-model continuation protocol the
+original Codex paper used; the completion is then a bare function body.
+
+Executing model-generated code is the entire point of the benchmark and also
+its only real hazard, so it never happens implicitly: pass
+``--allow-code-execution`` or the run refuses before it sends a single request.
+
+Determinism is the default (temperature 0, n=1, fixed seed) and every request
+parameter is recorded in the report, so two arms scored on different days are
+still comparable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as futures
+import hashlib
+import json
+import os
+import random
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mtplx.benchmarks.code_eval import (  # noqa: E402
+    CodeTask,
+    TaskResult,
+    load_tasks,
+    pass_at_k,
+    run_candidate,
+    summarize,
+)
+
+SCHEMA = "mtplx.code_eval_gate/1"
+
+# Retry these and nothing else. A 400 or a 404 is a misconfigured run and
+# retrying it just burns wall clock three times before reporting the same
+# thing; a 503 or a dropped socket is the server being busy, which is exactly
+# what a long eval run should ride out.
+_TRANSIENT_STATUS = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+
+_HUMANEVAL_SYSTEM = (
+    "You are a Python programming assistant. Complete the function you are "
+    "given. Reply with a single fenced Python code block containing the "
+    "complete function definition -- the signature, the body, and any imports "
+    "it needs. Do not include tests, example usage, or explanation."
+)
+
+_MBPP_SYSTEM = (
+    "You are a Python programming assistant. Write a Python function that "
+    "solves the task and satisfies the given tests. Reply with a single "
+    "fenced Python code block containing the complete function definition and "
+    "any imports it needs. Use exactly the function name the tests call. Do "
+    "not include the tests or any explanation."
+)
+
+# Base-model continuation has no stop token of its own: the model happily keeps
+# emitting the *next* top-level definition after finishing ours, which then
+# shadows or breaks the candidate. These are the standard HumanEval stops.
+_COMPLETION_STOPS = ["\nclass ", "\ndef ", "\n#", "\nif __name__", "\nprint("]
+
+
+class GateHTTPError(RuntimeError):
+    """An HTTP-layer failure, carrying the status when there was one."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+    @property
+    def transient(self) -> bool:
+        # No status at all means the socket died or timed out before a
+        # response existed -- always worth another attempt.
+        return self.status is None or self.status in _TRANSIENT_STATUS
+
+
+# --------------------------------------------------------------------------
+# provenance
+# --------------------------------------------------------------------------
+
+
+def _dataset_sha256(path: Path | str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _mtplx_version() -> str | None:
+    """Read the version without importing the package root (which pulls MLX)."""
+
+    try:
+        from mtplx.version import __version__
+
+        return str(__version__)
+    except Exception:
+        return None
+
+
+def _client_request_id(task_id: str, sample: int) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.:-]+", "-", task_id).strip("-")[:48]
+    suffix = time.time_ns() % 1_000_000_000
+    return f"codeeval-{safe or 'task'}-s{sample}-{os.getpid()}-{suffix}"
+
+
+# --------------------------------------------------------------------------
+# prompt / payload construction
+# --------------------------------------------------------------------------
+
+
+def build_messages(task: CodeTask) -> list[dict[str, str]]:
+    """Chat messages for one task."""
+
+    if task.suite == "humaneval":
+        system = _HUMANEVAL_SYSTEM
+        user = f"Complete this function:\n\n```python\n{task.prompt.rstrip()}\n```"
+    else:
+        system = _MBPP_SYSTEM
+        user = task.prompt.rstrip()
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def build_payload(
+    args: argparse.Namespace,
+    task: CodeTask,
+    *,
+    sample: int,
+    client_request_id: str,
+) -> dict[str, Any]:
+    """The exact request body for one sample of one task."""
+
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "temperature": float(args.temperature),
+        "max_tokens": int(args.max_tokens),
+        "stream": False,
+        "metadata": {
+            "mtplx_benchmark": "code_eval_gate",
+            "mtplx_request_id": client_request_id,
+            "task_id": task.task_id,
+            "suite": task.suite,
+            "sample": sample,
+        },
+    }
+    if args.endpoint == "chat":
+        payload["messages"] = build_messages(task)
+    else:
+        # Base-model continuation: the raw prompt IS the request, verbatim.
+        payload["prompt"] = task.prompt
+        if task.suite == "humaneval":
+            payload["stop"] = list(_COMPLETION_STOPS)
+    if args.top_p is not None:
+        payload["top_p"] = float(args.top_p)
+    if args.seed is not None:
+        # Distinct seed per sample, or n>1 just draws the same completion n
+        # times at a nonzero temperature and pass@k is a lie.
+        payload["seed"] = int(args.seed) + sample
+    return payload
+
+
+def endpoint_url(base_url: str, endpoint: str) -> str:
+    tail = "/v1/chat/completions" if endpoint == "chat" else "/v1/completions"
+    return f"{base_url.rstrip('/')}{tail}"
+
+
+# --------------------------------------------------------------------------
+# HTTP
+# --------------------------------------------------------------------------
+
+
+def _post_json(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    timeout_s: float,
+    api_key: str | None,
+    client_request_id: str,
+) -> dict[str, Any]:
+    """POST one request. This is the seam the tests replace."""
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-MTPLX-Request-ID": client_request_id,
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:2000]
+        raise GateHTTPError(f"HTTP {exc.code}: {body}", status=exc.code) from exc
+    except urllib.error.URLError as exc:
+        raise GateHTTPError(f"connection failed: {exc.reason!r}") from exc
+    except (TimeoutError, OSError) as exc:
+        raise GateHTTPError(f"transport failed: {exc!r}") from exc
+    except json.JSONDecodeError as exc:
+        raise GateHTTPError(f"malformed JSON response: {exc}") from exc
+
+
+def request_with_retries(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    timeout_s: float,
+    api_key: str | None,
+    client_request_id: str,
+    retries: int,
+    backoff_s: float = 0.5,
+    sleep=time.sleep,
+) -> tuple[dict[str, Any], int]:
+    """Post with bounded retries. Returns the response and the attempt count.
+
+    Looks ``_post_json`` up on the module rather than closing over it so a test
+    (or a caller) can swap the transport by patching the module attribute.
+    """
+
+    attempts = 0
+    last: Exception | None = None
+    for attempt in range(max(0, int(retries)) + 1):
+        attempts += 1
+        try:
+            return (
+                globals()["_post_json"](
+                    url,
+                    payload,
+                    timeout_s=timeout_s,
+                    api_key=api_key,
+                    client_request_id=client_request_id,
+                ),
+                attempts,
+            )
+        except GateHTTPError as exc:
+            last = exc
+            if not exc.transient or attempt >= int(retries):
+                break
+            # Jittered backoff: a whole thread pool retrying a 503 in lockstep
+            # is just the same thundering herd one second later.
+            sleep(backoff_s * (2**attempt) * (0.5 + random.random() / 2))
+        except Exception as exc:  # noqa: BLE001 - a bad transport must not kill the run
+            last = exc
+            break
+    raise last if last is not None else GateHTTPError("request failed")
+
+
+def extract_completion_text(response: dict[str, Any], endpoint: str) -> tuple[str, str | None]:
+    """Pull the generated text and finish_reason out of either response shape."""
+
+    choices = response.get("choices") or []
+    if not choices:
+        return "", None
+    choice = choices[0] or {}
+    finish_reason = choice.get("finish_reason")
+    if endpoint == "chat":
+        message = choice.get("message") or {}
+        text = message.get("content")
+    else:
+        text = choice.get("text")
+    return (text if isinstance(text, str) else ""), finish_reason
+
+
+# --------------------------------------------------------------------------
+# generate
+# --------------------------------------------------------------------------
+
+
+def generate_one(config: dict[str, Any], task: CodeTask, sample: int) -> dict[str, Any]:
+    """Fetch one completion. Never raises: a dead request becomes an error row.
+
+    One task failing to generate must not take the other 163 down with it, so
+    the failure is recorded and the run continues. It is still counted as a
+    non-pass in the summary -- a run that could not ask the model is not a run
+    that scored zero by accident.
+    """
+
+    args = argparse.Namespace(**config["request_args"])
+    client_request_id = _client_request_id(task.task_id, sample)
+    payload = build_payload(
+        args, task, sample=sample, client_request_id=client_request_id
+    )
+    url = endpoint_url(config["base_url"], args.endpoint)
+    started = time.perf_counter()
+    try:
+        response, attempts = request_with_retries(
+            url,
+            payload,
+            timeout_s=float(config["timeout_s"]),
+            api_key=config.get("api_key"),
+            client_request_id=client_request_id,
+            retries=int(config["retries"]),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "task_id": task.task_id,
+            "sample": sample,
+            "completion": None,
+            "error": repr(exc),
+            "attempts": int(config["retries"]) + 1,
+            "finish_reason": None,
+            "request_seconds": time.perf_counter() - started,
+            "usage": None,
+            "mtplx_stats": {},
+        }
+    text, finish_reason = extract_completion_text(response, args.endpoint)
+    return {
+        "task_id": task.task_id,
+        "sample": sample,
+        "completion": text,
+        "error": None,
+        "attempts": attempts,
+        "finish_reason": finish_reason,
+        "request_seconds": time.perf_counter() - started,
+        "usage": response.get("usage"),
+        "mtplx_stats": response.get("mtplx_stats") or {},
+    }
+
+
+# --------------------------------------------------------------------------
+# score
+# --------------------------------------------------------------------------
+
+
+def score_one(
+    task: CodeTask,
+    generation: dict[str, Any],
+    *,
+    allow_execution: bool,
+    timeout_s: float,
+) -> TaskResult:
+    """Score one generation, mapping a failed request onto its own status."""
+
+    if generation.get("error") is not None:
+        return TaskResult(
+            task.task_id, False, "request_error", str(generation["error"])[:400], 0.0
+        )
+    completion = generation.get("completion") or ""
+    try:
+        return run_candidate(
+            task,
+            completion,
+            allow_execution=allow_execution,
+            timeout_s=timeout_s,
+        )
+    except Exception as exc:  # noqa: BLE001 - a broken candidate is a row, not a crash
+        return TaskResult(task.task_id, False, "error", repr(exc)[:400], 0.0)
+
+
+def pass_at_k_report(
+    results: Sequence[TaskResult], *, n: int, ks: Sequence[int]
+) -> dict[str, float]:
+    """Per-task pass@k, averaged over tasks.
+
+    ``summarize`` deliberately is not used for this: its ``n>1`` branch treats
+    the whole run as one n-sample draw, which is only correct for a single
+    task. pass@k is defined per problem and then averaged.
+    """
+
+    by_task: dict[str, list[TaskResult]] = {}
+    for result in results:
+        by_task.setdefault(result.task_id, []).append(result)
+    report: dict[str, float] = {}
+    for k in ks:
+        if k > n or k <= 0:
+            continue
+        scores = [
+            pass_at_k(len(rows), sum(1 for r in rows if r.passed), k)
+            for rows in by_task.values()
+            if len(rows) >= k
+        ]
+        if scores:
+            report[f"pass@{k}"] = sum(scores) / len(scores)
+    return report
+
+
+# --------------------------------------------------------------------------
+# run
+# --------------------------------------------------------------------------
+
+
+def _request_args(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "model": args.model,
+        "endpoint": args.endpoint,
+        "temperature": args.temperature,
+        "top_p": args.top_p,
+        "max_tokens": args.max_tokens,
+        "seed": args.seed,
+    }
+
+
+def build_report(
+    *,
+    args: argparse.Namespace,
+    tasks: Sequence[CodeTask],
+    generations: Sequence[dict[str, Any]],
+    results: Sequence[TaskResult],
+    wall_s: float,
+    dataset_sha256: str,
+) -> dict[str, Any]:
+    by_id = {task.task_id: task for task in tasks}
+    rows: list[dict[str, Any]] = []
+    for result, generation in zip(results, generations):
+        rows.append(
+            {
+                "task_id": result.task_id,
+                "sample": generation["sample"],
+                "suite": by_id[result.task_id].suite
+                if result.task_id in by_id
+                else args.suite,
+                "status": result.status,
+                "passed": result.passed,
+                "seconds": result.seconds,
+                "request_seconds": generation["request_seconds"],
+                "attempts": generation["attempts"],
+                "finish_reason": generation["finish_reason"],
+                "detail": result.detail[:400],
+                "error": generation["error"],
+                "usage": generation["usage"],
+            }
+        )
+    ks = sorted({1, int(args.n)})
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "summary": summarize(list(results)),
+        "rows": rows,
+        "provenance": {
+            "base_url": args.base_url.rstrip("/"),
+            "model": args.model,
+            "suite": args.suite,
+            "endpoint": args.endpoint,
+            "dataset_path": str(args.dataset_path),
+            "dataset_sha256": dataset_sha256,
+            "tasks": len(tasks),
+            "samples_per_task": int(args.n),
+            "completions": len(generations),
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "mtplx_version": _mtplx_version(),
+            "python": sys.version.split()[0],
+            "wall_s": wall_s,
+        },
+        "params": {
+            **_request_args(args),
+            "n": int(args.n),
+            "limit": args.limit,
+            "workers": int(args.workers),
+            "score_workers": int(args.score_workers),
+            "retries": int(args.retries),
+            "timeout_s": float(args.timeout_s),
+            "execution_timeout_s": float(args.execution_timeout_s),
+            "allow_code_execution": bool(args.allow_code_execution),
+        },
+        "request_errors": sum(1 for r in results if r.status == "request_error"),
+    }
+    if int(args.n) > 1:
+        report["pass_at_k"] = pass_at_k_report(results, n=int(args.n), ks=ks)
+    return report
+
+
+def run(args: argparse.Namespace) -> int:
+    if not args.allow_code_execution:
+        print(
+            "REFUSING: scoring HumanEval/MBPP means executing code this model "
+            "wrote, in a subprocess on this machine. Pass --allow-code-execution "
+            "to acknowledge that. Nothing was requested and nothing was run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    dataset_path = Path(args.dataset_path)
+    tasks = load_tasks(args.suite, dataset_path)
+    if args.limit is not None:
+        tasks = tasks[: max(0, int(args.limit))]
+    if not tasks:
+        print("no tasks selected", file=sys.stderr)
+        return 2
+
+    config = {
+        "base_url": args.base_url.rstrip("/"),
+        "api_key": args.api_key,
+        "timeout_s": args.timeout_s,
+        "retries": args.retries,
+        "request_args": _request_args(args),
+    }
+
+    units = [(task, sample) for task in tasks for sample in range(int(args.n))]
+    started = time.perf_counter()
+
+    # Generation is network-bound and scoring is process-bound, so they run as
+    # two phases with independently bounded pools. Interleaving them would put
+    # `workers` sockets and `workers` subprocesses in flight at once, which is
+    # how a 164-task run turns into a fork bomb on a laptop.
+    generations: list[dict[str, Any]] = [None] * len(units)  # type: ignore[list-item]
+    with futures.ThreadPoolExecutor(max_workers=int(args.workers)) as pool:
+        pending = {
+            pool.submit(generate_one, config, task, sample): index
+            for index, (task, sample) in enumerate(units)
+        }
+        done = 0
+        for future in futures.as_completed(pending):
+            index = pending[future]
+            generations[index] = future.result()
+            done += 1
+            if args.progress:
+                _print_progress("generate", done, len(units), generations[index])
+
+    results: list[TaskResult] = [None] * len(units)  # type: ignore[list-item]
+    with futures.ThreadPoolExecutor(max_workers=int(args.score_workers)) as pool:
+        pending = {
+            pool.submit(
+                score_one,
+                task,
+                generations[index],
+                allow_execution=True,
+                timeout_s=float(args.execution_timeout_s),
+            ): index
+            for index, (task, sample) in enumerate(units)
+        }
+        done = 0
+        for future in futures.as_completed(pending):
+            index = pending[future]
+            results[index] = future.result()
+            done += 1
+            if args.progress:
+                _print_progress("score", done, len(units), results[index])
+
+    report = build_report(
+        args=args,
+        tasks=tasks,
+        generations=generations,
+        results=results,
+        wall_s=time.perf_counter() - started,
+        dataset_sha256=_dataset_sha256(dataset_path),
+    )
+
+    output_path = _resolve_output_path(args)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        report.setdefault("artifacts", {})["report_json"] = str(output_path)
+
+    print(
+        json.dumps(
+            {
+                "schema": report["schema"],
+                "summary": report["summary"],
+                "pass_at_k": report.get("pass_at_k"),
+                "request_errors": report["request_errors"],
+                "provenance": report["provenance"],
+                "artifacts": report.get("artifacts", {}),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    if report["request_errors"]:
+        return 1
+    if args.min_pass_rate is not None:
+        rate = report["summary"].get("pass@1", 0.0)
+        if rate < float(args.min_pass_rate):
+            print(
+                f"FAIL: pass@1 {rate:.4f} < --min-pass-rate {args.min_pass_rate}",
+                file=sys.stderr,
+            )
+            return 1
+    return 0
+
+
+def _resolve_output_path(args: argparse.Namespace) -> Path | None:
+    if args.output_json:
+        return Path(args.output_json)
+    if args.output_dir:
+        return Path(args.output_dir) / f"code-eval-{args.suite}-{args.endpoint}.json"
+    return None
+
+
+def _print_progress(phase: str, done: int, total: int, item: Any) -> None:
+    if isinstance(item, TaskResult):
+        detail = {"task_id": item.task_id, "status": item.status}
+    else:
+        detail = {
+            "task_id": item.get("task_id"),
+            "error": item.get("error"),
+            "finish": item.get("finish_reason"),
+        }
+    print(
+        json.dumps({"phase": phase, "done": done, "total": total, **detail}),
+        flush=True,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--base-url", default="http://127.0.0.1:18183")
+    parser.add_argument("--api-key", default=os.environ.get("MTPLX_API_KEY"))
+    parser.add_argument("--model", default="mtplx-qwen36-27b-optimized-speed")
+    parser.add_argument("--suite", choices=("humaneval", "mbpp"), default="humaneval")
+    parser.add_argument(
+        "--dataset-path",
+        required=True,
+        help="Path to HumanEval.jsonl, mbpp.jsonl, or sanitized-mbpp.json.",
+    )
+    parser.add_argument(
+        "--endpoint",
+        choices=("chat", "completions"),
+        default="chat",
+        help="chat = /v1/chat/completions (instruct); "
+        "completions = /v1/completions (base-model continuation).",
+    )
+    parser.add_argument("--limit", type=int, help="Score only the first N tasks.")
+    parser.add_argument(
+        "--workers", type=int, default=4, help="Concurrent in-flight requests."
+    )
+    parser.add_argument(
+        "--score-workers",
+        type=int,
+        default=4,
+        help="Concurrent scoring subprocesses. Each one is a real process.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=1024)
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="0.0 by default so two arms are comparable. Raise it for pass@k.",
+    )
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--n",
+        type=int,
+        default=1,
+        help="Samples per task. >1 enables pass@k and needs a nonzero temperature.",
+    )
+    parser.add_argument("--retries", type=int, default=2)
+    parser.add_argument("--timeout-s", type=float, default=600.0)
+    parser.add_argument(
+        "--execution-timeout-s",
+        type=float,
+        default=15.0,
+        help="Wall-clock limit per candidate subprocess.",
+    )
+    parser.add_argument("--output-json", help="Write the full report here.")
+    parser.add_argument("--output-dir", help="Write the report into this directory.")
+    parser.add_argument(
+        "--min-pass-rate",
+        type=float,
+        help="Exit nonzero if pass@1 falls below this.",
+    )
+    parser.add_argument("--progress", action="store_true", default=False)
+    parser.add_argument(
+        "--allow-code-execution",
+        action="store_true",
+        default=False,
+        help="Required. Acknowledges that scoring executes model-written code.",
+    )
+    args = parser.parse_args(argv)
+    if int(args.n) < 1:
+        parser.error("--n must be >= 1")
+    if int(args.n) > 1 and float(args.temperature) == 0.0:
+        parser.error(
+            "--n > 1 with --temperature 0 draws the same completion n times; "
+            "pass@k would be meaningless. Raise --temperature."
+        )
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_code_eval.py
+++ b/tests/test_code_eval.py
@@ -1,0 +1,259 @@
+"""Tests for the HumanEval / MBPP scoring harness."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mtplx.benchmarks import code_eval as ce
+
+
+# --------------------------------------------------------------------------
+# loading
+# --------------------------------------------------------------------------
+
+
+def test_load_humaneval(tmp_path) -> None:
+    path = tmp_path / "he.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "task_id": "HumanEval/0",
+                "prompt": "def add(a, b):\n    ",
+                "canonical_solution": "return a + b\n",
+                "test": "def check(candidate):\n    assert candidate(1, 2) == 3\n",
+                "entry_point": "add",
+            }
+        )
+        + "\n"
+    )
+    tasks = ce.load_humaneval(path)
+    assert len(tasks) == 1
+    assert tasks[0].entry_point == "add" and tasks[0].suite == "humaneval"
+
+
+def test_load_mbpp_embeds_the_asserts_in_the_prompt(tmp_path) -> None:
+    """MBPP is underspecified without its asserts -- they pin the function name."""
+
+    path = tmp_path / "mbpp.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "task_id": 3,
+                "text": "Write a function to add two numbers.",
+                "code": "def add(a,b): return a+b",
+                "test_list": ["assert add(1, 2) == 3"],
+                "test_setup_code": "",
+            }
+        )
+        + "\n"
+    )
+    task = ce.load_mbpp(path)[0]
+    assert task.task_id == "MBPP/3"
+    assert "assert add(1, 2) == 3" in task.prompt
+
+
+def test_empty_dataset_is_an_error(tmp_path) -> None:
+    path = tmp_path / "empty.jsonl"
+    path.write_text("")
+    with pytest.raises(ce.CodeEvalError):
+        ce.load_humaneval(path)
+
+
+# --------------------------------------------------------------------------
+# extraction -- instruct models wrap code in fences
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("completion", "expected"),
+    [
+        ("```python\ndef f():\n    return 1\n```", "def f():\n    return 1"),
+        ("```\ndef f():\n    return 1\n```", "def f():\n    return 1"),
+        ("Sure!\n```python\ndef f():\n    return 1\n```\nHope that helps!",
+         "def f():\n    return 1"),
+        ("    return 1", "    return 1"),  # bare continuation, no fence
+    ],
+)
+def test_extract_code(completion, expected) -> None:
+    assert ce.extract_code(completion) == expected
+
+
+def test_unterminated_fence_still_yields_code() -> None:
+    """Truncated at max_tokens mid-block is common; don't score it as empty."""
+
+    assert ce.extract_code("```python\ndef f():\n    return 1") == "def f():\n    return 1"
+
+
+# --------------------------------------------------------------------------
+# program assembly
+# --------------------------------------------------------------------------
+
+
+def _he_task() -> ce.CodeTask:
+    return ce.CodeTask(
+        task_id="HumanEval/0",
+        suite="humaneval",
+        prompt="def add(a, b):\n",
+        test="def check(candidate):\n    assert candidate(1, 2) == 3\n",
+        entry_point="add",
+    )
+
+
+def test_bare_body_is_concatenated_onto_the_prompt() -> None:
+    program = ce.build_program(_he_task(), "    return a + b")
+    assert program.startswith("def add(a, b):\n")
+    assert "check(add)" in program
+
+
+def test_redefined_function_replaces_the_prompt_rather_than_nesting() -> None:
+    """A fenced block that redefines the signature must not be indented under it."""
+
+    program = ce.build_program(
+        _he_task(), "```python\ndef add(a, b):\n    return a + b\n```"
+    )
+    assert program.count("def add(a, b):") == 1
+
+
+# --------------------------------------------------------------------------
+# execution -- the part that actually runs model output
+# --------------------------------------------------------------------------
+
+
+def test_execution_refuses_without_explicit_opt_in() -> None:
+    with pytest.raises(ce.CodeEvalError, match="allow_execution=True"):
+        ce.run_candidate(_he_task(), "    return a + b")
+
+
+def test_correct_solution_passes() -> None:
+    result = ce.run_candidate(_he_task(), "    return a + b", allow_execution=True)
+    assert result.passed and result.status == "passed"
+
+
+def test_wrong_solution_fails_without_raising() -> None:
+    result = ce.run_candidate(_he_task(), "    return a * b", allow_execution=True)
+    assert not result.passed and result.status in {"failed", "error"}
+
+
+def test_syntax_error_is_distinguished_from_a_failed_assert() -> None:
+    """Both exit 1, but unparseable output and wrong logic are different
+    signals when comparing quantization arms -- keep them separable."""
+
+    broken = ce.run_candidate(_he_task(), "    return (((", allow_execution=True)
+    assert not broken.passed and broken.status == "syntax_error"
+
+    wrong = ce.run_candidate(_he_task(), "    return a * b", allow_execution=True)
+    assert not wrong.passed and wrong.status == "failed"
+
+
+def test_empty_completion_is_its_own_status() -> None:
+    result = ce.run_candidate(_he_task(), "   \n  ", allow_execution=True)
+    assert not result.passed and result.status == "empty"
+
+
+def test_infinite_loop_is_killed_by_the_timeout() -> None:
+    """The whole point of the sandbox: a hung candidate must not hang the run."""
+
+    result = ce.run_candidate(
+        _he_task(), "    while True:\n        pass", allow_execution=True, timeout_s=3.0
+    )
+    assert not result.passed and result.status == "timeout"
+    assert result.seconds < 20.0
+
+
+def test_candidate_cannot_leave_a_file_behind_in_the_repo(tmp_path, monkeypatch) -> None:
+    """Candidates run in a scratch cwd that is removed afterwards."""
+
+    monkeypatch.chdir(tmp_path)
+    ce.run_candidate(
+        _he_task(),
+        "    open('escaped.txt', 'w').write('x')\n    return a + b",
+        allow_execution=True,
+    )
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+# --------------------------------------------------------------------------
+# pass@k
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n", "c", "k", "expected"),
+    [
+        (1, 1, 1, 1.0),
+        (1, 0, 1, 0.0),
+        (10, 10, 1, 1.0),
+        (10, 0, 5, 0.0),
+        (5, 1, 1, 0.2),
+        (10, 1, 10, 1.0),  # k == n and one correct -> certain
+    ],
+)
+def test_pass_at_k_known_values(n, c, k, expected) -> None:
+    assert ce.pass_at_k(n, c, k) == pytest.approx(expected)
+
+
+def test_pass_at_k_is_monotonic_in_k() -> None:
+    values = [ce.pass_at_k(20, 3, k) for k in range(1, 11)]
+    assert values == sorted(values)
+
+
+@pytest.mark.parametrize(("n", "c", "k"), [(0, 0, 1), (5, 6, 1), (5, -1, 1), (5, 1, 0)])
+def test_pass_at_k_rejects_impossible_inputs(n, c, k) -> None:
+    with pytest.raises(ce.CodeEvalError):
+        ce.pass_at_k(n, c, k)
+
+
+def test_summarize_counts_and_lists_failures() -> None:
+    results = [
+        ce.TaskResult("a", True, "passed"),
+        ce.TaskResult("b", False, "failed", "assert"),
+        ce.TaskResult("c", False, "timeout", "slow"),
+    ]
+    report = ce.summarize(results)
+    assert report["tasks"] == 3 and report["passed"] == 1
+    assert report["pass@1"] == pytest.approx(1 / 3)
+    assert report["by_status"] == {"passed": 1, "failed": 1, "timeout": 1}
+    assert {f["task_id"] for f in report["failures"]} == {"b", "c"}
+
+
+# --------------------------------------------------------------------------
+# summarize with multiple samples per task
+# --------------------------------------------------------------------------
+
+
+def test_summarize_groups_samples_by_task_for_pass_at_k() -> None:
+    """pass@k is a PER-TASK estimator averaged across tasks.
+
+    The earlier signature took n= and fed the corpus-wide pass count into
+    pass_at_k, which raised as soon as that count exceeded n. Sample counts
+    are now derived per task so callers cannot get it wrong.
+    """
+
+    # 2 tasks x 4 samples. Task A: 2/4 correct. Task B: 0/4.
+    results = (
+        [ce.TaskResult("A", i < 2, "passed" if i < 2 else "failed") for i in range(4)]
+        + [ce.TaskResult("B", False, "failed") for _ in range(4)]
+    )
+    report = ce.summarize(results, k=1)
+    assert report["tasks"] == 2 and report["samples"] == 8
+    assert report["passed"] == 1, "one task had at least one correct sample"
+    # pass@1 = mean(2/4, 0/4) = 0.25
+    assert report["pass@1"] == pytest.approx(0.25)
+
+
+def test_summarize_single_sample_per_task_is_plain_accuracy() -> None:
+    results = [
+        ce.TaskResult("a", True, "passed"),
+        ce.TaskResult("b", False, "failed"),
+        ce.TaskResult("c", False, "timeout"),
+    ]
+    assert ce.summarize(results, k=1)["pass@1"] == pytest.approx(1 / 3)
+
+
+def test_summarize_skips_tasks_with_fewer_samples_than_k() -> None:
+    """Estimating pass@5 from 2 samples would be optimistic; skip instead."""
+
+    results = [ce.TaskResult("a", True, "passed"), ce.TaskResult("a", False, "failed")]
+    assert ce.summarize(results, k=5)["pass@5"] == 0.0

--- a/tests/test_code_eval_gate.py
+++ b/tests/test_code_eval_gate.py
@@ -1,0 +1,547 @@
+"""Tests for the HumanEval / MBPP completion driver.
+
+Nothing here touches a server. The HTTP seam (``_post_json``) is replaced, so
+every test asserts on what the driver *would have sent* and how it behaves when
+the transport misbehaves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from mtplx.benchmarks import code_eval as ce
+
+
+def _load_gate_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "code_eval_gate.py"
+    spec = importlib.util.spec_from_file_location("code_eval_gate", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate_module()
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+def _he_task() -> ce.CodeTask:
+    return ce.CodeTask(
+        task_id="HumanEval/0",
+        suite="humaneval",
+        prompt="def add(a, b):\n",
+        test="def check(candidate):\n    assert candidate(1, 2) == 3\n",
+        entry_point="add",
+    )
+
+
+def _mbpp_task() -> ce.CodeTask:
+    return ce.CodeTask(
+        task_id="MBPP/3",
+        suite="mbpp",
+        prompt="Write a function to add two numbers.\nassert add(1, 2) == 3\n",
+        test="assert add(1, 2) == 3",
+    )
+
+
+def _args(**overrides) -> argparse.Namespace:
+    values = {
+        "model": "mtplx-test",
+        "endpoint": "chat",
+        "temperature": 0.0,
+        "top_p": None,
+        "max_tokens": 512,
+        "seed": 42,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _humaneval_dataset(tmp_path: Path) -> Path:
+    path = tmp_path / "HumanEval.jsonl"
+    path.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "task_id": f"HumanEval/{index}",
+                    "prompt": "def add(a, b):\n",
+                    "canonical_solution": "    return a + b\n",
+                    "test": "def check(candidate):\n    assert candidate(1, 2) == 3\n",
+                    "entry_point": "add",
+                }
+            )
+            for index in range(3)
+        )
+        + "\n"
+    )
+    return path
+
+
+def _chat_response(text: str) -> dict:
+    return {
+        "id": "chatcmpl-x",
+        "choices": [
+            {"finish_reason": "stop", "message": {"role": "assistant", "content": text}}
+        ],
+        "usage": {"completion_tokens": 7},
+    }
+
+
+_GOOD = "```python\ndef add(a, b):\n    return a + b\n```"
+_WRONG = "```python\ndef add(a, b):\n    return a * b\n```"
+
+
+def _cli(dataset: Path, output: Path, *extra: str) -> list[str]:
+    return [
+        "--dataset-path",
+        str(dataset),
+        "--output-json",
+        str(output),
+        "--base-url",
+        "http://127.0.0.1:9",
+        "--model",
+        "mtplx-test",
+        "--workers",
+        "2",
+        "--score-workers",
+        "2",
+        *extra,
+    ]
+
+
+# --------------------------------------------------------------------------
+# prompt construction
+# --------------------------------------------------------------------------
+
+
+def test_humaneval_chat_prompt_carries_the_signature_and_asks_for_a_fence() -> None:
+    messages = gate.build_messages(_he_task())
+    assert [m["role"] for m in messages] == ["system", "user"]
+    assert "def add(a, b):" in messages[1]["content"]
+    assert "fenced" in messages[0]["content"].lower()
+
+
+def test_mbpp_chat_prompt_keeps_the_asserts() -> None:
+    """The asserts pin the function name; dropping them makes MBPP unscoreable."""
+
+    messages = gate.build_messages(_mbpp_task())
+    assert "assert add(1, 2) == 3" in messages[1]["content"]
+
+
+def test_chat_payload_is_deterministic_by_default() -> None:
+    payload = gate.build_payload(
+        _args(), _he_task(), sample=0, client_request_id="rid"
+    )
+    assert payload["temperature"] == 0.0
+    assert payload["max_tokens"] == 512
+    assert payload["seed"] == 42
+    assert payload["stream"] is False
+    assert "messages" in payload and "prompt" not in payload
+
+
+def test_completions_endpoint_sends_the_raw_prompt_verbatim() -> None:
+    """Base-model continuation: any wrapper text changes what is being measured."""
+
+    payload = gate.build_payload(
+        _args(endpoint="completions"), _he_task(), sample=0, client_request_id="rid"
+    )
+    assert payload["prompt"] == "def add(a, b):\n"
+    assert "messages" not in payload
+    assert "\ndef " in payload["stop"]
+
+
+def test_completions_endpoint_omits_humaneval_stops_for_mbpp() -> None:
+    payload = gate.build_payload(
+        _args(endpoint="completions"), _mbpp_task(), sample=0, client_request_id="rid"
+    )
+    assert "stop" not in payload
+
+
+def test_each_sample_gets_its_own_seed() -> None:
+    """Without this, n>1 draws the same completion n times and pass@k is a lie."""
+
+    seeds = {
+        gate.build_payload(
+            _args(temperature=0.8), _he_task(), sample=i, client_request_id="rid"
+        )["seed"]
+        for i in range(4)
+    }
+    assert len(seeds) == 4
+
+
+def test_top_p_is_omitted_unless_asked_for() -> None:
+    assert "top_p" not in gate.build_payload(
+        _args(), _he_task(), sample=0, client_request_id="rid"
+    )
+    assert (
+        gate.build_payload(
+            _args(top_p=0.9), _he_task(), sample=0, client_request_id="rid"
+        )["top_p"]
+        == 0.9
+    )
+
+
+def test_endpoint_url() -> None:
+    assert (
+        gate.endpoint_url("http://h:1/", "chat") == "http://h:1/v1/chat/completions"
+    )
+    assert gate.endpoint_url("http://h:1", "completions") == "http://h:1/v1/completions"
+
+
+# --------------------------------------------------------------------------
+# response parsing
+# --------------------------------------------------------------------------
+
+
+def test_extract_completion_text_handles_both_shapes() -> None:
+    assert gate.extract_completion_text(_chat_response("hi"), "chat") == ("hi", "stop")
+    raw = {"choices": [{"text": "  body", "finish_reason": "length"}]}
+    assert gate.extract_completion_text(raw, "completions") == ("  body", "length")
+
+
+def test_missing_choices_is_empty_not_an_exception() -> None:
+    assert gate.extract_completion_text({}, "chat") == ("", None)
+    assert gate.extract_completion_text({"choices": [{}]}, "chat") == ("", None)
+
+
+# --------------------------------------------------------------------------
+# retry behavior
+# --------------------------------------------------------------------------
+
+
+def _retry_call(monkeypatch, responses, *, retries=2):
+    calls = {"n": 0}
+
+    def fake_post(url, payload, **kwargs):
+        index = calls["n"]
+        calls["n"] += 1
+        outcome = responses[min(index, len(responses) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(gate, "_post_json", fake_post)
+    monkeypatch.setattr(gate.time, "sleep", lambda _s: None)
+    return calls, fake_post
+
+
+def test_transient_failure_is_retried_then_succeeds(monkeypatch) -> None:
+    calls, _ = _retry_call(
+        monkeypatch,
+        [gate.GateHTTPError("busy", status=503), _chat_response("ok")],
+    )
+    response, attempts = gate.request_with_retries(
+        "u", {}, timeout_s=1, api_key=None, client_request_id="r", retries=2,
+        sleep=lambda _s: None,
+    )
+    assert attempts == 2 and calls["n"] == 2
+    assert response["choices"][0]["message"]["content"] == "ok"
+
+
+def test_retries_are_bounded(monkeypatch) -> None:
+    calls, _ = _retry_call(monkeypatch, [gate.GateHTTPError("busy", status=503)])
+    with pytest.raises(gate.GateHTTPError):
+        gate.request_with_retries(
+            "u", {}, timeout_s=1, api_key=None, client_request_id="r", retries=2,
+            sleep=lambda _s: None,
+        )
+    assert calls["n"] == 3  # 1 attempt + 2 retries
+
+
+def test_a_client_error_is_not_retried(monkeypatch) -> None:
+    """A 400 is a misconfigured run; retrying it three times just wastes time."""
+
+    calls, _ = _retry_call(monkeypatch, [gate.GateHTTPError("bad", status=400)])
+    with pytest.raises(gate.GateHTTPError):
+        gate.request_with_retries(
+            "u", {}, timeout_s=1, api_key=None, client_request_id="r", retries=5,
+            sleep=lambda _s: None,
+        )
+    assert calls["n"] == 1
+
+
+def test_a_connection_failure_with_no_status_is_transient(monkeypatch) -> None:
+    calls, _ = _retry_call(monkeypatch, [gate.GateHTTPError("socket died")])
+    with pytest.raises(gate.GateHTTPError):
+        gate.request_with_retries(
+            "u", {}, timeout_s=1, api_key=None, client_request_id="r", retries=1,
+            sleep=lambda _s: None,
+        )
+    assert calls["n"] == 2
+
+
+def test_rate_limit_is_treated_as_transient() -> None:
+    assert gate.GateHTTPError("x", status=429).transient
+    assert not gate.GateHTTPError("x", status=404).transient
+
+
+# --------------------------------------------------------------------------
+# per-task failure must not kill the run
+# --------------------------------------------------------------------------
+
+
+def test_generate_one_records_a_failure_instead_of_raising(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gate,
+        "_post_json",
+        lambda *a, **k: (_ for _ in ()).throw(gate.GateHTTPError("down", status=500)),
+    )
+    monkeypatch.setattr(gate.time, "sleep", lambda _s: None)
+    config = {
+        "base_url": "http://x",
+        "api_key": None,
+        "timeout_s": 1,
+        "retries": 0,
+        "request_args": vars(_args()),
+    }
+    row = gate.generate_one(config, _he_task(), 0)
+    assert row["completion"] is None
+    assert "down" in row["error"]
+
+
+def test_a_failed_request_scores_as_its_own_status() -> None:
+    """It must not be silently dropped, and it must not look like a wrong answer."""
+
+    result = gate.score_one(
+        _he_task(),
+        {"error": "boom", "completion": None},
+        allow_execution=True,
+        timeout_s=5,
+    )
+    assert not result.passed and result.status == "request_error"
+
+
+def test_one_dead_task_does_not_kill_the_run(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+    seen = {"n": 0}
+
+    def fake_post(url, payload, **kwargs):
+        seen["n"] += 1
+        if payload["metadata"]["task_id"] == "HumanEval/1":
+            raise gate.GateHTTPError("gateway gone", status=502)
+        return _chat_response(_GOOD)
+
+    monkeypatch.setattr(gate, "_post_json", fake_post)
+    monkeypatch.setattr(gate.time, "sleep", lambda _s: None)
+
+    code = gate.main(_cli(dataset, output, "--allow-code-execution", "--retries", "1"))
+
+    report = json.loads(output.read_text())
+    assert report["summary"]["tasks"] == 3
+    assert report["summary"]["passed"] == 2
+    assert report["request_errors"] == 1
+    statuses = {row["task_id"]: row["status"] for row in report["rows"]}
+    assert statuses["HumanEval/1"] == "request_error"
+    assert statuses["HumanEval/0"] == "passed"
+    assert code == 1  # a run that could not reach the model is not a green run
+
+
+# --------------------------------------------------------------------------
+# the execution opt-in
+# --------------------------------------------------------------------------
+
+
+def test_refuses_without_the_execution_flag(tmp_path, monkeypatch, capsys) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+
+    def explode(*a, **k):
+        raise AssertionError("no request may be sent before the opt-in")
+
+    monkeypatch.setattr(gate, "_post_json", explode)
+
+    code = gate.main(_cli(dataset, output))
+
+    assert code == 2
+    assert "--allow-code-execution" in capsys.readouterr().err
+    assert not output.exists()
+
+
+def test_the_flag_is_what_reaches_run_candidate(tmp_path, monkeypatch) -> None:
+    """The opt-in must actually be threaded through, not just checked at the door."""
+
+    seen = {}
+
+    def fake_run_candidate(task, completion, *, allow_execution=False, timeout_s=None):
+        seen["allow_execution"] = allow_execution
+        seen["timeout_s"] = timeout_s
+        return ce.TaskResult(task.task_id, True, "passed", "", 0.1)
+
+    monkeypatch.setattr(gate, "run_candidate", fake_run_candidate)
+    gate.score_one(
+        _he_task(),
+        {"error": None, "completion": _GOOD},
+        allow_execution=True,
+        timeout_s=9.0,
+    )
+    assert seen == {"allow_execution": True, "timeout_s": 9.0}
+
+
+# --------------------------------------------------------------------------
+# report shape
+# --------------------------------------------------------------------------
+
+
+def test_report_shape_and_provenance(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "nested" / "report.json"
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_GOOD))
+
+    code = gate.main(_cli(dataset, output, "--allow-code-execution"))
+    assert code == 0
+
+    report = json.loads(output.read_text())
+    assert report["schema"] == gate.SCHEMA
+
+    summary = report["summary"]
+    assert summary["tasks"] == 3 and summary["passed"] == 3
+    assert summary["pass@1"] == pytest.approx(1.0)
+    assert summary["by_status"] == {"passed": 3}
+
+    rows = report["rows"]
+    assert len(rows) == 3
+    assert {"task_id", "status", "seconds"} <= set(rows[0])
+    assert all(row["suite"] == "humaneval" for row in rows)
+
+    prov = report["provenance"]
+    assert prov["base_url"] == "http://127.0.0.1:9"
+    assert prov["model"] == "mtplx-test"
+    assert prov["suite"] == "humaneval"
+    assert prov["tasks"] == 3
+    assert len(prov["dataset_sha256"]) == 64
+    assert prov["dataset_sha256"] == gate._dataset_sha256(dataset)
+    assert prov["timestamp_utc"].endswith("+00:00")
+    assert "mtplx_version" in prov
+
+    params = report["params"]
+    assert params["temperature"] == 0.0 and params["n"] == 1
+    assert params["allow_code_execution"] is True
+    assert params["endpoint"] == "chat"
+
+    # n == 1 is not a pass@k run.
+    assert "pass_at_k" not in report
+
+
+def test_wrong_answers_are_scored_wrong(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_WRONG))
+
+    gate.main(_cli(dataset, output, "--allow-code-execution"))
+    report = json.loads(output.read_text())
+    assert report["summary"]["passed"] == 0
+    assert report["summary"]["by_status"] == {"failed": 3}
+
+
+def test_limit_truncates_the_task_list(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_GOOD))
+
+    gate.main(_cli(dataset, output, "--allow-code-execution", "--limit", "2"))
+    report = json.loads(output.read_text())
+    assert report["provenance"]["tasks"] == 2 and len(report["rows"]) == 2
+
+
+def test_output_dir_is_accepted_like_the_sibling_gates(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_GOOD))
+
+    gate.main(
+        [
+            "--dataset-path",
+            str(dataset),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--allow-code-execution",
+        ]
+    )
+    assert (tmp_path / "out" / "code-eval-humaneval-chat.json").exists()
+
+
+def test_min_pass_rate_gates_the_exit_code(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_WRONG))
+
+    code = gate.main(
+        _cli(dataset, output, "--allow-code-execution", "--min-pass-rate", "0.5")
+    )
+    assert code == 1
+
+
+# --------------------------------------------------------------------------
+# pass@k
+# --------------------------------------------------------------------------
+
+
+def test_pass_at_k_is_averaged_per_task_not_pooled() -> None:
+    """Two tasks, 2 samples each: one always right, one always wrong -> 0.5."""
+
+    results = [
+        ce.TaskResult("a", True, "passed"),
+        ce.TaskResult("a", True, "passed"),
+        ce.TaskResult("b", False, "failed"),
+        ce.TaskResult("b", False, "failed"),
+    ]
+    report = gate.pass_at_k_report(results, n=2, ks=[1, 2])
+    assert report["pass@1"] == pytest.approx(0.5)
+    assert report["pass@2"] == pytest.approx(0.5)
+
+
+def test_pass_at_k_rewards_one_lucky_sample() -> None:
+    results = [
+        ce.TaskResult("a", False, "failed"),
+        ce.TaskResult("a", True, "passed"),
+    ]
+    report = gate.pass_at_k_report(results, n=2, ks=[1, 2])
+    assert report["pass@1"] == pytest.approx(0.5)
+    assert report["pass@2"] == pytest.approx(1.0)
+
+
+def test_pass_at_k_skips_k_larger_than_n() -> None:
+    results = [ce.TaskResult("a", True, "passed")]
+    assert gate.pass_at_k_report(results, n=1, ks=[1, 5]) == {"pass@1": 1.0}
+
+
+def test_n_greater_than_one_appears_in_the_report(tmp_path, monkeypatch) -> None:
+    dataset = _humaneval_dataset(tmp_path)
+    output = tmp_path / "report.json"
+    monkeypatch.setattr(gate, "_post_json", lambda *a, **k: _chat_response(_GOOD))
+
+    gate.main(
+        _cli(
+            dataset,
+            output,
+            "--allow-code-execution",
+            "--n",
+            "2",
+            "--temperature",
+            "0.6",
+        )
+    )
+    report = json.loads(output.read_text())
+    assert len(report["rows"]) == 6  # 3 tasks x 2 samples
+    assert report["pass_at_k"]["pass@1"] == pytest.approx(1.0)
+    assert report["pass_at_k"]["pass@2"] == pytest.approx(1.0)
+    assert report["params"]["n"] == 2
+
+
+def test_sampling_n_at_temperature_zero_is_rejected(tmp_path) -> None:
+    """n>1 at temp 0 returns the same completion n times; pass@k would be fake."""
+
+    dataset = _humaneval_dataset(tmp_path)
+    with pytest.raises(SystemExit):
+        gate.main(
+            _cli(dataset, tmp_path / "r.json", "--allow-code-execution", "--n", "3")
+        )

--- a/tests/test_compile_state.py
+++ b/tests/test_compile_state.py
@@ -1,0 +1,46 @@
+"""compile_state: the trace-active flag that suppresses the submit-cadence
+async_eval inside a compiled forward (issue #51).
+
+The flag is the whole fix for "[async_eval] Not allowed inside a graph
+transformation": the model decode loop checks compile_trace_active() and skips
+its per-N-layer async_eval while a compiled forward runs. These guard that the
+flag is False by default, True only inside the context, restores correctly
+(including nesting), and that CompiledARForward actually raises it during its
+compiled call — the behavior the real model relies on.
+"""
+
+from __future__ import annotations
+
+from mtplx.compile_state import compile_trace, compile_trace_active
+
+
+def test_flag_false_by_default() -> None:
+    assert compile_trace_active() is False
+
+
+def test_context_sets_and_restores() -> None:
+    assert compile_trace_active() is False
+    with compile_trace():
+        assert compile_trace_active() is True
+    assert compile_trace_active() is False
+
+
+def test_context_restores_on_exception() -> None:
+    try:
+        with compile_trace():
+            assert compile_trace_active() is True
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    assert compile_trace_active() is False
+
+
+def test_nesting_restores_previous() -> None:
+    with compile_trace():
+        assert compile_trace_active() is True
+        with compile_trace():
+            assert compile_trace_active() is True
+        # inner exit must restore the OUTER True, not the module default
+        assert compile_trace_active() is True
+    assert compile_trace_active() is False
+

--- a/tests/test_compiled_ar_wiring.py
+++ b/tests/test_compiled_ar_wiring.py
@@ -1,0 +1,116 @@
+"""forward_ar engages the compiled AR path when flagged (wiring test)."""
+import json
+
+import pytest
+
+hy_v3 = pytest.importorskip(
+    "mlx_lm.models.hy_v3",
+    reason="mlx-lm does not ship models/hy_v3 yet (unreleased upstream)",
+)
+
+import mlx.core as mx
+from pathlib import Path
+
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+
+
+def _tiny_model():
+    args = hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        num_experts=4, num_experts_per_tok=2, num_shared_experts=1, expert_hidden_dim=64,
+        first_k_dense_replace=1, rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=0)
+    return hy_v3.Model(args)
+
+
+def _runtime(model):
+    return MTPLXRuntime(
+        model=model,
+        tokenizer=None,
+        model_path=Path("t"),
+        mtp_enabled=False,
+        contract=MTPContract(),
+    )
+
+
+def _primed_cache(model):
+    from mlx_lm.models.cache import KVCache
+
+    cache = [KVCache() for _ in model.model.layers]
+    _ = model(mx.array([[1, 2, 3, 4]]), cache=cache)
+    mx.eval(cache[0].keys)
+    return cache
+
+
+def test_compiled_path_engages_and_matches_eager(monkeypatch):
+    model = _tiny_model()
+    rt = _runtime(model)
+    cache = _primed_cache(model)
+
+    monkeypatch.delenv("MTPLX_COMPILE_AR_FORWARD", raising=False)
+    eager = rt.forward_ar(mx.array([[5]]), cache=cache)
+    mx.eval(eager)
+    assert rt.diagnostic_counters.get("compiled_forward_calls", 0) == 0
+
+    model2 = _tiny_model()
+    model2.update(model.parameters())
+    rt2 = _runtime(model2)
+    cache2 = _primed_cache(model2)
+    monkeypatch.setenv("MTPLX_COMPILE_AR_FORWARD", "1")
+    compiled = rt2.forward_ar(mx.array([[5]]), cache=cache2)
+    mx.eval(compiled)
+    assert rt2.diagnostic_counters.get("compiled_forward_calls", 0) == 1, (
+        "compiled AR path did not engage"
+    )
+    assert mx.allclose(
+        eager.astype(mx.float32), compiled.astype(mx.float32), atol=1e-4
+    ).item()
+    # steps advance through the compiled path and stay engaged
+    again = rt2.forward_ar(mx.array([[6]]), cache=cache2)
+    mx.eval(again)
+    assert rt2.diagnostic_counters["compiled_forward_calls"] == 2
+
+
+def _grafted_runtime(tmp_path):
+    """MTP-wrapped runtime (the live serving shape that missed engagement)."""
+    from mlx.utils import tree_flatten
+
+    from mtplx.hy_v3_mtp_patch import inject_hy_v3_mtp_support
+
+    args = hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        num_experts=4, num_experts_per_tok=2, num_shared_experts=1, expert_hidden_dim=64,
+        first_k_dense_replace=1, rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=1)
+    model = hy_v3.Model(args)
+    donor = hy_v3.DecoderLayer(args, layer_idx=2)
+    tensors = {f"model.layers.2.{k}": v for k, v in tree_flatten(donor.parameters())}
+    for name in ("enorm", "hnorm", "final_layernorm"):
+        tensors[f"model.layers.2.{name}.weight"] = mx.ones((64,))
+    tensors["model.layers.2.eh_proj.weight"] = 0.02 * mx.random.normal((64, 128))
+    mx.save_safetensors(str(tmp_path / "model-mtp.safetensors"), tensors)
+    json.dump({"metadata": {}, "weight_map": {k: "model-mtp.safetensors" for k in tensors}},
+              open(tmp_path / "model.safetensors.index.json", "w"))
+    cfg = {"model_type": "hy_v3", "num_nextn_predict_layers": 1, "num_hidden_layers": 2}
+    assert inject_hy_v3_mtp_support(model, tmp_path, cfg, None)
+    rt = MTPLXRuntime(
+        model=model, tokenizer=None, model_path=tmp_path,
+        mtp_enabled=True, contract=MTPContract(),
+    )
+    return rt
+
+
+def test_compiled_path_engages_on_mtp_wrapped_runtime(tmp_path, monkeypatch):
+    rt = _grafted_runtime(tmp_path)
+    cache = _primed_cache(rt.model)
+    monkeypatch.setenv("MTPLX_COMPILE_AR_FORWARD", "1")
+    out = rt.forward_ar(mx.array([[5]]), cache=cache)
+    mx.eval(out)
+    assert rt.diagnostic_counters.get("compiled_forward_calls", 0) == 1, (
+        "compiled AR path must engage on MTP-wrapped runtimes (the serving shape)"
+    )

--- a/tests/test_compiled_forward.py
+++ b/tests/test_compiled_forward.py
@@ -1,0 +1,139 @@
+"""CompiledARForward: compile + KV-cache state threading, validated on a toy model.
+
+The real model needs a GPU to load, so this proves the MECHANISM on a tiny 2-layer
+attention model on CPU: that threading each layer's (keys, values, offset) as
+explicit compile inputs/outputs preserves decode correctness across steps, that
+the offset advances, and that the engagement counter fires. Parity is checked at
+fp tolerance (the toy uses fp32 matmul, which compiles exactly; the real model's
+quantized-gather divergence is the separate A/B question).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import KVCache
+
+from mtplx.graphbank import TensorOffsetKVCache
+from mtplx.compiled_forward import CompiledARForward, compiled_forward_calls
+
+
+class _ToyAttn(nn.Module):
+    def __init__(self, dim: int, heads: int) -> None:
+        super().__init__()
+        self.heads = heads
+        self.hd = dim // heads
+        self.qkv = nn.Linear(dim, 3 * dim, bias=False)
+        self.o = nn.Linear(dim, dim, bias=False)
+
+    def __call__(self, x, cache):
+        b, t, d = x.shape
+        q, k, v = mx.split(self.qkv(x), 3, axis=-1)
+        shp = lambda z: z.reshape(b, t, self.heads, self.hd).transpose(0, 2, 1, 3)  # noqa: E731
+        q, k, v = shp(q), shp(k), shp(v)
+        # Build the mask from the PRE-update offset (the real model builds it
+        # before the layer loop). A fixed-buffer cache returns the whole buffer
+        # incl. an uninitialized tail beyond `offset`; a post-update mask would
+        # attend into that garbage, and the garbage differs between the compiled
+        # trace and eager runtime — the divergence this ordering avoids. A
+        # trimmed KVCache returns only valid rows and needs no mask.
+        mask = cache.make_mask(t) if isinstance(cache, TensorOffsetKVCache) else None
+        k, v = cache.update_and_fetch(k, v)
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.hd ** -0.5, mask=mask
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(b, t, d)
+        return self.o(out)
+
+
+class _ToyLayer(nn.Module):
+    def __init__(self, dim: int, heads: int) -> None:
+        super().__init__()
+        self.attn = _ToyAttn(dim, heads)
+        self.norm = nn.RMSNorm(dim)
+        self.mlp = nn.Linear(dim, dim, bias=False)
+
+    def __call__(self, x, cache):
+        h = x + self.attn(self.norm(x), cache)
+        return h + self.mlp(h)
+
+
+class _ToyModel(nn.Module):
+    def __init__(self, vocab: int, dim: int, heads: int, layers: int) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab, dim)
+        self.layers = [_ToyLayer(dim, heads) for _ in range(layers)]
+        self.norm = nn.RMSNorm(dim)
+        self.head = nn.Linear(dim, vocab, bias=False)
+        self._n = layers
+
+    def make_cache(self):
+        return [KVCache() for _ in range(self._n)]
+
+    def __call__(self, inputs, cache=None):
+        h = self.embed(inputs)
+        for i, layer in enumerate(self.layers):
+            h = layer(h, cache[i])
+        return self.head(self.norm(h))
+
+
+def _decode_eager(model, cache, tokens):
+    logits = []
+    for tok in tokens:
+        out = model(mx.array([[tok]]), cache=cache)
+        logits.append(out)
+    return logits
+
+
+def _decode_compiled(model, comp, cache, tokens):
+    logits = []
+    for tok in tokens:
+        out = comp(mx.array([[tok]]), cache)
+        logits.append(out)
+    return logits
+
+
+def test_compiled_forward_matches_eager_decode_across_steps() -> None:
+    mx.random.seed(0)
+    model = _ToyModel(vocab=64, dim=32, heads=4, layers=2)
+    mx.eval(model.parameters())
+
+    prompt = mx.array([[1, 2, 3, 4, 5]])
+    decode = [7, 9, 11, 13]
+
+    # eager: prime + decode
+    ce = model.make_cache()
+    model(prompt, cache=ce)
+    eager = _decode_eager(model, ce, decode)
+
+    # compiled: prime with the SAME live cache path, then compiled decode
+    cc = model.make_cache()
+    model(prompt, cache=cc)
+    comp = CompiledARForward(model, reserve_tokens=64)
+    before = compiled_forward_calls()
+    compiled = _decode_compiled(model, comp, cc, decode)
+
+    assert compiled_forward_calls() == before + len(decode), "compiled path did not fire each step"
+    for e, c in zip(eager, compiled):
+        mx.eval(e, c)
+        # fp32 path compiles exactly; allow a hair for sdpa fusion
+        assert float(mx.abs(e - c).max()) < 1e-3, "compiled decode diverged from eager"
+
+
+def test_offset_advances_and_argmax_tokens_match() -> None:
+    mx.random.seed(1)
+    model = _ToyModel(vocab=64, dim=32, heads=4, layers=3)
+    mx.eval(model.parameters())
+    prompt = mx.array([[2, 4, 6]])
+    decode = [8, 10, 12, 14, 16]
+
+    ce = model.make_cache()
+    model(prompt, cache=ce)
+    eager_tokens = [int(mx.argmax(m[:, -1, :])) for m in _decode_eager(model, ce, decode)]
+
+    cc = model.make_cache()
+    model(prompt, cache=cc)
+    comp = CompiledARForward(model, reserve_tokens=64)
+    comp_tokens = [int(mx.argmax(m[:, -1, :])) for m in _decode_compiled(model, comp, cc, decode)]
+
+    assert eager_tokens == comp_tokens, "argmax tokens diverged under compiled forward"

--- a/tests/test_env_flag_parsing.py
+++ b/tests/test_env_flag_parsing.py
@@ -1,0 +1,346 @@
+"""One parse, one meaning, for the documented MTPLX_* boolean/enum flags.
+
+Each of these four vars had two or three independent readers that disagreed
+on at least one spelling (docs/AUDIT_2026-07-18.md, Tier 2). The tests below
+pin the agreement rather than any single reader's behaviour: every reader is
+asked about the same spelling and must answer the same thing.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from mtplx.runtime_options import (
+    block_prefix_restore_enabled,
+    env_bool,
+    normalize_paged_kv_quantization,
+)
+
+
+# ---------------------------------------------------------------------------
+# the shared parser
+
+
+@pytest.mark.parametrize("spelling", ["1", "true", "TRUE", " yes ", "on", "enabled"])
+def test_env_bool_accepts_the_true_vocabulary(monkeypatch, spelling: str) -> None:
+    monkeypatch.setenv("MTPLX_TEST_FLAG", spelling)
+    assert env_bool("MTPLX_TEST_FLAG", default=False) is True
+
+
+@pytest.mark.parametrize("spelling", ["0", "false", "No", "off", "disabled"])
+def test_env_bool_accepts_the_false_vocabulary(monkeypatch, spelling: str) -> None:
+    monkeypatch.setenv("MTPLX_TEST_FLAG", spelling)
+    assert env_bool("MTPLX_TEST_FLAG", default=True) is False
+
+
+@pytest.mark.parametrize("default", [True, False])
+def test_env_bool_unset_and_empty_take_the_default(monkeypatch, default: bool) -> None:
+    monkeypatch.delenv("MTPLX_TEST_FLAG", raising=False)
+    assert env_bool("MTPLX_TEST_FLAG", default=default) is default
+    monkeypatch.setenv("MTPLX_TEST_FLAG", "   ")
+    assert env_bool("MTPLX_TEST_FLAG", default=default) is default
+
+
+@pytest.mark.parametrize("spelling", ["unlimited", "maybe", "2", "none"])
+def test_env_bool_raises_rather_than_guessing(monkeypatch, spelling: str) -> None:
+    monkeypatch.setenv("MTPLX_TEST_FLAG", spelling)
+    with pytest.raises(ValueError, match="is not a boolean"):
+        env_bool("MTPLX_TEST_FLAG", default=False)
+
+
+# ---------------------------------------------------------------------------
+# MTPLX_SESSION_BLOCK_PREFIX_RESTORE — 4 readers that used to hold 3 semantics
+
+
+def _block_prefix_readers() -> list:
+    """Every independent reader of the flag, as zero-arg predicates."""
+
+    from mtplx.engine_session import _block_prefix_restore_enabled
+    from mtplx.server.openai import _effective_ram_session_cache_settings
+
+    return [
+        block_prefix_restore_enabled,
+        _block_prefix_restore_enabled,
+        lambda: _effective_ram_session_cache_settings()[
+            "ram_session_block_prefix_restore"
+        ],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("spelling", "expected"),
+    [
+        (None, True),  # unset meant OFF in session_bank's cold tier
+        ("1", True),
+        ("0", False),
+        ("off", False),
+        ("enabled", True),  # the server's allowlist read this as OFF
+        ("on", True),
+    ],
+)
+def test_block_prefix_restore_readers_agree(
+    monkeypatch, spelling: str | None, expected: bool
+) -> None:
+    if spelling is None:
+        monkeypatch.delenv("MTPLX_SESSION_BLOCK_PREFIX_RESTORE", raising=False)
+    else:
+        monkeypatch.setenv("MTPLX_SESSION_BLOCK_PREFIX_RESTORE", spelling)
+    for reader in _block_prefix_readers():
+        assert bool(reader()) is expected, reader
+
+
+def test_block_prefix_restore_cold_tier_defaults_on(monkeypatch) -> None:
+    """The cold-tier lookup used to bail out whenever the var was unset."""
+
+    from mtplx.session_bank import SessionBank
+
+    monkeypatch.delenv("MTPLX_SESSION_BLOCK_PREFIX_RESTORE", raising=False)
+
+    seen: dict = {}
+
+    class _ColdTier:
+        def lookup_prefix_boundary(self, tokens, **kwargs):
+            seen["called"] = True
+            return None
+
+    bank = SessionBank.__new__(SessionBank)
+    bank.cold_tier = _ColdTier()
+    bank._cold_near_prefix_candidate(
+        [1, 2, 3],
+        max_token_gap=0,
+        min_matched_tokens=1,
+        block_size=1,
+        block_min_matched_tokens=1,
+        allow_block_prefix=True,
+        model_path="/model",
+        mtp_enabled=True,
+        hidden_variant=None,
+        template_hash=None,
+        mtp_history_policy=None,
+        draft_head_identity=None,
+        policy_fingerprint=None,
+    )
+    assert seen.get("called") is True
+
+
+# ---------------------------------------------------------------------------
+# MTPLX_PAGED_KV_QUANT — normalize / raise / silently-wrong-layout
+
+
+@pytest.mark.parametrize(
+    ("spelling", "expected"),
+    [
+        ("8", "q8"),
+        ("8bit", "q8"),
+        ("uint8", "q8"),
+        ("int8", "q8"),
+        ("q8_0", "q8"),
+        ("q8", "q8"),
+        ("4", "q4"),
+        ("uint4", "q4"),
+        ("q4", "q4"),
+        ("off", "off"),
+        ("none", "off"),
+        ("", "off"),
+    ],
+)
+def test_paged_kv_quant_readers_agree(
+    monkeypatch, spelling: str, expected: str
+) -> None:
+    from mtplx.generation import _sustained_prefill_layout
+    from mtplx.kv_quant import config_from_env, paged_kv_quant_mode_from_env
+    from mtplx.server.openai import _effective_paged_kv_quantization
+
+    monkeypatch.setenv("MTPLX_PAGED_KV_QUANT", spelling)
+    monkeypatch.delenv("MTPLX_VLLM_METAL_PAGED_KV_QUANT", raising=False)
+
+    assert paged_kv_quant_mode_from_env() == expected
+    assert normalize_paged_kv_quantization(spelling) == expected
+    assert _effective_paged_kv_quantization() == expected
+
+    config = config_from_env()
+    if expected == "off":
+        assert config is None
+    else:
+        assert config is not None and config.normalized_mode == expected
+
+    # The layout picker used to test raw membership, so "8"/"8bit"/"uint8"
+    # fell through to the dense-decode layout with a quantized cache.
+    monkeypatch.setenv("MTPLX_SUSTAINED_PREFILL_LAYOUT", "auto")
+    layout = _sustained_prefill_layout()
+    if expected == "off":
+        assert layout in {"contiguous_dense_decode", "contiguous_then_repage"}
+    else:
+        assert layout == "contiguous_then_repage"
+
+
+def test_paged_kv_quant_rejects_an_unknown_mode(monkeypatch) -> None:
+    from mtplx.kv_quant import config_from_env
+
+    monkeypatch.setenv("MTPLX_PAGED_KV_QUANT", "q3")
+    monkeypatch.delenv("MTPLX_VLLM_METAL_PAGED_KV_QUANT", raising=False)
+    with pytest.raises(ValueError, match="unsupported paged KV quantization"):
+        config_from_env()
+
+
+# ---------------------------------------------------------------------------
+# MTPLX_LOOP_GUARD — server answer vs the guard actually built
+
+
+@pytest.mark.parametrize(
+    ("spelling", "expected"),
+    [(None, False), ("1", True), ("on", True), ("0", False), ("off", False)],
+)
+def test_loop_guard_server_answer_matches_the_built_guard(
+    monkeypatch, spelling: str | None, expected: bool
+) -> None:
+    from mtplx.loop_guard import loop_guard_config_from_env
+    from mtplx.server.openai import _loop_guard_enabled
+
+    if spelling is None:
+        monkeypatch.delenv("MTPLX_LOOP_GUARD", raising=False)
+    else:
+        monkeypatch.setenv("MTPLX_LOOP_GUARD", spelling)
+
+    reported = _loop_guard_enabled()
+    built = loop_guard_config_from_env(reported).enabled
+    assert reported is expected
+    assert built is expected
+
+
+@pytest.mark.parametrize("spelling", ["unlimited", "none"])
+def test_loop_guard_no_longer_borrows_the_lease_vocabulary(
+    monkeypatch, spelling: str
+) -> None:
+    """These made the server report "off" while the guard was built on."""
+
+    from mtplx.loop_guard import loop_guard_config_from_env
+    from mtplx.server.openai import _loop_guard_enabled
+
+    monkeypatch.setenv("MTPLX_LOOP_GUARD", spelling)
+    with pytest.raises(ValueError, match="is not a boolean"):
+        _loop_guard_enabled()
+    with pytest.raises(ValueError, match="is not a boolean"):
+        loop_guard_config_from_env(False)
+
+
+# ---------------------------------------------------------------------------
+# MTPLX_SKIP_VERIFY_SNAPSHOT — the strategy list must fail safe
+
+
+@pytest.mark.parametrize(
+    ("spelling", "expected"),
+    [(None, False), ("1", True), ("enabled", True), ("0", False), ("off", False)],
+)
+def test_skip_verify_snapshot_single_parse(
+    monkeypatch, spelling: str | None, expected: bool
+) -> None:
+    from mtplx.generation import _skip_verify_snapshot
+
+    if spelling is None:
+        monkeypatch.delenv("MTPLX_SKIP_VERIFY_SNAPSHOT", raising=False)
+    else:
+        monkeypatch.setenv("MTPLX_SKIP_VERIFY_SNAPSHOT", spelling)
+    assert _skip_verify_snapshot() is expected
+
+
+@pytest.mark.parametrize(
+    "strategy", ["trim_commit", "target_prefix", "some_future_strategy"]
+)
+def test_unknown_verify_strategies_keep_the_snapshot(strategy: str) -> None:
+    """Fail safe: a strategy nobody vetted must not inherit the fast-path skip."""
+
+    from mtplx.server.openai import _server_runtime_env_overrides
+
+    args = argparse.Namespace(verify_strategy=strategy, generation_mode="mtp")
+    overrides = _server_runtime_env_overrides(args, {"MTPLX_SKIP_VERIFY_SNAPSHOT": "1"})
+    assert overrides["MTPLX_SKIP_VERIFY_SNAPSHOT"] == "0"
+
+
+@pytest.mark.parametrize(
+    "strategy", ["batched", "sequential", "capture", "capture_commit", "graphbank"]
+)
+def test_vetted_verify_strategies_still_skip(strategy: str) -> None:
+    from mtplx.server.openai import _server_runtime_env_overrides
+
+    args = argparse.Namespace(verify_strategy=strategy, generation_mode="mtp")
+    overrides = _server_runtime_env_overrides(args, {"MTPLX_SKIP_VERIFY_SNAPSHOT": "1"})
+    assert overrides["MTPLX_SKIP_VERIFY_SNAPSHOT"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# --chat-template-profile provenance
+
+
+def _gemma4_args(profile: str) -> argparse.Namespace:
+    from mtplx.server.openai import GEMMA4_BACKEND
+
+    return argparse.Namespace(
+        backend_id=GEMMA4_BACKEND,
+        model=None,
+        chat_template_profile=profile,
+        reasoning_effort=None,
+    )
+
+
+def test_explicitly_typed_chat_template_profile_is_preserved() -> None:
+    from mtplx.server.openai import (
+        _CHAT_TEMPLATE_PROFILE_LOCAL,
+        _apply_backend_server_defaults,
+    )
+
+    args = _gemma4_args(_CHAT_TEMPLATE_PROFILE_LOCAL)
+    _apply_backend_server_defaults(args, explicit_flags={"chat-template-profile"})
+    assert args.chat_template_profile == _CHAT_TEMPLATE_PROFILE_LOCAL
+
+
+def test_abbreviated_flags_count_as_explicitly_typed() -> None:
+    """``--temp 0.9`` set args.temperature but read as *not typed*.
+
+    ~30 ``cli_flags`` checks key off that signal, so the config file then
+    overwrote the value the user had just asked for.
+    """
+
+    from mtplx.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["serve", "--temp", "0.9"])
+    assert args.temperature == pytest.approx(0.9)
+    assert "temperature" in args._cli_flags
+    # The raw token is kept too, so checks on either spelling still work.
+    assert "temp" in args._cli_flags
+
+
+def test_flag_canonicalization_does_not_invent_untyped_flags() -> None:
+    from mtplx.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["serve", "--host", "1.2.3.4"])
+    assert "host" in args._cli_flags
+    assert "temperature" not in args._cli_flags
+    assert "model" not in args._cli_flags
+
+
+def test_abbreviations_still_parse() -> None:
+    """The fix must not cost users their muscle memory."""
+
+    from mtplx.cli import build_parser
+
+    parser = build_parser()
+    assert parser.parse_args(["serve", "--temp", "0.5"]).temperature == pytest.approx(
+        0.5
+    )
+
+
+def test_untyped_chat_template_profile_still_gets_the_gemma4_default() -> None:
+    from mtplx.server.openai import (
+        _CHAT_TEMPLATE_PROFILE_LOCAL,
+        _CHAT_TEMPLATE_PROFILE_TOKENIZER,
+        _apply_backend_server_defaults,
+    )
+
+    args = _gemma4_args(_CHAT_TEMPLATE_PROFILE_LOCAL)
+    _apply_backend_server_defaults(args, explicit_flags=set())
+    assert args.chat_template_profile == _CHAT_TEMPLATE_PROFILE_TOKENIZER

--- a/tests/test_hy_v3_mtp_backend.py
+++ b/tests/test_hy_v3_mtp_backend.py
@@ -33,18 +33,49 @@ def test_hy_v3_in_supported_arch_ids():
     assert "hy-v3-mtp" in SUPPORTED_ARCH_IDS
 
 
-def test_inject_and_validate():
+def _checkpoint_dir(tmp_path):
+    """Tiny standard checkpoint carrying the appended NextN layer (see
+    test_hy_v3_mtp_graft.py for the full graft matrix)."""
+    import json
+    from mlx.utils import tree_flatten
+
+    args = _tiny().args
+    donor = hy_v3.DecoderLayer(args, layer_idx=2)
+    tensors = {f"model.layers.2.{k}": v for k, v in tree_flatten(donor.parameters())}
+    for name in ("enorm", "hnorm", "final_layernorm"):
+        tensors[f"model.layers.2.{name}.weight"] = mx.ones((64,))
+    tensors["model.layers.2.eh_proj.weight"] = 0.02 * mx.random.normal((64, 128))
+    mx.save_safetensors(str(tmp_path / "model-mtp.safetensors"), tensors)
+    json.dump({"metadata": {}, "weight_map": {k: "model-mtp.safetensors" for k in tensors}},
+              open(tmp_path / "model.safetensors.index.json", "w"))
+    return tmp_path
+
+
+def _cfg():
+    return {
+        "model_type": "hy_v3", "num_nextn_predict_layers": 1,
+        "num_hidden_layers": 2, "vocab_size": 128, "hidden_size": 64,
+        "intermediate_size": 128, "num_attention_heads": 4,
+        "num_key_value_heads": 2, "head_dim": 16, "num_experts": 4,
+        "num_experts_per_tok": 2, "num_shared_experts": 1,
+        "expert_hidden_dim": 64, "first_k_dense_replace": 1,
+        "rms_norm_eps": 1e-5,
+        "rope_parameters": {"rope_theta": 10000.0, "rope_type": "default"},
+    }
+
+
+def test_inject_and_validate(tmp_path):
     m = _tiny()
-    cfg = {"model_type": "hy_v3", "num_nextn_predict_layers": 1}
+    cfg = _cfg()
     assert is_hy_v3_mtp_config(cfg)
-    assert inject_hy_v3_mtp_support(m, Path("t"), cfg, None)
+    assert inject_hy_v3_mtp_support(m, _checkpoint_dir(tmp_path), cfg, None)
     # validate_mtp_support needs model.mtp.layers -> alias must exist
     assert validate_mtp_support(m)
 
 
-def test_post_norm_contract_default_does_not_crash():
+def test_post_norm_contract_default_does_not_crash(tmp_path):
     m = _tiny()
-    inject_hy_v3_mtp_support(m, Path("t"), {"model_type": "hy_v3", "num_nextn_predict_layers": 1}, None)
+    inject_hy_v3_mtp_support(m, _checkpoint_dir(tmp_path), _cfg(), None)
     x = mx.array([[1, 2, 3, 4]])
     # the bare-contract default is post_norm; the backend must tolerate it
     assert MTPContract().hidden_variant == "post_norm"

--- a/tests/test_hy_v3_mtp_graft.py
+++ b/tests/test_hy_v3_mtp_graft.py
@@ -91,14 +91,15 @@ def test_graft_injects_and_validates(tmp_path):
     assert validate_mtp_support(model)
 
 
-def test_return_hidden_is_pre_final_norm(tmp_path):
+def test_return_hidden_is_post_final_norm(tmp_path):
     model = _grafted(tmp_path)
     x = mx.array([[1, 2, 3, 4]])
     logits, hidden = model(x, return_hidden=True)
     assert logits.shape == (1, 4, VOCAB) and hidden.shape == (1, 4, HIDDEN)
-    # hidden must be the PRE-final-norm trunk state: re-applying the trunk's
-    # final norm + head must reproduce the returned logits exactly.
-    again = model.lm_head(model.model.norm(hidden))
+    # hidden must be the POST-final-norm trunk state (the measured draft
+    # contract — teacher-forced agreement 0.773 post vs 0.387 pre on real
+    # code): the head applied directly must reproduce the returned logits.
+    again = model.lm_head(hidden)
     assert mx.allclose(again, logits, atol=1e-5).item()
 
 

--- a/tests/test_hy_v3_mtp_graft.py
+++ b/tests/test_hy_v3_mtp_graft.py
@@ -1,0 +1,208 @@
+"""hy_v3 MTP graft: build the draft head from a standard sharded checkpoint.
+
+The released mlx-lm hy_v3 model class (PR#1211 line) loads the trunk and
+sanitizes away the appended NextN layer; the MTPLX injection must therefore
+graft the draft head itself from the checkpoint's canonical
+``model.layers.{num_hidden_layers}.*`` tensors (tencent-native appended-layer
+layout, the form real exports ship in) rather than requiring a native
+``model.mtp`` submodule.
+"""
+import json
+
+import pytest
+
+hy_v3 = pytest.importorskip(
+    "mlx_lm.models.hy_v3",
+    reason="mlx-lm does not ship models/hy_v3 yet (unreleased upstream)",
+)
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from mtplx.hy_v3_mtp_patch import inject_hy_v3_mtp_support, is_hy_v3_mtp_config
+from mtplx.mtp_patch import validate_mtp_support
+
+VOCAB, HIDDEN, LAYERS = 128, 64, 2
+SPEC_IDX = LAYERS  # appended NextN layer index
+
+
+def _args(nextn=1):
+    return hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=VOCAB, hidden_size=HIDDEN,
+        intermediate_size=128, num_hidden_layers=LAYERS, num_attention_heads=4,
+        num_key_value_heads=2, head_dim=16, num_experts=4, num_experts_per_tok=2,
+        num_shared_experts=1, expert_hidden_dim=64, first_k_dense_replace=1,
+        rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=nextn)
+
+
+def _config(nextn=1, quantization=None):
+    cfg = {
+        "model_type": "hy_v3", "vocab_size": VOCAB, "hidden_size": HIDDEN,
+        "intermediate_size": 128, "num_hidden_layers": LAYERS,
+        "num_attention_heads": 4, "num_key_value_heads": 2, "head_dim": 16,
+        "num_experts": 4, "num_experts_per_tok": 2, "num_shared_experts": 1,
+        "expert_hidden_dim": 64, "first_k_dense_replace": 1,
+        "rms_norm_eps": 1e-5,
+        "rope_parameters": {"rope_theta": 10000.0, "rope_type": "default"},
+        "num_nextn_predict_layers": nextn,
+    }
+    if quantization is not None:
+        cfg["quantization"] = quantization
+    return cfg
+
+
+def _mtp_tensors():
+    """Canonical appended-layer tensors, named via the donor layer itself."""
+    donor = hy_v3.DecoderLayer(_args(), layer_idx=SPEC_IDX)
+    tensors = {
+        f"model.layers.{SPEC_IDX}.{k}": v for k, v in tree_flatten(donor.parameters())
+    }
+    p = f"model.layers.{SPEC_IDX}"
+    tensors[f"{p}.enorm.weight"] = mx.ones((HIDDEN,))
+    tensors[f"{p}.hnorm.weight"] = mx.ones((HIDDEN,))
+    tensors[f"{p}.eh_proj.weight"] = 0.02 * mx.random.normal((HIDDEN, 2 * HIDDEN))
+    tensors[f"{p}.final_layernorm.weight"] = mx.ones((HIDDEN,))
+    return tensors
+
+
+def _write_checkpoint(tmp_path, tensors, config):
+    shard = "model-mtp.safetensors"
+    mx.save_safetensors(str(tmp_path / shard), tensors)
+    json.dump(
+        {"metadata": {}, "weight_map": {k: shard for k in tensors}},
+        open(tmp_path / "model.safetensors.index.json", "w"),
+    )
+    json.dump(config, open(tmp_path / "config.json", "w"))
+
+
+def _grafted(tmp_path, config=None):
+    cfg = config or _config()
+    _write_checkpoint(tmp_path, _mtp_tensors(), cfg)
+    model = hy_v3.Model(_args())
+    assert is_hy_v3_mtp_config(cfg)
+    assert inject_hy_v3_mtp_support(model, tmp_path, cfg, None)
+    return model
+
+
+def test_graft_injects_and_validates(tmp_path):
+    model = _grafted(tmp_path)
+    assert validate_mtp_support(model)
+
+
+def test_return_hidden_is_pre_final_norm(tmp_path):
+    model = _grafted(tmp_path)
+    x = mx.array([[1, 2, 3, 4]])
+    logits, hidden = model(x, return_hidden=True)
+    assert logits.shape == (1, 4, VOCAB) and hidden.shape == (1, 4, HIDDEN)
+    # hidden must be the PRE-final-norm trunk state: re-applying the trunk's
+    # final norm + head must reproduce the returned logits exactly.
+    again = model.lm_head(model.model.norm(hidden))
+    assert mx.allclose(again, logits, atol=1e-5).item()
+
+
+def test_mtp_forward_shapes_and_cache(tmp_path):
+    model = _grafted(tmp_path)
+    x = mx.array([[1, 2, 3, 4]])
+    _logits, hidden = model(x, return_hidden=True)
+    mtp_cache = model.make_mtp_cache()
+    d = model.mtp_forward(
+        hidden[:, -1:, :], mx.array([[5]]), mtp_cache=mtp_cache,
+        concat_order="embedding_hidden",
+    )
+    assert d.shape == (1, 1, VOCAB)
+    d2, h2 = model.mtp_forward(
+        hidden[:, -1:, :], mx.array([[5]]), mtp_cache=mtp_cache,
+        concat_order="embedding_hidden", return_hidden=True,
+    )
+    assert h2.shape == (1, 1, HIDDEN)
+    hidden_upd = model.mtp_update_cache(
+        hidden[:, -1:, :], mx.array([[5]]), mtp_cache=mtp_cache)
+    assert hidden_upd.shape == (1, 1, HIDDEN)
+
+
+def test_mtp_logits_use_final_layernorm_and_shared_head(tmp_path):
+    model = _grafted(tmp_path)
+    x = mx.array([[1, 2, 3, 4]])
+    _logits, hidden = model(x, return_hidden=True)
+    logits, h = model.mtp_forward(
+        hidden[:, -1:, :], mx.array([[5]]), return_hidden=True,
+        concat_order="embedding_hidden",
+    )
+    again = model.lm_head(model.mtp.final_layernorm(h))
+    assert mx.allclose(again, logits, atol=1e-5).item()
+
+
+def test_quantized_overrides_are_honored(tmp_path):
+    import mlx.nn as nn
+
+    tensors = _mtp_tensors()
+    p = f"model.layers.{SPEC_IDX}"
+    quant = {"group_size": 32, "bits": 4, "mode": "affine"}
+    overrides = {}
+    for mod in (f"{p}.self_attn.q_proj", f"{p}.eh_proj"):
+        w = tensors.pop(f"{mod}.weight")
+        wq, sc, bs = mx.quantize(w, group_size=32, bits=8)
+        tensors[f"{mod}.weight"] = wq
+        tensors[f"{mod}.scales"] = sc
+        tensors[f"{mod}.biases"] = bs
+        overrides[mod] = {"group_size": 32, "bits": 8, "mode": "affine"}
+    cfg = _config(quantization={**quant, **overrides})
+    _write_checkpoint(tmp_path, tensors, cfg)
+    model = hy_v3.Model(_args())
+    assert inject_hy_v3_mtp_support(model, tmp_path, cfg, None)
+    assert isinstance(model.mtp.layer.self_attn.q_proj, nn.QuantizedLinear)
+    assert model.mtp.layer.self_attn.q_proj.bits == 8
+    assert isinstance(model.mtp.eh_proj, nn.QuantizedLinear)
+    # un-quantized tensors stay plain even with a global quantization block
+    assert not isinstance(model.mtp.layer.self_attn.k_proj, nn.QuantizedLinear)
+    x = mx.array([[1, 2, 3]])
+    _logits, hidden = model(x, return_hidden=True)
+    d = model.mtp_forward(hidden[:, -1:, :], mx.array([[5]]),
+                          concat_order="embedding_hidden")
+    assert d.shape == (1, 1, VOCAB)
+
+
+def test_ar_only_checkpoint_raises_clearly(tmp_path):
+    cfg = _config()
+    _write_checkpoint(
+        tmp_path, {"model.embed_tokens.weight": mx.zeros((VOCAB, HIDDEN))}, cfg)
+    model = hy_v3.Model(_args())
+    with pytest.raises(RuntimeError, match="AR-only|no MTP"):
+        inject_hy_v3_mtp_support(model, tmp_path, cfg, None)
+
+
+def test_registry_gate_accepts_tencent_native_layout():
+    from mtplx.backends.registry import _passes_hy_v3_gate
+
+    class _Inspection:
+        num_hidden_layers = 80
+        mtp_num_hidden_layers = 1
+        weight_keys = (
+            "model.layers.80.enorm.weight",
+            "model.layers.80.hnorm.weight",
+            "model.layers.80.eh_proj.weight",
+            "model.layers.80.final_layernorm.weight",
+            "model.layers.80.self_attn.q_proj.weight",
+            "model.layers.80.mlp.switch_mlp.gate_proj.weight",
+        )
+
+    assert _passes_hy_v3_gate(_Inspection())
+
+
+def test_registry_gate_still_accepts_mtp_prefix_layout():
+    from mtplx.backends.registry import _passes_hy_v3_gate
+
+    class _Inspection:
+        num_hidden_layers = 80
+        mtp_num_hidden_layers = 1
+        weight_keys = (
+            "mtp.enorm.weight",
+            "mtp.hnorm.weight",
+            "mtp.eh_proj.weight",
+            "mtp.final_layernorm.weight",
+            "mtp.layer.self_attn.q_proj.weight",
+        )
+
+    assert _passes_hy_v3_gate(_Inspection())

--- a/tests/test_metadata_scrub.py
+++ b/tests/test_metadata_scrub.py
@@ -1,0 +1,153 @@
+"""Publish-time scrubbing of machine-identifying artifact metadata.
+
+The fixtures below mirror the shapes found in real local artifacts:
+``mtplx_runtime.json``'s ``forge_provenance.forge_inputs`` and a conversion
+manifest's ``source``/``target`` paths.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from mtplx.metadata_scrub import (
+    REDACTED_PATH,
+    runtime_metadata_leaks,
+    scrub_path_value,
+    scrub_runtime_metadata,
+)
+
+
+def _runtime_fixture() -> dict:
+    """Mirrors ~/.cache/huggingface/hy3-q4-mlx-mtp/mtplx_runtime.json."""
+
+    return {
+        "arch_id": "hy_v3",
+        "artifact_role": "forge-local",
+        "base_trunk": "tencent/Hy3",
+        "mtp_depth_max": 3,
+        "mtp_sidecar": "mtp.safetensors",
+        "mtp_sidecar_file": "mtp.safetensors",
+        "mtplx_version": "2.0.2",
+        "forge_provenance": {
+            "forge_inputs": {
+                "bf16_head_source_path": "/Users/davidtai/.cache/huggingface/hy3-mtp-layer80/layer80-bf16.safetensors",
+                "checkpoint_path": "/Users/davidtai/.cache/huggingface/hy3-q4-mlx-mtp/conversion-checkpoint.jsonl",
+                "layout_oracle_path": "/Users/davidtai/.cache/huggingface/hub/models--pipenetwork--Hy3-4bit/snapshots/160619d3",
+                "output_path": "/Users/davidtai/.cache/huggingface/hy3-q4-mlx-mtp",
+                "source_path": "/Users/davidtai/.cache/huggingface/hy3-mtp-layer80",
+            },
+            "forge_recipe": {"mtp_policy": "keep_bf16", "bits": 4},
+            "forged_at": "2026-07-11T15:23:33Z",
+            "forged_locally": True,
+            "mtplx_version": "2.0.2",
+            "intended_hf_repo": "davidtai/hy3-q4-mlx-mtp",
+            "published_to_hf": None,
+            "source_format": "bf16_native",
+            "source_repo": "tencent/Hy3",
+            "source_sha": "716aa7241bd6d95896be4ebfc761162a9c4d49ef",
+            "tool": "mtplx.hy3_native_quantizer v1",
+        },
+    }
+
+
+def _conversion_manifest_fixture() -> dict:
+    """Mirrors hy3-expert-only-mlx-q2/conversion-manifest.json."""
+
+    return {
+        "alignment": 16384,
+        "producer": "mtplx.hy3_expert_q2",
+        "source": {
+            "path": "/Users/davidtai/.cache/huggingface/hy3-expert-only-mlx-q4",
+            "revision": "716aa7241bd6d95896be4ebfc761162a9c4d49ef",
+        },
+        "journal": [
+            {"step": "quantize", "note": "read /Users/davidtai/models/in.safetensors ok"},
+        ],
+        "target_descriptor": {"bits": 2, "group_size": 32},
+    }
+
+
+def test_forge_inputs_paths_are_redacted():
+    scrubbed = scrub_runtime_metadata(_runtime_fixture())
+    inputs = scrubbed["forge_provenance"]["forge_inputs"]
+
+    assert inputs["source_path"] == f"{REDACTED_PATH}/hy3-mtp-layer80"
+    assert inputs["output_path"] == f"{REDACTED_PATH}/hy3-q4-mlx-mtp"
+    assert inputs["bf16_head_source_path"] == f"{REDACTED_PATH}/layer80-bf16.safetensors"
+    for value in inputs.values():
+        assert "/Users/" not in value
+
+
+def test_intended_hf_repo_is_dropped():
+    scrubbed = scrub_runtime_metadata(_runtime_fixture())
+
+    assert "intended_hf_repo" not in scrubbed["forge_provenance"]
+
+
+def test_useful_provenance_survives():
+    scrubbed = scrub_runtime_metadata(_runtime_fixture())
+    provenance = scrubbed["forge_provenance"]
+
+    assert provenance["source_repo"] == "tencent/Hy3"
+    assert provenance["source_sha"] == "716aa7241bd6d95896be4ebfc761162a9c4d49ef"
+    assert provenance["forge_recipe"] == {"mtp_policy": "keep_bf16", "bits": 4}
+    assert provenance["forged_at"] == "2026-07-11T15:23:33Z"
+    assert provenance["mtplx_version"] == "2.0.2"
+    assert scrubbed["arch_id"] == "hy_v3"
+    assert scrubbed["mtp_sidecar_file"] == "mtp.safetensors"
+    assert scrubbed["mtp_depth_max"] == 3
+
+
+def test_input_is_not_mutated():
+    original = _runtime_fixture()
+    snapshot = copy.deepcopy(original)
+
+    scrub_runtime_metadata(original)
+
+    assert original == snapshot
+
+
+def test_conversion_manifest_paths_are_redacted():
+    scrubbed = scrub_runtime_metadata(_conversion_manifest_fixture())
+
+    assert scrubbed["source"]["path"] == f"{REDACTED_PATH}/hy3-expert-only-mlx-q4"
+    assert scrubbed["source"]["revision"] == "716aa7241bd6d95896be4ebfc761162a9c4d49ef"
+    assert scrubbed["alignment"] == 16384
+
+
+def test_paths_embedded_in_free_text_are_redacted():
+    scrubbed = scrub_runtime_metadata(_conversion_manifest_fixture())
+
+    note = scrubbed["journal"][0]["note"]
+    assert "/Users/davidtai" not in note
+    assert note.startswith("read ") and note.endswith(" ok")
+
+
+def test_leak_detector_finds_and_then_clears():
+    fixture = _runtime_fixture()
+
+    assert runtime_metadata_leaks(fixture)
+    assert runtime_metadata_leaks(scrub_runtime_metadata(fixture)) == []
+
+
+def test_scrub_covers_linux_and_temp_dirs():
+    assert scrub_path_value("/home/alice/models/x") == f"{REDACTED_PATH}/x"
+    assert scrub_path_value("/var/folders/ab/T/run") == f"{REDACTED_PATH}/run"
+    assert scrub_path_value("~/models/y") == f"{REDACTED_PATH}/y"
+
+
+def test_non_path_values_are_left_alone():
+    payload = {"repo": "owner/name", "license": "apache-2.0", "n": 3, "ok": True}
+
+    assert scrub_runtime_metadata(payload) == payload
+
+
+def test_lists_of_paths_are_redacted():
+    scrubbed = scrub_runtime_metadata(
+        {"inputs": ["/Users/davidtai/a.safetensors", "relative/b.safetensors"]}
+    )
+
+    assert scrubbed["inputs"] == [
+        f"{REDACTED_PATH}/a.safetensors",
+        "relative/b.safetensors",
+    ]

--- a/tests/test_mtp_payload_guards.py
+++ b/tests/test_mtp_payload_guards.py
@@ -1,0 +1,65 @@
+"""MTP payload guards reject stray-key checkpoints (Tier-1 audit findings).
+
+An appended-layer checkpoint whose weight map is non-empty but carries no
+real MTP tensors previously passed the `if not mapped:` completeness check
+and injected a headless draft surface; each backend guard must demand its
+layer's actual marker tensors, per declared layer count.
+"""
+from __future__ import annotations
+
+def test_deepseek_payload_guard_rejects_stray_keys() -> None:
+    from mtplx.deepseek_mtp_patch import _has_complete_deepseek_mtp_payload
+
+    complete = {
+        "layers.0.enorm.weight": 1,
+        "layers.0.hnorm.weight": 1,
+        "layers.0.eh_proj.weight": 1,
+        "layers.0.mtp_block.self_attn.q_proj.weight": 1,
+    }
+    assert _has_complete_deepseek_mtp_payload(complete, num_mtp_layers=1)
+    # Non-empty, but no real MTP tensors -- the old `if not mapped:` passed.
+    assert not _has_complete_deepseek_mtp_payload(
+        {"layers.0.something_else": 1}, num_mtp_layers=1
+    )
+    # Projections present but the draft block missing.
+    missing_block = {k: v for k, v in complete.items() if "mtp_block" not in k}
+    assert not _has_complete_deepseek_mtp_payload(missing_block, num_mtp_layers=1)
+    # Declared two layers, only one supplied.
+    assert not _has_complete_deepseek_mtp_payload(complete, num_mtp_layers=2)
+
+
+def test_mimo_payload_guard_rejects_stray_keys() -> None:
+    from mtplx.mimo_mtp_patch import _has_complete_mimo_mtp_payload
+
+    complete = {
+        "layers.0.token_layernorm.weight": 1,
+        "layers.0.hidden_layernorm.weight": 1,
+        "layers.0.input_proj.weight": 1,
+        "layers.0.final_layernorm.weight": 1,
+        "layers.0.mtp_block.self_attn.q_proj.weight": 1,
+    }
+    assert _has_complete_mimo_mtp_payload(complete, num_mtp_layers=1)
+    assert not _has_complete_mimo_mtp_payload(
+        {"lm_head.weight": 1}, num_mtp_layers=1
+    )
+    missing_block = {k: v for k, v in complete.items() if "mtp_block" not in k}
+    assert not _has_complete_mimo_mtp_payload(missing_block, num_mtp_layers=1)
+
+
+def test_nemotron_h_payload_guard_rejects_stray_keys() -> None:
+    from mtplx.nemotron_h_mtp_patch import _has_complete_nemotron_h_mtp_payload
+
+    complete = {
+        "layers.0.norm.weight": 1,
+        "layers.0.mixer.in_proj.weight": 1,
+    }
+    assert _has_complete_nemotron_h_mtp_payload(complete, physical_layers=1)
+    assert not _has_complete_nemotron_h_mtp_payload(
+        {"layers.0.block_type": 1}, physical_layers=1
+    )
+    assert not _has_complete_nemotron_h_mtp_payload(
+        {"layers.0.norm.weight": 1}, physical_layers=1
+    )
+    assert not _has_complete_nemotron_h_mtp_payload(complete, physical_layers=2)
+
+

--- a/tests/test_optimization_profiles.py
+++ b/tests/test_optimization_profiles.py
@@ -1,0 +1,63 @@
+"""Per-model optimization-profile registry."""
+import pytest
+
+from mtplx.optimization_profiles import (
+    KNOB_NAMES,
+    KnobEntry,
+    OptimizationProfile,
+    canonical_model_key,
+    get_profile,
+    not_applicable_violations,
+    profile_conflict_warnings,
+    resolve_profile_defaults,
+)
+
+
+def test_schema_rejects_bad_state_and_empty_provenance():
+    with pytest.raises(ValueError, match="state must be one of"):
+        KnobEntry(state="on", value=True, provenance="x")
+    with pytest.raises(ValueError, match="provenance"):
+        KnobEntry(state="default_on", value=True, provenance="  ")
+    with pytest.raises(ValueError, match="unknown knob names"):
+        OptimizationProfile(
+            model_key="m",
+            knobs={"bogus": KnobEntry("default_on", 1, "measured somewhere")},
+        )
+
+
+def test_registry_entries_are_schema_valid():
+    profile = get_profile("hy3-oq2e")
+    assert profile is not None
+    for name, entry in profile.knobs.items():
+        assert name in KNOB_NAMES
+        assert entry.provenance.strip()
+
+
+def test_aliases_resolve_to_canonical_key():
+    assert canonical_model_key("mlx-community/Hy3-oQ2e") == "hy3-oq2e"
+    assert canonical_model_key("hy3-oq2e-r4") == "hy3-oq2e"
+    assert resolve_profile_defaults("hy3-oq2e-stock-mtp")
+
+
+def test_unregistered_model_is_silent():
+    assert resolve_profile_defaults("some-other-model") == {}
+    assert profile_conflict_warnings("some-other-model", {"draft_core": "x"}) == []
+    assert not_applicable_violations("some-other-model", {"kv_quant": "q4"}) == []
+
+
+def test_conflict_warnings_are_advisory_and_specific():
+    warnings = profile_conflict_warnings(
+        "hy3-oq2e", {"draft_core": "stock", "speculative_depth": 1}
+    )
+    assert len(warnings) == 1
+    assert "draft_core" in warnings[0] and "device" in warnings[0]
+    # matching values and unset knobs warn nothing
+    assert profile_conflict_warnings("hy3-oq2e", {"draft_core": "device"}) == []
+    assert profile_conflict_warnings("hy3-oq2e", {"draft_core": None}) == []
+
+
+def test_not_applicable_violation_names_the_measurement():
+    violations = not_applicable_violations("hy3-oq2e", {"kv_quant": "q4"})
+    assert len(violations) == 1
+    assert "kv_quant" in violations[0] and "not_applicable" in violations[0]
+    assert not_applicable_violations("hy3-oq2e", {"kv_quant": "off"}) == []

--- a/tests/test_proj_quant.py
+++ b/tests/test_proj_quant.py
@@ -1,0 +1,107 @@
+"""Load-time trunk *_proj quantization (mtplx.proj_quant)."""
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mtplx.proj_quant import (
+    ProjQuantError,
+    proj_quant_covers,
+    quantize_projections,
+    requantize_projections,
+)
+
+H = 64
+
+
+class _Attn(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(H, H, bias=False)
+        self.k_proj = nn.Linear(H, H, bias=False)
+
+
+class _Mlp(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.Linear(H, H, bias=False)
+        self.down_proj = nn.Linear(H, H, bias=False)
+
+
+class _Router(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate = nn.Linear(H, 8, bias=False)
+
+
+class _Layer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.self_attn = _Attn()
+        self.mlp = _Mlp()
+        self.router = _Router()
+
+
+class _Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(128, H)
+        self.layers = [_Layer() for _ in range(2)]
+        self.lm_head = nn.Linear(H, 128, bias=False)
+
+
+def test_scope_predicate():
+    assert proj_quant_covers("model.layers.3.self_attn.q_proj")
+    assert proj_quant_covers("model.layers.3.mlp.down_proj")
+    assert proj_quant_covers("model.layers.3.mlp.shared_mlp.up_proj")
+    assert not proj_quant_covers("model.layers.3.mlp.router.gate")
+    assert not proj_quant_covers("lm_head")
+    assert not proj_quant_covers("model.embed_tokens")
+
+
+def test_quantize_projections_scopes_and_bits():
+    model = _Model()
+    touched = quantize_projections(model, "q4")
+    # 2 layers x (2 attn + 2 mlp) projections
+    assert len(touched) == 8
+    layer = model.layers[0]
+    assert isinstance(layer.self_attn.q_proj, nn.QuantizedLinear)
+    assert layer.self_attn.q_proj.bits == 4
+    assert layer.self_attn.q_proj.group_size == 64
+    assert isinstance(layer.mlp.gate_proj, nn.QuantizedLinear)
+    # router / embeddings / head untouched
+    assert not isinstance(layer.router.gate, nn.QuantizedLinear)
+    assert not isinstance(model.lm_head, nn.QuantizedLinear)
+
+
+def test_quantize_rejects_bad_mode_and_empty_scope():
+    with pytest.raises(ProjQuantError, match="mode must be one of"):
+        quantize_projections(_Model(), "q2")
+
+    class _Bare(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lm_head = nn.Linear(H, 128, bias=False)
+
+    with pytest.raises(ProjQuantError, match="matched no trunk"):
+        quantize_projections(_Bare(), "q4")
+
+
+def test_requantize_q8_to_q4_via_canonical_builder():
+    model = _Model()
+    quantize_projections(model, "q8")
+    q8 = model.layers[0].self_attn.q_proj
+    assert q8.bits == 8
+    touched = requantize_projections(model, "q4")
+    assert len(touched) == 8
+    q4 = model.layers[0].self_attn.q_proj
+    assert isinstance(q4, nn.QuantizedLinear) and q4.bits == 4
+    # dequantized q4 stays close to the q8 dequantization it derived from
+    a = mx.dequantize(q8.weight, q8.scales, q8.biases,
+                      group_size=q8.group_size, bits=8).astype(mx.float32)
+    b = mx.dequantize(q4.weight, q4.scales, q4.biases,
+                      group_size=q4.group_size, bits=4).astype(mx.float32)
+    cos = (a * b).sum() / (mx.sqrt((a * a).sum()) * mx.sqrt((b * b).sum()))
+    assert cos.item() > 0.99
+    # idempotence: nothing left above the target -> loud error, not silence
+    with pytest.raises(ProjQuantError, match="matched no quantized trunk"):
+        requantize_projections(model, "q4")

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -7422,3 +7422,13 @@ def test_qwen36_35b_a3b_defaults_to_measured_best_depth():
     sustained = public.get_profile("sustained")
 
     assert public._model_contract_depth(inspection, profile=sustained, fallback=3) == 2
+
+
+def test_serve_parser_accepts_draft_core():
+    from mtplx.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["serve", "--model", "m", "--draft-core", "device"])
+    assert args.draft_core == "device"
+    default = parser.parse_args(["serve", "--model", "m"])
+    assert default.draft_core == "stock"

--- a/tests/test_runtime_kpis.py
+++ b/tests/test_runtime_kpis.py
@@ -62,3 +62,75 @@ def test_run_exactness_smoke_uses_vector_paged_profile(monkeypatch, tmp_path):
     assert "mlx_vector_paged" in seen["cmd"]
     assert "--partition-threshold" in seen["cmd"]
     assert "2048" in seen["cmd"]
+
+
+def test_decode_trace_tolerates_lane_specific_counter_sets(tmp_path, monkeypatch):
+    """AR totals omit MTP-only counters; emitting twice (the second emit
+    diffs against the lane's own totals) must not KeyError and must report
+    zero deltas for absent counters."""
+
+    import json as _json
+
+    monkeypatch.setenv("MTPLX_DECODE_TRACE_JSONL", str(tmp_path / "trace.jsonl"))
+    monkeypatch.setenv("MTPLX_DECODE_TRACE_INTERVAL_S", "0.1")
+    from mtplx.generation import SamplerConfig, _DecodeTrace
+
+    trace = _DecodeTrace(
+        prompt_tokens=8,
+        max_tokens=4,
+        speculative_depth=0,
+        sampler=SamplerConfig(),
+        verify_strategy="ar",
+        verify_core="stock",
+        mtp_history_policy="none",
+        mtp_cache_policy="none",
+        trace_label=None,
+        trace_metadata={"generation_mode": "ar"},
+    )
+    # The scalar/list key set the AR lane's trace_totals() actually
+    # provides — everything else (MTP-only counters like
+    # target_distribution_materialized_rows) is intentionally absent.
+    ar_scalar_keys = (
+        "accepted_drafts rejected_drafts drafted_tokens evaluated_drafts "
+        "fully_accepted_verify_calls verify_calls correction_tokens "
+        "bonus_tokens verify_time_s verify_forward_time_s verify_eval_time_s "
+        "verify_logits_eval_time_s verify_hidden_eval_time_s "
+        "verify_joint_eval_time_s verify_target_distribution_time_s "
+        "verify_eval_unattributed_time_s draft_time_s accept_time_s "
+        "repair_time_s commit_time_s capture_commit_time_s snapshot_time_s "
+        "bonus_time_s verify_output_nbytes draft_output_nbytes "
+        "mtp_history_append_nbytes clear_cache_events clear_cache_time_s "
+        "trunk_cache_materialize_events trunk_cache_materialize_time_s "
+        "dirty_detach_events dirty_detach_time_s dirty_detach_arrays "
+        "dirty_detach_bytes live_output_detach_events "
+        "live_output_detach_time_s live_output_detach_arrays "
+        "live_output_detach_bytes state_rebase_events state_rebase_time_s "
+        "state_root_eval_events state_root_eval_time_s "
+        "state_root_eval_arrays trace_accounting_time_s"
+    ).split()
+    ar_totals = {key: 0 for key in ar_scalar_keys}
+    ar_totals.update(
+        generated_tokens=2,
+        accepted_by_depth=[],
+        drafted_by_depth=[],
+        evaluated_by_depth=[],
+        accept_probability_sum_by_depth=[],
+    )
+    for generated in (2, 4):
+        ar_totals = dict(ar_totals, generated_tokens=generated)
+        trace.maybe_emit(
+            force=True,
+            final=generated == 4,
+            totals=ar_totals,
+            cache=None,
+            mtp_cache=None,
+            mtp_history_materialize_every=0,
+            mtp_history_materialize_events=0,
+        )
+    rows = [
+        _json.loads(line)
+        for line in (tmp_path / "trace.jsonl").read_text().splitlines()
+    ]
+    assert len(rows) == 2
+    assert rows[1]["generated_tokens_delta"] == 2
+    assert rows[1]["target_distribution_materialized_rows_delta"] == 0

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -11004,3 +11004,68 @@ def test_parallel_tool_calls_false_streaming_android_studio_shape(monkeypatch):
     assert "pwd" not in arguments
     assert final[-1]["choices"][0]["finish_reason"] == "tool_calls"
     assert final[-1]["mtplx_stats"]["tool_calls_emitted"] == 1
+
+
+def test_run_generation_passes_draft_core_from_serve_args(monkeypatch):
+    state = _fake_streaming_session_state()
+    state.draft_sampler = None
+    state.requests_completed = 0
+    state.args.draft_core = "device"
+    captured: dict[str, object] = {}
+
+    def fake_generate_mtpk(*_args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            tokens=[],
+            text="",
+            stats=SimpleNamespace(
+                to_dict=lambda: {
+                    "prompt_eval_time_s": 0.0,
+                    "generated_tokens": 0,
+                    "elapsed_s": 0.0,
+                    "tok_s": 0.0,
+                }
+            ),
+            final_state=None,
+        )
+
+    monkeypatch.setattr(openai, "generate_mtpk", fake_generate_mtpk)
+
+    openai._run_generation(
+        state,
+        [1, 2, 3],
+        max_tokens=1,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        seed=None,
+        generation_mode="mtp",
+        depth=1,
+        session_id="sess-draft-core",
+        session_bank=state.sessions.bank,
+        session_template_hash=state.template_hash,
+        session_draft_head_identity=state.draft_head_identity,
+        session_policy_fingerprint="policy",
+    )
+    assert captured["draft_core"] == "device"
+
+    # serve args without the attribute (older callers) fall back to stock
+    del state.args.draft_core
+    captured.clear()
+    openai._run_generation(
+        state,
+        [1, 2, 3],
+        max_tokens=1,
+        temperature=None,
+        top_p=None,
+        top_k=None,
+        seed=None,
+        generation_mode="mtp",
+        depth=1,
+        session_id="sess-draft-core-2",
+        session_bank=state.sessions.bank,
+        session_template_hash=state.template_hash,
+        session_draft_head_identity=state.draft_head_identity,
+        session_policy_fingerprint="policy",
+    )
+    assert captured["draft_core"] == "stock"

--- a/tests/test_snapshot_free_rejection_repair.py
+++ b/tests/test_snapshot_free_rejection_repair.py
@@ -1,0 +1,123 @@
+"""Rejection repair without a verify snapshot (all-trimmable caches).
+
+Profiles set MTPLX_SKIP_VERIFY_SNAPSHOT=1 for the product lanes; under plain
+batched verify a rejected draft then had no repair path (no snapshot, no
+trim/capture lane) and generate_mtpk raised — killing the first request that
+ever saw a rejection. Attention-only models (every cache entry trimmable) can
+always repair by trimming the uncommitted verify tail, snapshot or not.
+"""
+import json
+
+import pytest
+
+hy_v3 = pytest.importorskip(
+    "mlx_lm.models.hy_v3",
+    reason="mlx-lm does not ship models/hy_v3 yet (unreleased upstream)",
+)
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from mtplx.cache_state import trim_verified_window_without_snapshot
+from mtplx.generation import generate_mtpk
+from mtplx.mtp_patch import MTPContract
+from mtplx.runtime import MTPLXRuntime
+from mtplx.sampling import SamplerConfig
+
+
+class _FixedTokenizer:
+    eos_token_id = None
+    eos_token_ids: set[int] = set()
+
+    def decode(self, tokens):
+        return " ".join(str(t) for t in tokens)
+
+
+def _grafted_runtime(tmp_path):
+    from pathlib import Path
+
+    from mtplx.hy_v3_mtp_patch import inject_hy_v3_mtp_support
+
+    args = hy_v3.ModelArgs(
+        model_type="hy_v3", vocab_size=128, hidden_size=64, intermediate_size=128,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        num_experts=4, num_experts_per_tok=2, num_shared_experts=1, expert_hidden_dim=64,
+        first_k_dense_replace=1, rms_norm_eps=1e-5,
+        rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+        num_nextn_predict_layers=1)
+    mx.random.seed(7)
+    model = hy_v3.Model(args)
+    donor = hy_v3.DecoderLayer(args, layer_idx=2)
+    tensors = {f"model.layers.2.{k}": v for k, v in tree_flatten(donor.parameters())}
+    for name in ("enorm", "hnorm", "final_layernorm"):
+        tensors[f"model.layers.2.{name}.weight"] = mx.ones((64,))
+    tensors["model.layers.2.eh_proj.weight"] = 0.02 * mx.random.normal((64, 128))
+    mx.save_safetensors(str(tmp_path / "model-mtp.safetensors"), tensors)
+    json.dump(
+        {"metadata": {}, "weight_map": {k: "model-mtp.safetensors" for k in tensors}},
+        open(tmp_path / "model.safetensors.index.json", "w"),
+    )
+    cfg = {"model_type": "hy_v3", "num_nextn_predict_layers": 1, "num_hidden_layers": 2}
+    assert inject_hy_v3_mtp_support(model, Path(tmp_path), cfg, None)
+    return MTPLXRuntime(
+        model=model, tokenizer=_FixedTokenizer(), model_path=Path(tmp_path),
+        mtp_enabled=True, contract=MTPContract(),
+    )
+
+
+def _generate(rt, *, skip_snapshot, monkeypatch):
+    if skip_snapshot:
+        monkeypatch.setenv("MTPLX_SKIP_VERIFY_SNAPSHOT", "1")
+    else:
+        monkeypatch.delenv("MTPLX_SKIP_VERIFY_SNAPSHOT", raising=False)
+    out = generate_mtpk(
+        rt,
+        [1, 2, 3, 4, 5],
+        max_tokens=24,
+        sampler=SamplerConfig(temperature=0.0),
+        speculative_depth=1,
+        mtp_history_policy="committed",
+        stop_token_ids=set(),
+    )
+    return out
+
+
+def test_unit_snapshot_free_trim_on_plain_kv_cache():
+    from mlx_lm.models.cache import KVCache
+
+    cache = [KVCache() for _ in range(2)]
+    for entry in cache:
+        entry.update_and_fetch(
+            mx.zeros((1, 2, 8, 4)), mx.zeros((1, 2, 8, 4))
+        )
+    assert all(entry.offset == 8 for entry in cache)
+    # verified window of 4, keep 1 committed token -> trim 3
+    assert trim_verified_window_without_snapshot(
+        cache, verified_tokens=4, keep_tokens=1
+    )
+    assert all(entry.offset == 5 for entry in cache)
+
+    class _Recurrent:  # no trim() => not trimmable
+        offset = 5
+        state = object()
+
+    assert not trim_verified_window_without_snapshot(
+        [cache[0], _Recurrent()], verified_tokens=2, keep_tokens=1
+    )
+
+
+def test_skip_snapshot_rejections_complete_and_match_snapshot_arm(
+    tmp_path, monkeypatch
+):
+    rt = _grafted_runtime(tmp_path)
+    baseline = _generate(rt, skip_snapshot=False, monkeypatch=monkeypatch)
+    stats = baseline.stats.to_dict()
+    assert stats.get("rejected_drafts", 0) > 0, (
+        "test premise: the random draft head must produce rejections"
+    )
+
+    rt2 = _grafted_runtime(tmp_path)
+    repaired = _generate(rt2, skip_snapshot=True, monkeypatch=monkeypatch)
+    assert repaired.tokens == baseline.tokens, (
+        "snapshot-free repair must reproduce the snapshot arm token-for-token"
+    )


### PR DESCRIPTION
Serves Tencent Hy3 (295B MoE) from the standard `mlx-community/Hy3-oQ2e` checkpoint, fully resident, with working K=1 speculation and a load-time requantization mode that is the recommended way to run it. Continues #152 — same goal, without the SSD-streaming runtime that PR proposed. The hy_v3 backend's contract gate asked for a hardware-measured runtime contract; this PR supplies it.

| Flagship: 4-bit dynamic requant, full residency | |
|---|---|
| Throughput | **48 tok/s** (K=1, this hardware, this recipe, development lane) · this branch receipts **43.1** — gap attribution below |
| Quality | HumanEval statistically unchanged vs q8 (paired full-164, McNemar p = 1.0) · served gate: **0.8659** HumanEval / **0.7947** MBPP, zero request errors |
| Memory | ~90 GB resident (vs 94–95 GB default) · 16k context fits (default does not) |
| vs default | **+19–23% decode** at every measured shape |

Hardware for all numbers: Apple silicon M-class, 614 GB/s unified memory, mlx-lm PR #1211.

## Running it

```bash
MTPLX_PROJ_REQUANT=q4 mtplx serve --model mlx-community/Hy3-oQ2e \
    --mtp --depth 1 --verify-strategy batched --verify-core stock \
    --draft-core device --profile performance-cold
```

The checkpoint's `mtplx_runtime.json` (included) carries the measured contract: arch id, depth max 1, recommended profile, and the env overrides that keep verify snapshots on.

## Dynamic requant

Decode at this scale is bytes-per-token bound, and the always-read set — attention `q/k/v/o_proj` plus dense/shared-MLP projections — dominates. The checkpoint ships those at q8; `MTPLX_PROJ_REQUANT=q4` (or `load(proj_requant="q4")`) re-quantizes exactly that set at load time, from the published artifact, no republishing:

- Pre-quantized residents are taken down via dequantize → canonical `QuantizedLinear.from_linear` at q4/gs64 — byte-identical to what a load-time quantization would produce. The q8→q4 double quantization is deliberate and disclosed; a BF16 source (via the sibling `proj_quant`) remains the higher-quality route when available.
- Expert banks are excluded by module type, routers/embeddings/lm_head/norms by path, and the pass runs before MTP injection, so the draft head's precision is never touched. Per-token reads drop ~11.9 → ~7.9 GB.

## Results

Decode tok/s, real-code prefill, greedy 256-token decode, bf16 KV. Peak GB in parentheses.

| Context | Lane | Default (q8 residents) | Dynamic requant (q4) |
|---|---|---|---|
| 256 | AR | 30.9 (94.4) | **37.9** |
| 256 | MTP K=1 | 31.2 · accept .796 | **37.2** (90.5) · accept .861 |
| 1,024 | AR | 29.5 (95.4) | **36.2** (91.6) |
| 1,024 | MTP K=1 | 32.9 · accept .875 | **37.0** (91.6) · accept .875 |
| 16,384 | AR | does not fit (101 GB projected) | 24.6 — see note |
| 16,384 | MTP K=1 | does not fit | blocked by the long-context guard |

16k note: the cell ran, but the non-chunked prefill route materializes full hidden/logits intermediates (observed 105 GB peak, decode degraded under the pressure), and the engine's guard blocks the MTP equivalent outside the sustained profile — correctly. Long context belongs to the sustained/chunked lane and is out of scope here; 64k is structurally infeasible fully resident (21.4 GB of KV on top of ~90 GB of weights).

Acceptance trends up with context (.80–.86 at 256 → .875–.903 at 1k) as committed history accumulates.

> **Known issue — MTP acceptance instability.** Acceptance on this family is not stable run-to-run in longer field use: it flips from 90+% to below 50% with no configuration change. The MTP numbers above are samples from the good mode. At sub-50% accept, K=1 drops below AR (the win margin is ~1–5 tok/s), so treat AR as the stable floor and MTP as an opportunistic win until this is root-caused. Suspects: committed-history/session state across requests; near-tie numerics in the draft path.

### Kernel profile

Queued lane (N submits, one eval), real loaded modules, B=1 decode shapes, L2 defeated by cycling layers and random expert slots. ms/call and achieved GB/s vs the 614 GB/s ceiling:

| Kernel | Default q8 | Requant q4 |
|---|---|---|
| attention projs (q,k,v,o) | 0.141 / 570 (93%) | **0.081** / 523 (85%) |
| MoE experts, 8-of-192 gather | 0.105 / 406 (66%) | 0.267 / 159 ¹ |
| shared MLP | 0.037 / 538 (88%) | **0.023** / 454 (74%) |
| router gate (bf16, real path) | 0.011 | 0.011 |
| lm_head (q8, untouched) | 0.856 / 614 (100%) | 0.901 / 584 (95%) |

¹ Expert banks are byte-identical in both variants; this delta is bench variance, not a requant effect. ² An earlier revision showed the router at 63–90 µs — a mixed-dtype bench artifact (fp32 input against bf16 weights), corrected here; see the erratum comment.

Reading: the byte-carrying kernels run at 85–100% of DRAM ceiling, and the requant column is the same kernels moving half the bytes — that is the whole +23%. Summed kernel time accounts for ~60% of the measured AR step; the remaining gap to the 48 flagship (AR step 27.9 ms vs ~13 ms of bytes at 1k) is distributed attention/eval overhead with no single hot kernel, and its attribution is the branch's active work along with the K=1 verify's byte-floor gap (cycle 1.88 → 1.66 AR-steps).

## MTP: what was broken, what was fixed

Acceptance was 0.12–0.26 when this work started. Three measured causes:

1. **The draft head consumes the post-final-norm trunk hidden.** Teacher-forced 2×2 probe over a 1024-token real-code prompt: 0.773 agreement post-norm vs 0.387 pre-norm vs 0.000 with the eh_proj concat flipped. The pre-norm contract previously documented in the backend is refuted by measurement and corrected.
2. **Draft history must be primed over the prompt** (`committed` policy) — unprimed, the head is context-starved at 0.26.
3. **The device draft core** (single sync per cycle, already in-tree) was unreachable from serving; `serve --draft-core` exposes it. It is the difference between speculation losing to AR and beating it.

Supporting engine work, each with regression tests:

- **Checkpoint graft** — released mlx-lm sanitizes the appended NextN layer away; injection now builds the draft head from the checkpoint's canonical `model.layers.{N}.*` tensors (index-driven, per-module quant overrides honored). Native `model.mtp` binding remains the fast path for when mlx-lm's MTP revision lands; the registry gate accepts the tencent-native layout alongside repacked `mtp.*`.
- **Snapshot-free rejection repair** — product profiles set `MTPLX_SKIP_VERIFY_SNAPSHOT=1`; under batched verify the first rejected draft then had no repair path and the request 500'd. Attention-only caches now repair by trimming the uncommitted verify tail, token-for-token identical to the snapshot arm.
- **Compiled-AR hook reachability** — MTP wrappers advertise `emit_logits` via `**kwargs`, which made the decode fast branch unreachable on exactly the runtimes it targets.

## Quality

Full suites over HTTP against the served model (requant arm), chat endpoint, temperature 0, seed 42, zero request errors:

| Arm | HumanEval pass@1 | MBPP pass@1 |
|---|---|---|
| MTP K=1 device | **0.8659** (142/164) | **0.7947** (774/974) |
| AR | 0.8598 (141/164) | — |

One task apart — the paired McNemar-p≈1.0 shape; exact verification is quality-neutral as promised.

## Also in the diff

- Canonicalized env-flag parsing (one strict reader per variable; the paged-KV membership test silently picked the dense-decode layout for a quantized cache) — 62-test suite.
- MTP payload guards for deepseek/mimo/nemotron_h (non-empty weight maps with no real draft tensors no longer inject headless surfaces).
- Decode-trace tolerance for lane-specific counter sets; publish-metadata scrub (a published manifest leaked home paths).
- Per-model measured-knob registry (advisory): every decision above as reviewable data with provenance, including the negatives — capture-class verify (slower here, accept .903→.776), compiled-AR (flag-gated; engagement-proofed null with a greedy parity flip), kv-quant (not applicable).
- HumanEval/MBPP harness (offline pass@k, explicit `allow_execution` gate; validated 164/164 and 972/974 on canonical solutions), real-code prompt corpus, roofline/AR-profile diagnostics.

Suite: 2,171 passing (two pre-existing vllm-metal dylib environment failures predate this branch; hy_v3 test files skip on released mlx-lm until the model lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
