### PR TITLE
Fix slow Hugging Face config probes in Forge

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Onboarding/HuggingFaceProbe.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Onboarding/HuggingFaceProbe.swift
@@ -204,7 +204,15 @@ public struct HuggingFaceProbe: Sendable {
     /// object. `nil` on any failure — callers treat these fetches as
     /// best-effort signals, never hard errors.
     private func fetchRepoJSON(repo: String, path: String) async -> [String: Any]? {
-        guard let url = URL(string: "\(endpointBase)/\(repo)/resolve/main/\(path)") else {
+        await fetchRepoJSON(repo: repo, revision: "main", path: path)
+    }
+
+    private func fetchRepoJSON(
+        repo: String,
+        revision: String,
+        path: String
+    ) async -> [String: Any]? {
+        guard let url = URL(string: "\(endpointBase)/\(repo)/resolve/\(revision)/\(path)") else {
             return nil
         }
         do {
@@ -276,6 +284,14 @@ public struct HuggingFaceProbe: Sendable {
     }
 
     // MARK: - Step 1: GET <endpoint>/<repo>/resolve/main/config.json
+    //
+    // The Hub's raw-file route can occasionally stall long enough to
+    // trip URLSession's short onboarding timeout, especially for
+    // generated MLX configs with large per-tensor quantization maps.
+    // On transport errors, transient HTTP failures, or malformed raw
+    // responses, fall back to the model API's `config` expansion. The
+    // raw file remains authoritative and auth/404 handling stays
+    // unchanged.
 
     private func fetchConfig(repo: String) async -> ConfigOutcome {
         guard let url = URL(string: "\(endpointBase)/\(repo)/resolve/main/config.json") else {
@@ -307,6 +323,9 @@ public struct HuggingFaceProbe: Sendable {
                 // instead of claiming the repo does not exist.
                 return .failed(await classifyMissingConfig(repo: repo))
             default:
+                if let config = await fetchConfigFromModelAPI(repo: repo) {
+                    return .ok(config)
+                }
                 return .failed(OtherModelProbe(
                     verdict: .probeFailed,
                     hfRepo: repo,
@@ -315,6 +334,9 @@ public struct HuggingFaceProbe: Sendable {
                 ))
             }
             guard let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+                if let config = await fetchConfigFromModelAPI(repo: repo) {
+                    return .ok(config)
+                }
                 return .failed(OtherModelProbe(
                     verdict: .probeFailed,
                     hfRepo: repo,
@@ -324,6 +346,9 @@ public struct HuggingFaceProbe: Sendable {
             }
             return .ok(json)
         } catch {
+            if let config = await fetchConfigFromModelAPI(repo: repo) {
+                return .ok(config)
+            }
             return .failed(OtherModelProbe(
                 verdict: .probeFailed,
                 hfRepo: repo,
@@ -331,6 +356,47 @@ public struct HuggingFaceProbe: Sendable {
                 diagnostic: error.localizedDescription
             ))
         }
+    }
+
+    /// Uses Hugging Face's compact model metadata to recover from a
+    /// raw-file failure. The indexed config is accepted only when it
+    /// carries a positive MTP marker; the Hub intentionally omits many
+    /// model-specific fields from that representation, so treating its
+    /// absence as "no MTP" would create a false negative. Prefer the
+    /// returned immutable revision to retry the complete raw config,
+    /// retaining the indexed config only as a last positive signal.
+    /// Failures return nil so the caller preserves the original raw-file
+    /// diagnostic.
+    private func fetchConfigFromModelAPI(repo: String) async -> [String: Any]? {
+        guard var components = URLComponents(string: "\(endpointBase)/api/models/\(repo)") else {
+            return nil
+        }
+        components.queryItems = [
+            URLQueryItem(name: "expand", value: "config"),
+            URLQueryItem(name: "expand", value: "sha"),
+        ]
+        guard let url = components.url else { return nil }
+        guard let (status, body) = try? await runner(url, "GET"), status == 200 else {
+            return nil
+        }
+        guard let metadata = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+            return nil
+        }
+        let indexedConfig = (metadata["config"] as? [String: Any]) ?? [:]
+
+        if let revision = metadata["sha"] as? String,
+           !revision.isEmpty,
+           revision.unicodeScalars.allSatisfy({
+               CharacterSet.alphanumerics.contains($0)
+           }),
+           let config = await fetchRepoJSON(
+               repo: repo,
+               revision: revision,
+               path: "config.json"
+           ) {
+            return config
+        }
+        return Self.configDeclaresMTP(indexedConfig) ? indexedConfig : nil
     }
 
     // MARK: - Missing-config triage
@@ -554,7 +620,11 @@ public struct HuggingFaceProbe: Sendable {
     public static func defaultRunner(_ url: URL, _ method: String) async throws -> (Int, Data) {
         var request = URLRequest(url: url)
         request.httpMethod = method
-        request.timeoutInterval = 12
+        // Generated MLX configs can exceed 500 KB because they carry
+        // per-tensor quantization maps. Twelve seconds produced false
+        // "Unknown format" failures on otherwise public, forgeable
+        // repos; keep the probe bounded but allow slow Hub responses.
+        request.timeoutInterval = 30
         // Hugging Face honors a User-Agent and uses it to gate scraping
         // heuristics. Identify ourselves clearly so a probe failure is
         // traceable in HF logs back to MTPLX.

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/HuggingFaceProbeForgeTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/HuggingFaceProbeForgeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import MTPLXAppCore
 
@@ -9,6 +10,7 @@ final class HuggingFaceProbeForgeTests: XCTestCase {
     ///
     ///   /<repo>/resolve/main/mtplx_runtime.json
     ///   /<repo>/resolve/main/config.json
+    ///   /api/models/<repo>?expand=config&expand=sha
     ///   /api/models/<repo>/tree/main
     ///
     /// Missing entries return 404; throwing entries simulate network
@@ -206,6 +208,65 @@ final class HuggingFaceProbeForgeTests: XCTestCase {
         let probe = HuggingFaceProbe(runner: fake.runner())
         let result = await probe.forgeProbe(repo: "nonexistent/repo")
         XCTAssertEqual(result.verdict, .probeFailed)
+    }
+
+    func testForgeProbeFallsBackToModelAPIWhenLargeHy3ConfigTimesOut() async {
+        let fake = FakeRunner()
+        let repo = "philipjohnbasile/hy3-demolition-mlx-reap25-v1-mtp"
+        fake.errors.insert(
+            "https://huggingface.co/\(repo)/resolve/main/config.json"
+        )
+        fake.install(
+            url: "https://huggingface.co/api/models/\(repo)?expand=config&expand=sha",
+            body: """
+            {
+              "sha": "ac84bc50a90acdcbbffc632877f60be4b7efdddf",
+              "config": {
+                "model_type": "hy_v3"
+              }
+            }
+            """
+        )
+        fake.install(
+            url: "https://huggingface.co/\(repo)/resolve/ac84bc50a90acdcbbffc632877f60be4b7efdddf/config.json",
+            body: """
+            {
+              "model_type": "hy_v3",
+              "num_nextn_predict_layers": 1,
+              "quantization": {
+                "bits": 4,
+                "group_size": 64
+              }
+            }
+            """
+        )
+        fake.install(
+            url: "https://huggingface.co/api/models/\(repo)/tree/main",
+            body: "[]"
+        )
+
+        let probe = HuggingFaceProbe(runner: fake.runner())
+        let result = await probe.forgeProbe(repo: repo)
+
+        XCTAssertEqual(result.verdict, .forgeable)
+        XCTAssertEqual(result.sourceFormat, .mlxAffine)
+        XCTAssertEqual(result.hfRepo, repo)
+        XCTAssertNil(result.diagnostic)
+    }
+
+    func testForgeProbePreservesRawFetchDiagnosticWhenAPIFallbackAlsoFails() async {
+        let fake = FakeRunner()
+        let repo = "someone/flaky-model"
+        fake.errors.insert(
+            "https://huggingface.co/\(repo)/resolve/main/config.json"
+        )
+
+        let probe = HuggingFaceProbe(runner: fake.runner())
+        let result = await probe.forgeProbe(repo: repo)
+
+        XCTAssertEqual(result.verdict, .probeFailed)
+        XCTAssertEqual(result.message, "Couldn't fetch config.json.")
+        XCTAssertEqual(result.diagnostic, URLError(.notConnectedToInternet).localizedDescription)
     }
 
     // MARK: - classifySourceFormat unit (config-only, no IO)


### PR DESCRIPTION
## What changed

- Raise the app probe request timeout from 12 to 30 seconds for large generated MLX configs.
- Recover transport, transient HTTP, and decode failures through Hugging Face model metadata.
- Retry the complete config at the immutable repository SHA so compact indexed metadata cannot create false `no MTP` verdicts or lose quantization details.
- Preserve the existing auth, missing-repo, GGUF, mirror, and pair-bundle behavior.
- Add a regression using `philipjohnbasile/hy3-demolition-mlx-reap25-v1-mtp`, including its real source revision and sparse indexed-config shape.

## Why

The Forge picker fetched only `<repo>/resolve/main/config.json` with a 12-second timeout. The Hy3 MLX artifact has a generated config of roughly 539 KB with a large per-tensor quantization map. A slow raw-file response therefore surfaced as `Couldn't fetch config.json` / `Unknown format`, even though the CLI correctly recognizes the public artifact as forgeable `hy-v3-mtp`.

## Impact

Slow but valid public MLX/MTP repositories can now pass preflight instead of being falsely rejected, while negative MTP classification still requires the complete authoritative config.

## Validation

- `HuggingFaceProbeForgeTests`: 28 tests passed, 0 failures.
- Dedicated timeout fallback harness: 3 tests passed, 0 failures.
- `git diff --check`: clean.
- Cross-fork compare is based directly on current upstream `main`: 2 commits ahead, 0 behind, only the probe and its tests changed.

The full Swift package gate could not run in the Codex sandbox because external package resolution is network-blocked and Xcode-beta's SwiftData macro plugin cannot launch under the nested sandbox. The focused production probe suite compiled and passed against the exact modified source.