### PR TITLE
fix: remove unsupported MTP sidecar graft guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ On a 16 GB M4 Mac mini, tuning the 9B model lands on depth 1: 14.4 tok/s baselin
 
 Forge takes a Hugging Face repo and turns it into an MTPLX-ready MTP model: convert to MLX, train the MTP adapter, verify that the result is actually faster and still exact, and publish back to the Hub if you want to share it. The honest part matters: Forge measures before and after on your hardware and shows you the verdict ("Depth 1 is fastest: 227.1 to 296.1, 1.30x") rather than assuming the adapter helped. Available in the app and as `mtplx forge`.
 
+MTPLX does not support attaching a separately supplied MTP sidecar to an arbitrary MLX trunk. Matching architecture fields, tensor shapes, or provenance labels cannot prove that the head was trained against those exact trunk weights. Use a complete model that already includes its matching MTP weights, or use Forge to build and verify an artifact from its original source checkpoint.
+
 The official catalog lives on Hugging Face under [Youssofal](https://huggingface.co/Youssofal): Qwen 3.5 (4B, 9B), Qwen 3.6 (27B, 35B MoE) in speed, balance, and quality builds, plus Gemma 4. The app recommends from these based on your hardware.
 
 ## The server

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1259,9 +1259,11 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                 message=(
                     f"{marker_text}, but this folder does not contain runnable "
                     "Qwen MTP tensors. mtplx_runtime.json is optional metadata; "
-                    "the blocker is missing MTP weights. Use a model with "
-                    "mtp.safetensors, embedded mtp.* / language_model.mtp.* "
-                    "weights, or graft an MTP sidecar into this base model."
+                    "the blocker is missing MTP weights. Use a complete model with "
+                    "mtp.safetensors or embedded mtp.* / language_model.mtp.* "
+                    "weights, or build and verify one from its original source with "
+                    "Forge. MTPLX cannot safely attach an arbitrary sidecar: matching "
+                    "tensor shapes do not prove it was trained for this trunk."
                 ),
                 recommended_backend="qwen3_next",
                 recommended_profile=DEFAULT_PROFILE_NAME,

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -550,8 +550,10 @@ def _model_gate_error_lines(inspection: dict[str, Any]) -> list[str]:
         )
     if runtime_compatibility == "missing-mtp-weights":
         lines.append(
-            "fix: choose a model with real MTP weights, or graft an MTP sidecar "
-            "into this base model."
+            "fix: use a complete model with matching MTP weights, or build and "
+            "verify one from its original source with mtplx forge. MTPLX does not "
+            "attach arbitrary sidecars because config/tensor checks cannot prove "
+            "their trunk lineage."
         )
     elif compatibility.get("tier") == TIER_ARCH_COMPATIBLE_UNVERIFIED:
         lines.append(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -100,6 +100,10 @@ def test_inspect_model_reads_qwen_mtp_config_without_weights(tmp_path):
     assert result.compatibility["unsafe_force_required"] is False
     assert "mtplx_runtime.json is optional metadata" in result.compatibility["message"]
     assert "missing MTP weights" in result.compatibility["message"]
+    assert "complete model" in result.compatibility["message"]
+    assert "original source with Forge" in result.compatibility["message"]
+    assert "cannot safely attach an arbitrary sidecar" in result.compatibility["message"]
+    assert "graft an MTP sidecar" not in result.compatibility["message"]
 
 
 def test_qwen3_5_text_subtype_can_pass_primary_gate_when_mtp_is_valid(monkeypatch, tmp_path):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -7299,7 +7299,10 @@ def test_start_gate_failure_is_human_readable_for_config_only_qwen(tmp_path, cap
     assert "error: model cannot run with MTPLX" in captured
     assert "runtime: missing-mtp-weights" in captured
     assert "mtplx_runtime.json is optional metadata" in captured
-    assert "fix: choose a model with real MTP weights" in captured
+    assert "fix: use a complete model with matching MTP weights" in captured
+    assert "original source with mtplx forge" in captured
+    assert "does not attach arbitrary sidecars" in captured
+    assert "graft an MTP sidecar" not in captured
     assert '"model_files"' not in captured
 
 
@@ -7325,7 +7328,10 @@ def test_start_gate_failure_is_human_readable_for_config_only_glm(tmp_path, caps
     assert "error: model cannot run with MTPLX" in captured
     assert "runtime: missing-mtp-weights" in captured
     assert "mtplx_runtime.json is optional metadata" in captured
-    assert "fix: choose a model with real MTP weights" in captured
+    assert "fix: use a complete model with matching MTP weights" in captured
+    assert "original source with mtplx forge" in captured
+    assert "does not attach arbitrary sidecars" in captured
+    assert "graft an MTP sidecar" not in captured
     assert "MTP MTP markers" not in captured
     assert '"model_files"' not in captured
 


### PR DESCRIPTION
## What changed

- replace the runtime and CLI suggestion to graft an arbitrary MTP sidecar
- direct users to a complete paired model or a Forge build from the original source
- document why architecture, tensor, and provenance labels alone do not prove trunk and sidecar pairing
- preserve the existing `runtime_compatibility` machine value

## Why

Issue #215 points out that the documented `graft_mtp_sidecar.py` workflow does not exist. More importantly, exposing an arbitrary attachment command without content-addressed pairing evidence would be unsafe. This patch makes the supported boundary explicit without pretending to solve arbitrary trunk and sidecar pairing.

This addresses the misleading remediation reported in #215; it does not close the broader comparison workflow request.

## Validation

- `git diff --check`
- `uv run --extra dev ruff check README.md mtplx/backends/registry.py mtplx/commands/public.py tests/test_artifacts.py tests/test_public_cli.py`
- `uv run --extra dev python -m compileall -q mtplx/backends/registry.py mtplx/commands/public.py`
- `uv run --extra dev pytest tests/test_artifacts.py tests/test_public_cli.py -q` — 321 passed
