### PR TITLE
feat(app): add bounded daemon crash recovery

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Models/AppConfiguration.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Models/AppConfiguration.swift
@@ -108,6 +108,10 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
     public var streamSnapshotIntervalMs: Int
     public var performanceLock: Bool
     public var launchDaemonOnOpen: Bool
+    /// Opt-in app-managed recovery after an abnormal daemon exit. It applies
+    /// to launches created in this app session; the launch command and API key
+    /// remain process-memory-only in DaemonSupervisor.
+    public var automaticDaemonRestart: Bool
     /// When on, the app launches Hermes in auto-approve ("YOLO") mode so
     /// the agent runs tools without prompting. Off makes Hermes ask for
     /// approval. Applies the next time Hermes is started.
@@ -222,6 +226,7 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
         streamSnapshotIntervalMs: Int = 100,
         performanceLock: Bool = false,
         launchDaemonOnOpen: Bool = false,
+        automaticDaemonRestart: Bool = false,
         hermesAutoApprove: Bool = true,
         fanMode: String? = nil,
         pinFansAtMaxOnStart: Bool = false,
@@ -285,6 +290,7 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
         self.streamSnapshotIntervalMs = streamSnapshotIntervalMs
         self.performanceLock = performanceLock
         self.launchDaemonOnOpen = launchDaemonOnOpen
+        self.automaticDaemonRestart = automaticDaemonRestart
         self.hermesAutoApprove = hermesAutoApprove
         let resolvedFanMode = MTPLXFanMode.normalized(
             fanMode ?? (pinFansAtMaxOnStart ? MTPLXFanMode.max.rawValue : MTPLXFanMode.smart.rawValue)
@@ -470,6 +476,7 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
         case streamSnapshotIntervalMs = "stream_snapshot_interval_ms"
         case performanceLock = "performance_lock"
         case launchDaemonOnOpen = "launch_daemon_on_open"
+        case automaticDaemonRestart = "automatic_daemon_restart"
         case hermesAutoApprove = "hermes_auto_approve"
         case fanMode = "fan_mode"
         case pinFansAtMaxOnStart = "pin_fans_at_max_on_start"
@@ -545,6 +552,7 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
         streamSnapshotIntervalMs = try container.decodeIfPresent(Int.self, forKey: .streamSnapshotIntervalMs) ?? defaults.streamSnapshotIntervalMs
         performanceLock = try container.decodeIfPresent(Bool.self, forKey: .performanceLock) ?? defaults.performanceLock
         launchDaemonOnOpen = try container.decodeIfPresent(Bool.self, forKey: .launchDaemonOnOpen) ?? defaults.launchDaemonOnOpen
+        automaticDaemonRestart = try container.decodeIfPresent(Bool.self, forKey: .automaticDaemonRestart) ?? defaults.automaticDaemonRestart
         hermesAutoApprove = try container.decodeIfPresent(Bool.self, forKey: .hermesAutoApprove) ?? defaults.hermesAutoApprove
         let decodedFanMode = try container.decodeIfPresent(String.self, forKey: .fanMode)
         let legacyPin = try container.decodeIfPresent(Bool.self, forKey: .pinFansAtMaxOnStart)

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Services/DaemonSupervisor.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Services/DaemonSupervisor.swift
@@ -52,20 +52,254 @@ public enum DaemonStartupPhase: Equatable, Sendable {
     case failed(String)
 }
 
+/// Bounds automatic recovery for an app-owned daemon. The policy lives only
+/// in the app process: it never writes a command line, environment, or API key
+/// to disk.
+public struct DaemonRestartPolicy: Equatable, Sendable {
+    public var maximumAttempts: Int
+    public var initialDelaySeconds: TimeInterval
+    public var maximumDelaySeconds: TimeInterval
+    public var crashWindowSeconds: TimeInterval
+
+    public init(
+        maximumAttempts: Int = 3,
+        initialDelaySeconds: TimeInterval = 1,
+        maximumDelaySeconds: TimeInterval = 30,
+        crashWindowSeconds: TimeInterval = 120
+    ) {
+        self.maximumAttempts = max(0, maximumAttempts)
+        self.initialDelaySeconds = max(0, initialDelaySeconds)
+        self.maximumDelaySeconds = max(self.initialDelaySeconds, maximumDelaySeconds)
+        self.crashWindowSeconds = max(0, crashWindowSeconds)
+    }
+
+    public static let `default` = DaemonRestartPolicy()
+}
+
+public enum DaemonRestartStatus: Equatable, Sendable {
+    case idle
+    case scheduled(attempt: Int, delaySeconds: TimeInterval)
+    case restarting(attempt: Int)
+    case runningAfterRestart(attempt: Int)
+    case exhausted(attempts: Int, lastExitStatus: Int32?)
+}
+
+public enum DaemonRestartEligibility: Equatable, Sendable {
+    case noDaemon
+    case currentSessionProtected
+    case currentSessionUnprotected
+    case adoptedPriorSession
+}
+
+/// Small, secret-free status surface for the app chrome and logs view.
+public struct DaemonSupervisionSnapshot: Equatable, Sendable {
+    /// Monotonic delivery revision. Consumers that hop onto another executor
+    /// must ignore an older snapshot that arrives after a newer one.
+    public let revision: Int
+    public let state: DaemonState
+    public let restartStatus: DaemonRestartStatus
+    public let restartCount: Int
+    public let restartEligibility: DaemonRestartEligibility
+    /// Monotonic for each app-owned or adopted daemon lifecycle attempt. It
+    /// advances before the first asynchronous probe, so a terminal callback
+    /// from an older daemon cannot be mistaken for a newer launch that has
+    /// not yet reserved a Process.
+    public let lifecycleEpoch: Int
+    /// Monotonic for this supervisor instance; unlike restartCount it never
+    /// resets when the circuit-breaker window rolls over.
+    public let recoveryGeneration: Int
+
+    public init(
+        revision: Int = 0,
+        state: DaemonState,
+        restartStatus: DaemonRestartStatus,
+        restartCount: Int,
+        restartEligibility: DaemonRestartEligibility = .noDaemon,
+        lifecycleEpoch: Int = 0,
+        recoveryGeneration: Int
+    ) {
+        self.revision = revision
+        self.state = state
+        self.restartStatus = restartStatus
+        self.restartCount = restartCount
+        self.restartEligibility = restartEligibility
+        self.lifecycleEpoch = lifecycleEpoch
+        self.recoveryGeneration = recoveryGeneration
+    }
+}
+
 public final class DaemonSupervisor: @unchecked Sendable {
+    private struct OwnedLaunch: Sendable {
+        let command: DaemonCommand
+        let healthBaseURL: URL
+        let apiKey: String?
+        let probeHealth: Bool
+        let timeoutSeconds: TimeInterval
+        let expectedLaunchID: String?
+        let requireActualFanRamp: Bool
+        let onPhase: (@Sendable (DaemonStartupPhase) -> Void)?
+    }
+
     private let lock = NSLock()
     private var process: Process?
     private var adoptedProcessID: pid_t?
     private let logStore: BoundedLogStore
+    private let restartPolicy: DaemonRestartPolicy
+    private let restartSleeper: @Sendable (TimeInterval) async -> Void
+    private let initialHealthProbe: @Sendable (URL, String?) async -> HealthPayload?
+    private let healthWaitProbe: @Sendable (URL, String?) async -> HealthPayload?
+    private let beforeProcessReservation: @Sendable () async -> Void
+    private let beforeProcessRun: @Sendable () async -> Void
+    private let beforePostRunLivenessCheck: @Sendable () async -> Void
+    private let beforeAutomaticRestartStart: @Sendable () async -> Void
+    private let beforeStopProcessFamilyResolution: @Sendable () async -> Void
+    private let beforeStopProcessFamilySignal: @Sendable () async -> Void
+    private let beforeTerminationHandling: @Sendable (Process) -> Void
+    private var lastOwnedLaunch: OwnedLaunch?
+    private var restartTask: Task<Void, Never>?
+    /// Task identity is separate from its generation: an attempt that queues
+    /// its successor must not clear the successor's task in its defer block.
+    private var restartTaskID: UUID?
+    private var restartGeneration = 0
+    private var lifecycleEpoch = 0
+    private var recentCrashDates: [Date] = []
+    private var automaticRestartEnabled = false
+    private var automaticRestartEligible = false
+    private var automaticLaunchGeneration: Int?
+    // Kept independently from the restart recipe so a Stop that begins just
+    // before its root exits can still find inherited-token descendants after
+    // the parent has been reaped and its PPID relationship has disappeared.
+    private var ownedLaunchID: String?
+    private var launchInProgress = false
+    private var launchCompletionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var statusObserver: (@Sendable (DaemonSupervisionSnapshot) -> Void)?
+    private var statusRevision = 0
 
     public private(set) var state: DaemonState = .stopped
+    public private(set) var restartStatus: DaemonRestartStatus = .idle
+    public private(set) var restartCount = 0
+    public private(set) var recoveryGeneration = 0
 
-    public init(logStore: BoundedLogStore = BoundedLogStore()) {
+    public init(
+        logStore: BoundedLogStore = BoundedLogStore(),
+        restartPolicy: DaemonRestartPolicy = .default,
+        restartSleeper: @escaping @Sendable (TimeInterval) async -> Void = { delay in
+            guard delay > 0 else { return }
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        },
+        initialHealthProbe: @escaping @Sendable (URL, String?) async -> HealthPayload? = { baseURL, apiKey in
+            try? await MTPLXAPIClient(baseURL: baseURL, apiKey: apiKey).health()
+        },
+        healthWaitProbe: @escaping @Sendable (URL, String?) async -> HealthPayload? = { baseURL, apiKey in
+            try? await MTPLXAPIClient(baseURL: baseURL, apiKey: apiKey).health()
+        },
+        // Test seam immediately before the atomic lifecycle reservation.
+        beforeProcessReservation: @escaping @Sendable () async -> Void = {},
+        // Test seam for the narrow period after ownership is published but
+        // before Process.run() assigns a PID. Production uses the no-op.
+        beforeProcessRun: @escaping @Sendable () async -> Void = {},
+        // Test seam after Process.run() but before the first liveness check.
+        beforePostRunLivenessCheck: @escaping @Sendable () async -> Void = {},
+        // Test seam after automatic restart state is published but before it
+        // starts the next owned launch. Production uses the no-op.
+        beforeAutomaticRestartStart: @escaping @Sendable () async -> Void = {},
+        // Test seam immediately before Stop resolves the current process
+        // family. Production uses the no-op.
+        beforeStopProcessFamilyResolution: @escaping @Sendable () async -> Void = {},
+        // Test seam after the full process family is snapshotted for Stop,
+        // before any signal is sent. Production uses the no-op.
+        beforeStopProcessFamilySignal: @escaping @Sendable () async -> Void = {},
+        // Test seam immediately before a Process termination handler acquires
+        // supervisor state. Production uses the no-op.
+        beforeTerminationHandling: @escaping @Sendable (Process) -> Void = { _ in }
+    ) {
         self.logStore = logStore
+        self.restartPolicy = restartPolicy
+        self.restartSleeper = restartSleeper
+        self.initialHealthProbe = initialHealthProbe
+        self.healthWaitProbe = healthWaitProbe
+        self.beforeProcessReservation = beforeProcessReservation
+        self.beforeProcessRun = beforeProcessRun
+        self.beforePostRunLivenessCheck = beforePostRunLivenessCheck
+        self.beforeAutomaticRestartStart = beforeAutomaticRestartStart
+        self.beforeStopProcessFamilyResolution = beforeStopProcessFamilyResolution
+        self.beforeStopProcessFamilySignal = beforeStopProcessFamilySignal
+        self.beforeTerminationHandling = beforeTerminationHandling
     }
 
     public var logs: BoundedLogStore {
         logStore
+    }
+
+    public func supervisionSnapshot() -> DaemonSupervisionSnapshot {
+        lock.withLock { supervisionSnapshotLocked() }
+    }
+
+    // Narrow test observability for the secret-lifetime invariant. These
+    // report only booleans; no command, API key, or task details escape.
+    var hasRetainedRestartRecipeForTesting: Bool {
+        lock.withLock { lastOwnedLaunch != nil }
+    }
+
+    var hasOutstandingRestartTaskForTesting: Bool {
+        lock.withLock { restartTask != nil || restartTaskID != nil }
+    }
+
+    /// Explicit user-controlled opt-in. Disabled is the safe default because a
+    /// crash can be caused by an out-of-memory condition that should not spin.
+    public func setAutomaticRestartEnabled(_ enabled: Bool) {
+        let changed = lock.withLock { () -> Bool in
+            guard automaticRestartEnabled != enabled else { return false }
+            automaticRestartEnabled = enabled
+            guard !enabled else { return true }
+            // restartGeneration also guards manual launches while they are
+            // between the initial probe and Process reservation. Changing an
+            // unrelated Settings toggle must not make such a launch throw
+            // "cancelled" and leave its process running. Invalidate it only
+            // when an automatic attempt is actually pending or in progress.
+            let hasAutomaticWork: Bool
+            switch restartStatus {
+            case .scheduled, .restarting:
+                hasAutomaticWork = true
+            case .idle, .runningAfterRestart, .exhausted:
+                hasAutomaticWork = automaticLaunchGeneration != nil
+            }
+            if hasAutomaticWork {
+                restartGeneration &+= 1
+                cancelRestartTaskLocked()
+            }
+            restartStatus = .idle
+            recentCrashDates.removeAll()
+            restartCount = 0
+            automaticRestartEligible = false
+            // A disabled setting must not retain an API key merely so a later
+            // toggle can restart an old daemon. Enable before a fresh launch.
+            lastOwnedLaunch = nil
+            // This is an expected cancellation rather than a crash. Do not
+            // raw-terminate the root here: its termination handler would drop
+            // `process` before stopInternal can discover/reap its children.
+            // The cancelled restart task observes this state and performs the
+            // normal full-family stop while it still owns the Process.
+            if automaticLaunchGeneration != nil {
+                state = .stopping
+            }
+            return true
+        }
+        if changed {
+            notifyStatusObserver()
+        }
+    }
+
+    /// The app store uses this to mirror supervised restarts into its published
+    /// state. The callback deliberately contains no launch command or API key.
+    public func setStatusObserver(
+        _ observer: (@Sendable (DaemonSupervisionSnapshot) -> Void)?
+    ) {
+        let snapshot = lock.withLock { () -> DaemonSupervisionSnapshot in
+            statusObserver = observer
+            return supervisionSnapshotLocked()
+        }
+        observer?(snapshot)
     }
 
     public func isRunning() -> Bool {
@@ -85,28 +319,110 @@ public final class DaemonSupervisor: @unchecked Sendable {
         adoptExistingAppOwnedDaemon: Bool = false,
         onPhase: (@Sendable (DaemonStartupPhase) -> Void)? = nil
     ) async throws -> HealthPayload? {
-        try lock.withLock {
-            if process?.isRunning == true || adoptedProcessID != nil {
+        try await startOwned(
+            OwnedLaunch(
+                command: command,
+                healthBaseURL: healthBaseURL,
+                apiKey: apiKey,
+                probeHealth: probeHealth,
+                timeoutSeconds: timeoutSeconds,
+                expectedLaunchID: expectedLaunchID,
+                requireActualFanRamp: requireActualFanRamp,
+                onPhase: onPhase
+            ),
+            adoptExistingAppOwnedDaemon: adoptExistingAppOwnedDaemon,
+            resetSupervision: true,
+            automaticAttempt: nil
+        )
+    }
+
+    private func startOwned(
+        _ launch: OwnedLaunch,
+        adoptExistingAppOwnedDaemon: Bool,
+        resetSupervision: Bool,
+        automaticAttempt: Int?,
+        expectedRestartGeneration: Int? = nil
+    ) async throws -> HealthPayload? {
+        let command = launch.command
+        let healthBaseURL = launch.healthBaseURL
+        let apiKey = launch.apiKey
+        let probeHealth = launch.probeHealth
+        let timeoutSeconds = launch.timeoutSeconds
+        let expectedLaunchID = launch.expectedLaunchID
+        let requireActualFanRamp = launch.requireActualFanRamp
+        let onPhase = launch.onPhase
+        let launchContext = try lock.withLock { () throws -> (generation: Int, lifecycleEpoch: Int) in
+            if process != nil || adoptedProcessID != nil || launchInProgress {
                 throw DaemonSupervisorError.alreadyRunning
             }
+            if resetSupervision {
+                restartGeneration &+= 1
+                cancelRestartTaskLocked()
+                recentCrashDates.removeAll()
+                restartCount = 0
+                restartStatus = .idle
+                lastOwnedLaunch = nil
+                automaticRestartEligible = false
+            }
+            if let expectedRestartGeneration,
+               (restartGeneration != expectedRestartGeneration || !automaticRestartEnabled) {
+                throw DaemonSupervisorError.launchFailed("automatic restart was cancelled")
+            }
+            automaticLaunchGeneration = automaticAttempt == nil ? nil : restartGeneration
+            // Allocate the lifecycle token before the first health probe.
+            // A stopped/crashed callback for the prior daemon can otherwise
+            // arrive while this launch is suspended and clear the store's
+            // active launch ID before a Process exists.
+            lifecycleEpoch &+= 1
             state = .starting
+            return (restartGeneration, lifecycleEpoch)
         }
+        let launchGeneration = launchContext.generation
+        let launchLifecycleEpoch = launchContext.lifecycleEpoch
+        notifyStatusObserver()
         onPhase?(.launching)
 
-        let healthClient = MTPLXAPIClient(baseURL: healthBaseURL, apiKey: apiKey)
-        if probeHealth, let existing = try? await healthClient.health(), existing.ok {
+        let existingHealth = probeHealth ? await initialHealthProbe(healthBaseURL, apiKey) : nil
+        if Task.isCancelled, automaticAttempt != nil {
+            await stopCancelledAutomaticLaunchIfCurrent(
+                generation: launchGeneration,
+                lifecycleEpoch: launchLifecycleEpoch
+            )
+            throw DaemonSupervisorError.launchFailed("automatic restart was cancelled")
+        }
+        if let existing = existingHealth, existing.ok {
             if adoptExistingAppOwnedDaemon,
                canAdopt(existing, for: command, requireActualFanRamp: requireActualFanRamp) {
-                await adopt(existing)
+                guard adoptCurrentLaunch(
+                    existing,
+                    generation: launchGeneration,
+                    lifecycleEpoch: launchLifecycleEpoch,
+                    automaticAttempt: automaticAttempt
+                ) else {
+                    abortUnstartedLaunch(
+                        generation: launchGeneration,
+                        lifecycleEpoch: launchLifecycleEpoch
+                    )
+                    await stopCancelledAutomaticLaunchIfCurrent(
+                        generation: launchGeneration,
+                        lifecycleEpoch: launchLifecycleEpoch
+                    )
+                    throw DaemonSupervisorError.launchFailed("daemon launch was cancelled")
+                }
+                notifyStatusObserver()
+                await logAdoption(existing)
                 onPhase?(.ready)
                 return existing
             }
+            abortUnstartedLaunch(
+                generation: launchGeneration,
+                lifecycleEpoch: launchLifecycleEpoch
+            )
             throw DaemonSupervisorError.portOccupied(
                 pid: existing.startup?.pid,
                 launchID: existing.startup?.launchId
             )
         }
-
         let next = Process()
         next.executableURL = command.executableURL
         next.arguments = command.arguments
@@ -121,35 +437,156 @@ public final class DaemonSupervisor: @unchecked Sendable {
         attach(pipe: stdout, stream: .stdout)
         attach(pipe: stderr, stream: .stderr)
         next.terminationHandler = { [weak self] process in
-            guard let self else { return }
-            let status = process.terminationStatus
-            Task {
-                await self.logStore.append("daemon exited with status \(status)", stream: .system)
-            }
-            self.lock.withLock {
-                if self.state != .stopping {
-                    self.state = status == 0 ? .stopped : .crashed(status)
+            self?.beforeTerminationHandling(process)
+            self?.handleTermination(of: process)
+        }
+
+        await beforeProcessReservation()
+
+        // Validate and publish ownership under the same lock. Stop increments
+        // restartGeneration under this lock, so it cannot return between a
+        // successful validation and this pre-PID reservation.
+        let reserved = lock.withLock { () -> Bool in
+            guard launchMayProceedLocked(
+                generation: launchGeneration,
+                automaticAttempt: automaticAttempt
+            ), lifecycleEpoch == launchLifecycleEpoch,
+               process == nil, adoptedProcessID == nil, !launchInProgress
+            else { return false }
+            process = next
+            adoptedProcessID = nil
+            ownedLaunchID = launchIdentifier(from: command)
+            launchInProgress = true
+            // A Process has been reserved but does not have a usable PID until
+            // run() returns. Keep the public phase at .starting through that
+            // hand-off; Stop's launch barrier covers this interval.
+            state = .starting
+            return true
+        }
+        guard reserved else {
+            abortUnstartedLaunch(
+                generation: launchGeneration,
+                lifecycleEpoch: launchLifecycleEpoch
+            )
+            await stopCancelledAutomaticLaunchIfCurrent(
+                generation: launchGeneration,
+                lifecycleEpoch: launchLifecycleEpoch
+            )
+            throw DaemonSupervisorError.launchFailed("daemon launch was cancelled")
+        }
+        notifyStatusObserver()
+
+        await beforeProcessRun()
+        let mayRun = lock.withLock {
+            process === next &&
+                lifecycleEpoch == launchLifecycleEpoch &&
+                state != .stopping
+        }
+        guard mayRun else {
+            let waiters = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+                if process === next, lifecycleEpoch == launchLifecycleEpoch {
+                    process = nil
                 }
-                self.process = nil
+                return finishLaunchLocked()
             }
+            waiters.forEach { $0.resume() }
+            notifyStatusObserver()
+            await stopCancelledAutomaticLaunchIfCurrent(
+                generation: launchGeneration,
+                lifecycleEpoch: launchLifecycleEpoch
+            )
+            throw DaemonSupervisorError.launchFailed("daemon launch was cancelled")
         }
 
         do {
             try next.run()
         } catch {
-            lock.withLock { state = .stopped }
+            let waiters = lock.withLock { () -> [CheckedContinuation<Void, Never>] in
+                if process === next, lifecycleEpoch == launchLifecycleEpoch {
+                    process = nil
+                    state = .stopped
+                }
+                automaticLaunchGeneration = nil
+                return finishLaunchLocked()
+            }
+            waiters.forEach { $0.resume() }
+            notifyStatusObserver()
             throw DaemonSupervisorError.launchFailed(error.localizedDescription)
         }
 
-        lock.withLock {
-            process = next
-            adoptedProcessID = nil
-            state = .warming
+        let wasCancelledBeforeRunCompleted = lock.withLock { () -> Bool in
+            let cancelled = restartGeneration != launchGeneration ||
+                (automaticAttempt != nil && !automaticRestartEnabled) ||
+                lifecycleEpoch != launchLifecycleEpoch ||
+                state == .stopping || process !== next
+            if !cancelled {
+                state = .warming
+            }
+            return cancelled
         }
+        let launchWaiters = lock.withLock { finishLaunchLocked() }
+        launchWaiters.forEach { $0.resume() }
+        if wasCancelledBeforeRunCompleted {
+            // The PID is valid now. An explicit Stop is already waiting on the
+            // launch barrier; a disabled automatic recovery has no such caller
+            // and therefore tears itself down here.
+            if automaticAttempt != nil {
+                await stopInternal(
+                    graceSeconds: 2,
+                    additionalProcessIDs: [],
+                    clearSupervision: false,
+                    expectedProcess: next,
+                    expectedLifecycleEpoch: launchLifecycleEpoch
+                )
+            }
+            throw DaemonSupervisorError.launchFailed("daemon launch was cancelled")
+        }
+        notifyStatusObserver()
         await logStore.append(
             "launched \(command.executableURL.path) \(command.arguments.joined(separator: " "))",
             stream: .system
         )
+
+        // Do not turn a failed initial launch into a restart loop. A process
+        // that has already exited before this start returns is surfaced to the
+        // caller; an automatic retry records the failure through its bounded
+        // retry path below.
+        await beforePostRunLivenessCheck()
+        guard next.isRunning else {
+            let exitStatus = next.terminationStatus
+            lock.withLock {
+                guard process === next, lifecycleEpoch == launchLifecycleEpoch else { return }
+                process = nil
+                automaticLaunchGeneration = nil
+                if state == .stopping {
+                    state = .stopped
+                } else if exitStatus == 0 {
+                    // The handler may not have acquired the lock yet. Mirror
+                    // its clean-exit cleanup here before dropping ownership;
+                    // otherwise a retry task sees .restarting + a retained
+                    // recipe and incorrectly restarts a clean exit.
+                    state = .stopped
+                    automaticRestartEligible = false
+                    lastOwnedLaunch = nil
+                    restartStatus = .idle
+                    if automaticAttempt != nil {
+                        // This is the task currently executing this exact
+                        // Process/lifecycle. Drop its retained launch recipe
+                        // now rather than waiting for its catch/defer path;
+                        // a newer recovery cannot exist while ownership still
+                        // matches this Process under the lock.
+                        restartTask = nil
+                        restartTaskID = nil
+                    }
+                } else {
+                    state = .crashed(exitStatus)
+                }
+            }
+            notifyStatusObserver()
+            throw DaemonSupervisorError.launchFailed(
+                "daemon exited during launch with status \(exitStatus)"
+            )
+        }
 
         let readyHealth: HealthPayload?
         if probeHealth {
@@ -163,15 +600,364 @@ public final class DaemonSupervisor: @unchecked Sendable {
                     onPhase: onPhase
                 )
             } catch {
-                await stop()
+                await stopInternal(
+                    graceSeconds: 2,
+                    additionalProcessIDs: [],
+                    clearSupervision: resetSupervision,
+                    expectedProcess: next,
+                    expectedLifecycleEpoch: launchLifecycleEpoch
+                )
                 throw error
             }
         } else {
             readyHealth = nil
         }
-        lock.withLock { state = .running }
+        let automaticLaunchStillCurrent = lock.withLock { () -> Bool in
+            guard restartGeneration == launchGeneration,
+                  lifecycleEpoch == launchLifecycleEpoch,
+                  process === next,
+                  state != .stopping
+            else { return false }
+            state = .running
+            if automaticRestartEnabled {
+                lastOwnedLaunch = launch
+            }
+            automaticRestartEligible = automaticRestartEnabled && lastOwnedLaunch != nil
+            automaticLaunchGeneration = nil
+            if let automaticAttempt {
+                restartStatus = .runningAfterRestart(attempt: automaticAttempt)
+                recoveryGeneration &+= 1
+            }
+            return true
+        }
+        guard automaticLaunchStillCurrent else {
+            if automaticAttempt != nil {
+                await stopInternal(
+                    graceSeconds: 2,
+                    additionalProcessIDs: [],
+                    clearSupervision: false,
+                    expectedProcess: next,
+                    expectedLifecycleEpoch: launchLifecycleEpoch
+                )
+            }
+            throw DaemonSupervisorError.launchFailed("daemon launch was cancelled")
+        }
+        notifyStatusObserver()
         onPhase?(.ready)
         return readyHealth
+    }
+
+    private func handleTermination(of terminatedProcess: Process) {
+        let exitStatus = terminatedProcess.terminationStatus
+        let transition = lock.withLock { () -> (recovery: (attempt: Int, delay: TimeInterval, generation: Int)?, evidence: DaemonRestartStatus?)? in
+            guard process === terminatedProcess else { return nil }
+            process = nil
+            automaticLaunchGeneration = nil
+            guard state != .stopping else {
+                state = .stopped
+                return (nil, nil)
+            }
+            state = exitStatus == 0 ? .stopped : .crashed(exitStatus)
+            guard exitStatus != 0 else {
+                automaticRestartEligible = false
+                lastOwnedLaunch = nil
+                restartStatus = .idle
+                return (nil, nil)
+            }
+            guard automaticRestartEligible else { return (nil, nil) }
+            automaticRestartEligible = false
+            let recovery = scheduleRestartLocked(lastExitStatus: exitStatus)
+            return (recovery, restartStatus)
+        }
+        notifyStatusObserver()
+        Task { [weak self] in
+            guard let self else { return }
+            await self.logStore.append("daemon exited with status \(exitStatus)", stream: .system)
+            if let evidence = transition?.evidence {
+                await self.logRestartEvidence(evidence)
+            }
+        }
+    }
+
+    private func scheduleRestartLocked(
+        lastExitStatus: Int32?
+    ) -> (attempt: Int, delay: TimeInterval, generation: Int)? {
+        guard automaticRestartEnabled, let launch = lastOwnedLaunch else { return nil }
+        let now = Date()
+        recentCrashDates.removeAll {
+            now.timeIntervalSince($0) > restartPolicy.crashWindowSeconds
+        }
+        recentCrashDates.append(now)
+        let attempt = recentCrashDates.count
+        guard attempt <= restartPolicy.maximumAttempts else {
+            restartStatus = .exhausted(
+                attempts: restartCount,
+                lastExitStatus: lastExitStatus
+            )
+            lastOwnedLaunch = nil
+            return nil
+        }
+        restartCount = attempt
+        let multiplier = pow(2.0, Double(max(0, attempt - 1)))
+        let delay = min(
+            restartPolicy.maximumDelaySeconds,
+            restartPolicy.initialDelaySeconds * multiplier
+        )
+        restartStatus = .scheduled(attempt: attempt, delaySeconds: delay)
+        let generation = restartGeneration
+        let taskID = UUID()
+        restartTaskID = taskID
+        restartTask = Task { [weak self] in
+            await self?.runAutomaticRestart(
+                launch: launch,
+                attempt: attempt,
+                delay: delay,
+                generation: generation,
+                taskID: taskID
+            )
+        }
+        return (attempt, delay, generation)
+    }
+
+    private func runAutomaticRestart(
+        launch: OwnedLaunch,
+        attempt: Int,
+        delay: TimeInterval,
+        generation: Int,
+        taskID: UUID
+    ) async {
+        defer { clearFinishedRestartTask(taskID) }
+        await restartSleeper(delay)
+        guard !Task.isCancelled else { return }
+        let mayRestart = lock.withLock { () -> Bool in
+            guard restartGeneration == generation else { return false }
+            guard case .scheduled(let scheduledAttempt, _) = restartStatus,
+                  scheduledAttempt == attempt
+            else { return false }
+            restartStatus = .restarting(attempt: attempt)
+            // Reserve automatic ownership before the first await below. A
+            // Settings toggle in the logging/start gap must settle this
+            // attempt to stopped rather than leaving .starting forever.
+            automaticLaunchGeneration = generation
+            state = .starting
+            return true
+        }
+        guard mayRestart else { return }
+        notifyStatusObserver()
+        await beforeAutomaticRestartStart()
+        if Task.isCancelled {
+            await stopCancelledAutomaticLaunchIfCurrent(generation: generation)
+            return
+        }
+        await logStore.append(
+            "automatic restart attempt \(attempt) of \(restartPolicy.maximumAttempts) starting",
+            stream: .system
+        )
+        if Task.isCancelled {
+            await stopCancelledAutomaticLaunchIfCurrent(generation: generation)
+            return
+        }
+        do {
+            _ = try await startOwned(
+                launch,
+                adoptExistingAppOwnedDaemon: false,
+                resetSupervision: false,
+                automaticAttempt: attempt,
+                expectedRestartGeneration: generation
+            )
+            await logStore.append(
+                "automatic restart attempt \(attempt) recovered daemon health",
+                stream: .system
+            )
+        } catch {
+            await stopCancelledAutomaticLaunchIfCurrent(generation: generation)
+            let alreadyQueued = lock.withLock { () -> Bool in
+                if case .scheduled(let nextAttempt, _) = restartStatus {
+                    return nextAttempt > attempt
+                }
+                return false
+            }
+            if !alreadyQueued {
+                let transition = lock.withLock { () -> (recovery: (attempt: Int, delay: TimeInterval, generation: Int)?, evidence: DaemonRestartStatus?)? in
+                    // An explicit Stop, a manual Start, or disabling the setting can
+                    // happen while the health probe above is suspended. Those actions
+                    // invalidate this recovery generation, so they must never be
+                    // followed by a stale retry.
+                    guard restartGeneration == generation else { return nil }
+                    let recovery = scheduleRestartLocked(lastExitStatus: nil)
+                    return (recovery, restartStatus)
+                }
+                notifyStatusObserver()
+                if let evidence = transition?.evidence {
+                    await logRestartEvidence(evidence)
+                }
+            }
+            await logStore.append(
+                "automatic restart attempt \(attempt) failed: \(String(describing: error))",
+                stream: .system
+            )
+        }
+    }
+
+    private func logRestartEvidence(_ status: DaemonRestartStatus) async {
+        switch status {
+        case .scheduled(let attempt, let delay):
+            await logStore.append(
+                "automatic restart scheduled: attempt \(attempt) of \(restartPolicy.maximumAttempts) in \(String(format: "%.1f", delay))s",
+                stream: .system
+            )
+        case .exhausted(let attempts, let status):
+            await logStore.append(
+                "automatic restart circuit breaker open after \(attempts) attempts; last exit status \(status.map(String.init) ?? "unknown")",
+                stream: .system
+            )
+        default:
+            break
+        }
+    }
+
+    private func supervisionSnapshotLocked() -> DaemonSupervisionSnapshot {
+        DaemonSupervisionSnapshot(
+            revision: statusRevision,
+            state: state,
+            restartStatus: restartStatus,
+            restartCount: restartCount,
+            restartEligibility: restartEligibilityLocked(),
+            lifecycleEpoch: lifecycleEpoch,
+            recoveryGeneration: recoveryGeneration
+        )
+    }
+
+    private func notifyStatusObserver() {
+        let (observer, snapshot) = lock.withLock { () -> ((@Sendable (DaemonSupervisionSnapshot) -> Void)?, DaemonSupervisionSnapshot) in
+            statusRevision &+= 1
+            return (statusObserver, supervisionSnapshotLocked())
+        }
+        observer?(snapshot)
+    }
+
+    private func cancelRestartTaskLocked() {
+        restartTask?.cancel()
+        restartTask = nil
+        restartTaskID = nil
+    }
+
+    private func clearFinishedRestartTask(_ taskID: UUID) {
+        lock.withLock {
+            guard restartTaskID == taskID else { return }
+            restartTask = nil
+            restartTaskID = nil
+        }
+    }
+
+    private func finishLaunchLocked() -> [CheckedContinuation<Void, Never>] {
+        launchInProgress = false
+        let waiters = launchCompletionWaiters
+        launchCompletionWaiters.removeAll()
+        return waiters
+    }
+
+    private func restartEligibilityLocked() -> DaemonRestartEligibility {
+        if adoptedProcessID != nil {
+            return .adoptedPriorSession
+        }
+        if process != nil {
+            return automaticRestartEligible ? .currentSessionProtected : .currentSessionUnprotected
+        }
+        return .noDaemon
+    }
+
+    private func launchMayProceedLocked(generation: Int, automaticAttempt: Int?) -> Bool {
+        restartGeneration == generation &&
+            state != .stopping &&
+            (automaticAttempt == nil || automaticRestartEnabled)
+    }
+
+    private func abortUnstartedLaunch(
+        generation: Int,
+        lifecycleEpoch: Int
+    ) {
+        let changed = lock.withLock { () -> Bool in
+            // A second manual Start can overtake the first while both are in
+            // their initial health probes. Only the owning attempt may turn
+            // .starting back into .stopped or emit a terminal snapshot.
+            guard restartGeneration == generation,
+                  self.lifecycleEpoch == lifecycleEpoch,
+                  process == nil,
+                  adoptedProcessID == nil,
+                  !launchInProgress
+            else { return false }
+            if automaticLaunchGeneration == generation {
+                automaticLaunchGeneration = nil
+            }
+            guard state != .stopping else { return false }
+            state = .stopped
+            return true
+        }
+        if changed {
+            notifyStatusObserver()
+        }
+    }
+
+    private func stopCancelledAutomaticLaunchIfCurrent(
+        generation: Int,
+        lifecycleEpoch: Int? = nil
+    ) async {
+        let cancelledLaunch = lock.withLock { () -> (process: Process?, lifecycleEpoch: Int)? in
+            automaticLaunchGeneration == generation &&
+                (lifecycleEpoch == nil || self.lifecycleEpoch == lifecycleEpoch) &&
+                state == .stopping
+                ? (process, self.lifecycleEpoch)
+                : nil
+        }
+        guard let cancelledLaunch else { return }
+        await stopInternal(
+            graceSeconds: 2,
+            additionalProcessIDs: [],
+            clearSupervision: false,
+            expectedProcess: cancelledLaunch.process,
+            expectedLifecycleEpoch: cancelledLaunch.lifecycleEpoch
+        )
+    }
+
+    private func adoptCurrentLaunch(
+        _ health: HealthPayload,
+        generation: Int,
+        lifecycleEpoch: Int,
+        automaticAttempt: Int?
+    ) -> Bool {
+        let pid = health.startup?.pid.map(pid_t.init)
+        return lock.withLock {
+            guard launchMayProceedLocked(
+                generation: generation,
+                automaticAttempt: automaticAttempt
+            ), self.lifecycleEpoch == lifecycleEpoch,
+               process == nil, adoptedProcessID == nil, !launchInProgress
+            else { return false }
+            adoptedProcessID = pid
+            lastOwnedLaunch = nil
+            automaticRestartEligible = false
+            restartStatus = .idle
+            restartCount = 0
+            automaticLaunchGeneration = nil
+            state = .running
+            return true
+        }
+    }
+
+    private func waitForLaunchCompletion() async {
+        let shouldWait = lock.withLock { launchInProgress }
+        guard shouldWait else { return }
+        await withCheckedContinuation { continuation in
+            let completed = lock.withLock { () -> Bool in
+                guard launchInProgress else { return true }
+                launchCompletionWaiters.append(continuation)
+                return false
+            }
+            if completed {
+                continuation.resume()
+            }
+        }
     }
 
     /// Whether `start(... adoptExistingAppOwnedDaemon: true)` would adopt
@@ -192,19 +978,52 @@ public final class DaemonSupervisor: @unchecked Sendable {
         apiKey: String? = nil,
         requireActualFanRamp: Bool = false
     ) async throws -> HealthPayload? {
-        try lock.withLock {
-            if process?.isRunning == true || adoptedProcessID != nil {
+        let adoption = try lock.withLock { () throws -> (generation: Int, lifecycleEpoch: Int) in
+            if process != nil || adoptedProcessID != nil || launchInProgress {
                 throw DaemonSupervisorError.alreadyRunning
             }
+            restartGeneration &+= 1
+            cancelRestartTaskLocked()
+            lastOwnedLaunch = nil
+            automaticRestartEligible = false
+            automaticLaunchGeneration = nil
+            restartStatus = .idle
+            restartCount = 0
+            lifecycleEpoch &+= 1
+            state = .starting
+            return (restartGeneration, lifecycleEpoch)
         }
-        let client = MTPLXAPIClient(baseURL: healthBaseURL, apiKey: apiKey)
-        guard let existing = try? await client.health(), existing.ok else {
+        let adoptionGeneration = adoption.generation
+        let adoptionLifecycleEpoch = adoption.lifecycleEpoch
+        notifyStatusObserver()
+        guard let existing = await initialHealthProbe(healthBaseURL, apiKey), existing.ok else {
+            abortUnstartedLaunch(
+                generation: adoptionGeneration,
+                lifecycleEpoch: adoptionLifecycleEpoch
+            )
             return nil
         }
         guard canAdopt(existing, for: command, requireActualFanRamp: requireActualFanRamp) else {
+            abortUnstartedLaunch(
+                generation: adoptionGeneration,
+                lifecycleEpoch: adoptionLifecycleEpoch
+            )
             return nil
         }
-        await adopt(existing)
+        guard adoptCurrentLaunch(
+            existing,
+            generation: adoptionGeneration,
+            lifecycleEpoch: adoptionLifecycleEpoch,
+            automaticAttempt: nil
+        ) else {
+            abortUnstartedLaunch(
+                generation: adoptionGeneration,
+                lifecycleEpoch: adoptionLifecycleEpoch
+            )
+            return nil
+        }
+        notifyStatusObserver()
+        await logAdoption(existing)
         return existing
     }
 
@@ -212,23 +1031,98 @@ public final class DaemonSupervisor: @unchecked Sendable {
         graceSeconds: TimeInterval = 2,
         additionalProcessIDs: [pid_t] = []
     ) async {
-        let current = lock.withLock { () -> Process? in
+        await stopInternal(
+            graceSeconds: graceSeconds,
+            additionalProcessIDs: additionalProcessIDs,
+            clearSupervision: true
+        )
+    }
+
+    private func stopInternal(
+        graceSeconds: TimeInterval,
+        additionalProcessIDs: [pid_t],
+        clearSupervision: Bool,
+        expectedProcess: Process? = nil,
+        expectedLifecycleEpoch: Int? = nil
+    ) async {
+        let stopContext = lock.withLock { () -> (
+            waitsForLaunch: Bool,
+            process: Process?,
+            adoptedPID: pid_t?,
+            lifecycleEpoch: Int,
+            launchID: String?
+        )? in
+            // Start A can fail its health wait after Stop A has returned and
+            // Start B has already claimed this supervisor. Its cleanup must
+            // never signal or clear B merely because the shared slot is live.
+            guard expectedLifecycleEpoch == nil || self.lifecycleEpoch == expectedLifecycleEpoch else {
+                return nil
+            }
+            if let expectedProcess,
+               let currentProcess = process,
+               currentProcess !== expectedProcess
+            {
+                return nil
+            }
+            if clearSupervision {
+                restartGeneration &+= 1
+                cancelRestartTaskLocked()
+                lastOwnedLaunch = nil
+                automaticRestartEligible = false
+                automaticLaunchGeneration = nil
+                restartStatus = .idle
+                recentCrashDates.removeAll()
+                restartCount = 0
+            }
+            // Keep a strong Process reference while stopping. Its termination
+            // handler may clear the shared slot before this async method gets
+            // to the old second lock; the retained object still gives us the
+            // root PID after the launch barrier opens.
+            let currentProcess = expectedProcess ?? process
+            let currentAdoptedPID = adoptedProcessID
+            let currentLaunchID = ownedLaunchID
+            let currentLifecycleEpoch = lifecycleEpoch
             state = .stopping
-            return process
+            return (
+                launchInProgress,
+                currentProcess,
+                currentAdoptedPID,
+                currentLifecycleEpoch,
+                currentLaunchID
+            )
         }
-        let adopted = lock.withLock { adoptedProcessID }
+        guard let stopContext else { return }
+        notifyStatusObserver()
+        // Process.run() assigns its PID synchronously. If Stop raced with the
+        // published-but-not-yet-run Process, wait for that hand-off before
+        // resolving the process family so Stop cannot return and leak it.
+        if stopContext.waitsForLaunch {
+            await waitForLaunchCompletion()
+        }
         var rootPIDs: [pid_t] = []
-        if let currentPID = current?.processIdentifier {
+        if let currentPID = stopContext.process?.processIdentifier {
             rootPIDs.append(currentPID)
         }
-        if let adopted {
+        if let adopted = stopContext.adoptedPID {
             rootPIDs.append(adopted)
         }
         rootPIDs.append(contentsOf: additionalProcessIDs)
         rootPIDs = rootPIDs.filter { $0 > 1 }
-        let family = Self.processFamily(rootPIDs: rootPIDs)
+        // A daemon can exit after Stop has claimed the lifecycle but before
+        // pgrep expands its descendants. Those descendants then reparent and
+        // are no longer discoverable by PPID, so include the exact inherited
+        // app launch token in the one-time family snapshot.
+        await beforeStopProcessFamilyResolution()
+        let family = Self.processFamily(
+            rootPIDs: rootPIDs,
+            launchID: stopContext.launchID
+        )
 
         if !family.isEmpty {
+            // The family has already been resolved, so a concurrent root
+            // termination in this narrow testable gap cannot orphan a child
+            // by erasing its parent relationship before expansion.
+            await beforeStopProcessFamilySignal()
             Self.signal(family, SIGTERM)
             await Self.waitUntilExited(family, timeoutSeconds: graceSeconds)
             let afterTerm = family.filter(Self.pidIsAlive)
@@ -243,10 +1137,28 @@ public final class DaemonSupervisor: @unchecked Sendable {
             }
         }
 
-        lock.withLock {
+        let finalized = lock.withLock { () -> Bool in
+            guard lifecycleEpoch == stopContext.lifecycleEpoch else { return false }
+            if let capturedProcess = stopContext.process,
+               let currentProcess = process,
+               currentProcess !== capturedProcess
+            {
+                return false
+            }
+            guard adoptedProcessID == nil || adoptedProcessID == stopContext.adoptedPID else {
+                return false
+            }
             process = nil
             adoptedProcessID = nil
+            automaticLaunchGeneration = nil
+            if ownedLaunchID == stopContext.launchID {
+                ownedLaunchID = nil
+            }
             state = .stopped
+            return true
+        }
+        if finalized {
+            notifyStatusObserver()
         }
         let pidList = family.map(String.init).joined(separator: ",")
         await logStore.append(
@@ -346,12 +1258,7 @@ public final class DaemonSupervisor: @unchecked Sendable {
         return true
     }
 
-    private func adopt(_ health: HealthPayload) async {
-        let pid = health.startup?.pid.map(pid_t.init)
-        lock.withLock {
-            adoptedProcessID = pid
-            state = .running
-        }
+    private func logAdoption(_ health: HealthPayload) async {
         await logStore.append(
             "adopted existing app-owned MTPLX daemon pid \(health.startup?.pid.map(String.init) ?? "unknown") launch \(health.startup?.launchId ?? "unknown")",
             stream: .system
@@ -371,6 +1278,12 @@ public final class DaemonSupervisor: @unchecked Sendable {
         NSString(string: path).standardizingPath
     }
 
+    private func launchIdentifier(from command: DaemonCommand) -> String? {
+        let launchID = command.environment["MTPLX_APP_LAUNCH_ID"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return launchID?.isEmpty == false ? launchID : nil
+    }
+
     private static func pidIsAlive(_ pid: pid_t) -> Bool {
         if kill(pid, 0) == 0 {
             return true
@@ -378,10 +1291,16 @@ public final class DaemonSupervisor: @unchecked Sendable {
         return errno != ESRCH
     }
 
-    private static func processFamily(rootPIDs: [pid_t]) -> [pid_t] {
+    private static func processFamily(
+        rootPIDs: [pid_t],
+        launchID: String? = nil
+    ) -> [pid_t] {
         var seen: Set<pid_t> = []
         var ordered: [pid_t] = []
         var queue = rootPIDs
+        if let launchID {
+            queue.append(contentsOf: processIDs(inheritingLaunchID: launchID))
+        }
         while !queue.isEmpty {
             let pid = queue.removeFirst()
             guard pid > 1, !seen.contains(pid) else { continue }
@@ -390,6 +1309,102 @@ public final class DaemonSupervisor: @unchecked Sendable {
             queue.append(contentsOf: childPIDs(of: pid))
         }
         return ordered.reversed()
+    }
+
+    private static func processIDs(inheritingLaunchID launchID: String) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        // Restrict to this user. ps only enumerates PIDs here: its textual
+        // command/environment rendering has no reliable argv/env boundary.
+        process.arguments = ["-x", "-o", "pid="]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        let watchdog = SubprocessWatchdog(process)
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+        let drain = SubprocessPipeDrain(output)
+        guard watchdog.wait(for: process, timeout: 10) else { return [] }
+        guard process.terminationStatus == 0 else { return [] }
+        drain.join()
+        return drain.snapshot()
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> pid_t? in
+                guard let pid = pid_t(
+                    line.trimmingCharacters(in: .whitespacesAndNewlines)
+                ),
+                      processHasExactLaunchID(pid, launchID: launchID)
+                else { return nil }
+                return pid
+            }
+            .filter { $0 > 1 }
+    }
+
+    /// ps merges argv and environment into one display field, so a substring
+    /// cannot establish ownership: an unrelated process could pass the token
+    /// as an argument or put it inside a different environment value. Darwin's
+    /// KERN_PROCARGS2 preserves the argv/environment boundary; fail closed if
+    /// it cannot be read or parsed for this PID.
+    private static func processHasExactLaunchID(
+        _ pid: pid_t,
+        launchID: String
+    ) -> Bool {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var byteCount = 0
+        guard sysctl(&mib, UInt32(mib.count), nil, &byteCount, nil, 0) == 0,
+              byteCount > MemoryLayout<Int32>.size
+        else { return false }
+
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        guard bytes.withUnsafeMutableBytes({ buffer in
+            sysctl(&mib, UInt32(mib.count), buffer.baseAddress, &byteCount, nil, 0)
+        }) == 0
+        else { return false }
+        guard byteCount <= bytes.count else { return false }
+        bytes.removeSubrange(byteCount..<bytes.count)
+        guard bytes.count >= MemoryLayout<Int32>.size else { return false }
+
+        let argc = bytes.withUnsafeBytes {
+            Int($0.loadUnaligned(fromByteOffset: 0, as: Int32.self))
+        }
+        guard argc >= 0 else { return false }
+        var cursor = MemoryLayout<Int32>.size
+        guard skipCString(in: bytes, cursor: &cursor) else { return false }
+        while cursor < bytes.count, bytes[cursor] == 0 {
+            cursor += 1
+        }
+        for _ in 0..<argc {
+            guard skipCString(in: bytes, cursor: &cursor) else { return false }
+        }
+
+        let expected = Array("MTPLX_APP_LAUNCH_ID=\(launchID)".utf8)
+        while cursor < bytes.count {
+            while cursor < bytes.count, bytes[cursor] == 0 {
+                cursor += 1
+            }
+            guard cursor < bytes.count else { break }
+            let start = cursor
+            guard skipCString(in: bytes, cursor: &cursor) else { return false }
+            let end = cursor - 1
+            if bytes[start..<end].elementsEqual(expected) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func skipCString(
+        in bytes: [UInt8],
+        cursor: inout Int
+    ) -> Bool {
+        guard cursor < bytes.count,
+              let terminator = bytes[cursor...].firstIndex(of: 0)
+        else { return false }
+        cursor = terminator + 1
+        return true
     }
 
     private static func childPIDs(of pid: pid_t) -> [pid_t] {
@@ -447,11 +1462,15 @@ public final class DaemonSupervisor: @unchecked Sendable {
         requireActualFanRamp: Bool,
         onPhase: (@Sendable (DaemonStartupPhase) -> Void)?
     ) async throws -> HealthPayload {
-        let client = MTPLXAPIClient(baseURL: baseURL, apiKey: apiKey)
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         var sawHealthyWithUnverifiedFan = false
         onPhase?(.waitingForOwnedHealth)
         while Date() < deadline {
+            // A cancelled automatic-restart Task must relinquish the Process
+            // through startOwned's catch/stopInternal path. Swallowing the
+            // cancelled sleep below used to leave it hot-looping health probes
+            // for the entire startup timeout.
+            try Task.checkCancellation()
             if !isRunning() {
                 let tail = await logStore.snapshot().suffix(8).map(\.message).joined(separator: " | ")
                 let detail = tail.isEmpty
@@ -459,7 +1478,8 @@ public final class DaemonSupervisor: @unchecked Sendable {
                     : "daemon exited before /health became ready: \(tail)"
                 throw DaemonSupervisorError.launchFailed(detail)
             }
-            if let health = try? await client.health(), health.ok {
+            if let health = await healthWaitProbe(baseURL, apiKey), health.ok {
+                try Task.checkCancellation()
                 if let expectedLaunchID {
                     guard health.startup?.launchId == expectedLaunchID else {
                         throw DaemonSupervisorError.launchIdentityMismatch(
@@ -472,13 +1492,13 @@ public final class DaemonSupervisor: @unchecked Sendable {
                    health.thermal?.actualRampVerified != true {
                     sawHealthyWithUnverifiedFan = true
                     onPhase?(.rampingFans)
-                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    try await Task.sleep(nanoseconds: 250_000_000)
                     continue
                 }
                 onPhase?(.warming)
                 return health
             }
-            try? await Task.sleep(nanoseconds: 250_000_000)
+            try await Task.sleep(nanoseconds: 250_000_000)
         }
         if requireActualFanRamp && sawHealthyWithUnverifiedFan {
             throw DaemonSupervisorError.fanRampTimeout

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Services/HermesIntegration.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Services/HermesIntegration.swift
@@ -4,6 +4,391 @@ import Foundation
 import AppKit
 #endif
 
+/// Ownership receipt for one Terminal client handoff. The UUID travels in the
+/// terminal process environment, so a later reap can fail closed unless the
+/// exact PID still belongs to this invocation.
+public struct MTPLXTerminalHandoffLease: Equatable, Sendable {
+    public let handoffID: UUID
+    public let processID: Int
+    public let cancellationMarkerURL: URL
+    /// The durable Terminal script that created this receipt. It lets a
+    /// failed marker write fail closed before a delayed Terminal launch reads
+    /// that one-use script.
+    public let commandURL: URL?
+    /// The receipt is retained only long enough to unlink it during explicit
+    /// cancellation if an earlier cleanup attempt did not complete.
+    public let receiptURL: URL?
+
+    public init(
+        handoffID: UUID,
+        processID: Int,
+        cancellationMarkerURL: URL,
+        commandURL: URL? = nil,
+        receiptURL: URL? = nil
+    ) {
+        self.handoffID = handoffID
+        self.processID = processID
+        self.cancellationMarkerURL = cancellationMarkerURL
+        self.commandURL = commandURL
+        self.receiptURL = receiptURL
+    }
+}
+
+/// Result of receipt collection. Once cancellation is marked, a receipt is
+/// useful only to reap a process that escaped the script's final marker check;
+/// it must never be reported as a successful handoff.
+struct MTPLXTerminalHandoffReceiptResult: Sendable {
+    let lease: MTPLXTerminalHandoffLease?
+    let cancellationMarked: Bool
+    /// A cancellation was requested even when the marker write failed.
+    /// Callers must never report this result as a live handoff.
+    let cancellationRequested: Bool
+}
+
+extension MTPLXTerminalHandoffLease {
+    static let environmentVariable = "MTPLX_APP_HANDOFF_ID"
+
+    @MainActor
+    static func awaitReceipt(
+        handoffID: UUID,
+        receiptURL: URL,
+        cancellationMarkerURL: URL,
+        commandURL: URL? = nil,
+        isCurrent: (() -> Bool)?,
+        timeoutSeconds: TimeInterval = 5,
+        delayedCancellationSeconds: TimeInterval = 1,
+        markerWriter: ((URL) -> Bool)? = nil
+    ) async -> MTPLXTerminalHandoffReceiptResult {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let lease = lease(
+                handoffID: handoffID,
+                receiptURL: receiptURL,
+                cancellationMarkerURL: cancellationMarkerURL,
+                commandURL: commandURL
+            ) {
+                guard removeHandoffArtifacts(
+                    commandURL: commandURL,
+                    receiptURL: receiptURL
+                ) else {
+                    let cancellationMarked = markerWriter?(cancellationMarkerURL)
+                        ?? writeCancellationMarker(at: cancellationMarkerURL)
+                    if !cancellationMarked {
+                        _ = removeDurableCommandScript(at: commandURL)
+                    }
+                    return MTPLXTerminalHandoffReceiptResult(
+                        lease: lease,
+                        cancellationMarked: cancellationMarked,
+                        cancellationRequested: true
+                    )
+                }
+                return MTPLXTerminalHandoffReceiptResult(
+                    lease: lease,
+                    cancellationMarked: false,
+                    cancellationRequested: false
+                )
+            }
+            if !(isCurrent?() ?? true) {
+                let cancellationMarked = markerWriter?(cancellationMarkerURL)
+                    ?? writeCancellationMarker(at: cancellationMarkerURL)
+                if !cancellationMarked {
+                    _ = removeDurableCommandScript(at: commandURL)
+                }
+                return await delayedReceipt(
+                    handoffID: handoffID,
+                    receiptURL: receiptURL,
+                    cancellationMarkerURL: cancellationMarkerURL,
+                    commandURL: commandURL,
+                    timeoutSeconds: delayedCancellationSeconds,
+                    cancellationMarked: cancellationMarked
+                )
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        let cancellationMarked = markerWriter?(cancellationMarkerURL)
+            ?? writeCancellationMarker(at: cancellationMarkerURL)
+        if !cancellationMarked {
+            _ = removeDurableCommandScript(at: commandURL)
+        }
+        return await delayedReceipt(
+            handoffID: handoffID,
+            receiptURL: receiptURL,
+            cancellationMarkerURL: cancellationMarkerURL,
+            commandURL: commandURL,
+            timeoutSeconds: delayedCancellationSeconds,
+            cancellationMarked: cancellationMarked
+        )
+    }
+
+    static func prepareArtifactDirectory(_ directory: URL) throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    }
+
+    static func writeSecureCommandScript(_ script: String, to destination: URL) throws {
+        let fileManager = FileManager.default
+        let directory = destination.deletingLastPathComponent()
+        try prepareArtifactDirectory(directory)
+        let temporary = directory.appendingPathComponent(
+            ".\(destination.lastPathComponent).\(UUID().uuidString.lowercased()).tmp"
+        )
+        guard fileManager.createFile(
+            atPath: temporary.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        defer { try? fileManager.removeItem(at: temporary) }
+        let handle = try FileHandle(forWritingTo: temporary)
+        try handle.write(contentsOf: Data(script.utf8))
+        try handle.close()
+        try fileManager.moveItem(at: temporary, to: destination)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: destination.path)
+    }
+
+    @discardableResult
+    static func writeCancellationMarker(at url: URL) -> Bool {
+        do {
+            try prepareArtifactDirectory(url.deletingLastPathComponent())
+            let fileManager = FileManager.default
+            if fileManager.fileExists(atPath: url.path) {
+                let attributes = try fileManager.attributesOfItem(atPath: url.path)
+                guard attributes[.type] as? FileAttributeType == .typeRegular else {
+                    return false
+                }
+                try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+                return true
+            }
+            let temporary = url.deletingLastPathComponent().appendingPathComponent(
+                ".\(url.lastPathComponent).\(UUID().uuidString.lowercased()).tmp"
+            )
+            guard fileManager.createFile(
+                atPath: temporary.path,
+                contents: Data("cancelled\n".utf8),
+                attributes: [.posixPermissions: 0o600]
+            ) else { return false }
+            defer { try? fileManager.removeItem(at: temporary) }
+            let renameStatus = temporary.path.withCString { sourcePath in
+                url.path.withCString { destinationPath in
+                    rename(sourcePath, destinationPath)
+                }
+            }
+            guard renameStatus == 0 else { return false }
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// A private marker is the primary cancellation mechanism. If creating it
+    /// fails, removing the one-use command artifact prevents a delayed
+    /// Terminal invocation from executing it. An already-absent artifact is
+    /// safe by definition.
+    @discardableResult
+    static func removeDurableCommandScript(at url: URL?) -> Bool {
+        guard let url else { return false }
+        return removeArtifact(at: url)
+    }
+
+    private static func removeHandoffArtifacts(
+        commandURL: URL?,
+        receiptURL: URL?
+    ) -> Bool {
+        let commandRemoved = commandURL.map { removeArtifact(at: $0) } ?? true
+        let receiptRemoved = receiptURL.map { removeArtifact(at: $0) } ?? true
+        return commandRemoved && receiptRemoved
+    }
+
+    private static func removeArtifact(at url: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: url.path) else { return true }
+        do {
+            try fileManager.removeItem(at: url)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func process(
+        pid: pid_t,
+        hasExactHandoffID handoffID: UUID,
+        timeoutSeconds: TimeInterval = 1
+    ) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-wwE", "-p", String(pid), "-o", "command="]
+        let output = Pipe()
+        process.standardOutput = output
+        let watchdog = SubprocessWatchdog(process)
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        let drain = SubprocessPipeDrain(output)
+        guard watchdog.wait(
+            for: process,
+            timeout: timeoutSeconds,
+            terminateGrace: 0.1,
+            killGrace: 0.1
+        ), drain.join(timeout: 1), process.terminationStatus == 0
+        else { return false }
+        // `ps` is bounded and drained only as a liveness/readability check.
+        // Its command column merges argv and environment, so it must not
+        // decide ownership: an arbitrary argv token could impersonate this
+        // UUID. KERN_PROCARGS2 retains the boundary and fails closed. The
+        // Terminal script can be observed for a few milliseconds between its
+        // final marker check and `exec`, so retry the *same PID* briefly for
+        // the post-exec environment rather than abandoning that narrow race.
+        for attempt in 0..<6 {
+            if processHasExactHandoffID(pid, handoffID: handoffID) {
+                return true
+            }
+            if attempt < 5 {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        return false
+    }
+
+    /// Darwin's KERN_PROCARGS2 stores argv and environment as distinct NUL
+    /// strings. This is deliberately not parsed from `ps -E`, whose display
+    /// column permits an argv token to look like an environment assignment.
+    private static func processHasExactHandoffID(
+        _ pid: pid_t,
+        handoffID: UUID
+    ) -> Bool {
+        var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var byteCount = 0
+        guard sysctl(&mib, UInt32(mib.count), nil, &byteCount, nil, 0) == 0,
+              byteCount > MemoryLayout<Int32>.size
+        else { return false }
+
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        guard bytes.withUnsafeMutableBytes({ buffer in
+            sysctl(&mib, UInt32(mib.count), buffer.baseAddress, &byteCount, nil, 0)
+        }) == 0,
+        byteCount <= bytes.count
+        else { return false }
+        bytes.removeSubrange(byteCount..<bytes.count)
+        guard bytes.count >= MemoryLayout<Int32>.size else { return false }
+
+        let argc = bytes.withUnsafeBytes {
+            Int($0.loadUnaligned(fromByteOffset: 0, as: Int32.self))
+        }
+        guard argc >= 0 else { return false }
+        var cursor = MemoryLayout<Int32>.size
+        guard skipCString(in: bytes, cursor: &cursor) else { return false }
+        while cursor < bytes.count, bytes[cursor] == 0 {
+            cursor += 1
+        }
+        for _ in 0..<argc {
+            guard skipCString(in: bytes, cursor: &cursor) else { return false }
+        }
+
+        let expected = Array(
+            "\(environmentVariable)=\(handoffID.uuidString.lowercased())".utf8
+        )
+        while cursor < bytes.count {
+            while cursor < bytes.count, bytes[cursor] == 0 {
+                cursor += 1
+            }
+            guard cursor < bytes.count else { break }
+            let start = cursor
+            guard skipCString(in: bytes, cursor: &cursor) else { return false }
+            let end = cursor - 1
+            if bytes[start..<end].elementsEqual(expected) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func skipCString(in bytes: [UInt8], cursor: inout Int) -> Bool {
+        guard cursor < bytes.count,
+              let terminator = bytes[cursor...].firstIndex(of: 0)
+        else { return false }
+        cursor = terminator + 1
+        return true
+    }
+
+    private static func lease(
+        handoffID: UUID,
+        receiptURL: URL,
+        cancellationMarkerURL: URL,
+        commandURL: URL?
+    ) -> MTPLXTerminalHandoffLease? {
+        guard let contents = try? String(contentsOf: receiptURL, encoding: .utf8),
+              let processID = Int(contents.trimmingCharacters(in: .whitespacesAndNewlines)),
+              processID > 1
+        else { return nil }
+        return MTPLXTerminalHandoffLease(
+            handoffID: handoffID,
+            processID: processID,
+            cancellationMarkerURL: cancellationMarkerURL,
+            commandURL: commandURL,
+            receiptURL: receiptURL
+        )
+    }
+
+    @MainActor
+    private static func delayedReceipt(
+        handoffID: UUID,
+        receiptURL: URL,
+        cancellationMarkerURL: URL,
+        commandURL: URL?,
+        timeoutSeconds: TimeInterval,
+        cancellationMarked: Bool
+    ) async -> MTPLXTerminalHandoffReceiptResult {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let lease = lease(
+                handoffID: handoffID,
+                receiptURL: receiptURL,
+                cancellationMarkerURL: cancellationMarkerURL,
+                commandURL: commandURL
+            ) {
+                _ = removeHandoffArtifacts(
+                    commandURL: commandURL,
+                    receiptURL: receiptURL
+                )
+                return MTPLXTerminalHandoffReceiptResult(
+                    lease: lease,
+                    cancellationMarked: cancellationMarked,
+                    cancellationRequested: true
+                )
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        _ = removeHandoffArtifacts(commandURL: commandURL, receiptURL: receiptURL)
+        return MTPLXTerminalHandoffReceiptResult(
+            lease: nil,
+            cancellationMarked: cancellationMarked,
+            cancellationRequested: true
+        )
+    }
+}
+
+/// PID reuse protection for LaunchServices clients. A stale lifecycle may
+/// target an app only when both its PID and launch identity still match.
+public struct MTPLXDesktopHandoffIdentity: Equatable, Sendable {
+    public let processID: Int
+    public let launchDate: Date
+
+    public init(processID: Int, launchDate: Date) {
+        self.processID = processID
+        self.launchDate = launchDate
+    }
+
+    public func matches(processID: Int, launchDate: Date?) -> Bool {
+        self.processID == processID && self.launchDate == launchDate
+    }
+}
+
 public struct HermesProfile: Identifiable, Equatable, Sendable {
     public let name: String
     public let path: String
@@ -141,6 +526,33 @@ public struct HermesLaunchResult: Equatable, Sendable {
     public let action: HermesLaunchAction
     public let command: String
     public let detail: String
+    /// Exact processes opened by this handoff, when the platform can report
+    /// them.  The backend uses this to reap only a stale handoff, never a
+    /// client belonging to a newer daemon lifecycle.
+    public let launchedProcessIDs: [Int]
+    /// Terminal ownership is a UUID-backed lease rather than an inferred
+    /// process-list delta. Desktop launches leave this nil and use their
+    /// exact LaunchServices PID in `launchedProcessIDs`.
+    public let terminalHandoffLease: MTPLXTerminalHandoffLease?
+    /// LaunchServices identity for an app created by this invocation. PID
+    /// reuse must fail closed when a stale lifecycle later tries to reap it.
+    public let desktopHandoffIdentity: MTPLXDesktopHandoffIdentity?
+
+    public init(
+        action: HermesLaunchAction,
+        command: String,
+        detail: String,
+        launchedProcessIDs: [Int] = [],
+        terminalHandoffLease: MTPLXTerminalHandoffLease? = nil,
+        desktopHandoffIdentity: MTPLXDesktopHandoffIdentity? = nil
+    ) {
+        self.action = action
+        self.command = command
+        self.detail = detail
+        self.launchedProcessIDs = launchedProcessIDs
+        self.terminalHandoffLease = terminalHandoffLease
+        self.desktopHandoffIdentity = desktopHandoffIdentity
+    }
 }
 
 public enum HermesIntegrationError: Error, Equatable, LocalizedError {
@@ -495,6 +907,55 @@ public struct HermesIntegration: Sendable {
         return pids.count
     }
 
+    /// Reap only the LaunchServices app created by this invocation. Terminal
+    /// ownership uses `cancelTerminalHandoff(_:)`; a PID alone is never a
+    /// sufficient desktop ownership proof.
+    @MainActor
+    @discardableResult
+    public func cancelLaunchedDesktop(_ identity: MTPLXDesktopHandoffIdentity) -> Bool {
+        #if os(macOS)
+        guard identity.processID > 1,
+              let application = NSRunningApplication
+                .runningApplications(withBundleIdentifier: Self.desktopBundleIdentifier)
+                .first(where: {
+                    !$0.isTerminated
+                        && identity.matches(
+                            processID: Int($0.processIdentifier),
+                            launchDate: $0.launchDate
+                        )
+                })
+        else { return false }
+        application.terminate()
+        return true
+        #else
+        _ = identity
+        return false
+        #endif
+    }
+
+    /// Cancels one Terminal lease. The marker makes a delayed Terminal launch
+    /// self-cancel; the signal is sent only after proving the exact PID still
+    /// carries this invocation's UUID token.
+    @MainActor
+    @discardableResult
+    public func cancelTerminalHandoff(_ lease: MTPLXTerminalHandoffLease) -> Bool {
+        let cancellationMarked = MTPLXTerminalHandoffLease.writeCancellationMarker(
+            at: lease.cancellationMarkerURL
+        )
+        let commandRemoved = lease.commandURL.map {
+            MTPLXTerminalHandoffLease.removeDurableCommandScript(at: $0)
+        } ?? true
+        let receiptRemoved = lease.receiptURL.map {
+            MTPLXTerminalHandoffLease.removeDurableCommandScript(at: $0)
+        } ?? true
+        let pid = pid_t(lease.processID)
+        guard pid > 1,
+              MTPLXTerminalHandoffLease.process(pid: pid, hasExactHandoffID: lease.handoffID)
+        else { return false }
+        Self.terminate(pid: pid)
+        return cancellationMarked && commandRemoved && receiptRemoved
+    }
+
     public func hasLaunchedTerminalAgent() -> Bool {
         !Self.appLaunchedTerminalAgentPIDs().isEmpty
     }
@@ -561,9 +1022,13 @@ public struct HermesIntegration: Sendable {
     /// exists so the caller can fall back to the Terminal handoff.
     @MainActor
     public func launchDesktopApplication(
-        configuration: MTPLXAppConfiguration
+        configuration: MTPLXAppConfiguration,
+        isCurrent: (() -> Bool)? = nil
     ) async -> HermesLaunchResult? {
         guard let appURL = desktopApplicationURL() else { return nil }
+        guard isCurrent?() ?? true else {
+            return staleHandoffResult(command: "open \(appURL.path)")
+        }
         let command = "open \(appURL.path)"
         do {
             _ = try sync(configuration: configuration)
@@ -574,6 +1039,7 @@ public struct HermesIntegration: Sendable {
                 detail: "could not sync Hermes profile: \(error)"
             )
         }
+        guard isCurrent?() ?? true else { return staleHandoffResult(command: command) }
         let previous: String?
         do {
             previous = try writeActiveDesktopProfile()
@@ -584,17 +1050,51 @@ public struct HermesIntegration: Sendable {
                 detail: "could not pin Hermes Desktop to the MTPLX profile: \(error)"
             )
         }
+        guard isCurrent?() ?? true else { return staleHandoffResult(command: command) }
+        let preexistingDesktopPIDs = Set(
+            NSRunningApplication
+                .runningApplications(withBundleIdentifier: Self.desktopBundleIdentifier)
+                .filter { !$0.isTerminated }
+                .map(\.processIdentifier)
+        )
         let openConfiguration = NSWorkspace.OpenConfiguration()
         openConfiguration.activates = true
-        let opened = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        let opened = await withCheckedContinuation { (continuation: CheckedContinuation<(Bool, Int?, Date?), Never>) in
             NSWorkspace.shared.openApplication(
                 at: appURL,
                 configuration: openConfiguration
-            ) { _, error in
-                continuation.resume(returning: error == nil)
+            ) { application, error in
+                continuation.resume(
+                    returning: (
+                        error == nil,
+                        application.map { Int($0.processIdentifier) },
+                        application?.launchDate
+                    )
+                )
             }
         }
-        guard opened else {
+        let desktopHandoffIdentity: MTPLXDesktopHandoffIdentity?
+        if opened.0,
+           let processID = opened.1,
+           let launchDate = opened.2,
+           !preexistingDesktopPIDs.contains(pid_t(processID)) {
+            desktopHandoffIdentity = MTPLXDesktopHandoffIdentity(
+                processID: processID,
+                launchDate: launchDate
+            )
+        } else {
+            desktopHandoffIdentity = nil
+        }
+        guard isCurrent?() ?? true else {
+            return HermesLaunchResult(
+                action: .unavailable,
+                command: command,
+                detail: "Hermes handoff cancelled because the daemon lifecycle changed.",
+                launchedProcessIDs: desktopHandoffIdentity.map { [$0.processID] } ?? [],
+                desktopHandoffIdentity: desktopHandoffIdentity
+            )
+        }
+        guard opened.0 else {
             return HermesLaunchResult(
                 action: .unavailable,
                 command: command,
@@ -610,7 +1110,9 @@ public struct HermesIntegration: Sendable {
         return HermesLaunchResult(
             action: .launched,
             command: command,
-            detail: "opened Hermes Desktop pinned to profile \(Self.profileName)\(previousNote)"
+            detail: "opened Hermes Desktop pinned to profile \(Self.profileName)\(previousNote)",
+            launchedProcessIDs: desktopHandoffIdentity.map { [$0.processID] } ?? [],
+            desktopHandoffIdentity: desktopHandoffIdentity
         )
     }
 
@@ -619,23 +1121,46 @@ public struct HermesIntegration: Sendable {
     /// broken Desktop bundle falls back to Terminal rather than stranding
     /// the user, carrying both details.
     @MainActor
-    public func launch(configuration: MTPLXAppConfiguration) async -> HermesLaunchResult {
-        guard let desktop = await launchDesktopApplication(configuration: configuration) else {
-            return launchInTerminal(configuration: configuration)
+    public func launch(
+        configuration: MTPLXAppConfiguration,
+        isCurrent: (() -> Bool)? = nil
+    ) async -> HermesLaunchResult {
+        guard isCurrent?() ?? true else {
+            return staleHandoffResult(command: Self.launchCommand(for: configuration.model))
         }
+        guard let desktop = await launchDesktopApplication(
+            configuration: configuration,
+            isCurrent: isCurrent
+        ) else {
+            guard isCurrent?() ?? true else {
+                return staleHandoffResult(command: Self.launchCommand(for: configuration.model))
+            }
+            return await launchInTerminal(configuration: configuration, isCurrent: isCurrent)
+        }
+        guard isCurrent?() ?? true else { return desktop }
         if desktop.action == .launched {
             return desktop
         }
-        let terminal = launchInTerminal(configuration: configuration)
+        guard isCurrent?() ?? true else { return desktop }
+        let terminal = await launchInTerminal(configuration: configuration, isCurrent: isCurrent)
         return HermesLaunchResult(
             action: terminal.action,
             command: terminal.command,
-            detail: "\(desktop.detail); fell back to Terminal: \(terminal.detail)"
+            detail: "\(desktop.detail); fell back to Terminal: \(terminal.detail)",
+            launchedProcessIDs: terminal.launchedProcessIDs,
+            terminalHandoffLease: terminal.terminalHandoffLease,
+            desktopHandoffIdentity: terminal.desktopHandoffIdentity
         )
     }
     #endif
 
-    public func launchInTerminal(configuration: MTPLXAppConfiguration) -> HermesLaunchResult {
+    @MainActor
+    public func launchInTerminal(
+        configuration: MTPLXAppConfiguration,
+        isCurrent: (() -> Bool)? = nil
+    ) async -> HermesLaunchResult {
+        let fallbackCommand = Self.launchCommand(for: configuration.model)
+        guard isCurrent?() ?? true else { return staleHandoffResult(command: fallbackCommand) }
         do {
             _ = try sync(configuration: configuration)
         } catch {
@@ -645,6 +1170,8 @@ public struct HermesIntegration: Sendable {
                 detail: "could not sync Hermes profile: \(error)"
             )
         }
+
+        guard isCurrent?() ?? true else { return staleHandoffResult(command: fallbackCommand) }
 
         guard let executable = resolveExecutable() else {
             return HermesLaunchResult(
@@ -661,12 +1188,14 @@ public struct HermesIntegration: Sendable {
             autoApprove: configuration.hermesAutoApprove
         )
         #if os(macOS)
-        let scriptURL: URL
+        let handoff = makeTerminalHandoffFiles()
         do {
-            scriptURL = try writeTerminalCommandFile(
+            guard isCurrent?() ?? true else { return staleHandoffResult(command: command) }
+            try writeTerminalCommandFile(
                 command: command,
                 hermesExecutablePath: executable.path,
-                configuration: configuration
+                configuration: configuration,
+                handoff: handoff
             )
         } catch {
             return HermesLaunchResult(
@@ -678,7 +1207,7 @@ public struct HermesIntegration: Sendable {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = ["-a", "Terminal", scriptURL.path]
+        process.arguments = ["-a", "Terminal", handoff.commandURL.path]
         let stderr = Pipe()
         process.standardError = stderr
         // The backend store calls this from the main actor, so a wedged
@@ -692,8 +1221,13 @@ public struct HermesIntegration: Sendable {
         defer { stderr.fileHandleForReading.readabilityHandler = nil }
         let watchdog = SubprocessWatchdog(process)
         do {
+            guard isCurrent?() ?? true else {
+                await cancelPendingTerminalHandoff(handoff)
+                return staleHandoffResult(command: command)
+            }
             try process.run()
             guard watchdog.wait(for: process, timeout: 30) else {
+                await cancelPendingTerminalHandoff(handoff)
                 return HermesLaunchResult(
                     action: .unavailable,
                     command: command,
@@ -701,6 +1235,7 @@ public struct HermesIntegration: Sendable {
                 )
             }
             guard process.terminationStatus == 0 else {
+                await cancelPendingTerminalHandoff(handoff)
                 let message = stderrTail.snapshot()
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 return HermesLaunchResult(
@@ -711,12 +1246,52 @@ public struct HermesIntegration: Sendable {
                         : "could not open Hermes automatically: \(message)"
                 )
             }
+            let receipt = await MTPLXTerminalHandoffLease.awaitReceipt(
+                handoffID: handoff.handoffID,
+                receiptURL: handoff.receiptURL,
+                cancellationMarkerURL: handoff.cancellationMarkerURL,
+                commandURL: handoff.commandURL,
+                isCurrent: isCurrent
+            )
+            if receipt.cancellationRequested {
+                if let lease = receipt.lease {
+                    _ = cancelTerminalHandoff(lease)
+                }
+                let stale = !(isCurrent?() ?? true)
+                return HermesLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: stale
+                        ? "Hermes handoff cancelled because the daemon lifecycle changed."
+                        : "Hermes Terminal did not report its launch receipt."
+                )
+            }
+            guard let lease = receipt.lease else {
+                return HermesLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: "Hermes Terminal did not report its launch receipt."
+                )
+            }
+            guard isCurrent?() ?? true else {
+                _ = cancelTerminalHandoff(lease)
+                return HermesLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: "Hermes handoff cancelled because the daemon lifecycle changed.",
+                    launchedProcessIDs: [lease.processID],
+                    terminalHandoffLease: lease
+                )
+            }
             return HermesLaunchResult(
                 action: .launched,
                 command: command,
-                detail: "opened Hermes in Terminal"
+                detail: "opened Hermes in Terminal",
+                launchedProcessIDs: [lease.processID],
+                terminalHandoffLease: lease
             )
         } catch {
+            await cancelPendingTerminalHandoff(handoff)
             return HermesLaunchResult(
                 action: .unavailable,
                 command: command,
@@ -730,6 +1305,25 @@ public struct HermesIntegration: Sendable {
             detail: "automatic Hermes launch currently requires macOS Terminal"
         )
         #endif
+    }
+
+    /// Once a handoff script exists, every abandoned path marks it cancelled
+    /// and gives a delayed Terminal one short receipt window. That closes the
+    /// marker-after-final-check race without ever treating the lease as live.
+    @MainActor
+    private func cancelPendingTerminalHandoff(_ handoff: TerminalHandoffFiles) async {
+        let receipt = await MTPLXTerminalHandoffLease.awaitReceipt(
+            handoffID: handoff.handoffID,
+            receiptURL: handoff.receiptURL,
+            cancellationMarkerURL: handoff.cancellationMarkerURL,
+            commandURL: handoff.commandURL,
+            isCurrent: { false },
+            timeoutSeconds: 0,
+            delayedCancellationSeconds: 1
+        )
+        if let lease = receipt.lease {
+            _ = cancelTerminalHandoff(lease)
+        }
     }
 
     public func startDashboard(
@@ -1149,16 +1743,34 @@ public struct HermesIntegration: Sendable {
         return parts.joined(separator: " ")
     }
 
+    private struct TerminalHandoffFiles: Sendable {
+        let handoffID: UUID
+        let commandURL: URL
+        let receiptURL: URL
+        let cancellationMarkerURL: URL
+    }
+
+    private func makeTerminalHandoffFiles() -> TerminalHandoffFiles {
+        let handoffID = UUID()
+        let directory = terminalCommandURL.deletingLastPathComponent()
+        let basename = terminalCommandURL.deletingPathExtension().lastPathComponent
+        let suffix = handoffID.uuidString.lowercased()
+        return TerminalHandoffFiles(
+            handoffID: handoffID,
+            commandURL: directory.appendingPathComponent("\(basename)-\(suffix).command"),
+            receiptURL: directory.appendingPathComponent("\(basename)-\(suffix).pid"),
+            cancellationMarkerURL: directory.appendingPathComponent("\(basename)-\(suffix).cancelled")
+        )
+    }
+
     private func writeTerminalCommandFile(
         command: String,
         hermesExecutablePath: String,
-        configuration: MTPLXAppConfiguration
-    ) throws -> URL {
-        let directory = terminalCommandURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true
-        )
+        configuration: MTPLXAppConfiguration,
+        handoff: TerminalHandoffFiles
+    ) throws {
+        let directory = handoff.commandURL.deletingLastPathComponent()
+        try MTPLXTerminalHandoffLease.prepareArtifactDirectory(directory)
         let profileURL = hermesHome
             .appendingPathComponent("profiles", isDirectory: true)
             .appendingPathComponent(Self.profileName, isDirectory: true)
@@ -1169,6 +1781,12 @@ public struct HermesIntegration: Sendable {
         )
         let script = """
         #!/bin/zsh
+        _mtplx_handoff_cancel=\(Self.shellQuote(handoff.cancellationMarkerURL.path))
+        _mtplx_handoff_receipt=\(Self.shellQuote(handoff.receiptURL.path))
+        export MTPLX_APP_HANDOFF_ID=\(Self.shellQuote(handoff.handoffID.uuidString.lowercased()))
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
         cd \(Self.shellQuote(workspacePath))
         print -r -- \(Self.shellQuote("MTPLX Hermes tools: \(Self.codingToolsets)"))
         print -r -- \(Self.shellQuote(Self.messagingSetupHint))
@@ -1215,14 +1833,18 @@ public struct HermesIntegration: Sendable {
         export HERMES_SESSION_PLATFORM=\(Self.shellQuote(env["HERMES_SESSION_PLATFORM"] ?? ""))
         export HERMES_WORKSPACE=\(Self.shellQuote(workspacePath))
         export TERMINAL_CWD=\(Self.shellQuote(workspacePath))
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
+        umask 077
+        print -r -- "$$" > "${_mtplx_handoff_receipt}.$$.tmp"
+        mv -f "${_mtplx_handoff_receipt}.$$.tmp" "$_mtplx_handoff_receipt"
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
         exec \(command)
         """ + "\n"
-        try script.write(to: terminalCommandURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o700],
-            ofItemAtPath: terminalCommandURL.path
-        )
-        return terminalCommandURL
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript(script, to: handoff.commandURL)
     }
 
     private struct LocalMessagingStatus {
@@ -1613,6 +2235,14 @@ public struct HermesIntegration: Sendable {
             let command = String(text[firstSpace...])
             return isAppLaunchedTerminalAgentCommand(command) ? pid : nil
         }
+    }
+
+    private func staleHandoffResult(command: String) -> HermesLaunchResult {
+        HermesLaunchResult(
+            action: .unavailable,
+            command: command,
+            detail: "Hermes handoff cancelled because the daemon lifecycle changed."
+        )
     }
 
     private static func terminate(pid: pid_t) {

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Services/OpenCodeIntegration.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Services/OpenCodeIntegration.swift
@@ -43,6 +43,29 @@ public struct OpenCodeDesktopResult: Equatable, Sendable {
     public let didTerminateExistingInstance: Bool
     public let didOpen: Bool
     public let detail: String
+    /// A PID is exposed only when LaunchServices created a process that was
+    /// not already present before this invocation. It is diagnostic only;
+    /// stale cleanup needs the PID-plus-launch-date identity below.
+    public let launchedProcessID: Int?
+    public let launchedDesktopIdentity: MTPLXDesktopHandoffIdentity?
+
+    public init(
+        action: OpenCodeDesktopAction,
+        wasRunning: Bool,
+        didTerminateExistingInstance: Bool,
+        didOpen: Bool,
+        detail: String,
+        launchedProcessID: Int? = nil,
+        launchedDesktopIdentity: MTPLXDesktopHandoffIdentity? = nil
+    ) {
+        self.action = action
+        self.wasRunning = wasRunning
+        self.didTerminateExistingInstance = didTerminateExistingInstance
+        self.didOpen = didOpen
+        self.detail = detail
+        self.launchedProcessID = launchedProcessID
+        self.launchedDesktopIdentity = launchedDesktopIdentity
+    }
 }
 
 private struct OpenCodeReasoningVisibilityResult: Equatable, Sendable {
@@ -173,7 +196,9 @@ public struct OpenCodeIntegration: Sendable {
     /// target therefore owns this handoff: after the daemon is ready, reload
     /// Desktop so users do not have to discover the "restart OpenCode" fix.
     @MainActor
-    public func reloadDesktopAfterDaemonReady() async -> OpenCodeDesktopResult {
+    public func reloadDesktopAfterDaemonReady(
+        isCurrent: (() -> Bool)? = nil
+    ) async -> OpenCodeDesktopResult {
         #if canImport(AppKit)
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: desktopApplicationURL.path) else {
@@ -185,7 +210,15 @@ public struct OpenCodeIntegration: Sendable {
                 detail: "OpenCode.app not found at \(desktopApplicationURL.path)"
             )
         }
+        guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
+        let preexistingProcessIDs = Set(
+            NSRunningApplication
+                .runningApplications(withBundleIdentifier: desktopBundleIdentifier)
+                .filter { !$0.isTerminated }
+                .map { Int($0.processIdentifier) }
+        )
         let stateRepair = repairDesktopStateBeforeLaunch()
+        guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
 
         let running = NSRunningApplication
             .runningApplications(withBundleIdentifier: desktopBundleIdentifier)
@@ -194,37 +227,59 @@ public struct OpenCodeIntegration: Sendable {
         var terminatedExisting = false
 
         if wasRunning {
+            guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
             for app in running {
                 app.terminate()
             }
             terminatedExisting = await waitUntilApplicationsExit(running, timeoutSeconds: 5)
+            guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
             if !terminatedExisting {
+                guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
                 for app in running where !app.isTerminated {
                     app.forceTerminate()
                 }
                 terminatedExisting = await waitUntilApplicationsExit(running, timeoutSeconds: 2)
+                guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
             }
         }
 
-        let didOpen = await openDesktopApplication()
+        guard isCurrent?() ?? true else { return staleDesktopHandoffResult() }
+        let opened = await openDesktopApplication()
+        let launchedDesktopIdentity: MTPLXDesktopHandoffIdentity?
+        if opened.didOpen,
+           let processID = opened.processID,
+           let launchDate = opened.launchDate,
+           !preexistingProcessIDs.contains(processID) {
+            launchedDesktopIdentity = MTPLXDesktopHandoffIdentity(
+                processID: processID,
+                launchDate: launchDate
+            )
+        } else {
+            launchedDesktopIdentity = nil
+        }
+        guard isCurrent?() ?? true else {
+            return staleDesktopHandoffResult(launchedDesktopIdentity: launchedDesktopIdentity)
+        }
         let action: OpenCodeDesktopAction
         if wasRunning {
-            action = didOpen ? .relaunched : .unavailable
+            action = opened.didOpen ? .relaunched : .unavailable
         } else {
-            action = didOpen ? .opened : .unavailable
+            action = opened.didOpen ? .opened : .unavailable
         }
 
         return OpenCodeDesktopResult(
             action: action,
             wasRunning: wasRunning,
             didTerminateExistingInstance: wasRunning ? terminatedExisting : false,
-            didOpen: didOpen,
+            didOpen: opened.didOpen,
             detail: (wasRunning
                 ? "reloaded OpenCode Desktop so its sidecar re-reads MTPLX provider config"
                 : "opened OpenCode Desktop")
                 + (stateRepair.didChange
                    ? "; repaired \(stateRepair.removedEntries) stale OpenCode workspace state entr\(stateRepair.removedEntries == 1 ? "y" : "ies")"
-                   : "")
+                   : ""),
+            launchedProcessID: launchedDesktopIdentity?.processID,
+            launchedDesktopIdentity: launchedDesktopIdentity
         )
         #else
         return OpenCodeDesktopResult(
@@ -234,6 +289,46 @@ public struct OpenCodeIntegration: Sendable {
             didOpen: false,
             detail: "AppKit is unavailable"
         )
+        #endif
+    }
+
+    private func staleDesktopHandoffResult(
+        launchedDesktopIdentity: MTPLXDesktopHandoffIdentity? = nil
+    ) -> OpenCodeDesktopResult {
+        OpenCodeDesktopResult(
+            action: .unavailable,
+            wasRunning: false,
+            didTerminateExistingInstance: false,
+            didOpen: false,
+            detail: "OpenCode handoff cancelled because the daemon lifecycle changed.",
+            launchedProcessID: launchedDesktopIdentity?.processID,
+            launchedDesktopIdentity: launchedDesktopIdentity
+        )
+    }
+
+    /// Reap only the process opened by this invocation. The Store calls this
+    /// when the lifecycle changes after LaunchServices returns a new PID; an
+    /// already-running OpenCode instance is deliberately never targeted.
+    @MainActor
+    @discardableResult
+    public func cancelLaunchedDesktop(_ identity: MTPLXDesktopHandoffIdentity) -> Bool {
+        #if canImport(AppKit)
+        guard identity.processID > 1,
+              let application = NSRunningApplication
+                .runningApplications(withBundleIdentifier: desktopBundleIdentifier)
+                .first(where: {
+                    !$0.isTerminated
+                        && identity.matches(
+                            processID: Int($0.processIdentifier),
+                            launchDate: $0.launchDate
+                        )
+                })
+        else { return false }
+        application.terminate()
+        return true
+        #else
+        _ = identity
+        return false
         #endif
     }
 
@@ -760,7 +855,11 @@ public struct OpenCodeIntegration: Sendable {
     }
 
     @MainActor
-    private func openDesktopApplication() async -> Bool {
+    private func openDesktopApplication() async -> (
+        didOpen: Bool,
+        processID: Int?,
+        launchDate: Date?
+    ) {
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
 
@@ -768,8 +867,14 @@ public struct OpenCodeIntegration: Sendable {
             NSWorkspace.shared.openApplication(
                 at: desktopApplicationURL,
                 configuration: configuration
-            ) { _, error in
-                continuation.resume(returning: error == nil)
+            ) { application, error in
+                continuation.resume(
+                    returning: (
+                        error == nil,
+                        application.map { Int($0.processIdentifier) },
+                        application?.launchDate
+                    )
+                )
             }
         }
     }

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Services/PiIntegration.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Services/PiIntegration.swift
@@ -20,17 +20,23 @@ public struct PiLaunchResult: Equatable, Sendable {
     public let command: String
     public let detail: String
     public let launchedProcessIDs: [Int]
+    /// Exact ownership of the Terminal-launched Pi process when it reports
+    /// its UUID receipt. Callers must use this lease, not process discovery,
+    /// for stale cleanup.
+    public let terminalHandoffLease: MTPLXTerminalHandoffLease?
 
     public init(
         action: PiLaunchAction,
         command: String,
         detail: String,
-        launchedProcessIDs: [Int] = []
+        launchedProcessIDs: [Int] = [],
+        terminalHandoffLease: MTPLXTerminalHandoffLease? = nil
     ) {
         self.action = action
         self.command = command
         self.detail = detail
         self.launchedProcessIDs = launchedProcessIDs
+        self.terminalHandoffLease = terminalHandoffLease
     }
 }
 
@@ -49,9 +55,19 @@ public struct PiIntegration: Sendable {
     """
 
     public let configURL: URL
+    /// Per-invocation scripts, receipts, and cancellation markers live here.
+    /// Keeping the directory injectable makes ownership deterministic in
+    /// service tests without reusing a fixed command filename.
+    public let handoffDirectory: URL
 
-    public init(configURL: URL = PiIntegration.defaultConfigURL()) {
+    public init(
+        configURL: URL = PiIntegration.defaultConfigURL(),
+        handoffDirectory: URL = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".mtplx", isDirectory: true)
+            .appendingPathComponent("handoffs", isDirectory: true)
+    ) {
         self.configURL = configURL
+        self.handoffDirectory = handoffDirectory
     }
 
     public static func defaultConfigURL() -> URL {
@@ -82,15 +98,23 @@ public struct PiIntegration: Sendable {
             .appendingPathComponent(agentOperatingHintsFilename)
     }
 
-    public func launchInTerminal(configuration: MTPLXAppConfiguration) -> PiLaunchResult {
+    @MainActor
+    public func launchInTerminal(
+        configuration: MTPLXAppConfiguration,
+        isCurrent: (() -> Bool)? = nil
+    ) async -> PiLaunchResult {
         let command = Self.terminalLaunchCommand(for: configuration.model)
+        guard isCurrent?() ?? true else {
+            return staleHandoffResult(command: command)
+        }
         #if os(macOS)
-        let existingAgentPIDs = Self.runningPiAgentPIDs()
-        let scriptURL: URL
+        let handoff = makeTerminalHandoffFiles()
         do {
-            scriptURL = try writeTerminalCommandFile(
+            guard isCurrent?() ?? true else { return staleHandoffResult(command: command) }
+            try writeTerminalCommandFile(
                 command: command,
-                configuration: configuration
+                configuration: configuration,
+                handoff: handoff
             )
         } catch {
             return PiLaunchResult(
@@ -99,10 +123,14 @@ public struct PiIntegration: Sendable {
                 detail: "could not prepare Pi terminal command: \(error)"
             )
         }
+        guard isCurrent?() ?? true else {
+            await cancelPendingTerminalHandoff(handoff)
+            return staleHandoffResult(command: command)
+        }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = ["-a", "Terminal", scriptURL.path]
+        process.arguments = ["-a", "Terminal", handoff.commandURL.path]
         let stderr = Pipe()
         process.standardError = stderr
         // The backend store calls this from the main actor, so a wedged
@@ -116,8 +144,13 @@ public struct PiIntegration: Sendable {
         defer { stderr.fileHandleForReading.readabilityHandler = nil }
         let watchdog = SubprocessWatchdog(process)
         do {
+            guard isCurrent?() ?? true else {
+                await cancelPendingTerminalHandoff(handoff)
+                return staleHandoffResult(command: command)
+            }
             try process.run()
             guard watchdog.wait(for: process, timeout: 30) else {
+                await cancelPendingTerminalHandoff(handoff)
                 return PiLaunchResult(
                     action: .unavailable,
                     command: command,
@@ -125,6 +158,7 @@ public struct PiIntegration: Sendable {
                 )
             }
             guard process.terminationStatus == 0 else {
+                await cancelPendingTerminalHandoff(handoff)
                 let message = stderrTail.snapshot()
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 return PiLaunchResult(
@@ -135,14 +169,52 @@ public struct PiIntegration: Sendable {
                         : "could not open Pi automatically: \(message)"
                 )
             }
-            let launchedPIDs = Self.waitForNewPiAgentPIDs(excluding: existingAgentPIDs)
+            let receipt = await MTPLXTerminalHandoffLease.awaitReceipt(
+                handoffID: handoff.handoffID,
+                receiptURL: handoff.receiptURL,
+                cancellationMarkerURL: handoff.cancellationMarkerURL,
+                commandURL: handoff.commandURL,
+                isCurrent: isCurrent
+            )
+            if receipt.cancellationRequested {
+                if let lease = receipt.lease {
+                    _ = cancelTerminalHandoff(lease)
+                }
+                let stale = !(isCurrent?() ?? true)
+                return PiLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: stale
+                        ? "Pi handoff cancelled because the daemon lifecycle changed."
+                        : "Pi Terminal did not report its launch receipt."
+                )
+            }
+            guard let lease = receipt.lease else {
+                return PiLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: "Pi Terminal did not report its launch receipt."
+                )
+            }
+            guard isCurrent?() ?? true else {
+                _ = cancelTerminalHandoff(lease)
+                return PiLaunchResult(
+                    action: .unavailable,
+                    command: command,
+                    detail: "Pi handoff cancelled because the daemon lifecycle changed.",
+                    launchedProcessIDs: [lease.processID],
+                    terminalHandoffLease: lease
+                )
+            }
             return PiLaunchResult(
                 action: .launched,
                 command: command,
                 detail: "opened Pi in Terminal",
-                launchedProcessIDs: launchedPIDs.map(Int.init).sorted()
+                launchedProcessIDs: [lease.processID],
+                terminalHandoffLease: lease
             )
         } catch {
+            await cancelPendingTerminalHandoff(handoff)
             return PiLaunchResult(
                 action: .unavailable,
                 command: command,
@@ -158,16 +230,53 @@ public struct PiIntegration: Sendable {
         #endif
     }
 
-    @discardableResult
-    public func stopLaunchedAgents(processIDs: [Int]) -> Int {
-        var stopped = 0
-        for processID in Set(processIDs) {
-            let pid = pid_t(processID)
-            guard pid > 1, Self.isPiAgentProcess(pid: pid) else { continue }
-            Self.terminate(pid: pid)
-            stopped += 1
+    private func staleHandoffResult(command: String) -> PiLaunchResult {
+        PiLaunchResult(
+            action: .unavailable,
+            command: command,
+            detail: "Pi handoff cancelled because the daemon lifecycle changed."
+        )
+    }
+
+    /// Covers every failure after the script is durable. A late Terminal
+    /// launch sees the marker; a receipt from the final-check race is reaped
+    /// only after proving the exact UUID environment token.
+    @MainActor
+    private func cancelPendingTerminalHandoff(_ handoff: TerminalHandoffFiles) async {
+        let receipt = await MTPLXTerminalHandoffLease.awaitReceipt(
+            handoffID: handoff.handoffID,
+            receiptURL: handoff.receiptURL,
+            cancellationMarkerURL: handoff.cancellationMarkerURL,
+            commandURL: handoff.commandURL,
+            isCurrent: { false },
+            timeoutSeconds: 0,
+            delayedCancellationSeconds: 1
+        )
+        if let lease = receipt.lease {
+            _ = cancelTerminalHandoff(lease)
         }
-        return stopped
+    }
+
+    /// Cancels one exact lease. A stale Store callback must use this method
+    /// rather than process discovery or a raw PID list.
+    @MainActor
+    @discardableResult
+    public func cancelTerminalHandoff(_ lease: MTPLXTerminalHandoffLease) -> Bool {
+        let cancellationMarked = MTPLXTerminalHandoffLease.writeCancellationMarker(
+            at: lease.cancellationMarkerURL
+        )
+        let commandRemoved = lease.commandURL.map {
+            MTPLXTerminalHandoffLease.removeDurableCommandScript(at: $0)
+        } ?? true
+        let receiptRemoved = lease.receiptURL.map {
+            MTPLXTerminalHandoffLease.removeDurableCommandScript(at: $0)
+        } ?? true
+        let pid = pid_t(lease.processID)
+        guard pid > 1,
+              MTPLXTerminalHandoffLease.process(pid: pid, hasExactHandoffID: lease.handoffID)
+        else { return false }
+        Self.terminate(pid: pid)
+        return cancellationMarked && commandRemoved && receiptRemoved
     }
 
     @discardableResult
@@ -373,6 +482,24 @@ public struct PiIntegration: Sendable {
             && isDirectory.boolValue
     }
 
+    private struct TerminalHandoffFiles: Sendable {
+        let handoffID: UUID
+        let commandURL: URL
+        let receiptURL: URL
+        let cancellationMarkerURL: URL
+    }
+
+    private func makeTerminalHandoffFiles() -> TerminalHandoffFiles {
+        let handoffID = UUID()
+        let suffix = handoffID.uuidString.lowercased()
+        return TerminalHandoffFiles(
+            handoffID: handoffID,
+            commandURL: handoffDirectory.appendingPathComponent("open-pi-\(suffix).command"),
+            receiptURL: handoffDirectory.appendingPathComponent("open-pi-\(suffix).pid"),
+            cancellationMarkerURL: handoffDirectory.appendingPathComponent("open-pi-\(suffix).cancelled")
+        )
+    }
+
     static func isPiAgentCommand(_ command: String) -> Bool {
         let words = commandWords(command)
         guard let first = words.first else { return false }
@@ -390,70 +517,6 @@ public struct PiIntegration: Sendable {
         guard hasPiScript else { return false }
 
         return hasPiLaunchIntent(words)
-    }
-
-    private static func waitForNewPiAgentPIDs(excluding existing: Set<pid_t>) -> [pid_t] {
-        let deadline = Date().addingTimeInterval(3)
-        while Date() < deadline {
-            let next = runningPiAgentPIDs().subtracting(existing)
-            if !next.isEmpty {
-                return Array(next)
-            }
-            Thread.sleep(forTimeInterval: 0.1)
-        }
-        return []
-    }
-
-    private static func isPiAgentProcess(pid: pid_t) -> Bool {
-        runningPiAgentPIDs().contains(pid)
-    }
-
-    private static func runningPiAgentPIDs() -> Set<pid_t> {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-axo", "pid=,command="]
-        let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("mtplx-pi-ps-\(UUID().uuidString).txt")
-        FileManager.default.createFile(atPath: outputURL.path, contents: nil)
-        guard let outputHandle = try? FileHandle(forWritingTo: outputURL) else { return [] }
-        defer {
-            try? outputHandle.close()
-            try? FileManager.default.removeItem(at: outputURL)
-        }
-        process.standardOutput = outputHandle
-        let exitDone = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            exitDone.signal()
-        }
-        do {
-            try process.run()
-        } catch {
-            return []
-        }
-        if exitDone.wait(timeout: .now() + 1.0) == .timedOut {
-            process.terminate()
-            if exitDone.wait(timeout: .now() + 0.5) == .timedOut {
-                return []
-            }
-        }
-        try? outputHandle.synchronize()
-        let outputData = (try? Data(contentsOf: outputURL)) ?? Data()
-        guard let output = String(data: outputData, encoding: .utf8) else { return [] }
-        let currentPID = getpid()
-        return Set(output.split(separator: "\n").compactMap { row -> pid_t? in
-            let text = String(row).trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let firstSpace = text.firstIndex(where: { $0.isWhitespace }) else {
-                return nil
-            }
-            guard let pid = pid_t(text[..<firstSpace]),
-                  pid > 1,
-                  pid != currentPID
-            else {
-                return nil
-            }
-            let command = String(text[firstSpace...])
-            return isPiAgentCommand(command) ? pid : nil
-        })
     }
 
     private static func terminate(pid: pid_t) {
@@ -514,28 +577,34 @@ public struct PiIntegration: Sendable {
 
     private func writeTerminalCommandFile(
         command: String,
-        configuration: MTPLXAppConfiguration
-    ) throws -> URL {
-        let directory = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".mtplx")
-        try FileManager.default.createDirectory(
-            at: directory,
-            withIntermediateDirectories: true
-        )
-        let scriptURL = directory.appendingPathComponent("open-pi.command")
+        configuration: MTPLXAppConfiguration,
+        handoff: TerminalHandoffFiles
+    ) throws {
+        let directory = handoff.commandURL.deletingLastPathComponent()
+        try MTPLXTerminalHandoffLease.prepareArtifactDirectory(directory)
         _ = try Self.writeAgentOperatingHintsFile()
         let workspacePath = Self.resolvedWorkspacePath(configuration: configuration)
         let script = """
         #!/bin/zsh
+        _mtplx_handoff_cancel=\(Self.shellQuote(handoff.cancellationMarkerURL.path))
+        _mtplx_handoff_receipt=\(Self.shellQuote(handoff.receiptURL.path))
+        export MTPLX_APP_HANDOFF_ID=\(Self.shellQuote(handoff.handoffID.uuidString.lowercased()))
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
         cd \(Self.shellQuote(workspacePath))
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
+        umask 077
+        print -r -- "$$" > "${_mtplx_handoff_receipt}.$$.tmp"
+        mv -f "${_mtplx_handoff_receipt}.$$.tmp" "$_mtplx_handoff_receipt"
+        if [[ -e "$_mtplx_handoff_cancel" ]]; then
+          exit 0
+        fi
         exec \(command)
         """
-        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o700],
-            ofItemAtPath: scriptURL.path
-        )
-        return scriptURL
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript(script, to: handoff.commandURL)
     }
 
     @discardableResult

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Stores/HermesAgentStore.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Stores/HermesAgentStore.swift
@@ -255,6 +255,12 @@ public final class HermesAgentStore: ObservableObject {
     private var client: HermesGatewayClient?
     private var shuttingDown = false
     private var gatewayGeneration = 0
+    /// Manual Terminal launches are owned by their receipt, not by a broad
+    /// process scan. Stop and a superseding manual launch invalidate this
+    /// generation before awaiting any external work.
+    private var terminalHandoffGeneration = 0
+    private var terminalHandoffLease: MTPLXTerminalHandoffLease?
+    private var terminalHandoffTask: Task<Void, Never>?
 
     public init(integration: HermesIntegration = HermesIntegration()) {
         self.integration = integration
@@ -296,8 +302,27 @@ public final class HermesAgentStore: ObservableObject {
     /// the handoff panel's "Open in Terminal" action so the user can get
     /// back to the live agent without restarting the daemon.
     public func openTerminal(configuration: MTPLXAppConfiguration) {
-        _ = integration.launchInTerminal(configuration: configuration)
-        terminalAgentRunning = integration.hasLaunchedTerminalAgent()
+        invalidateManualTerminalHandoff()
+        let generation = terminalHandoffGeneration
+        terminalHandoffTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.integration.launchInTerminal(
+                configuration: configuration,
+                isCurrent: { [weak self] in
+                    guard let self else { return false }
+                    return self.terminalHandoffGeneration == generation
+                }
+            )
+            guard self.terminalHandoffGeneration == generation else {
+                if let lease = result.terminalHandoffLease {
+                    _ = self.integration.cancelTerminalHandoff(lease)
+                }
+                return
+            }
+            self.terminalHandoffLease = result.terminalHandoffLease
+            self.terminalAgentRunning = result.action == .launched
+            self.terminalHandoffTask = nil
+        }
     }
 
     public func repairGateway() async {
@@ -474,6 +499,7 @@ public final class HermesAgentStore: ObservableObject {
 
     public func stop() async {
         shuttingDown = true
+        invalidateManualTerminalHandoff()
         gatewayGeneration += 1
         client?.close()
         client = nil
@@ -484,12 +510,35 @@ public final class HermesAgentStore: ObservableObject {
         gatewayReady = false
         isStreaming = false
         activeSessionID = nil
-        terminalAgentRunning = integration.hasLaunchedTerminalAgent()
+        terminalAgentRunning = false
         connectionState = .idle
     }
 
     public func refreshTerminalAgentState() {
         terminalAgentRunning = integration.hasLaunchedTerminalAgent()
+    }
+
+    /// Narrow package test seam for the Store-owned manual Terminal lease.
+    /// Production receipts arrive through `openTerminal(configuration:)`.
+    func recordManualTerminalHandoffLeaseForTesting(_ lease: MTPLXTerminalHandoffLease) {
+        invalidateManualTerminalHandoff()
+        terminalHandoffLease = lease
+        terminalAgentRunning = true
+    }
+
+    var manualTerminalHandoffLeaseIDForTesting: UUID? {
+        terminalHandoffLease?.handoffID
+    }
+
+    private func invalidateManualTerminalHandoff() {
+        terminalHandoffGeneration &+= 1
+        terminalHandoffTask?.cancel()
+        terminalHandoffTask = nil
+        if let lease = terminalHandoffLease {
+            _ = integration.cancelTerminalHandoff(lease)
+        }
+        terminalHandoffLease = nil
+        terminalAgentRunning = false
     }
 
     private func ensureGateway(

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Stores/MTPLXBackendStore.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Stores/MTPLXBackendStore.swift
@@ -156,6 +156,9 @@ public struct ClientHandoffNotice: Equatable, Sendable {
 @MainActor
 public final class MTPLXBackendStore: ObservableObject {
     @Published public private(set) var daemonState: DaemonState = .stopped
+    @Published public private(set) var daemonRestartStatus: DaemonRestartStatus = .idle
+    @Published public private(set) var daemonRestartCount: Int = 0
+    @Published public private(set) var daemonRestartEligibility: DaemonRestartEligibility = .noDaemon
     @Published public private(set) var connectionState: MetricsConnectionState = .idle
     @Published public private(set) var startupPhase: DaemonStartupPhase = .idle
     @Published public private(set) var health: HealthPayload?
@@ -286,9 +289,25 @@ public final class MTPLXBackendStore: ObservableObject {
     private let autoTuner: AutoTuner
     private let runtimeUpdateService: MTPLXRuntimeUpdateService
     private let localFanRestorer: @Sendable () async -> Bool
+    private let fanModeSetter: @Sendable (MTPLXAPIClient, String, Bool, Double?) async throws -> FanModeResponse
+    private let beforePostStartRefresh: @Sendable () async -> Void
+    private let beforeThermalStatusRefresh: @Sendable () async -> Void
+    /// Test seam for the narrow window immediately before a client launcher
+    /// performs external work. Production uses a no-op; lifecycle checks on
+    /// both sides make delayed completions harmless.
+    private let beforeClientHandoffLaunch: @Sendable (LaunchTarget) async -> Void
+    /// Keeps the stale-handoff gate observable without asking package tests to
+    /// start a real AppKit desktop client.
+    private let cancelOpenCodeDesktop: (MTPLXDesktopHandoffIdentity) -> Bool
     private var launchedPiAgentPIDs: Set<Int> = []
+    /// Store-owned terminal launches are reaped by their UUID receipts, never
+    /// by a process-list scan. The PID set remains presentation-only.
+    private var launchedPiHandoffLeases: [UUID: MTPLXTerminalHandoffLease] = [:]
+    private var launchedHermesHandoffLeases: [UUID: MTPLXTerminalHandoffLease] = [:]
+    private var activeClientHandoffID: UUID?
     private var streamTask: Task<Void, Never>?
     private var healthWatchTask: Task<Void, Never>?
+    private var daemonTransportGeneration = 0
     private var modelDownloadTask: Task<Void, Never>?
     private var modelTuneTask: Task<Void, Never>?
     private var lateHealthRecoveryTask: Task<Void, Never>?
@@ -306,6 +325,10 @@ public final class MTPLXBackendStore: ObservableObject {
     private var fanRestoreRequiredOnStop: Bool = false
     private var activeLaunchID: String?
     private var cancelledLaunchIDs: Set<String> = []
+    private var lastDaemonTarget: LaunchTarget?
+    private var recoveredAutomaticRestartGeneration = 0
+    private var lastAppliedSupervisionRevision = -1
+    private var lastTerminalCleanupLifecycleEpoch = 0
     private let daemonStartupTimeoutSeconds: TimeInterval = 600
 
     public init(
@@ -319,7 +342,12 @@ public final class MTPLXBackendStore: ObservableObject {
         modelDownloader: ModelDownloader = ModelDownloader(),
         autoTuner: AutoTuner = AutoTuner(),
         runtimeUpdateService: MTPLXRuntimeUpdateService? = nil,
-        localFanRestorer: (@Sendable () async -> Bool)? = nil
+        localFanRestorer: (@Sendable () async -> Bool)? = nil,
+        fanModeSetter: (@Sendable (MTPLXAPIClient, String, Bool, Double?) async throws -> FanModeResponse)? = nil,
+        beforePostStartRefresh: (@Sendable () async -> Void)? = nil,
+        beforeThermalStatusRefresh: (@Sendable () async -> Void)? = nil,
+        beforeClientHandoffLaunch: (@Sendable (LaunchTarget) async -> Void)? = nil,
+        openCodeDesktopCanceller: ((MTPLXDesktopHandoffIdentity) -> Bool)? = nil
     ) {
         self.configuration = configuration
         self.settingsStore = settingsStore
@@ -335,6 +363,24 @@ public final class MTPLXBackendStore: ObservableObject {
         self.localFanRestorer = localFanRestorer ?? {
             await MTPLXBackendStore.restoreFanModeWithLocalThermalforge()
         }
+        self.fanModeSetter = fanModeSetter ?? { client, mode, requireActualRamp, timeoutS in
+            try await client.setFanMode(
+                mode,
+                requireActualRamp: requireActualRamp,
+                timeoutS: timeoutS
+            )
+        }
+        self.beforePostStartRefresh = beforePostStartRefresh ?? {}
+        self.beforeThermalStatusRefresh = beforeThermalStatusRefresh ?? {}
+        self.beforeClientHandoffLaunch = beforeClientHandoffLaunch ?? { _ in }
+        self.cancelOpenCodeDesktop = openCodeDesktopCanceller
+            ?? { identity in openCodeIntegration.cancelLaunchedDesktop(identity) }
+        self.supervisor.setAutomaticRestartEnabled(configuration.automaticDaemonRestart)
+        self.supervisor.setStatusObserver { [weak self] snapshot in
+            Task { @MainActor [weak self] in
+                self?.applySupervisorSnapshot(snapshot)
+            }
+        }
     }
 
     public func loadPersistedSettings() {
@@ -345,12 +391,14 @@ public final class MTPLXBackendStore: ObservableObject {
             }
             configuration = loaded
             seedLiveSettingsFromConfiguration(loaded)
+            supervisor.setAutomaticRestartEnabled(loaded.automaticDaemonRestart)
         }
     }
 
     public func saveSettings(_ next: MTPLXAppConfiguration) throws {
         configuration = next
         seedLiveSettingsFromConfiguration(next)
+        supervisor.setAutomaticRestartEnabled(next.automaticDaemonRestart)
         try settingsStore.save(next)
     }
 
@@ -362,6 +410,7 @@ public final class MTPLXBackendStore: ObservableObject {
         let target = LaunchTarget(rawValue: next.lastLaunchTarget)
         configuration = next
         try settingsStore.save(next)
+        supervisor.setAutomaticRestartEnabled(next.automaticDaemonRestart)
         guard shouldRestart else { return }
         if promptForModelDownloadIfNeeded(
             configuration: next,
@@ -377,6 +426,8 @@ public final class MTPLXBackendStore: ObservableObject {
         let launchID = UUID().uuidString
         let recoveryTarget = target
         do {
+            supervisor.setAutomaticRestartEnabled(next.automaticDaemonRestart)
+            lastDaemonTarget = target
             try await prepareRuntimeForDaemonStart()
             if target == .openCode {
                 let result = try openCodeIntegration.sync(configuration: next)
@@ -413,6 +464,7 @@ public final class MTPLXBackendStore: ObservableObject {
                 launchID: launchID
             )
             startupPhase = .launching
+            activeLaunchID = launchID
             let startupHealth = try await supervisor.restart(
                 command: command,
                 healthBaseURL: baseURL,
@@ -433,12 +485,21 @@ public final class MTPLXBackendStore: ObservableObject {
                 fanRestoreRequiredOnStop = fanRestoreRequiredOnStop
                     || modeRequiresFanRestore(currentFanMode)
             }
+            let lifecycleEpoch = supervisor.supervisionSnapshot().lifecycleEpoch
             await finishReadyDaemon(
                 target: target,
                 configuration: next,
-                replaceExistingClient: true
+                replaceExistingClient: true,
+                launchID: launchID,
+                lifecycleEpoch: lifecycleEpoch
             )
+            if activeLaunchID == launchID {
+                activeLaunchID = nil
+            }
         } catch {
+            if activeLaunchID == launchID {
+                activeLaunchID = nil
+            }
             let failureDescription = Self.humanizedStartFailure(
                 error,
                 port: configuration.port
@@ -557,6 +618,8 @@ public final class MTPLXBackendStore: ObservableObject {
         healthWatchTask = nil
         let launchID = UUID().uuidString
         do {
+            supervisor.setAutomaticRestartEnabled(configuration.automaticDaemonRestart)
+            lastDaemonTarget = target
             try await prepareRuntimeForDaemonStart()
             // Pre-flight the configured port before any integration writes
             // its config: adoptable app-owned daemons are left for the
@@ -614,10 +677,13 @@ public final class MTPLXBackendStore: ObservableObject {
                 fanRestoreRequiredOnStop = fanRestoreRequiredOnStop
                     || modeRequiresFanRestore(currentFanMode)
             }
+            let lifecycleEpoch = supervisor.supervisionSnapshot().lifecycleEpoch
             await finishReadyDaemon(
                 target: target,
                 configuration: configuration,
-                replaceExistingClient: true
+                replaceExistingClient: true,
+                launchID: launchID,
+                lifecycleEpoch: lifecycleEpoch
             )
             if activeLaunchID == launchID {
                 activeLaunchID = nil
@@ -939,13 +1005,24 @@ public final class MTPLXBackendStore: ObservableObject {
         // Show Stopping while the process family is being reaped, then only
         // return to Stopped after the wrapper, model server child, and thermal
         // sidecar have been signalled and verified gone.
+        // This path owns its local client/metrics cleanup. Mark the active
+        // lifecycle before asking the supervisor to stop so its terminal
+        // snapshot cannot run a duplicate passive cleanup afterward.
+        let stoppingLifecycleEpoch = supervisor.supervisionSnapshot().lifecycleEpoch
+        if stoppingLifecycleEpoch > 0 {
+            lastTerminalCleanupLifecycleEpoch = max(
+                lastTerminalCleanupLifecycleEpoch,
+                stoppingLifecycleEpoch
+            )
+        }
         if let launchID = activeLaunchID {
             cancelledLaunchIDs.insert(launchID)
             activeLaunchID = nil
         }
         let shouldWarnIfFanRestoreFails = shouldRestoreFanModeOnStop()
         let startupPID = health?.startup?.pid.map(pid_t.init)
-        let piPIDsToStop = Array(launchedPiAgentPIDs)
+        let piHandoffsToStop = Array(launchedPiHandoffLeases.values)
+        let hermesHandoffsToStop = Array(launchedHermesHandoffLeases.values)
         modelDownloadTask?.cancel()
         modelDownloadTask = nil
         isModelDownloading = false
@@ -955,12 +1032,16 @@ public final class MTPLXBackendStore: ObservableObject {
         healthWatchTask = nil
         streamTask?.cancel()
         streamTask = nil
+        daemonTransportGeneration &+= 1
         launchedPiAgentPIDs.removeAll()
+        launchedPiHandoffLeases.removeAll()
+        launchedHermesHandoffLeases.removeAll()
         piTerminalAgentRunning = false
         piTerminalAgentProcessIDs = []
         piTerminalLaunchCommand = nil
         piTerminalLaunchDetail = nil
         clientHandoffNotice = nil
+        activeClientHandoffID = nil
         daemonState = .stopping
         startupPhase = .idle
         connectionState = .idle
@@ -981,14 +1062,18 @@ public final class MTPLXBackendStore: ObservableObject {
                 )
             }
             await previousTeardown?.value
-            let stoppedHermes = hermesIntegration.stopLaunchedTerminalAgents()
+            let stoppedHermes = hermesHandoffsToStop.reduce(into: 0) { count, lease in
+                if hermesIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
             if stoppedHermes > 0 {
                 await supervisor.logs.append(
                     "stopped \(stoppedHermes) Hermes Terminal handoff(s)",
                     stream: .system
                 )
             }
-            let stoppedPi = piIntegration.stopLaunchedAgents(processIDs: piPIDsToStop)
+            let stoppedPi = piHandoffsToStop.reduce(into: 0) { count, lease in
+                if piIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
             if stoppedPi > 0 {
                 await supervisor.logs.append(
                     "stopped \(stoppedPi) Pi Terminal handoff(s)",
@@ -1230,26 +1315,40 @@ public final class MTPLXBackendStore: ObservableObject {
         metricsRequestGeneration &+= 1
     }
 
-    public func refreshStaticState() async throws {
+    public func refreshStaticState(
+        isCurrent: (() -> Bool)? = nil,
+        markUnreachableOnTransportFailure: Bool = true
+    ) async throws {
         let client = apiClient
         do {
             async let health = client.health()
             async let capabilities = client.capabilities()
             async let sessions = client.sessions()
-            self.health = try await health
-            self.capabilities = try await capabilities
-            self.sessions = try await sessions
-            await refreshPrefillHistory()
-            await refreshModels()
-            await refreshLogs()
+            let fetchedHealth = try await health
+            let fetchedCapabilities = try await capabilities
+            let fetchedSessions = try await sessions
+            guard isCurrent?() ?? true else { return }
+            self.health = fetchedHealth
+            self.capabilities = fetchedCapabilities
+            self.sessions = fetchedSessions
+            await refreshPrefillHistory(isCurrent: isCurrent)
+            guard isCurrent?() ?? true else { return }
+            await refreshModels(isCurrent: isCurrent)
+            guard isCurrent?() ?? true else { return }
+            let refreshedLogs = await supervisor.logs.snapshot()
+            guard isCurrent?() ?? true else { return }
+            logs = refreshedLogs
         } catch is DecodingError {
             // The daemon answered; only the app-side schema mapping failed.
             // Never treat a decode bug as a dead daemon (2026-07-06 reap).
             throw MTPLXAPIClientError.invalidResponse
         } catch {
-            markDaemonUnreachableIfNeeded(
-                reason: "MTPLX lost contact with the model server. Start it again."
-            )
+            guard isCurrent?() ?? true else { throw error }
+            if markUnreachableOnTransportFailure {
+                markDaemonUnreachableIfNeeded(
+                    reason: "MTPLX lost contact with the model server. Start it again."
+                )
+            }
             throw error
         }
     }
@@ -1361,7 +1460,9 @@ public final class MTPLXBackendStore: ObservableObject {
         pendingLiveSettingsModel = nil
     }
 
-    private func flushFreshLaunchLiveOnlySettingsIfNeeded() async throws {
+    private func flushFreshLaunchLiveOnlySettingsIfNeeded(
+        isCurrent: (() -> Bool)? = nil
+    ) async throws {
         guard let pending = pendingLiveSettings else { return }
         guard pendingLiveSettingsModel == nil || pendingLiveSettingsModel == configuration.model else {
             pendingLiveSettings = nil
@@ -1373,7 +1474,9 @@ public final class MTPLXBackendStore: ObservableObject {
             pendingLiveSettingsModel = nil
             return
         }
-        settings = try await apiClient.updateSettings(liveOnlyPatch)
+        let updatedSettings = try await apiClient.updateSettings(liveOnlyPatch)
+        guard isCurrent?() ?? true else { return }
+        settings = updatedSettings
         liveSettingsModel = configuration.model
         pendingLiveSettings = nil
         pendingLiveSettingsModel = nil
@@ -1710,20 +1813,291 @@ public final class MTPLXBackendStore: ObservableObject {
 
     public func startMetricsStream() {
         streamTask?.cancel()
+        daemonTransportGeneration &+= 1
+        let transportGeneration = daemonTransportGeneration
         let client = MetricsStreamClient(apiClient: apiClient)
         let interval = configuration.performanceLock ? 1000 : configuration.streamSnapshotIntervalMs
         streamTask = Task { [weak self] in
             await client.connect(
                 snapshotIntervalMs: interval,
                 onState: { state in
-                    await MainActor.run { self?.connectionState = state }
+                    await MainActor.run {
+                        guard self?.daemonTransportGeneration == transportGeneration else { return }
+                        self?.connectionState = state
+                    }
                 },
                 onEvent: { event in
-                    await MainActor.run { self?.apply(event: event) }
+                    await MainActor.run {
+                        guard self?.daemonTransportGeneration == transportGeneration else { return }
+                        self?.apply(event: event)
+                    }
                 }
             )
         }
         startDaemonHealthWatchdog()
+    }
+
+    func applySupervisorSnapshot(_ snapshot: DaemonSupervisionSnapshot) {
+        // The supervisor invokes its callback serially, but this store must
+        // hop onto MainActor. Ignore an older Task that arrives after a newer
+        // snapshot rather than moving the visible state backwards.
+        guard snapshot.revision > lastAppliedSupervisionRevision else { return }
+        lastAppliedSupervisionRevision = snapshot.revision
+        // Status observers run after the supervisor releases its lock, so a
+        // terminal callback from lifecycle N can arrive while lifecycle N+1
+        // is already running. Revision order alone cannot distinguish that
+        // case; never let an older lifecycle mutate or tear down the live
+        // store state for the current daemon.
+        let currentSupervisorSnapshot = supervisor.supervisionSnapshot()
+        guard snapshot.lifecycleEpoch >= currentSupervisorSnapshot.lifecycleEpoch else {
+            return
+        }
+        daemonRestartStatus = snapshot.restartStatus
+        daemonRestartCount = snapshot.restartCount
+        daemonRestartEligibility = snapshot.restartEligibility
+
+        switch snapshot.restartStatus {
+        case .scheduled:
+            daemonState = .crashed({
+                if case .crashed(let status) = snapshot.state { return status }
+                return nil
+            }())
+            startupPhase = .failed("MTPLX crashed; automatic restart is scheduled.")
+            connectionState = .connecting
+        case .restarting:
+            daemonState = .starting
+            startupPhase = .launching
+            connectionState = .connecting
+        case .runningAfterRestart(let attempt):
+            daemonState = .running
+            startupPhase = .ready
+            guard snapshot.recoveryGeneration > recoveredAutomaticRestartGeneration else { return }
+            recoveredAutomaticRestartGeneration = snapshot.recoveryGeneration
+            Task { @MainActor [weak self] in
+                await self?.recoverAfterAutomaticRestart(attempt: attempt)
+            }
+        case .exhausted(let attempts, let status):
+            cleanupTerminalDaemonSessionIfNeeded(
+                lifecycleEpoch: snapshot.lifecycleEpoch,
+                terminalState: .crashed(status),
+                terminalStartupPhase: .failed(
+                    "MTPLX crashed repeatedly; automatic recovery stopped after \(attempts) attempts."
+                ),
+                terminalConnectionState: .failed("Automatic restart circuit breaker is open.")
+            )
+        case .idle:
+            // Normal startup phases remain owned by the explicit start path.
+            // Terminal transitions must still mirror so a clean exit becomes
+            // visible as .stopped instead of leaving stale .running chrome.
+            switch snapshot.state {
+            case .stopped:
+                // Observers run outside the supervisor lock, so a newer
+                // terminal snapshot can legitimately arrive before its prior
+                // running snapshot. Lifecycle epochs make this idempotent
+                // without depending on callback arrival order; epoch zero is
+                // only the initial/no-daemon state and must never clear live
+                // store state.
+                guard snapshot.lifecycleEpoch > lastTerminalCleanupLifecycleEpoch
+                else { break }
+                cleanupTerminalDaemonSessionIfNeeded(
+                    lifecycleEpoch: snapshot.lifecycleEpoch,
+                    terminalState: .stopped,
+                    terminalStartupPhase: .idle,
+                    terminalConnectionState: .idle
+                )
+            case .crashed:
+                if case .crashed(let status) = snapshot.state {
+                    cleanupTerminalDaemonSessionIfNeeded(
+                        lifecycleEpoch: snapshot.lifecycleEpoch,
+                        terminalState: .crashed(status),
+                        terminalStartupPhase: .failed("MTPLX crashed and is no longer running."),
+                        terminalConnectionState: .failed("MTPLX crashed and is no longer running.")
+                    )
+                }
+            case .starting, .warming, .running, .degraded, .stopping:
+                break
+            }
+        }
+    }
+
+    private func cleanupTerminalDaemonSessionIfNeeded(
+        lifecycleEpoch: Int,
+        terminalState: DaemonState,
+        terminalStartupPhase: DaemonStartupPhase,
+        terminalConnectionState: MetricsConnectionState
+    ) {
+        let currentSupervisorSnapshot = supervisor.supervisionSnapshot()
+        guard lifecycleEpoch >= currentSupervisorSnapshot.lifecycleEpoch else { return }
+        guard lifecycleEpoch > lastTerminalCleanupLifecycleEpoch else { return }
+        lastTerminalCleanupLifecycleEpoch = lifecycleEpoch
+        // A daemon can exit cleanly or terminally crash without the user
+        // pressing Stop. Mirror the local teardown, but never call
+        // supervisor.stop() here: this is a notification from that supervisor
+        // and re-entry would race it.
+        if activeLaunchID != nil {
+            // This is a terminal supervisor outcome, not an explicit user
+            // Stop. Clear the ID so post-start work can no longer claim the
+            // launch, but do not mark it user-cancelled: a run failure must
+            // still surface as a visible failed/degraded startup.
+            activeLaunchID = nil
+        }
+        let shouldRestoreFans = shouldRestoreFansAfterTerminalExit()
+        let piHandoffsToStop = Array(launchedPiHandoffLeases.values)
+        let hermesHandoffsToStop = Array(launchedHermesHandoffLeases.values)
+        healthWatchTask?.cancel()
+        healthWatchTask = nil
+        streamTask?.cancel()
+        streamTask = nil
+        daemonTransportGeneration &+= 1
+        lateHealthRecoveryTask?.cancel()
+        lateHealthRecoveryTask = nil
+        launchedPiAgentPIDs.removeAll()
+        // Keep exact ownership until the asynchronous terminal gate proves
+        // this remains a true terminal exit. Automatic recovery returns at
+        // that gate, and a later explicit Stop must still be able to reap the
+        // client it originally launched.
+        piTerminalAgentRunning = false
+        piTerminalAgentProcessIDs = []
+        piTerminalLaunchCommand = nil
+        piTerminalLaunchDetail = nil
+        clientHandoffNotice = nil
+        activeClientHandoffID = nil
+        connectionState = terminalConnectionState
+        startupPhase = terminalStartupPhase
+        daemonState = terminalState
+        clearLiveMetricsState()
+
+        // Client terminal handoffs do not automatically exit just because the
+        // daemon did. Reap them through the same serialized path as explicit
+        // Stop, but do not call supervisor.stop(): this method is itself
+        // running in response to that supervisor's termination notification.
+        let previousTeardown = daemonTeardownTask
+        daemonTeardownTask = Task { @MainActor [self] in
+            await previousTeardown?.value
+            // A new lifecycle waits for this teardown before starting. Keep
+            // this second gate for delayed terminal callbacks: an old
+            // callback must never reset a newer daemon's fan policy.
+            let terminalLifecycleIsCurrent = {
+                let latest = self.supervisor.supervisionSnapshot()
+                // A greater epoch has already claimed the store. A smaller
+                // epoch only occurs in synthetic observer-order tests, where
+                // this terminal cleanup remains the most recent real session.
+                guard latest.lifecycleEpoch <= lifecycleEpoch else { return false }
+                guard latest.lifecycleEpoch == lifecycleEpoch else { return true }
+                switch latest.restartStatus {
+                case .scheduled, .restarting, .runningAfterRestart:
+                    return false
+                case .idle, .exhausted:
+                    return true
+                }
+            }
+            guard terminalLifecycleIsCurrent() else { return }
+            if shouldRestoreFans {
+                let restored = await restoreFansLocally(
+                    successLog: "fan profile restored locally after daemon exit",
+                    isCurrent: terminalLifecycleIsCurrent
+                )
+                guard terminalLifecycleIsCurrent() else { return }
+                if !restored {
+                    currentFanMode = nil
+                    await supervisor.logs.append(
+                        "fan restore fallback failed after daemon exit; check ThermalForge status",
+                        stream: .system
+                    )
+                }
+            }
+            // Remove only the snapshot we are about to reap. A new lifecycle
+            // may have acquired a different lease while this teardown waited.
+            for lease in hermesHandoffsToStop {
+                launchedHermesHandoffLeases.removeValue(forKey: lease.handoffID)
+            }
+            for lease in piHandoffsToStop {
+                launchedPiHandoffLeases.removeValue(forKey: lease.handoffID)
+            }
+            let stoppedHermes = hermesHandoffsToStop.reduce(into: 0) { count, lease in
+                if hermesIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
+            if stoppedHermes > 0 {
+                await supervisor.logs.append(
+                    "stopped \(stoppedHermes) Hermes Terminal handoff(s) after daemon exit",
+                    stream: .system
+                )
+            }
+            let stoppedPi = piHandoffsToStop.reduce(into: 0) { count, lease in
+                if piIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
+            if stoppedPi > 0 {
+                await supervisor.logs.append(
+                    "stopped \(stoppedPi) Pi Terminal handoff(s) after daemon exit",
+                    stream: .system
+                )
+            }
+            await refreshLogs()
+        }
+    }
+
+    var hasActiveDaemonTransportForTesting: Bool {
+        streamTask != nil || healthWatchTask != nil
+    }
+
+    /// Records the processes created by the Pi Terminal handoff. Kept as one
+    /// operation so lifecycle cleanup can safely snapshot and reap them.
+    func recordLaunchedPiAgentProcessIDs(_ processIDs: [Int]) {
+        launchedPiAgentPIDs.formUnion(processIDs)
+        piTerminalAgentRunning = !launchedPiAgentPIDs.isEmpty
+        piTerminalAgentProcessIDs = Array(launchedPiAgentPIDs).sorted()
+    }
+
+    /// Registers the real ownership receipt and its presentation PID as one
+    /// operation. Package tests use this narrow seam to exercise lifecycle
+    /// cleanup without inventing a Terminal process discovery fixture.
+    func recordLaunchedPiTerminalHandoffLease(_ lease: MTPLXTerminalHandoffLease) {
+        launchedPiHandoffLeases[lease.handoffID] = lease
+        recordLaunchedPiAgentProcessIDs([lease.processID])
+    }
+
+    /// Hermes has no Pi-style presentation state, but it still needs the
+    /// exact receipt retained across automatic daemon recovery.
+    func recordLaunchedHermesTerminalHandoffLease(_ lease: MTPLXTerminalHandoffLease) {
+        launchedHermesHandoffLeases[lease.handoffID] = lease
+    }
+
+    var terminalHandoffLeaseIDsForTesting: Set<UUID> {
+        Set(launchedPiHandoffLeases.keys).union(launchedHermesHandoffLeases.keys)
+    }
+
+    /// Package tests can exercise transport-failure policy without starting a
+    /// real server just to drive the visible running state.
+    func setDaemonStateForTesting(_ state: DaemonState) {
+        daemonState = state
+    }
+
+    private func recoverAfterAutomaticRestart(attempt: Int) async {
+        let snapshot = supervisor.supervisionSnapshot()
+        guard case .runningAfterRestart(let activeAttempt) = snapshot.restartStatus,
+              activeAttempt == attempt,
+              snapshot.lifecycleEpoch > 0
+        else { return }
+        await supervisor.logs.append(
+            "app observed automatic daemon recovery (attempt \(attempt)); reconnecting metrics",
+            stream: .system
+        )
+        // The supervisor has already passed its restart health check. One
+        // immediate refresh miss is not confirmation that this daemon died;
+        // the normal watchdog owns that decision with its two-miss policy.
+        await beforePostStartRefresh()
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: snapshot.lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: snapshot.recoveryGeneration
+        ) else { return }
+        _ = await refreshPostStartState(
+            target: lastDaemonTarget,
+            configuration: configuration,
+            lifecycleEpoch: snapshot.lifecycleEpoch,
+            recoveryGeneration: snapshot.recoveryGeneration
+        )
+        await refreshLogs()
     }
 
     public func markDaemonUnreachable(reason: String) {
@@ -1748,6 +2122,7 @@ public final class MTPLXBackendStore: ObservableObject {
 
     private func startDaemonHealthWatchdog() {
         healthWatchTask?.cancel()
+        let watchdogTransportGeneration = daemonTransportGeneration
         let probeClient = MTPLXAPIClient.livenessProbe(
             baseURL: baseURL,
             apiKey: configuration.apiKey
@@ -1759,13 +2134,18 @@ public final class MTPLXBackendStore: ObservableObject {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
                 guard let self, !Task.isCancelled else { return }
+                guard self.daemonTransportGeneration == watchdogTransportGeneration else { return }
                 guard self.shouldProbeDaemonHealth else {
                     consecutiveMisses = 0
                     continue
                 }
-                switch await probeClient.livenessWithinDeadline(
+                let liveness = await probeClient.livenessWithinDeadline(
                     seconds: Self.watchdogProbeDeadlineSeconds
-                ) {
+                )
+                guard !Task.isCancelled,
+                      self.daemonTransportGeneration == watchdogTransportGeneration
+                else { return }
+                switch liveness {
                 case .healthy(let health) where health.ok:
                     consecutiveMisses = 0
                     self.health = health
@@ -1783,6 +2163,7 @@ public final class MTPLXBackendStore: ObservableObject {
                     // because one /health field stopped matching Codable).
                     consecutiveMisses = 0
                     if !loggedUndecodable {
+                        guard self.daemonTransportGeneration == watchdogTransportGeneration else { return }
                         loggedUndecodable = true
                         let excerpt = String(detail.prefix(300))
                         await self.supervisor.logs.append(
@@ -1796,6 +2177,7 @@ public final class MTPLXBackendStore: ObservableObject {
                     // configuration problem, never grounds to reap.
                     consecutiveMisses = 0
                     if !loggedUndecodable {
+                        guard self.daemonTransportGeneration == watchdogTransportGeneration else { return }
                         loggedUndecodable = true
                         await self.supervisor.logs.append(
                             "health probe rejected with 401/403; daemon is alive, check the API key in Settings",
@@ -1808,6 +2190,7 @@ public final class MTPLXBackendStore: ObservableObject {
                 }
                 consecutiveMisses += 1
                 guard consecutiveMisses >= 2 else { continue }
+                guard self.daemonTransportGeneration == watchdogTransportGeneration else { return }
                 self.markDaemonUnreachableIfNeeded(
                     reason: "MTPLX lost contact with the model server. Start it again."
                 )
@@ -2266,32 +2649,51 @@ public final class MTPLXBackendStore: ObservableObject {
     /// pre-set the mode so the UI flips immediately; on failure
     /// `currentFanMode` is rolled back to the previous state.
     public func setFanMode(_ mode: String) async throws {
+        try await setFanMode(mode, isCurrent: nil)
+    }
+
+    /// Lifecycle-scoped variant used only by post-start verification.  The
+    /// public fan control intentionally remains usable outside a daemon
+    /// lifecycle; this path must instead discard a late API result rather
+    /// than persisting or rolling back over newer settings.
+    func setFanMode(
+        _ mode: String,
+        isCurrent: (() -> Bool)?
+    ) async throws {
+        guard isCurrent?() ?? true else { return }
         let previous = currentFanMode
         let previousConfiguration = configuration
         let fanMode = MTPLXFanMode.normalized(mode)
         let canonicalMode = fanMode.rawValue
         if !canApplyFanModeLive {
+            guard isCurrent?() ?? true else { return }
             var next = configuration
             next.fanMode = canonicalMode
             next.pinFansAtMaxOnStart = fanMode == .max
+            guard isCurrent?() ?? true else { return }
             try saveSettings(next)
+            guard isCurrent?() ?? true else { return }
             currentFanMode = nil
             fanRestoreRequiredOnStop = false
             return
         }
         do {
-            let result = try await apiClient.setFanMode(
+            let result = try await fanModeSetter(
+                apiClient,
                 canonicalMode,
-                requireActualRamp: fanMode == .max,
-                timeoutS: fanMode == .max ? 25 : nil
+                fanMode == .max,
+                fanMode == .max ? 25 : nil
             )
+            guard isCurrent?() ?? true else { return }
             currentFanMode = MTPLXFanMode.normalized(result.currentMode ?? canonicalMode).rawValue
             fanRestoreRequiredOnStop = modeRequiresFanRestore(currentFanMode)
             var next = configuration
             next.fanMode = currentFanMode ?? canonicalMode
             next.pinFansAtMaxOnStart = MTPLXFanMode.normalized(next.fanMode) == .max
+            guard isCurrent?() ?? true else { return }
             try saveSettings(next)
         } catch {
+            guard isCurrent?() ?? true else { return }
             currentFanMode = previous
             configuration = previousConfiguration
             throw error
@@ -2300,9 +2702,12 @@ public final class MTPLXBackendStore: ObservableObject {
 
     /// Pull thermal detection + current mode + fan summary. Used after
     /// daemon start so `FanModeToggle` can decide whether to render.
-    public func refreshThermalStatus() async {
-        thermalStatus = try? await apiClient.thermalStatus()
-        if let mode = thermalStatus?.values["current_mode"]?.stringValue, !mode.isEmpty {
+    public func refreshThermalStatus(isCurrent: (() -> Bool)? = nil) async {
+        await beforeThermalStatusRefresh()
+        let fetchedThermalStatus = try? await apiClient.thermalStatus()
+        guard isCurrent?() ?? true else { return }
+        thermalStatus = fetchedThermalStatus
+        if let mode = fetchedThermalStatus?.values["current_mode"]?.stringValue, !mode.isEmpty {
             currentFanMode = MTPLXFanMode.normalized(mode).rawValue
             fanRestoreRequiredOnStop = modeRequiresFanRestore(currentFanMode)
         }
@@ -2335,9 +2740,38 @@ public final class MTPLXBackendStore: ObservableObject {
         }
     }
 
+    /// Passive terminal cleanup must restore a verified or configured max
+    /// startup ramp too. Unlike an explicit Stop, do not infer this from the
+    /// default smart preference alone: no daemon-owned max ramp may have
+    /// happened in that case, and a terminal callback must not create a new
+    /// hardware side effect just because the app exited.
+    private func shouldRestoreFansAfterTerminalExit() -> Bool {
+        if fanRestoreRequiredOnStop || modeRequiresFanRestore(currentFanMode) {
+            return true
+        }
+        if health?.thermal?.actualRampVerified == true {
+            return true
+        }
+        if let mode = thermalStatus?.values["current_mode"]?.stringValue?.lowercased(),
+           mode == "max" || mode == "performance" {
+            return true
+        }
+        // This also covers a stale post-start fan response that physically
+        // succeeded but was intentionally not allowed to mutate store state.
+        return requiresStartupFanRamp(configuration)
+    }
+
     @discardableResult
-    private func restoreFansLocally(successLog: String) async -> Bool {
+    private func restoreFansLocally(
+        successLog: String,
+        isCurrent: (() -> Bool)? = nil
+    ) async -> Bool {
+        guard isCurrent?() ?? true else { return false }
         let restored = await localFanRestorer()
+        // The physical restore may have completed while a newer daemon was
+        // starting. Do not let this terminal lifecycle change its fan state,
+        // warning, or log presentation after that handoff.
+        guard isCurrent?() ?? true else { return false }
         if restored {
             fanRestoreRequiredOnStop = false
             currentFanMode = MTPLXFanMode.default.rawValue
@@ -2479,155 +2913,461 @@ public final class MTPLXBackendStore: ObservableObject {
         )
     }
 
-    private func finishReadyDaemon(
+    func finishReadyDaemon(
         target: LaunchTarget?,
         configuration: MTPLXAppConfiguration,
-        replaceExistingClient: Bool
+        replaceExistingClient: Bool,
+        launchID: String?,
+        lifecycleEpoch: Int
     ) async {
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: launchID,
+            recoveryGeneration: nil
+        ) else { return }
         daemonState = .running
         startupPhase = .ready
-        await launchClientHandoff(
+        let handoffCompleted = await launchClientHandoff(
             target: target,
             configuration: configuration,
-            replaceExisting: replaceExistingClient
+            replaceExisting: replaceExistingClient,
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: launchID
         )
-        await refreshPostStartState(target: target, configuration: configuration)
+        guard handoffCompleted else { return }
+        await beforePostStartRefresh()
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: launchID,
+            recoveryGeneration: nil
+        ) else { return }
+        _ = await refreshPostStartState(
+            target: target,
+            configuration: configuration,
+            lifecycleEpoch: lifecycleEpoch,
+            recoveryGeneration: nil
+        )
     }
 
     private func launchClientHandoff(
         target: LaunchTarget?,
         configuration: MTPLXAppConfiguration,
-        replaceExisting: Bool
-    ) async {
-        if target == .hermes {
-            await launchHermesTerminalHandoff(
-                configuration: configuration,
-                replaceExisting: replaceExisting
+        replaceExisting: Bool,
+        lifecycleEpoch: Int,
+        launchID: String?
+    ) async -> Bool {
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: launchID,
+            recoveryGeneration: nil
+        ) else { return false }
+        let isCurrent = {
+            self.daemonSessionIsCurrent(
+                lifecycleEpoch: lifecycleEpoch,
+                launchID: launchID,
+                recoveryGeneration: nil
             )
         }
+        if target == .hermes {
+            let handoffID = UUID()
+            guard await launchHermesTerminalHandoff(
+                configuration: configuration,
+                replaceExisting: replaceExisting,
+                isCurrent: isCurrent,
+                handoffID: handoffID
+            ) else { return false }
+        }
         if target == .openCode {
-            let desktop = await openCodeIntegration.reloadDesktopAfterDaemonReady()
-            clientHandoffNotice = ClientHandoffNotice.openCode(result: desktop)
+            let handoffID = UUID()
+            guard isCurrent() else { return false }
+            await beforeClientHandoffLaunch(.openCode)
+            guard isCurrent() else { return false }
+            let desktop = await openCodeIntegration.reloadDesktopAfterDaemonReady(isCurrent: isCurrent)
+            guard continueOpenCodeHandoff(desktop, handoffID: handoffID, isCurrent: isCurrent) else {
+                return false
+            }
+            let notice = ClientHandoffNotice.openCode(result: desktop)
+            guard continueOpenCodeHandoff(desktop, handoffID: handoffID, isCurrent: isCurrent) else {
+                return false
+            }
+            clientHandoffNotice = notice
+            activeClientHandoffID = handoffID
+            guard continueOpenCodeHandoff(desktop, handoffID: handoffID, isCurrent: isCurrent) else {
+                return false
+            }
             await supervisor.logs.append(
                 "OpenCode Desktop handoff \(desktop.action.rawValue): \(desktop.detail)",
                 stream: .system
             )
+            guard continueOpenCodeHandoff(desktop, handoffID: handoffID, isCurrent: isCurrent) else {
+                return false
+            }
         }
         if target == .pi {
-            await launchPiTerminalHandoff(
+            let handoffID = UUID()
+            guard await launchPiTerminalHandoff(
                 configuration: configuration,
-                replaceExisting: replaceExisting
-            )
+                replaceExisting: replaceExisting,
+                isCurrent: isCurrent,
+                handoffID: handoffID
+            ) else { return false }
         }
+        guard isCurrent() else { return false }
         onDaemonReady?(target)
+        return isCurrent()
     }
 
     private func refreshPostStartState(
         target: LaunchTarget?,
-        configuration: MTPLXAppConfiguration
-    ) async {
+        configuration: MTPLXAppConfiguration,
+        lifecycleEpoch: Int,
+        recoveryGeneration: Int?
+    ) async -> Bool {
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        ) else { return false }
         do {
-            try await refreshStaticState()
+            try await refreshStaticState(isCurrent: {
+                self.daemonSessionIsCurrent(
+                    lifecycleEpoch: lifecycleEpoch,
+                    launchID: nil,
+                    recoveryGeneration: recoveryGeneration
+                )
+            }, markUnreachableOnTransportFailure: recoveryGeneration == nil)
         } catch {
             await supervisor.logs.append(
                 "post-start state refresh failed: \(String(describing: error))",
                 stream: .system
             )
         }
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        ) else { return false }
         do {
-            try await flushFreshLaunchLiveOnlySettingsIfNeeded()
+            try await flushFreshLaunchLiveOnlySettingsIfNeeded(isCurrent: {
+                self.daemonSessionIsCurrent(
+                    lifecycleEpoch: lifecycleEpoch,
+                    launchID: nil,
+                    recoveryGeneration: recoveryGeneration
+                )
+            })
         } catch {
             await supervisor.logs.append(
                 "post-start settings sync failed: \(String(describing: error))",
                 stream: .system
             )
         }
-        startMetricsStream()
-        await refreshThermalStatus()
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        ) else { return false }
+        guard await startMetricsAndRefreshThermal(
+            lifecycleEpoch: lifecycleEpoch,
+            recoveryGeneration: recoveryGeneration
+        ) else { return false }
         do {
-            try await verifyPinnedFansAfterStartup(configuration: configuration)
+            try await verifyPinnedFansAfterStartup(
+                configuration: configuration,
+                isCurrent: {
+                    self.daemonSessionIsCurrent(
+                        lifecycleEpoch: lifecycleEpoch,
+                        launchID: nil,
+                        recoveryGeneration: recoveryGeneration
+                    )
+                }
+            )
         } catch {
+            guard daemonSessionIsCurrent(
+                lifecycleEpoch: lifecycleEpoch,
+                launchID: nil,
+                recoveryGeneration: recoveryGeneration
+            ) else { return false }
             startupPhase = .ready
             await supervisor.logs.append(
                 "post-start fan verification failed: \(String(describing: error))",
                 stream: .system
             )
         }
+        return daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        )
     }
 
-    private func verifyPinnedFansAfterStartup(configuration: MTPLXAppConfiguration) async throws {
+    func startMetricsAndRefreshThermal(
+        lifecycleEpoch: Int,
+        recoveryGeneration: Int?
+    ) async -> Bool {
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        ) else { return false }
+        startMetricsStream()
+        let startedTransportGeneration = daemonTransportGeneration
+        await refreshThermalStatus(isCurrent: {
+            self.daemonSessionIsCurrent(
+                lifecycleEpoch: lifecycleEpoch,
+                launchID: nil,
+                recoveryGeneration: recoveryGeneration
+            )
+        })
+        guard daemonSessionIsCurrent(
+            lifecycleEpoch: lifecycleEpoch,
+            launchID: nil,
+            recoveryGeneration: recoveryGeneration
+        ) else {
+            // A newer lifecycle may have started its own stream while this
+            // lifecycle awaited thermal status. Only cancel the stream whose
+            // generation we created.
+            if daemonTransportGeneration == startedTransportGeneration {
+                streamTask?.cancel()
+                streamTask = nil
+                daemonTransportGeneration &+= 1
+            }
+            return false
+        }
+        return true
+    }
+
+    private func daemonSessionIsCurrent(
+        lifecycleEpoch: Int,
+        launchID: String?,
+        recoveryGeneration: Int?
+    ) -> Bool {
+        let snapshot = supervisor.supervisionSnapshot()
+        guard snapshot.lifecycleEpoch == lifecycleEpoch,
+              snapshot.state == .running
+        else { return false }
+        if let launchID,
+           (activeLaunchID != launchID || cancelledLaunchIDs.contains(launchID)) {
+            return false
+        }
+        if let recoveryGeneration,
+           snapshot.recoveryGeneration != recoveryGeneration {
+            return false
+        }
+        return true
+    }
+
+    private func verifyPinnedFansAfterStartup(
+        configuration: MTPLXAppConfiguration,
+        isCurrent: @escaping () -> Bool
+    ) async throws {
         guard requiresStartupFanRamp(configuration) else { return }
+        guard isCurrent() else { return }
         startupPhase = .rampingFans
-        try await setFanMode(MTPLXFanMode.max.rawValue)
-        await refreshThermalStatus()
+        try await setFanMode(MTPLXFanMode.max.rawValue, isCurrent: isCurrent)
+        guard isCurrent() else { return }
+        await refreshThermalStatus(isCurrent: isCurrent)
+        guard isCurrent() else { return }
         startupPhase = .ready
     }
 
     private func launchHermesTerminalHandoff(
         configuration: MTPLXAppConfiguration,
-        replaceExisting: Bool
-    ) async {
+        replaceExisting: Bool,
+        isCurrent: @escaping () -> Bool,
+        handoffID: UUID
+    ) async -> Bool {
+        guard isCurrent() else { return false }
         if replaceExisting {
-            let stopped = hermesIntegration.stopLaunchedTerminalAgents()
+            let stopped = launchedHermesHandoffLeases.values.reduce(into: 0) { count, lease in
+                if hermesIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
+            launchedHermesHandoffLeases.removeAll()
+            guard isCurrent() else { return false }
             if stopped > 0 {
+                guard isCurrent() else { return false }
                 await supervisor.logs.append(
                     "stopped \(stopped) previous Hermes Terminal handoff(s)",
                     stream: .system
                 )
+                guard isCurrent() else { return false }
             }
-        } else if hermesIntegration.hasLaunchedTerminalAgent() {
-            return
+        } else if !launchedHermesHandoffLeases.isEmpty {
+            return isCurrent()
         }
 
         // Desktop-first (2026-07-16): the built Hermes Desktop app is the
         // default handoff, matching the OpenCode card's flow; CLI-only
         // installs keep the Terminal path.
-        let launch = await hermesIntegration.launch(configuration: configuration)
-        clientHandoffNotice = ClientHandoffNotice.hermes(result: launch)
+        guard isCurrent() else { return false }
+        await beforeClientHandoffLaunch(.hermes)
+        guard isCurrent() else { return false }
+        let launch = await hermesIntegration.launch(
+            configuration: configuration,
+            isCurrent: isCurrent
+        )
+        guard isCurrent() else {
+            reapStaleHermesHandoff(launch, handoffID: handoffID)
+            return false
+        }
+        if let lease = launch.terminalHandoffLease {
+            recordLaunchedHermesTerminalHandoffLease(lease)
+        }
+        if let notice = ClientHandoffNotice.hermes(result: launch) {
+            guard isCurrent() else {
+                reapStaleHermesHandoff(launch, handoffID: handoffID)
+                return false
+            }
+            clientHandoffNotice = notice
+            activeClientHandoffID = handoffID
+        }
+        guard isCurrent() else {
+            reapStaleHermesHandoff(launch, handoffID: handoffID)
+            return false
+        }
         await supervisor.logs.append(
             "Hermes handoff \(launch.action.rawValue): \(launch.detail)",
             stream: .system
         )
+        guard isCurrent() else {
+            reapStaleHermesHandoff(launch, handoffID: handoffID)
+            return false
+        }
+        return true
     }
 
     private func launchPiTerminalHandoff(
         configuration: MTPLXAppConfiguration,
-        replaceExisting: Bool
-    ) async {
-        if replaceExisting && !launchedPiAgentPIDs.isEmpty {
-            let stopped = piIntegration.stopLaunchedAgents(processIDs: Array(launchedPiAgentPIDs))
+        replaceExisting: Bool,
+        isCurrent: @escaping () -> Bool,
+        handoffID: UUID
+    ) async -> Bool {
+        guard isCurrent() else { return false }
+        if replaceExisting && !launchedPiHandoffLeases.isEmpty {
+            let stopped = launchedPiHandoffLeases.values.reduce(into: 0) { count, lease in
+                if piIntegration.cancelTerminalHandoff(lease) { count += 1 }
+            }
+            launchedPiHandoffLeases.removeAll()
             launchedPiAgentPIDs.removeAll()
             piTerminalAgentRunning = false
             piTerminalAgentProcessIDs = []
             if stopped > 0 {
+                guard isCurrent() else { return false }
                 await supervisor.logs.append(
                     "stopped \(stopped) previous Pi Terminal handoff(s)",
                     stream: .system
                 )
+                guard isCurrent() else { return false }
             }
-        } else if !replaceExisting && !launchedPiAgentPIDs.isEmpty {
-            return
+        } else if !replaceExisting && !launchedPiHandoffLeases.isEmpty {
+            return isCurrent()
         }
 
-        let launch = piIntegration.launchInTerminal(configuration: configuration)
-        launchedPiAgentPIDs.formUnion(launch.launchedProcessIDs)
-        piTerminalAgentRunning = !launchedPiAgentPIDs.isEmpty
-        piTerminalAgentProcessIDs = Array(launchedPiAgentPIDs).sorted()
+        guard isCurrent() else { return false }
+        await beforeClientHandoffLaunch(.pi)
+        guard isCurrent() else { return false }
+        let launch = await piIntegration.launchInTerminal(
+            configuration: configuration,
+            isCurrent: isCurrent
+        )
+        guard isCurrent() else {
+            reapStalePiHandoff(launch, handoffID: handoffID)
+            return false
+        }
+        if let lease = launch.terminalHandoffLease {
+            recordLaunchedPiTerminalHandoffLease(lease)
+        }
+        if launch.terminalHandoffLease == nil {
+            recordLaunchedPiAgentProcessIDs(launch.launchedProcessIDs)
+        }
         piTerminalLaunchCommand = launch.command
         piTerminalLaunchDetail = launch.detail
         clientHandoffNotice = ClientHandoffNotice.pi(result: launch)
+        activeClientHandoffID = handoffID
+        guard isCurrent() else {
+            reapStalePiHandoff(launch, handoffID: handoffID)
+            return false
+        }
         await supervisor.logs.append(
             "Pi handoff \(launch.action.rawValue): \(launch.detail)",
             stream: .system
         )
+        guard isCurrent() else {
+            reapStalePiHandoff(launch, handoffID: handoffID)
+            return false
+        }
+        return true
     }
 
-    public func refreshPrefillHistory() async {
-        prefillHistory = try? await apiClient.prefillHistory()
+    private func clearClientHandoffNotice(for handoffID: UUID) {
+        guard activeClientHandoffID == handoffID else { return }
+        clientHandoffNotice = nil
+        activeClientHandoffID = nil
     }
 
-    public func refreshModels() async {
-        models = try? await apiClient.models()
+    private func reapStaleHermesHandoff(
+        _ launch: HermesLaunchResult,
+        handoffID: UUID
+    ) {
+        if let lease = launch.terminalHandoffLease {
+            _ = hermesIntegration.cancelTerminalHandoff(lease)
+            launchedHermesHandoffLeases.removeValue(forKey: lease.handoffID)
+        } else if let identity = launch.desktopHandoffIdentity {
+            _ = hermesIntegration.cancelLaunchedDesktop(identity)
+        }
+        clearClientHandoffNotice(for: handoffID)
+    }
+
+    @discardableResult
+    func continueOpenCodeHandoff(
+        _ launch: OpenCodeDesktopResult,
+        handoffID: UUID,
+        isCurrent: () -> Bool
+    ) -> Bool {
+        guard isCurrent() else {
+            reapStaleOpenCodeHandoff(launch, handoffID: handoffID)
+            return false
+        }
+        return true
+    }
+
+    private func reapStaleOpenCodeHandoff(
+        _ launch: OpenCodeDesktopResult,
+        handoffID: UUID
+    ) {
+        if let identity = launch.launchedDesktopIdentity {
+            _ = cancelOpenCodeDesktop(identity)
+        }
+        clearClientHandoffNotice(for: handoffID)
+    }
+
+    private func reapStalePiHandoff(
+        _ launch: PiLaunchResult,
+        handoffID: UUID
+    ) {
+        if let lease = launch.terminalHandoffLease {
+            _ = piIntegration.cancelTerminalHandoff(lease)
+            launchedPiHandoffLeases.removeValue(forKey: lease.handoffID)
+            launchedPiAgentPIDs.remove(lease.processID)
+        }
+        piTerminalAgentRunning = !launchedPiAgentPIDs.isEmpty
+        piTerminalAgentProcessIDs = Array(launchedPiAgentPIDs).sorted()
+        if activeClientHandoffID == handoffID {
+            piTerminalLaunchCommand = nil
+            piTerminalLaunchDetail = nil
+            clearClientHandoffNotice(for: handoffID)
+        }
+    }
+
+    public func refreshPrefillHistory(isCurrent: (() -> Bool)? = nil) async {
+        let fetchedPrefillHistory = try? await apiClient.prefillHistory()
+        guard isCurrent?() ?? true else { return }
+        prefillHistory = fetchedPrefillHistory
+    }
+
+    public func refreshModels(isCurrent: (() -> Bool)? = nil) async {
+        let fetchedModels = try? await apiClient.models()
+        guard isCurrent?() ?? true else { return }
+        models = fetchedModels
     }
 
     /// Up-to-date `MTPLXAPIClient` derived from the current
@@ -2675,10 +3415,13 @@ public final class MTPLXBackendStore: ObservableObject {
                 self.currentFanMode = self.verifiedFanMode(from: recoveredHealth)
                 self.fanRestoreRequiredOnStop = self.fanRestoreRequiredOnStop
                     || self.modeRequiresFanRestore(self.currentFanMode)
+                let lifecycleEpoch = self.supervisor.supervisionSnapshot().lifecycleEpoch
                 await self.finishReadyDaemon(
                     target: target,
                     configuration: self.configuration,
-                    replaceExistingClient: true
+                    replaceExistingClient: true,
+                    launchID: nil,
+                    lifecycleEpoch: lifecycleEpoch
                 )
             } catch {
                 guard !Task.isCancelled else { return }

--- a/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Tabs/SettingsTab.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Tabs/SettingsTab.swift
@@ -1050,6 +1050,18 @@ struct SettingsTab: View {
                     isOn: $draftConfig.launchDaemonOnOpen
                 )
 
+                FormToggleRow(
+                    label: "Restart this session's MTPLX after a crash",
+                    caption: "Applies to daemons launched after enabling this setting. Retries up to three times with backoff; Stop cancels pending retries.",
+                    isOn: $draftConfig.automaticDaemonRestart
+                )
+                if let restartStatusText {
+                    Text(restartStatusText)
+                        .font(.caption)
+                        .foregroundStyle(Brand.typeTertiary)
+                        .padding(.leading, 200)
+                }
+
                 Divider().overlay(Brand.separator).padding(.vertical, 4)
 
                 streamCadenceRow
@@ -1059,6 +1071,29 @@ struct SettingsTab: View {
 
     private var settingsFilePathHint: String {
         backend.settingsURL.path
+    }
+
+    private var restartStatusText: String? {
+        switch backend.daemonRestartStatus {
+        case .idle:
+            guard draftConfig.automaticDaemonRestart else { return nil }
+            switch backend.daemonRestartEligibility {
+            case .adoptedPriorSession:
+                return "This adopted prior-session daemon is not protected. Start a fresh daemon."
+            case .currentSessionUnprotected:
+                return "This daemon was launched before restart protection was enabled. Start a fresh daemon."
+            case .noDaemon, .currentSessionProtected:
+                return nil
+            }
+        case .scheduled(let attempt, let delay):
+            return "Restart \(attempt) scheduled in \(String(format: "%.1f", delay))s."
+        case .restarting(let attempt):
+            return "Restarting MTPLX (attempt \(attempt))."
+        case .runningAfterRestart(let attempt):
+            return "Recovered automatically on restart \(attempt)."
+        case .exhausted(let attempts, _):
+            return "Automatic recovery stopped after \(attempts) attempts."
+        }
     }
 
     private func chooseHermesWorkspace() {

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/DaemonSupervisorTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/DaemonSupervisorTests.swift
@@ -1693,7 +1693,7 @@ final class DaemonSupervisorTests: XCTestCase {
                 arguments: ["-c", script]
             ),
             healthBaseURL: URL(string: "http://127.0.0.1:9")!,
-            apiKey: "secret-that-must-not-outlive-the-session",
+            apiKey: "test-api-key",
             probeHealth: false
         )
         supervisor.setStatusObserver { snapshot in

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/DaemonSupervisorTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/DaemonSupervisorTests.swift
@@ -1,0 +1,2038 @@
+import Foundation
+import Darwin
+import XCTest
+@testable import MTPLXAppCore
+
+private actor SupervisionSignal {
+    private enum WaitKind: Sendable {
+        case scheduled
+        case exhausted
+        case stopped
+        case crashed
+        case warming
+        case stopping
+    }
+
+    private var latest = DaemonSupervisionSnapshot(
+        state: .stopped,
+        restartStatus: .idle,
+        restartCount: 0,
+        recoveryGeneration: 0
+    )
+    private var sawNonStoppedState = false
+    private var scheduledWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var exhaustedWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var stoppedWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var crashedWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var warmingWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var stoppingWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var recoveryWaiters: [UUID: (target: Int, continuation: CheckedContinuation<Bool, Never>)] = [:]
+
+    func record(_ snapshot: DaemonSupervisionSnapshot) {
+        latest = snapshot
+        if snapshot.state != .stopped {
+            sawNonStoppedState = true
+        }
+        if case .scheduled = snapshot.restartStatus {
+            scheduledWaiters.values.forEach { $0.resume(returning: true) }
+            scheduledWaiters.removeAll()
+        }
+        if case .exhausted = snapshot.restartStatus {
+            exhaustedWaiters.values.forEach { $0.resume(returning: true) }
+            exhaustedWaiters.removeAll()
+        }
+        if sawNonStoppedState, snapshot.state == .stopped {
+            stoppedWaiters.values.forEach { $0.resume(returning: true) }
+            stoppedWaiters.removeAll()
+        }
+        if case .crashed = snapshot.state {
+            crashedWaiters.values.forEach { $0.resume(returning: true) }
+            crashedWaiters.removeAll()
+        }
+        if snapshot.state == .warming {
+            warmingWaiters.values.forEach { $0.resume(returning: true) }
+            warmingWaiters.removeAll()
+        }
+        if snapshot.state == .stopping {
+            stoppingWaiters.values.forEach { $0.resume(returning: true) }
+            stoppingWaiters.removeAll()
+        }
+        let reachedRecovery = recoveryWaiters.filter {
+            snapshot.recoveryGeneration >= $0.value.target
+        }
+        reachedRecovery.values.forEach { $0.continuation.resume(returning: true) }
+        reachedRecovery.keys.forEach { recoveryWaiters.removeValue(forKey: $0) }
+    }
+
+    func waitForScheduled() async -> Bool {
+        if case .scheduled = latest.restartStatus { return true }
+        return await wait(kind: .scheduled)
+    }
+
+    func waitForExhausted() async -> Bool {
+        if case .exhausted = latest.restartStatus { return true }
+        return await wait(kind: .exhausted)
+    }
+
+    func waitForStoppedAfterLaunch() async -> Bool {
+        if sawNonStoppedState, latest.state == .stopped { return true }
+        return await wait(kind: .stopped)
+    }
+
+    func waitForCrash() async -> Bool {
+        if case .crashed = latest.state { return true }
+        return await wait(kind: .crashed)
+    }
+
+    func waitForWarming() async -> Bool {
+        if latest.state == .warming { return true }
+        return await wait(kind: .warming)
+    }
+
+    func waitForStopping() async -> Bool {
+        if latest.state == .stopping { return true }
+        return await wait(kind: .stopping)
+    }
+
+    func waitForRecoveryGeneration(_ target: Int) async -> Bool {
+        if latest.recoveryGeneration >= target { return true }
+        let id = UUID()
+        return await withCheckedContinuation { continuation in
+            recoveryWaiters[id] = (target, continuation)
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                await self?.timeoutRecovery(id)
+            }
+        }
+    }
+
+    private func wait(kind: WaitKind) async -> Bool {
+        let id = UUID()
+        return await withCheckedContinuation { continuation in
+            switch kind {
+            case .scheduled: scheduledWaiters[id] = continuation
+            case .exhausted: exhaustedWaiters[id] = continuation
+            case .stopped: stoppedWaiters[id] = continuation
+            case .crashed: crashedWaiters[id] = continuation
+            case .warming: warmingWaiters[id] = continuation
+            case .stopping: stoppingWaiters[id] = continuation
+            }
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                await self?.timeout(id, kind: kind)
+            }
+        }
+    }
+
+    private func timeout(_ id: UUID, kind: WaitKind) {
+        let continuation: CheckedContinuation<Bool, Never>?
+        switch kind {
+        case .scheduled: continuation = scheduledWaiters.removeValue(forKey: id)
+        case .exhausted: continuation = exhaustedWaiters.removeValue(forKey: id)
+        case .stopped: continuation = stoppedWaiters.removeValue(forKey: id)
+        case .crashed: continuation = crashedWaiters.removeValue(forKey: id)
+        case .warming: continuation = warmingWaiters.removeValue(forKey: id)
+        case .stopping: continuation = stoppingWaiters.removeValue(forKey: id)
+        }
+        continuation?.resume(returning: false)
+    }
+
+    private func timeoutRecovery(_ id: UUID) {
+        recoveryWaiters.removeValue(forKey: id)?.continuation.resume(returning: false)
+    }
+}
+
+private actor RestartGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor BeforeRunGate {
+    private var armed = false
+    private var didEnter = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func arm() {
+        armed = true
+        didEnter = false
+    }
+
+    func waitIfArmed() async {
+        guard armed else { return }
+        armed = false
+        didEnter = true
+        let entered = enteredWaiters
+        enteredWaiters.removeAll()
+        entered.forEach { $0.resume() }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        if didEnter { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+private actor RestartDelayRecorder {
+    private var values: [TimeInterval] = []
+
+    func record(_ delay: TimeInterval) {
+        values.append(delay)
+    }
+
+    func snapshot() -> [TimeInterval] {
+        values
+    }
+}
+
+private final class TerminationGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var armed = false
+    private let entered = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+
+    func arm() {
+        lock.lock()
+        armed = true
+        lock.unlock()
+    }
+
+    func blockIfArmed() {
+        lock.lock()
+        let shouldBlock = armed
+        lock.unlock()
+        guard shouldBlock else { return }
+        entered.signal()
+        _ = release.wait(timeout: .now() + 5)
+    }
+
+    func waitUntilEntered() -> Bool {
+        entered.wait(timeout: .now() + 1) == .success
+    }
+
+    func unblock() {
+        release.signal()
+    }
+}
+
+private actor FanRestoreRecorder {
+    private var calls = 0
+
+    func restore() -> Bool {
+        calls += 1
+        return true
+    }
+
+    func count() -> Int { calls }
+}
+
+private actor HealthProbeGate {
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var responseContinuation: CheckedContinuation<HealthPayload?, Never>?
+
+    func waitForResponse() async -> HealthPayload? {
+        let entered = enteredWaiters
+        enteredWaiters.removeAll()
+        entered.forEach { $0.resume() }
+        return await withCheckedContinuation { responseContinuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release(_ health: HealthPayload?) {
+        responseContinuation?.resume(returning: health)
+        responseContinuation = nil
+    }
+}
+
+/// Returns a ready health payload for the initial launch, then holds the
+/// automatic retry inside its health wait until the test releases it.
+private actor AutomaticRetryHealthGate {
+    private let readyHealth: HealthPayload
+    private var calls = 0
+    private var secondProbeWaiters: [CheckedContinuation<Void, Never>] = []
+    private var responseContinuation: CheckedContinuation<HealthPayload?, Never>?
+
+    init(readyHealth: HealthPayload) {
+        self.readyHealth = readyHealth
+    }
+
+    func probe() async -> HealthPayload? {
+        calls += 1
+        if calls == 1 {
+            return readyHealth
+        }
+        let waiters = secondProbeWaiters
+        secondProbeWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        return await withCheckedContinuation { responseContinuation = $0 }
+    }
+
+    func waitUntilAutomaticRetryProbe() async {
+        guard calls >= 2 else {
+            await withCheckedContinuation { secondProbeWaiters.append($0) }
+            return
+        }
+    }
+
+    func release(_ health: HealthPayload? = nil) {
+        responseContinuation?.resume(returning: health)
+        responseContinuation = nil
+    }
+}
+
+final class DaemonSupervisorTests: XCTestCase {
+    private func releaseControlledCommand(
+        releaseFile: URL,
+        exitStatus: Int32
+    ) -> DaemonCommand {
+        let path = shellQuoted(releaseFile.path)
+        return DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "while [ -e \(path) ]; do sleep 0.01; done; exit \(exitStatus)"]
+        )
+    }
+
+    private func shellQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\\"'\\\"'"))'"
+    }
+
+    private func temporaryReleaseFile() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let release = directory.appendingPathComponent("hold")
+        try Data().write(to: release)
+        return release
+    }
+
+    private func automaticRetryParentChildCommand(
+        releaseFile: URL,
+        counterFile: URL,
+        parentPIDFile: URL,
+        childPIDFile: URL
+    ) -> DaemonCommand {
+        let release = shellQuoted(releaseFile.path)
+        let counter = shellQuoted(counterFile.path)
+        let parent = shellQuoted(parentPIDFile.path)
+        let child = shellQuoted(childPIDFile.path)
+        let script = """
+        count=$(cat \(counter) 2>/dev/null || echo 0)
+        count=$((count + 1))
+        echo "$count" > \(counter)
+        if [ "$count" -eq 1 ]; then
+          while [ -e \(release) ]; do sleep 0.01; done
+          exit 17
+        fi
+        (trap 'exit 0' TERM INT; while :; do sleep 1; done) &
+        child_pid=$!
+        echo "$$" > \(parent)
+        echo "$child_pid" > \(child)
+        trap 'kill "$child_pid" 2>/dev/null; exit 0' TERM INT
+        while :; do sleep 1; done
+        """
+        return DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", script]
+        )
+    }
+
+    private func waitForPID(in file: URL) async -> pid_t? {
+        for _ in 0..<100 {
+            if let text = try? String(contentsOf: file),
+               let value = Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                return value
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
+    }
+
+    private func waitForExit(_ pid: pid_t) async -> Bool {
+        for _ in 0..<100 {
+            if kill(pid, 0) != 0 { return true }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return kill(pid, 0) != 0
+    }
+
+    private func waitForEvidence(
+        _ logs: BoundedLogStore,
+        containing expected: [String]
+    ) async -> String {
+        for _ in 0..<100 {
+            let evidence = await logs.snapshot().map(\.message).joined(separator: "\n")
+            if expected.allSatisfy(evidence.contains) {
+                return evidence
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await logs.snapshot().map(\.message).joined(separator: "\n")
+    }
+
+    private func adoptedHealth(pid: Int = 12345) throws -> HealthPayload {
+        let json = """
+        {
+          "ok": true,
+          "model": "fixture",
+          "model_path": "/tmp/fixture.gguf",
+          "generation_mode": "mtp",
+          "load_mtp": true,
+          "mtp_enabled": true,
+          "depth": 1,
+          "profile": {},
+          "context_window": 1024,
+          "active_requests": 0,
+          "reasoning_parser": "none",
+          "startup": {"launch_id": "prior-session", "pid": \(pid)}
+        }
+        """
+        return try JSONDecoder().decode(HealthPayload.self, from: Data(json.utf8))
+    }
+
+    func testAutomaticRestartIsOptInAndCleanExitDoesNotRestart() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 0),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+        XCTAssertEqual(snapshot.restartEligibility, .noDaemon)
+    }
+
+    func testRunFailureNeverBecomesRestartEligible() async throws {
+        let supervisor = DaemonSupervisor()
+        supervisor.setAutomaticRestartEnabled(true)
+        do {
+            _ = try await supervisor.start(
+                command: DaemonCommand(
+                    executableURL: URL(fileURLWithPath: "/definitely/not/a/daemon"),
+                    arguments: []
+                ),
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+                probeHealth: false
+            )
+            XCTFail("expected launch failure")
+        } catch {
+            // Expected: Process.run() failed before a daemon could be owned.
+        }
+        XCTAssertEqual(supervisor.supervisionSnapshot().restartEligibility, .noDaemon)
+    }
+
+    func testAbnormalExitDoesNotRestartUntilEnabled() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let crashed = await signal.waitForCrash()
+        XCTAssertTrue(crashed)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .crashed(17))
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+    }
+
+    func testAdoptedPriorSessionDaemonIsExplicitlyExcludedFromAutomaticRestart() async throws {
+        let health = try adoptedHealth()
+        let supervisor = DaemonSupervisor(initialHealthProbe: { _, _ in health })
+        supervisor.setAutomaticRestartEnabled(true)
+        let adopted = try await supervisor.adoptExistingIfAppOwned(
+            command: DaemonCommand(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: []),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!
+        )
+
+        XCTAssertEqual(adopted, health)
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .running)
+        XCTAssertEqual(snapshot.restartEligibility, .adoptedPriorSession)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+    }
+
+    func testStopDuringAdoptionHealthProbeCannotPublishRunning() async throws {
+        let health = try adoptedHealth()
+        let gate = HealthProbeGate()
+        let supervisor = DaemonSupervisor(initialHealthProbe: { _, _ in
+            await gate.waitForResponse()
+        })
+        let adoptionTask = Task {
+            try await supervisor.adoptExistingIfAppOwned(
+                command: DaemonCommand(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: []),
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!
+            )
+        }
+        await gate.waitUntilEntered()
+        await supervisor.stop(graceSeconds: 0)
+        await gate.release(health)
+        let adopted = try await adoptionTask.value
+
+        XCTAssertNil(adopted)
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        XCTAssertFalse(supervisor.isRunning())
+    }
+
+    func testStopDuringHealthWaitCannotPublishRunningOrKeepRecipe() async throws {
+        let health = try adoptedHealth()
+        let gate = HealthProbeGate()
+        let supervisor = DaemonSupervisor(
+            initialHealthProbe: { _, _ in nil },
+            healthWaitProbe: { _, _ in await gate.waitForResponse() }
+        )
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "while :; do sleep 1; done"]
+        )
+        let startTask = Task {
+            try await supervisor.start(
+                command: command,
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+                probeHealth: true,
+                timeoutSeconds: 10
+            )
+        }
+        await gate.waitUntilEntered()
+        await supervisor.stop(graceSeconds: 0)
+        await gate.release(health)
+        _ = try? await startTask.value
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartEligibility, .noDaemon)
+        XCTAssertFalse(supervisor.isRunning())
+    }
+
+    @MainActor
+    func testPassiveCleanExitClearsActiveTransportAndConnectionState() async throws {
+        let store = MTPLXBackendStore()
+        let handoffID = UUID()
+        let handoffDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "mtplx-passive-handoff-\(handoffID.uuidString.lowercased())",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(at: handoffDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: handoffDirectory) }
+
+        // Match the real handoff's terminal child shape: the exact token must
+        // live in the child environment, not merely in a PID presentation
+        // list or a command-line argument.
+        let pi = Process()
+        pi.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        pi.arguments = ["-c", "import time; time.sleep(30)"]
+        pi.environment = ProcessInfo.processInfo.environment.merging([
+            MTPLXTerminalHandoffLease.environmentVariable: handoffID.uuidString.lowercased()
+        ]) { _, new in new }
+        try pi.run()
+        guard pi.isRunning else {
+            XCTFail("could not launch the token-owned Pi handoff fixture")
+            return
+        }
+
+        let unrelated = Process()
+        unrelated.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        unrelated.arguments = ["-c", "import time; time.sleep(30)"]
+        unrelated.environment = ProcessInfo.processInfo.environment
+        try unrelated.run()
+        guard unrelated.isRunning else {
+            XCTFail("could not launch the unrelated handoff fixture")
+            return
+        }
+
+        let lookalike = Process()
+        lookalike.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        lookalike.arguments = ["-c", "import time; time.sleep(30)"]
+        lookalike.environment = ProcessInfo.processInfo.environment.merging([
+            "MTPLX_HANDOFF_NOTE": "\(MTPLXTerminalHandoffLease.environmentVariable)=\(handoffID.uuidString.lowercased())"
+        ]) { _, new in new }
+        try lookalike.run()
+        guard lookalike.isRunning else {
+            XCTFail("could not launch the lookalike handoff fixture")
+            return
+        }
+        defer {
+            for process in [pi, unrelated, lookalike] where process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        let lease = MTPLXTerminalHandoffLease(
+            handoffID: handoffID,
+            processID: Int(pi.processIdentifier),
+            cancellationMarkerURL: handoffDirectory.appendingPathComponent("cancelled")
+        )
+        XCTAssertTrue(MTPLXTerminalHandoffLease.process(
+            pid: pi.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+        XCTAssertFalse(MTPLXTerminalHandoffLease.process(
+            pid: lookalike.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+        store.recordLaunchedPiTerminalHandoffLease(lease)
+        XCTAssertEqual(store.piTerminalAgentProcessIDs, [Int(pi.processIdentifier)])
+        XCTAssertEqual(store.terminalHandoffLeaseIDsForTesting, [handoffID])
+        store.startMetricsStream()
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        // The observer's initial `.stopped` snapshot represents epoch zero;
+        // it must not clear a stream started before the callback is delivered.
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 0,
+                state: .stopped,
+                restartStatus: .idle,
+                restartCount: 0,
+                recoveryGeneration: 0
+            )
+        )
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        // Delivery order is not guaranteed once the supervisor releases its
+        // lock. Apply the terminal snapshot before its older `.running`
+        // snapshot and ensure the epoch still reaps this lifecycle exactly
+        // once.
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 2,
+                state: .stopped,
+                restartStatus: .idle,
+                restartCount: 0,
+                lifecycleEpoch: 1,
+                recoveryGeneration: 0
+            )
+        )
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 1,
+                state: .running,
+                restartStatus: .idle,
+                restartCount: 0,
+                lifecycleEpoch: 1,
+                recoveryGeneration: 0
+            )
+        )
+        await store.awaitDaemonTeardown()
+
+        XCTAssertEqual(store.daemonState, .stopped)
+        XCTAssertEqual(store.startupPhase, .idle)
+        XCTAssertEqual(store.connectionState, .idle)
+        XCTAssertFalse(store.hasActiveDaemonTransportForTesting)
+        let ownedPID = pi.processIdentifier
+        var didExit = kill(ownedPID, 0) != 0
+        for _ in 0..<100 where !didExit {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            didExit = kill(ownedPID, 0) != 0
+        }
+        XCTAssertTrue(
+            didExit,
+            "passive cleanup must reap the exact token-owned Pi handoff"
+        )
+        XCTAssertEqual(kill(unrelated.processIdentifier, 0), 0, "passive cleanup reaped an unrelated PID")
+        XCTAssertEqual(
+            kill(lookalike.processIdentifier, 0),
+            0,
+            "a token-shaped value in another environment variable must not be reaped"
+        )
+        XCTAssertEqual(store.piTerminalAgentProcessIDs, [])
+        XCTAssertTrue(store.terminalHandoffLeaseIDsForTesting.isEmpty)
+        XCTAssertNil(store.health)
+        XCTAssertNil(store.latest)
+    }
+
+    @MainActor
+    func testCrashDuringPostStartHandoffCannotResurrectMetrics() async throws {
+        let supervisor = DaemonSupervisor()
+        let store = MTPLXBackendStore(
+            supervisor: supervisor,
+            beforePostStartRefresh: {
+                await supervisor.stop(graceSeconds: 0)
+            }
+        )
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let running = supervisor.supervisionSnapshot()
+        XCTAssertEqual(running.state, .running)
+
+        await store.finishReadyDaemon(
+            target: nil,
+            configuration: store.configuration,
+            replaceExistingClient: false,
+            launchID: nil,
+            lifecycleEpoch: running.lifecycleEpoch
+        )
+        store.applySupervisorSnapshot(supervisor.supervisionSnapshot())
+        await store.awaitDaemonTeardown()
+
+        XCTAssertEqual(store.daemonState, .stopped)
+        XCTAssertFalse(store.hasActiveDaemonTransportForTesting)
+        XCTAssertNil(store.health)
+        XCTAssertNil(store.latest)
+    }
+
+    @MainActor
+    func testStaleFanResultCannotOverwriteNewerLifecycleSettings() async throws {
+        let supervisor = DaemonSupervisor()
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let firstLifecycle = supervisor.supervisionSnapshot()
+        let fanGate = BeforeRunGate()
+        await fanGate.arm()
+        let settingsURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-daemon-fan-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: settingsURL) }
+        var initialConfiguration = MTPLXAppConfiguration()
+        initialConfiguration.fanMode = MTPLXFanMode.max.rawValue
+        initialConfiguration.pinFansAtMaxOnStart = true
+        let store = MTPLXBackendStore(
+            configuration: initialConfiguration,
+            settingsStore: MTPLXSettingsStore(settingsURL: settingsURL),
+            supervisor: supervisor,
+            fanModeSetter: { _, mode, _, _ in
+                await fanGate.waitIfArmed()
+                return FanModeResponse(verified: true, currentMode: mode)
+            }
+        )
+        // Normal `.running` snapshots intentionally leave explicit-start
+        // presentation state alone. This synthetic recovery snapshot puts
+        // the store in the same live-fan-control state without starting a
+        // separate recovery task (generation zero is already observed).
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: firstLifecycle.revision,
+                state: .running,
+                restartStatus: .runningAfterRestart(attempt: 1),
+                restartCount: 0,
+                lifecycleEpoch: firstLifecycle.lifecycleEpoch,
+                recoveryGeneration: 0
+            )
+        )
+
+        let staleFanApply = Task { @MainActor in
+            try await store.setFanMode(MTPLXFanMode.max.rawValue, isCurrent: {
+                let snapshot = supervisor.supervisionSnapshot()
+                return snapshot.lifecycleEpoch == firstLifecycle.lifecycleEpoch
+                    && snapshot.state == .running
+            })
+        }
+        await fanGate.waitUntilEntered()
+
+        await supervisor.stop(graceSeconds: 0)
+        var newerSettings = store.configuration
+        newerSettings.fanMode = MTPLXFanMode.default.rawValue
+        newerSettings.pinFansAtMaxOnStart = false
+        try store.saveSettings(newerSettings)
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let secondLifecycle = supervisor.supervisionSnapshot()
+        XCTAssertGreaterThan(secondLifecycle.lifecycleEpoch, firstLifecycle.lifecycleEpoch)
+        store.applySupervisorSnapshot(secondLifecycle)
+
+        await fanGate.release()
+        try await staleFanApply.value
+
+        XCTAssertEqual(store.configuration.fanMode, MTPLXFanMode.default.rawValue)
+        XCTAssertFalse(store.configuration.pinFansAtMaxOnStart)
+        await supervisor.stop(graceSeconds: 0)
+    }
+
+    @MainActor
+    func testStalePiHandoffAfterNewLifecycleCannotLaunchClient() async throws {
+        let supervisor = DaemonSupervisor()
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let firstLifecycle = supervisor.supervisionSnapshot()
+        let handoffGate = BeforeRunGate()
+        await handoffGate.arm()
+        let store = MTPLXBackendStore(
+            supervisor: supervisor,
+            beforeClientHandoffLaunch: { target in
+                if target == .pi { await handoffGate.waitIfArmed() }
+            }
+        )
+        var didCallReady = false
+        store.onDaemonReady = { _ in didCallReady = true }
+        let staleHandoff = Task { @MainActor in
+            await store.finishReadyDaemon(
+                target: .pi,
+                configuration: store.configuration,
+                replaceExistingClient: false,
+                launchID: nil,
+                lifecycleEpoch: firstLifecycle.lifecycleEpoch
+            )
+        }
+        await handoffGate.waitUntilEntered()
+
+        await supervisor.stop(graceSeconds: 0)
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let secondLifecycle = supervisor.supervisionSnapshot()
+        XCTAssertGreaterThan(secondLifecycle.lifecycleEpoch, firstLifecycle.lifecycleEpoch)
+        store.applySupervisorSnapshot(secondLifecycle)
+
+        await handoffGate.release()
+        await staleHandoff.value
+
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .running)
+        XCTAssertFalse(didCallReady)
+        XCTAssertFalse(store.piTerminalAgentRunning)
+        XCTAssertEqual(store.piTerminalAgentProcessIDs, [])
+        XCTAssertNil(store.clientHandoffNotice)
+        await supervisor.stop(graceSeconds: 0)
+    }
+
+    @MainActor
+    func testStaleHermesHandoffAfterStopCannotLaunchClient() async throws {
+        let supervisor = DaemonSupervisor()
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let lifecycle = supervisor.supervisionSnapshot()
+        let handoffGate = BeforeRunGate()
+        await handoffGate.arm()
+        let store = MTPLXBackendStore(
+            supervisor: supervisor,
+            beforeClientHandoffLaunch: { target in
+                if target == .hermes { await handoffGate.waitIfArmed() }
+            }
+        )
+        var didCallReady = false
+        store.onDaemonReady = { _ in didCallReady = true }
+        let staleHandoff = Task { @MainActor in
+            await store.finishReadyDaemon(
+                target: .hermes,
+                configuration: store.configuration,
+                replaceExistingClient: false,
+                launchID: nil,
+                lifecycleEpoch: lifecycle.lifecycleEpoch
+            )
+        }
+        await handoffGate.waitUntilEntered()
+
+        await supervisor.stop(graceSeconds: 0)
+        await handoffGate.release()
+        await staleHandoff.value
+
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        XCTAssertFalse(didCallReady)
+        XCTAssertNil(store.clientHandoffNotice)
+    }
+
+    @MainActor
+    func testOlderTerminalLifecycleCannotClearNewerRunningSession() async throws {
+        let supervisor = DaemonSupervisor()
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let olderLifecycle = supervisor.supervisionSnapshot().lifecycleEpoch
+        await supervisor.stop(graceSeconds: 0)
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let current = supervisor.supervisionSnapshot()
+        XCTAssertGreaterThan(current.lifecycleEpoch, olderLifecycle)
+        XCTAssertEqual(current.state, .running)
+
+        let store = MTPLXBackendStore(supervisor: supervisor)
+        let pi = Process()
+        pi.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        pi.arguments = ["-c", "exec -a pi /bin/sleep 30"]
+        try pi.run()
+        defer {
+            if pi.isRunning { pi.terminate() }
+        }
+        store.recordLaunchedPiAgentProcessIDs([Int(pi.processIdentifier)])
+        store.startMetricsStream()
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 1,
+                state: .running,
+                restartStatus: .idle,
+                restartCount: 0,
+                restartEligibility: .currentSessionUnprotected,
+                lifecycleEpoch: current.lifecycleEpoch,
+                recoveryGeneration: current.recoveryGeneration
+            )
+        )
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        // Simulate delayed delivery of an older terminal callback after the
+        // next lifecycle is already genuinely running in the supervisor.
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 2,
+                state: .stopped,
+                restartStatus: .idle,
+                restartCount: 0,
+                lifecycleEpoch: olderLifecycle,
+                recoveryGeneration: 0
+            )
+        )
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+        XCTAssertEqual(store.piTerminalAgentProcessIDs, [Int(pi.processIdentifier)])
+        XCTAssertTrue(pi.isRunning)
+        XCTAssertEqual(store.daemonRestartEligibility, .currentSessionUnprotected)
+
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 3,
+                state: .running,
+                restartStatus: .idle,
+                restartCount: 0,
+                restartEligibility: .currentSessionUnprotected,
+                lifecycleEpoch: current.lifecycleEpoch,
+                recoveryGeneration: current.recoveryGeneration
+            )
+        )
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+        await store.stopDaemon()
+    }
+
+    @MainActor
+    func testStaleThermalCompletionCannotCancelNewerLifecycleMetricsStream() async throws {
+        let supervisor = DaemonSupervisor()
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let firstLifecycle = supervisor.supervisionSnapshot()
+        let thermalGate = BeforeRunGate()
+        await thermalGate.arm()
+        let store = MTPLXBackendStore(
+            supervisor: supervisor,
+            beforeThermalStatusRefresh: { await thermalGate.waitIfArmed() }
+        )
+        let staleRefresh = Task { @MainActor in
+            await store.startMetricsAndRefreshThermal(
+                lifecycleEpoch: firstLifecycle.lifecycleEpoch,
+                recoveryGeneration: nil
+            )
+        }
+        await thermalGate.waitUntilEntered()
+
+        await supervisor.stop(graceSeconds: 0)
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let secondLifecycle = supervisor.supervisionSnapshot()
+        XCTAssertGreaterThan(secondLifecycle.lifecycleEpoch, firstLifecycle.lifecycleEpoch)
+        store.startMetricsStream()
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        await thermalGate.release()
+        let staleRefreshResult = await staleRefresh.value
+        XCTAssertFalse(staleRefreshResult)
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+        await store.stopDaemon()
+    }
+
+    @MainActor
+    func testStorePublishesAdoptedDaemonAsUnprotected() async {
+        let store = MTPLXBackendStore()
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 1,
+                state: .running,
+                restartStatus: .idle,
+                restartCount: 0,
+                restartEligibility: .adoptedPriorSession,
+                recoveryGeneration: 0
+            )
+        )
+
+        XCTAssertEqual(store.daemonRestartEligibility, .adoptedPriorSession)
+    }
+
+    @MainActor
+    func testDisabledAbnormalExitCleansTransportButPreservesCrashState() async {
+        let store = MTPLXBackendStore()
+        store.startMetricsStream()
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 1,
+                state: .crashed(9),
+                restartStatus: .idle,
+                restartCount: 0,
+                lifecycleEpoch: 1,
+                recoveryGeneration: 0
+            )
+        )
+        await store.awaitDaemonTeardown()
+
+        XCTAssertEqual(store.daemonState, .crashed(9))
+        XCTAssertFalse(store.hasActiveDaemonTransportForTesting)
+        XCTAssertNil(store.health)
+        XCTAssertNil(store.latest)
+        if case .failed = store.startupPhase {} else {
+            XCTFail("terminal crash should preserve a failed startup phase")
+        }
+        if case .failed = store.connectionState {} else {
+            XCTFail("terminal crash should preserve a failed connection state")
+        }
+    }
+
+    @MainActor
+    func testPassiveTerminalCleanupRestoresConfiguredMaxFans() async throws {
+        let supervisor = DaemonSupervisor()
+        var configuration = MTPLXAppConfiguration()
+        configuration.fanMode = MTPLXFanMode.max.rawValue
+        configuration.pinFansAtMaxOnStart = true
+        let recorder = FanRestoreRecorder()
+        let store = MTPLXBackendStore(
+            configuration: configuration,
+            supervisor: supervisor,
+            localFanRestorer: { await recorder.restore() }
+        )
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let running = supervisor.supervisionSnapshot()
+        await supervisor.stop(graceSeconds: 0)
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: running.revision + 1,
+                state: .stopped,
+                restartStatus: .idle,
+                restartCount: 0,
+                lifecycleEpoch: running.lifecycleEpoch,
+                recoveryGeneration: running.recoveryGeneration
+            )
+        )
+        await store.awaitDaemonTeardown()
+
+        let restoreCount = await recorder.count()
+        XCTAssertEqual(restoreCount, 1)
+        XCTAssertEqual(store.currentFanMode, MTPLXFanMode.default.rawValue)
+    }
+
+    @MainActor
+    func testPassiveFanRestoreDoesNotOverwriteNewerConfigurationState() async throws {
+        let supervisor = DaemonSupervisor()
+        let restoreGate = BeforeRunGate()
+        await restoreGate.arm()
+        let settingsURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-passive-fan-race-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: settingsURL) }
+        var configuration = MTPLXAppConfiguration()
+        configuration.fanMode = MTPLXFanMode.max.rawValue
+        configuration.pinFansAtMaxOnStart = true
+        let store = MTPLXBackendStore(
+            configuration: configuration,
+            settingsStore: MTPLXSettingsStore(settingsURL: settingsURL),
+            supervisor: supervisor,
+            localFanRestorer: {
+                await restoreGate.waitIfArmed()
+                return true
+            }
+        )
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+        )
+        _ = try await supervisor.start(
+            command: command,
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        await supervisor.stop(graceSeconds: 0)
+        await restoreGate.waitUntilEntered()
+
+        var newerConfiguration = store.configuration
+        newerConfiguration.fanMode = MTPLXFanMode.default.rawValue
+        newerConfiguration.pinFansAtMaxOnStart = false
+        try store.saveSettings(newerConfiguration)
+        await restoreGate.release()
+        await store.awaitDaemonTeardown()
+
+        XCTAssertEqual(store.configuration.fanMode, MTPLXFanMode.default.rawValue)
+        XCTAssertFalse(store.configuration.pinFansAtMaxOnStart)
+    }
+
+    @MainActor
+    func testExhaustedAutomaticRecoveryCleansTransportButPreservesCircuitBreakerState() async {
+        let store = MTPLXBackendStore()
+        store.startMetricsStream()
+        XCTAssertTrue(store.hasActiveDaemonTransportForTesting)
+
+        store.applySupervisorSnapshot(
+            DaemonSupervisionSnapshot(
+                revision: 1,
+                state: .crashed(17),
+                restartStatus: .exhausted(attempts: 3, lastExitStatus: 17),
+                restartCount: 3,
+                lifecycleEpoch: 2,
+                recoveryGeneration: 0
+            )
+        )
+        await store.awaitDaemonTeardown()
+
+        XCTAssertEqual(store.daemonState, .crashed(17))
+        XCTAssertFalse(store.hasActiveDaemonTransportForTesting)
+        XCTAssertNil(store.health)
+        XCTAssertNil(store.latest)
+        XCTAssertEqual(
+            store.startupPhase,
+            .failed("MTPLX crashed repeatedly; automatic recovery stopped after 3 attempts.")
+        )
+        XCTAssertEqual(
+            store.connectionState,
+            .failed("Automatic restart circuit breaker is open.")
+        )
+    }
+
+    func testAbnormalExitRetriesWithCircuitBreakerAndEvidence() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let logs = BoundedLogStore()
+        let supervisor = DaemonSupervisor(
+            logStore: logs,
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let exhausted = await signal.waitForExhausted()
+        XCTAssertTrue(exhausted)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.restartCount, 2)
+        XCTAssertEqual(snapshot.restartStatus, .exhausted(attempts: 2, lastExitStatus: 17))
+        let evidence = await waitForEvidence(
+            logs,
+            containing: [
+                "automatic restart scheduled: attempt 1 of 2",
+                "automatic restart attempt 2 of 2 starting",
+                "automatic restart circuit breaker open after 2 attempts",
+            ]
+        )
+        XCTAssertTrue(evidence.contains("automatic restart scheduled: attempt 1 of 2"))
+        XCTAssertTrue(evidence.contains("automatic restart attempt 2 of 2 starting"))
+        XCTAssertTrue(evidence.contains("automatic restart circuit breaker open after 2 attempts"))
+    }
+
+    func testRestartBackoffDoublesAndCaps() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let delays = RestartDelayRecorder()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 3,
+                initialDelaySeconds: 1,
+                maximumDelaySeconds: 2,
+                crashWindowSeconds: 60
+            ),
+            restartSleeper: { delay in await delays.record(delay) }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let exhausted = await signal.waitForExhausted()
+        XCTAssertTrue(exhausted)
+        let recordedDelays = await delays.snapshot()
+        XCTAssertEqual(recordedDelays, [1, 2, 2])
+    }
+
+    func testStopWaitsForPublishedLaunchToReceiveAPID() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("daemon.pid")
+        let gate = BeforeRunGate()
+        let signal = SupervisionSignal()
+        await gate.arm()
+        let supervisor = DaemonSupervisor(beforeProcessRun: { await gate.waitIfArmed() })
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "echo $$ > \(shellQuoted(pidFile.path)); while :; do sleep 1; done"]
+        )
+        let startTask = Task {
+            try await supervisor.start(
+                command: command,
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+                probeHealth: false
+            )
+        }
+        await gate.waitUntilEntered()
+        let stopTask = Task { await supervisor.stop(graceSeconds: 0) }
+        let stopping = await signal.waitForStopping()
+        XCTAssertTrue(stopping)
+        await gate.release()
+        _ = try? await startTask.value
+        await stopTask.value
+
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        XCTAssertFalse(supervisor.isRunning())
+        if let pidText = try? String(contentsOf: pidFile), let pid = Int32(pidText.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            XCTAssertNotEqual(kill(pid, 0), 0, "Stop returned while the concurrently launched daemon was still alive")
+        }
+    }
+
+    func testStopBeforeProcessReservationPreventsAnyLaterLaunch() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("daemon.pid")
+        let gate = BeforeRunGate()
+        await gate.arm()
+        let supervisor = DaemonSupervisor(
+            beforeProcessReservation: { await gate.waitIfArmed() }
+        )
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "echo $$ > \(shellQuoted(pidFile.path)); while :; do sleep 1; done"]
+        )
+        let startTask = Task {
+            try await supervisor.start(
+                command: command,
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+                probeHealth: false
+            )
+        }
+        await gate.waitUntilEntered()
+        await supervisor.stop(graceSeconds: 0)
+        await gate.release()
+        _ = try? await startTask.value
+
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        XCTAssertFalse(supervisor.isRunning())
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: pidFile.path),
+            "Start published a process after Stop had completed"
+        )
+    }
+
+    func testDisablingAutomaticRestartDoesNotCancelManualLaunch() async throws {
+        let gate = BeforeRunGate()
+        await gate.arm()
+        let supervisor = DaemonSupervisor(
+            beforeProcessRun: { await gate.waitIfArmed() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        let command = DaemonCommand(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "while :; do sleep 1; done"]
+        )
+        let startTask = Task {
+            try await supervisor.start(
+                command: command,
+                healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+                probeHealth: false
+            )
+        }
+        await gate.waitUntilEntered()
+
+        supervisor.setAutomaticRestartEnabled(false)
+        await gate.release()
+        _ = try await startTask.value
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .running)
+        XCTAssertEqual(snapshot.restartEligibility, .currentSessionUnprotected)
+        XCTAssertFalse(supervisor.hasRetainedRestartRecipeForTesting)
+        await supervisor.stop(graceSeconds: 0)
+    }
+
+    func testDisablingAutomaticRetryReapsParentAndChildAndEndsStopped() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-auto-disable-family-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let release = directory.appendingPathComponent("release")
+        let counter = directory.appendingPathComponent("counter")
+        let parentPID = directory.appendingPathComponent("parent.pid")
+        let childPID = directory.appendingPathComponent("child.pid")
+        try Data().write(to: release)
+
+        let signal = SupervisionSignal()
+        let healthGate = AutomaticRetryHealthGate(readyHealth: try adoptedHealth())
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            initialHealthProbe: { _, _ in nil },
+            healthWaitProbe: { _, _ in await healthGate.probe() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: automaticRetryParentChildCommand(
+                releaseFile: release,
+                counterFile: counter,
+                parentPIDFile: parentPID,
+                childPIDFile: childPID
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: true,
+            timeoutSeconds: 10
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+
+        try FileManager.default.removeItem(at: release)
+        await healthGate.waitUntilAutomaticRetryProbe()
+        let parent = await waitForPID(in: parentPID)
+        let child = await waitForPID(in: childPID)
+        XCTAssertNotNil(parent)
+        XCTAssertNotNil(child)
+
+        supervisor.setAutomaticRestartEnabled(false)
+        await healthGate.release(try adoptedHealth())
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+        XCTAssertFalse(supervisor.hasOutstandingRestartTaskForTesting)
+        if let parent {
+            let parentExited = await waitForExit(parent)
+            XCTAssertTrue(parentExited, "automatic disable leaked parent")
+        }
+        if let child {
+            let childExited = await waitForExit(child)
+            XCTAssertTrue(childExited, "automatic disable leaked child")
+        }
+    }
+
+    func testStaleAutomaticHealthFailureCannotStopNewManualDaemon() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-stale-auto-stop-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let release = directory.appendingPathComponent("release")
+        let counter = directory.appendingPathComponent("counter")
+        let manualPID = directory.appendingPathComponent("manual.pid")
+        try Data().write(to: release)
+        let automaticScript = """
+        count=$(cat \(shellQuoted(counter.path)) 2>/dev/null || echo 0)
+        count=$((count + 1))
+        echo "$count" > \(shellQuoted(counter.path))
+        if [ "$count" -eq 1 ]; then
+          while [ -e \(shellQuoted(release.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        while :; do sleep 1; done
+        """
+        let healthGate = AutomaticRetryHealthGate(readyHealth: try adoptedHealth())
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            initialHealthProbe: { _, _ in nil },
+            healthWaitProbe: { _, _ in await healthGate.probe() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", automaticScript]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: true,
+            timeoutSeconds: 10
+        )
+
+        try FileManager.default.removeItem(at: release)
+        await healthGate.waitUntilAutomaticRetryProbe()
+        await supervisor.stop(graceSeconds: 0)
+
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: [
+                    "-c",
+                    "echo $$ > \(shellQuoted(manualPID.path)); while :; do sleep 1; done"
+                ]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let manual = await waitForPID(in: manualPID)
+        XCTAssertNotNil(manual)
+
+        await healthGate.release(try adoptedHealth())
+        for _ in 0..<100 where supervisor.hasOutstandingRestartTaskForTesting {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .running)
+        if let manual {
+            XCTAssertEqual(kill(manual, 0), 0, "stale automatic cleanup killed manual Start B")
+        }
+        await supervisor.stop(graceSeconds: 0)
+    }
+
+    func testDisablingInAutomaticRestartPublishGapSettlesStopped() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let gate = BeforeRunGate()
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            beforeAutomaticRestartStart: { await gate.waitIfArmed() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        await gate.arm()
+        try FileManager.default.removeItem(at: release)
+        await gate.waitUntilEntered()
+
+        supervisor.setAutomaticRestartEnabled(false)
+        await gate.release()
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        XCTAssertEqual(supervisor.supervisionSnapshot().restartStatus, .idle)
+        XCTAssertFalse(supervisor.hasOutstandingRestartTaskForTesting)
+    }
+
+    func testStopReapsOnlyExactTokenChildWhenRootExitsBeforeFamilyResolution() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-stop-family-gap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let parentPID = directory.appendingPathComponent("parent.pid")
+        let childPID = directory.appendingPathComponent("child.pid")
+        let launchID = "stop-family-\(UUID().uuidString)"
+        let unrelatedLaunchID = "unrelated-\(UUID().uuidString)"
+        let argumentImposterPID = directory.appendingPathComponent("argument-imposter.pid")
+        let valueImposterPID = directory.appendingPathComponent("value-imposter.pid")
+        let script = """
+        /usr/bin/python3 -c 'import time; time.sleep(300)' &
+        child_pid=$!
+        echo "$$" > \(shellQuoted(parentPID.path))
+        echo "$child_pid" > \(shellQuoted(childPID.path))
+        trap 'exit 0' TERM INT
+        while :; do sleep 1; done
+        """
+        let unrelated = Process()
+        unrelated.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        unrelated.arguments = ["-c", "import time; time.sleep(300)"]
+        unrelated.environment = ProcessInfo.processInfo.environment.merging(
+            ["MTPLX_APP_LAUNCH_ID": unrelatedLaunchID]
+        ) { _, new in new }
+        try unrelated.run()
+        let unrelatedPID = unrelated.processIdentifier
+        defer {
+            if unrelated.isRunning {
+                unrelated.terminate()
+            }
+        }
+        let argumentImposter = Process()
+        argumentImposter.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        argumentImposter.arguments = [
+            "-c",
+            "import os, time; open(os.environ['PID_FILE'], 'w').write(str(os.getpid())); time.sleep(300)",
+            "MTPLX_APP_LAUNCH_ID=\(launchID)"
+        ]
+        argumentImposter.environment = ProcessInfo.processInfo.environment.merging(
+            ["PID_FILE": argumentImposterPID.path]
+        ) { _, new in new }
+        try argumentImposter.run()
+        defer {
+            if argumentImposter.isRunning {
+                argumentImposter.terminate()
+            }
+        }
+        let valueImposter = Process()
+        valueImposter.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        valueImposter.arguments = [
+            "-c",
+            "import os, time; open(os.environ['PID_FILE'], 'w').write(str(os.getpid())); time.sleep(300)"
+        ]
+        valueImposter.environment = ProcessInfo.processInfo.environment.merging([
+            "PID_FILE": valueImposterPID.path,
+            "NOT_A_LAUNCH_ID": "MTPLX_APP_LAUNCH_ID=\(launchID)"
+        ]) { _, new in new }
+        try valueImposter.run()
+        defer {
+            if valueImposter.isRunning {
+                valueImposter.terminate()
+            }
+        }
+        let supervisor = DaemonSupervisor(
+            beforeStopProcessFamilyResolution: {
+                if let text = try? String(contentsOf: parentPID),
+                   let pid = Int32(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                    kill(pid, SIGTERM)
+                }
+            }
+        )
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script],
+                environment: ["MTPLX_APP_LAUNCH_ID": launchID]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        let parent = await waitForPID(in: parentPID)
+        let child = await waitForPID(in: childPID)
+        let argumentImposterPIDValue = await waitForPID(in: argumentImposterPID)
+        let valueImposterPIDValue = await waitForPID(in: valueImposterPID)
+        XCTAssertNotNil(parent)
+        XCTAssertNotNil(child)
+        XCTAssertNotNil(argumentImposterPIDValue)
+        XCTAssertNotNil(valueImposterPIDValue)
+
+        await supervisor.stop(graceSeconds: 0)
+        XCTAssertEqual(supervisor.supervisionSnapshot().state, .stopped)
+        if let parent {
+            let parentExited = await waitForExit(parent)
+            XCTAssertTrue(parentExited)
+        }
+        if let child {
+            let childExited = await waitForExit(child)
+            XCTAssertTrue(childExited, "Stop lost token-owned child after root termination")
+        }
+        XCTAssertEqual(kill(unrelatedPID, 0), 0, "Stop matched an unrelated launch token")
+        if let argumentImposterPIDValue {
+            XCTAssertEqual(
+                kill(argumentImposterPIDValue, 0),
+                0,
+                "Stop matched a launch token passed only as an argument"
+            )
+        }
+        if let valueImposterPIDValue {
+            XCTAssertEqual(
+                kill(valueImposterPIDValue, 0),
+                0,
+                "Stop matched a launch token embedded in another environment value"
+            )
+        }
+    }
+
+    func testCompletedRestartTaskReleasesItsRecipeAfterCleanExit() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-restart-recipe-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstRelease = directory.appendingPathComponent("first-release")
+        let secondRelease = directory.appendingPathComponent("second-release")
+        let counter = directory.appendingPathComponent("counter")
+        try Data().write(to: firstRelease)
+        try Data().write(to: secondRelease)
+        let script = """
+        count=$(cat \(shellQuoted(counter.path)) 2>/dev/null || echo 0)
+        count=$((count + 1))
+        echo "$count" > \(shellQuoted(counter.path))
+        if [ "$count" -eq 1 ]; then
+          while [ -e \(shellQuoted(firstRelease.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        while [ -e \(shellQuoted(secondRelease.path)) ]; do sleep 0.01; done
+        exit 0
+        """
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 1,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            apiKey: "secret-that-must-not-outlive-the-session",
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+
+        try FileManager.default.removeItem(at: firstRelease)
+        let recovered = await signal.waitForRecoveryGeneration(1)
+        XCTAssertTrue(recovered)
+        for _ in 0..<100 where supervisor.hasOutstandingRestartTaskForTesting {
+            await Task.yield()
+        }
+        XCTAssertFalse(supervisor.hasOutstandingRestartTaskForTesting)
+        XCTAssertTrue(supervisor.hasRetainedRestartRecipeForTesting)
+
+        try FileManager.default.removeItem(at: secondRelease)
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+        for _ in 0..<100 where supervisor.hasOutstandingRestartTaskForTesting {
+            await Task.yield()
+        }
+        XCTAssertFalse(supervisor.hasOutstandingRestartTaskForTesting)
+        XCTAssertFalse(supervisor.hasRetainedRestartRecipeForTesting)
+    }
+
+    func testAutomaticRetryCleanExitBeforeTerminationHandlerDoesNotReschedule() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-auto-clean-exit-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let release = directory.appendingPathComponent("release")
+        let counter = directory.appendingPathComponent("counter")
+        try Data().write(to: release)
+        let terminationGate = TerminationGate()
+        let restartGate = RestartGate()
+        let postRunGate = BeforeRunGate()
+        let script = """
+        count=$(cat \(shellQuoted(counter.path)) 2>/dev/null || echo 0)
+        count=$((count + 1))
+        echo "$count" > \(shellQuoted(counter.path))
+        if [ "$count" -eq 1 ]; then
+          while [ -e \(shellQuoted(release.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        exit 0
+        """
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 1,
+                maximumDelaySeconds: 1,
+                crashWindowSeconds: 60
+            ),
+            restartSleeper: { _ in await restartGate.wait() },
+            beforePostRunLivenessCheck: { await postRunGate.waitIfArmed() },
+            beforeTerminationHandling: { _ in
+                terminationGate.blockIfArmed()
+            }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+
+        try FileManager.default.removeItem(at: release)
+        let scheduled = await signal.waitForScheduled()
+        XCTAssertTrue(scheduled)
+        await postRunGate.arm()
+        terminationGate.arm()
+        var terminationGateUnblocked = false
+        defer {
+            if !terminationGateUnblocked {
+                terminationGate.unblock()
+            }
+        }
+        await restartGate.release()
+        await postRunGate.waitUntilEntered()
+        let handlerEntered = await Task.detached { terminationGate.waitUntilEntered() }.value
+        XCTAssertTrue(handlerEntered)
+        await postRunGate.release()
+
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+        // The supervisor must settle stopped before its delayed handler can
+        // re-enter. Unblock only after that assertion point so the task can
+        // finish its ordinary deferred cleanup.
+        terminationGate.unblock()
+        terminationGateUnblocked = true
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertFalse(supervisor.hasRetainedRestartRecipeForTesting)
+        for _ in 0..<100 where supervisor.hasOutstandingRestartTaskForTesting {
+            await Task.yield()
+        }
+        XCTAssertFalse(supervisor.hasOutstandingRestartTaskForTesting)
+    }
+
+    func testDisablingDuringRestartingAbortsTheInFlightAutomaticLaunch() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let gate = BeforeRunGate()
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            beforeProcessRun: { await gate.waitIfArmed() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        await gate.arm()
+        try FileManager.default.removeItem(at: release)
+        await gate.waitUntilEntered()
+        supervisor.setAutomaticRestartEnabled(false)
+        await gate.release()
+        let stopped = await signal.waitForStoppedAfterLaunch()
+        XCTAssertTrue(stopped)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+        XCTAssertEqual(snapshot.recoveryGeneration, 0)
+        XCTAssertFalse(supervisor.isRunning())
+    }
+
+    func testStopDuringRestartingWaitsForAndCancelsTheAutomaticLaunch() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let gate = BeforeRunGate()
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            beforeProcessRun: { await gate.waitIfArmed() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        await gate.arm()
+        try FileManager.default.removeItem(at: release)
+        await gate.waitUntilEntered()
+        let stopTask = Task { await supervisor.stop(graceSeconds: 0) }
+        let stopping = await signal.waitForStopping()
+        XCTAssertTrue(stopping)
+        await gate.release()
+        await stopTask.value
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+        XCTAssertFalse(supervisor.isRunning())
+    }
+
+    func testExplicitStopCancelsScheduledRestartBeforeSleeperReleases() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let gate = RestartGate()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 2,
+                initialDelaySeconds: 1,
+                maximumDelaySeconds: 1,
+                crashWindowSeconds: 60
+            ),
+            restartSleeper: { _ in await gate.wait() }
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let scheduled = await signal.waitForScheduled()
+        XCTAssertTrue(scheduled)
+        await supervisor.stop()
+        await gate.release()
+        for _ in 0..<8 { await Task.yield() }
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.state, .stopped)
+        XCTAssertEqual(snapshot.restartStatus, .idle)
+        XCTAssertEqual(snapshot.restartCount, 0)
+    }
+
+    func testReenablingWithoutAFreshLaunchDoesNotRetainThePreviousLaunchSecret() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 1,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        supervisor.setAutomaticRestartEnabled(false)
+        supervisor.setAutomaticRestartEnabled(true)
+        try FileManager.default.removeItem(at: release)
+
+        let crashed = await signal.waitForCrash()
+        XCTAssertTrue(crashed)
+        XCTAssertEqual(supervisor.supervisionSnapshot().restartCount, 0)
+        XCTAssertEqual(supervisor.supervisionSnapshot().restartStatus, .idle)
+    }
+
+    func testFreshStartAfterReenablingRestoresAutomaticRestartEligibility() async throws {
+        let release = try temporaryReleaseFile()
+        defer { try? FileManager.default.removeItem(at: release.deletingLastPathComponent()) }
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 1,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        supervisor.setAutomaticRestartEnabled(false)
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: releaseControlledCommand(releaseFile: release, exitStatus: 17),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+        try FileManager.default.removeItem(at: release)
+        let exhausted = await signal.waitForExhausted()
+        XCTAssertTrue(exhausted)
+        XCTAssertEqual(supervisor.supervisionSnapshot().restartCount, 1)
+    }
+
+    func testRecoveryGenerationRemainsMonotonicWhenCrashWindowResetsAttempts() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let counter = directory.appendingPathComponent("counter")
+        let firstCrashGate = directory.appendingPathComponent("first-crash-gate")
+        let secondCrashGate = directory.appendingPathComponent("second-crash-gate")
+        let keepThirdRunAlive = directory.appendingPathComponent("keep-third-run-alive")
+        try Data().write(to: firstCrashGate)
+        try Data().write(to: secondCrashGate)
+        try Data().write(to: keepThirdRunAlive)
+        let script = """
+        n=$(cat \(shellQuoted(counter.path)) 2>/dev/null || echo 0)
+        n=$((n + 1))
+        echo "$n" > \(shellQuoted(counter.path))
+        if [ "$n" -eq 1 ]; then
+          while [ -e \(shellQuoted(firstCrashGate.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        if [ "$n" -eq 2 ]; then
+          while [ -e \(shellQuoted(secondCrashGate.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        while [ -e \(shellQuoted(keepThirdRunAlive.path)) ]; do sleep 0.01; done
+        """
+        let signal = SupervisionSignal()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 1,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 0
+            )
+        )
+        supervisor.setAutomaticRestartEnabled(true)
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        supervisor.setStatusObserver { snapshot in
+            Task { await signal.record(snapshot) }
+        }
+
+        try FileManager.default.removeItem(at: firstCrashGate)
+        let firstRecovery = await signal.waitForRecoveryGeneration(1)
+        XCTAssertTrue(firstRecovery)
+        try FileManager.default.removeItem(at: secondCrashGate)
+        let secondRecovery = await signal.waitForRecoveryGeneration(2)
+        XCTAssertTrue(secondRecovery)
+
+        let snapshot = supervisor.supervisionSnapshot()
+        XCTAssertEqual(snapshot.restartCount, 1)
+        XCTAssertEqual(snapshot.recoveryGeneration, 2)
+        await supervisor.stop()
+    }
+}

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/TerminalHandoffLeaseTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/TerminalHandoffLeaseTests.swift
@@ -1,0 +1,559 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import MTPLXAppCore
+
+private actor HandoffRecoveryGate {
+    private var entered = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+final class TerminalHandoffLeaseTests: XCTestCase {
+    func testExactEnvironmentTokenRejectsLookalikesAndDrainsLargePSOutput() throws {
+        let handoffID = UUID()
+        let token = handoffID.uuidString.lowercased()
+        let process = try launchSleep(
+            environment: [
+                MTPLXTerminalHandoffLease.environmentVariable: token,
+                // A pipe reader that waits for process exit before draining
+                // hangs on this output. The lease validator must keep
+                // draining while bounded by its watchdog.
+                "MTPLX_HANDOFF_TEST_FILLER": String(repeating: "x", count: 65_536)
+            ]
+        )
+        defer { stop(process) }
+        XCTAssertTrue(waitUntilRunning(process))
+        XCTAssertTrue(MTPLXTerminalHandoffLease.process(
+            pid: process.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+
+        let wrongValue = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable: token + "-suffix"
+        ])
+        defer { stop(wrongValue) }
+        XCTAssertFalse(MTPLXTerminalHandoffLease.process(
+            pid: wrongValue.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+
+        let unrelatedValue = try launchSleep(environment: [
+            "MTPLX_HANDOFF_NOTE": "MTPLX_APP_HANDOFF_ID=\(token)"
+        ])
+        defer { stop(unrelatedValue) }
+        XCTAssertFalse(MTPLXTerminalHandoffLease.process(
+            pid: unrelatedValue.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+
+        let argvImpostor = try launchShell(
+            "exec /usr/bin/python3 -c 'import time; time.sleep(30)' MTPLX_APP_HANDOFF_ID=\(token)",
+            handoffID: nil
+        )
+        defer { stop(argvImpostor) }
+        XCTAssertFalse(MTPLXTerminalHandoffLease.process(
+            pid: argvImpostor.processIdentifier,
+            hasExactHandoffID: handoffID
+        ))
+        XCTAssertTrue(argvImpostor.isRunning, "same-token argv must not be reaped")
+    }
+
+    @MainActor
+    func testCancellationMarkerPreventsDelayedTerminalScriptFromExecuting() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let marker = directory.appendingPathComponent("cancelled")
+        let start = directory.appendingPathComponent("start")
+        let executed = directory.appendingPathComponent("executed")
+        let handoffID = UUID()
+        let script = """
+        while [[ ! -e \(shellQuote(start.path)) ]]; do sleep 0.01; done
+        if [[ -e \(shellQuote(marker.path)) ]]; then exit 0; fi
+        touch \(shellQuote(executed.path))
+        """
+        let process = try launchShell(script, handoffID: handoffID)
+        defer { stop(process) }
+        XCTAssertTrue(waitUntilRunning(process))
+
+        MTPLXTerminalHandoffLease.writeCancellationMarker(at: marker)
+        try Data().write(to: start)
+        let didExit = await waitForExit(process)
+        XCTAssertTrue(didExit)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: executed.path))
+    }
+
+    @MainActor
+    func testInjectedMarkerFailureRemovesDurableCommandBeforeDelayedLaunch() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let command = directory.appendingPathComponent("open-pi.command")
+        let receipt = directory.appendingPathComponent("open-pi.pid")
+        let marker = directory.appendingPathComponent("open-pi.cancelled")
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript(
+            "#!/bin/zsh\nexit 99\n",
+            to: command
+        )
+
+        let result = await MTPLXTerminalHandoffLease.awaitReceipt(
+            handoffID: UUID(),
+            receiptURL: receipt,
+            cancellationMarkerURL: marker,
+            commandURL: command,
+            isCurrent: { false },
+            timeoutSeconds: 0,
+            delayedCancellationSeconds: 0,
+            markerWriter: { _ in false }
+        )
+
+        XCTAssertTrue(result.cancellationRequested)
+        XCTAssertFalse(result.cancellationMarked)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: command.path),
+            "a failed marker write must remove the durable script before Terminal can read it"
+        )
+    }
+
+    @MainActor
+    func testSuccessfulReceiptRemovesSecretBearingCommandAndReceipt() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let handoffID = UUID()
+        let command = directory.appendingPathComponent("open-hermes.command")
+        let receipt = directory.appendingPathComponent("open-hermes.pid")
+        let marker = directory.appendingPathComponent("open-hermes.cancelled")
+        let sentinel = "test-openai-key-must-not-persist"
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript(
+            "#!/bin/zsh\nexport OPENAI_API_KEY='\(sentinel)'\nexit 0\n",
+            to: command
+        )
+        let process = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable: handoffID.uuidString.lowercased()
+        ])
+        defer { stop(process) }
+        try Data("\(process.processIdentifier)\n".utf8).write(to: receipt)
+
+        let result = await MTPLXTerminalHandoffLease.awaitReceipt(
+            handoffID: handoffID,
+            receiptURL: receipt,
+            cancellationMarkerURL: marker,
+            commandURL: command,
+            isCurrent: { true }
+        )
+
+        XCTAssertNotNil(result.lease)
+        XCTAssertFalse(result.cancellationRequested)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: command.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: receipt.path))
+    }
+
+    @MainActor
+    func testMarkerAfterFinalCheckCollectsReceiptAndReapsExactLease() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let marker = directory.appendingPathComponent("cancelled")
+        let receipt = directory.appendingPathComponent("receipt")
+        let reachedFinalCheck = directory.appendingPathComponent("final-check")
+        let handoffID = UUID()
+        let script = """
+        print -r -- "$$" > \(shellQuote(receipt.path + ".$$.tmp"))
+        mv -f \(shellQuote(receipt.path + ".$$.tmp")) \(shellQuote(receipt.path))
+        if [[ -e \(shellQuote(marker.path)) ]]; then exit 0; fi
+        touch \(shellQuote(reachedFinalCheck.path))
+        # Deliberately make the receipt-before-exec window observable. The
+        # handoff validator must retry this same PID until Python inherits the
+        # exact token, then reap it; a raw zsh process is not sufficient proof.
+        sleep 0.1
+        exec /usr/bin/python3 -c 'import time; time.sleep(30)'
+        """
+        let process = try launchShell(script, handoffID: handoffID)
+        defer { stop(process) }
+        let reachedCheck = await waitForFile(reachedFinalCheck)
+        XCTAssertTrue(reachedCheck)
+
+        let receiptResult = await MTPLXTerminalHandoffLease.awaitReceipt(
+            handoffID: handoffID,
+            receiptURL: receipt,
+            cancellationMarkerURL: marker,
+            isCurrent: { false },
+            timeoutSeconds: 0,
+            delayedCancellationSeconds: 1
+        )
+        XCTAssertTrue(receiptResult.cancellationMarked)
+        let lease = try XCTUnwrap(receiptResult.lease)
+        XCTAssertEqual(lease.processID, Int(process.processIdentifier))
+        XCTAssertTrue(PiIntegration().cancelTerminalHandoff(lease))
+        let didExit = await waitForExit(process)
+        XCTAssertTrue(didExit)
+    }
+
+    @MainActor
+    func testMismatchedLeaseFailsClosedAndUnrelatedProcessSurvives() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let expected = UUID()
+        let process = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable:
+                expected.uuidString.lowercased() + "-suffix"
+        ])
+        defer { stop(process) }
+        XCTAssertTrue(waitUntilRunning(process))
+
+        let lease = MTPLXTerminalHandoffLease(
+            handoffID: expected,
+            processID: Int(process.processIdentifier),
+            cancellationMarkerURL: directory.appendingPathComponent("cancelled")
+        )
+        XCTAssertFalse(PiIntegration().cancelTerminalHandoff(lease))
+        XCTAssertTrue(process.isRunning, "a lookalike token must not reap an unrelated PID")
+
+        let noTokenShell = try launchShell("while true; do sleep 1; done", handoffID: nil)
+        defer { stop(noTokenShell) }
+        let noTokenLease = MTPLXTerminalHandoffLease(
+            handoffID: expected,
+            processID: Int(noTokenShell.processIdentifier),
+            cancellationMarkerURL: directory.appendingPathComponent("no-token-cancelled")
+        )
+        XCTAssertFalse(PiIntegration().cancelTerminalHandoff(noTokenLease))
+        XCTAssertTrue(noTokenShell.isRunning, "unreadable zsh ownership must fail closed")
+    }
+
+    func testArtifactsArePrivateAndPathsRemainInvocationUnique() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstID = UUID().uuidString.lowercased()
+        let secondID = UUID().uuidString.lowercased()
+        let firstCommand = directory.appendingPathComponent("open-pi-\(firstID).command")
+        let secondCommand = directory.appendingPathComponent("open-pi-\(secondID).command")
+        let marker = directory.appendingPathComponent("open-pi-\(firstID).cancelled")
+
+        try MTPLXTerminalHandoffLease.prepareArtifactDirectory(directory)
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript("#!/bin/zsh\nexit 0\n", to: firstCommand)
+        try MTPLXTerminalHandoffLease.writeSecureCommandScript("#!/bin/zsh\nexit 0\n", to: secondCommand)
+        MTPLXTerminalHandoffLease.writeCancellationMarker(at: marker)
+
+        XCTAssertNotEqual(firstCommand, secondCommand)
+        XCTAssertEqual(try permissions(of: directory), 0o700)
+        XCTAssertEqual(try permissions(of: firstCommand), 0o700)
+        XCTAssertEqual(try permissions(of: secondCommand), 0o700)
+        XCTAssertEqual(try permissions(of: marker), 0o600)
+    }
+
+    func testDesktopIdentityRequiresBothPIDAndLaunchDate() {
+        let launchDate = Date(timeIntervalSinceReferenceDate: 123)
+        let identity = MTPLXDesktopHandoffIdentity(processID: 1234, launchDate: launchDate)
+        XCTAssertTrue(identity.matches(processID: 1234, launchDate: launchDate))
+        XCTAssertFalse(identity.matches(processID: 1235, launchDate: launchDate))
+        XCTAssertFalse(identity.matches(
+            processID: 1234,
+            launchDate: launchDate.addingTimeInterval(1)
+        ))
+        XCTAssertFalse(identity.matches(processID: 1234, launchDate: nil))
+    }
+
+    @MainActor
+    func testHermesStoreStopReapsItsExactManualTerminalLease() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let handoffID = UUID()
+        let process = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable: handoffID.uuidString.lowercased()
+        ])
+        defer { stop(process) }
+        XCTAssertTrue(waitUntilRunning(process))
+
+        let lease = MTPLXTerminalHandoffLease(
+            handoffID: handoffID,
+            processID: Int(process.processIdentifier),
+            cancellationMarkerURL: directory.appendingPathComponent("manual-hermes.cancelled")
+        )
+        let store = HermesAgentStore()
+        store.recordManualTerminalHandoffLeaseForTesting(lease)
+        XCTAssertEqual(store.manualTerminalHandoffLeaseIDForTesting, handoffID)
+
+        await store.stop()
+
+        XCTAssertNil(store.manualTerminalHandoffLeaseIDForTesting)
+        let clientExited = await waitForExit(process)
+        XCTAssertTrue(
+            clientExited,
+            "Stop must reap the exact manual Hermes receipt rather than a discovered process list"
+        )
+    }
+
+    @MainActor
+    func testStaleOpenCodeGateReapsExactDesktopIdentity() {
+        let identity = MTPLXDesktopHandoffIdentity(
+            processID: 1234,
+            launchDate: Date(timeIntervalSinceReferenceDate: 456)
+        )
+        let launch = OpenCodeDesktopResult(
+            action: .opened,
+            wasRunning: false,
+            didTerminateExistingInstance: false,
+            didOpen: true,
+            detail: "opened",
+            launchedProcessID: identity.processID,
+            launchedDesktopIdentity: identity
+        )
+        var reaped: [MTPLXDesktopHandoffIdentity] = []
+        let store = MTPLXBackendStore(openCodeDesktopCanceller: { identity in
+            reaped.append(identity)
+            return true
+        })
+
+        XCTAssertFalse(store.continueOpenCodeHandoff(
+            launch,
+            handoffID: UUID(),
+            isCurrent: { false }
+        ))
+        XCTAssertEqual(reaped, [identity])
+    }
+
+    @MainActor
+    func testToleratedRecoveryRefreshMissKeepsLeaseWhileExplicitRefreshStillDegrades() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let handoffID = UUID()
+        let client = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable: handoffID.uuidString.lowercased()
+        ])
+        defer { stop(client) }
+        let backend = MTPLXBackendStore(
+            configuration: MTPLXAppConfiguration(host: "127.0.0.1", port: 9)
+        )
+        backend.recordLaunchedPiTerminalHandoffLease(MTPLXTerminalHandoffLease(
+            handoffID: handoffID,
+            processID: Int(client.processIdentifier),
+            cancellationMarkerURL: directory.appendingPathComponent("recovery.cancelled")
+        ))
+        backend.setDaemonStateForTesting(.running)
+
+        do {
+            try await backend.refreshStaticState(markUnreachableOnTransportFailure: false)
+            XCTFail("the unavailable test endpoint must fail the refresh")
+        } catch {
+            // Recovery logs this one miss and lets the two-miss watchdog
+            // decide whether the verified restarted daemon is truly dead.
+        }
+        XCTAssertEqual(backend.terminalHandoffLeaseIDsForTesting, Set([handoffID]))
+        if case .running = backend.daemonState {
+            // Expected: tolerated recovery miss did not reap or degrade.
+        } else {
+            XCTFail("a tolerated recovery refresh miss must leave the daemon running")
+        }
+
+        do {
+            try await backend.refreshStaticState()
+            XCTFail("the unavailable test endpoint must fail the explicit refresh")
+        } catch {
+            // Default explicit refresh behavior remains fail-fast.
+        }
+        if case .degraded = backend.daemonState {
+            // Expected: the default remains unchanged.
+        } else {
+            XCTFail("an explicit refresh miss must still degrade the daemon")
+        }
+    }
+
+    @MainActor
+    func testLeaseSurvivesAutomaticRecoveryStatusesThenExplicitStopReapsIt() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let release = directory.appendingPathComponent("release")
+        let counter = directory.appendingPathComponent("counter")
+        try Data().write(to: release)
+
+        let scheduledGate = HandoffRecoveryGate()
+        let restartingGate = HandoffRecoveryGate()
+        let postStartGate = HandoffRecoveryGate()
+        let supervisor = DaemonSupervisor(
+            restartPolicy: DaemonRestartPolicy(
+                maximumAttempts: 1,
+                initialDelaySeconds: 0,
+                maximumDelaySeconds: 0,
+                crashWindowSeconds: 60
+            ),
+            restartSleeper: { _ in await scheduledGate.wait() },
+            beforeAutomaticRestartStart: { await restartingGate.wait() }
+        )
+        let configuration = MTPLXAppConfiguration(automaticDaemonRestart: true)
+        let backend = MTPLXBackendStore(
+            configuration: configuration,
+            supervisor: supervisor,
+            localFanRestorer: { true },
+            beforePostStartRefresh: { await postStartGate.wait() }
+        )
+        let handoffID = UUID()
+        let client = try launchSleep(environment: [
+            MTPLXTerminalHandoffLease.environmentVariable: handoffID.uuidString.lowercased()
+        ])
+        defer { stop(client) }
+        let lease = MTPLXTerminalHandoffLease(
+            handoffID: handoffID,
+            processID: Int(client.processIdentifier),
+            cancellationMarkerURL: directory.appendingPathComponent("client.cancelled")
+        )
+        backend.recordLaunchedPiTerminalHandoffLease(lease)
+
+        let script = """
+        count=$(cat \(shellQuote(counter.path)) 2>/dev/null || echo 0)
+        count=$((count + 1))
+        echo "$count" > \(shellQuote(counter.path))
+        if [ "$count" -eq 1 ]; then
+          while [ -e \(shellQuote(release.path)) ]; do sleep 0.01; done
+          exit 17
+        fi
+        while :; do sleep 1; done
+        """
+        _ = try await supervisor.start(
+            command: DaemonCommand(
+                executableURL: URL(fileURLWithPath: "/bin/sh"),
+                arguments: ["-c", script]
+            ),
+            healthBaseURL: URL(string: "http://127.0.0.1:9")!,
+            probeHealth: false
+        )
+        try FileManager.default.removeItem(at: release)
+
+        let reachedScheduled = await waitForRestartStatus(supervisor) {
+            if case .scheduled = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(reachedScheduled)
+        XCTAssertEqual(backend.terminalHandoffLeaseIDsForTesting, Set([handoffID]))
+
+        await scheduledGate.waitUntilEntered()
+        await scheduledGate.release()
+        await restartingGate.waitUntilEntered()
+        let reachedRestarting = await waitForRestartStatus(supervisor) {
+            if case .restarting = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(reachedRestarting)
+        XCTAssertEqual(backend.terminalHandoffLeaseIDsForTesting, Set([handoffID]))
+
+        await restartingGate.release()
+        let reachedRunningAfterRestart = await waitForRestartStatus(supervisor) {
+            if case .runningAfterRestart = $0 { return true }
+            return false
+        }
+        XCTAssertTrue(reachedRunningAfterRestart)
+        await postStartGate.waitUntilEntered()
+        XCTAssertEqual(backend.terminalHandoffLeaseIDsForTesting, Set([handoffID]))
+
+        let explicitStop = Task { @MainActor in
+            await backend.stopDaemon()
+        }
+        await Task.yield()
+        await postStartGate.release()
+        await explicitStop.value
+        let clientExited = await waitForExit(client)
+        XCTAssertTrue(clientExited, "explicit Stop must reap the retained lease after recovery")
+        XCTAssertTrue(backend.terminalHandoffLeaseIDsForTesting.isEmpty)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-handoff-tests-\(UUID().uuidString.lowercased())")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func permissions(of url: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.posixPermissions] as? NSNumber)?.intValue ?? -1
+    }
+
+    private func launchSleep(environment: [String: String]) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = ["-c", "import time; time.sleep(30)"]
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+        try process.run()
+        return process
+    }
+
+    private func launchShell(
+        _ script: String,
+        handoffID: UUID?,
+        additionalArguments: [String] = []
+    ) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", script] + additionalArguments
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "/usr/bin:/bin"
+        if let handoffID {
+            environment[MTPLXTerminalHandoffLease.environmentVariable] = handoffID.uuidString.lowercased()
+        }
+        process.environment = environment
+        try process.run()
+        return process
+    }
+
+    private func waitUntilRunning(_ process: Process) -> Bool {
+        for _ in 0..<50 where !process.isRunning {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return process.isRunning
+    }
+
+    @MainActor
+    private func waitForFile(_ url: URL) async -> Bool {
+        for _ in 0..<100 {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    @MainActor
+    private func waitForExit(_ process: Process) async -> Bool {
+        for _ in 0..<100 {
+            if !process.isRunning { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return !process.isRunning
+    }
+
+    @MainActor
+    private func waitForRestartStatus(
+        _ supervisor: DaemonSupervisor,
+        matching predicate: (DaemonRestartStatus) -> Bool
+    ) async -> Bool {
+        for _ in 0..<200 {
+            if predicate(supervisor.supervisionSnapshot().restartStatus) { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return predicate(supervisor.supervisionSnapshot().restartStatus)
+    }
+
+    private func stop(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+        process.waitUntilExit()
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\\\''"))'"
+    }
+}


### PR DESCRIPTION
## Summary

Implements the narrow app-managed supervision slice accepted in #202.

- Adds an opt-in automatic daemon restart setting (off by default).
- Retries abnormal exits at most three times with bounded exponential backoff and a visible circuit-breaker state.
- Makes explicit Stop and disabling recovery cancel scheduled or in-flight retries and reap only the exact app-owned process family.
- Keeps restart recipes, including the API key, in memory only and releases them after clean exit, disable, or exhaustion.
- Preserves lifecycle ownership across Pi, Hermes, and OpenCode handoffs using per-launch UUID or PID-plus-launch-date identities, including exact cleanup after restarts.
- Removes one-use Hermes command and receipt artifacts as soon as a receipt is collected so launch secrets are not left on disk.
- Exposes recovery status/count in the app and guards transport, fan, metrics, and client state against stale async completions.

An already-running daemon adopted from a previous app session is intentionally shown as unprotected. The user must start a fresh app-managed daemon before automatic recovery can own it safely.

## Scope

This does **not** claim to fix the underlying Metal out-of-memory crash, persist daemon logs, or add memory telemetry. Those are separate parts of #202 and need their own investigation and validation.

## Verification

CPU-only / no model weights:

- Swift parser: all 10 changed/new Swift files
- `git diff --check`
- `DaemonSupervisorTests`: 35 passed
- `TerminalHandoffLeaseTests`: 12 passed
- Full `MTPLXApp` suite: 593 tests, 1 skipped, 0 failures
- Six high-risk lifecycle/reparenting races: 6 passed, repeated three times
- Post-test process scan: no leaked supervisor or handoff processes

The final diff received independent Terra and Sol review approval before commit.

Closes the app-managed restart slice of #202; leaves the crash root cause, persistent logging, and memory telemetry open.
