### PR TITLE
DeepSeek V4: profit-gated adaptive K3 verifier width

### DIFF
--- a/mtplx/deepseek_v4_adaptive_width.py
+++ b/mtplx/deepseek_v4_adaptive_width.py
@@ -1,0 +1,167 @@
+"""Construction contract for the preregistered DeepSeek-V4 max-K3 policy."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .sampling import SamplerConfig
+
+
+D1_MARGIN_THRESHOLD = 0.25
+D2_MARGIN_THRESHOLD = 1.0
+MAX_SPECULATIVE_DEPTH = 3
+
+
+@dataclass(frozen=True, slots=True)
+class DeepSeekV4TargetWidthRoute:
+    """One prebound target-forward surface for an exact verify width."""
+
+    target_rows: int
+    forward: Callable[..., Any]
+
+    def __call__(self, input_ids: Any, **kwargs: Any) -> Any:
+        return self.forward(input_ids, **kwargs)
+
+
+@dataclass(frozen=True, slots=True)
+class DeepSeekV4AdaptiveWidthPolicy:
+    """The single preregistered policy and its construction-validated surfaces."""
+
+    runtime_object_id: int
+    target_routes: tuple[
+        DeepSeekV4TargetWidthRoute,
+        DeepSeekV4TargetWidthRoute,
+        DeepSeekV4TargetWidthRoute,
+    ]
+    d1_margin_threshold: float = field(default=D1_MARGIN_THRESHOLD, init=False)
+    d2_margin_threshold: float = field(default=D2_MARGIN_THRESHOLD, init=False)
+    max_speculative_depth: int = field(default=MAX_SPECULATIVE_DEPTH, init=False)
+    verify_strategy: str = field(default="capture_commit", init=False)
+    verify_core: str = field(default="stock", init=False)
+    mtp_history_policy: str = field(default="committed", init=False)
+
+    def stop_after_d1(self, margin: float) -> bool:
+        return float(margin) < self.d1_margin_threshold
+
+    def stop_after_d2(self, margin: float) -> bool:
+        return float(margin) < self.d2_margin_threshold
+
+    def validate_request(
+        self,
+        rt: Any,
+        *,
+        sampler: SamplerConfig,
+        draft_sampler: SamplerConfig,
+        speculative_depth: int,
+        verify_strategy: str,
+        verify_core: str,
+        mtp_history_policy: str,
+    ) -> None:
+        """Reject a launch that differs from the installed policy contract."""
+
+        if id(rt) != self.runtime_object_id:
+            raise ValueError("adaptive width policy belongs to a different runtime")
+        _validate_launch(
+            sampler=sampler,
+            draft_sampler=draft_sampler,
+            speculative_depth=speculative_depth,
+            verify_strategy=verify_strategy,
+            verify_core=verify_core,
+            mtp_history_policy=mtp_history_policy,
+        )
+
+
+def _validate_launch(
+    *,
+    sampler: SamplerConfig,
+    draft_sampler: SamplerConfig,
+    speculative_depth: int,
+    verify_strategy: str,
+    verify_core: str,
+    mtp_history_policy: str,
+) -> None:
+    if float(sampler.temperature) > 0.0:
+        raise ValueError("adaptive width policy requires a greedy target sampler")
+    if float(draft_sampler.temperature) > 0.0:
+        raise ValueError("adaptive width policy requires a greedy draft sampler")
+    if int(speculative_depth) != MAX_SPECULATIVE_DEPTH:
+        raise ValueError("adaptive width policy requires fixed planned max-K3")
+    if verify_strategy != "capture_commit":
+        raise ValueError("adaptive width policy requires capture_commit verification")
+    if verify_core != "stock":
+        raise ValueError("adaptive width policy requires the stock verify core")
+    if mtp_history_policy != "committed":
+        raise ValueError("adaptive width policy requires committed MTP history")
+
+
+def _validate_runtime(rt: Any) -> Callable[..., Any]:
+    if not bool(getattr(rt, "mtp_enabled", False)):
+        raise ValueError("adaptive width policy requires an MTP-enabled runtime")
+    model = getattr(rt, "model", None)
+    model_type = str(getattr(model, "model_type", "") or "").lower()
+    if model_type != "deepseek_v4":
+        raise ValueError("adaptive width policy is only valid for DeepSeek-V4")
+
+    report = getattr(rt, "deepseek_v4_o_lora_report", None)
+    census = report.get("callable_census", {}) if isinstance(report, dict) else {}
+    route_ok = bool(
+        isinstance(report, dict)
+        and report.get("mode") == "gather_qmm"
+        and report.get("module_count") == 44
+        and report.get("trunk_module_count") == 43
+        and report.get("mtp_module_count") == 1
+        and report.get("body_direct") == 43
+        and report.get("mtp_stock") == 1
+        and report.get("body_all_mode_matches") is True
+        and report.get("route_plan_matches") is True
+        and census.get("body_route_objects") == 43
+        and census.get("body_route_kind") == "gather_qmm_direct"
+        and census.get("body_callable_class") == "_DirectGatherOLora"
+        and census.get("mtp_route_objects") == 1
+        and census.get("mtp_route_kind") == "dense_bf16_stock_direct"
+        and census.get("mtp_callable_class") == "_DirectDenseMTPOLora"
+        and census.get("total_route_objects") == 44
+        and census.get("unique_route_objects") == 44
+        and census.get("mtp_distinct_type") is True
+    )
+    if not route_ok:
+        raise ValueError("adaptive width policy requires the canonical o-LoRA route")
+
+    forward = getattr(rt, "forward_ar_capture", None)
+    if not callable(forward):
+        raise ValueError("adaptive width policy requires a callable capture target forward")
+    return forward
+
+
+def install_deepseek_v4_adaptive_width_policy(
+    rt: Any,
+    *,
+    sampler: SamplerConfig,
+    draft_sampler: SamplerConfig | None,
+    speculative_depth: int,
+    verify_strategy: str,
+    verify_core: str,
+    mtp_history_policy: str,
+) -> DeepSeekV4AdaptiveWidthPolicy:
+    """Validate and bind the only supported adaptive-width configuration."""
+
+    resolved_draft_sampler = sampler if draft_sampler is None else draft_sampler
+    _validate_launch(
+        sampler=sampler,
+        draft_sampler=resolved_draft_sampler,
+        speculative_depth=speculative_depth,
+        verify_strategy=verify_strategy,
+        verify_core=verify_core,
+        mtp_history_policy=mtp_history_policy,
+    )
+    target_forward = _validate_runtime(rt)
+    target_routes = tuple(
+        DeepSeekV4TargetWidthRoute(target_rows=rows, forward=target_forward)
+        for rows in (2, 3, 4)
+    )
+    return DeepSeekV4AdaptiveWidthPolicy(
+        runtime_object_id=id(rt),
+        target_routes=target_routes,  # type: ignore[arg-type]
+    )

--- a/mtplx/deepseek_v4_adaptive_width.py
+++ b/mtplx/deepseek_v4_adaptive_width.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+import json
 from typing import Any
 
 from .sampling import SamplerConfig
@@ -12,28 +13,104 @@ from .sampling import SamplerConfig
 D1_MARGIN_THRESHOLD = 0.25
 D2_MARGIN_THRESHOLD = 1.0
 MAX_SPECULATIVE_DEPTH = 3
+_FACTORY_SEAL = object()
+_CANONICAL_TARGET_ROWS = (2, 3, 4)
+_CANONICAL_O_LORA_FINGERPRINT = (
+    "gather_qmm",
+    44,
+    43,
+    1,
+    43,
+    1,
+    True,
+    True,
+    43,
+    "gather_qmm_direct",
+    "_DirectGatherOLora",
+    1,
+    "dense_bf16_stock_direct",
+    "_DirectDenseMTPOLora",
+    44,
+    44,
+    True,
+)
 
 
-@dataclass(frozen=True, slots=True)
-class DeepSeekV4TargetWidthRoute:
+def _o_lora_fingerprint(report: Any) -> tuple[Any, ...] | None:
+    if not isinstance(report, dict):
+        return None
+    census = report.get("callable_census")
+    if not isinstance(census, dict):
+        return None
+    return (
+        report.get("mode"),
+        report.get("module_count"),
+        report.get("trunk_module_count"),
+        report.get("mtp_module_count"),
+        report.get("body_direct"),
+        report.get("mtp_stock"),
+        report.get("body_all_mode_matches"),
+        report.get("route_plan_matches"),
+        census.get("body_route_objects"),
+        census.get("body_route_kind"),
+        census.get("body_callable_class"),
+        census.get("mtp_route_objects"),
+        census.get("mtp_route_kind"),
+        census.get("mtp_callable_class"),
+        census.get("total_route_objects"),
+        census.get("unique_route_objects"),
+        census.get("mtp_distinct_type"),
+    )
+
+
+def _serialized_report(report: Any) -> str:
+    return json.dumps(report, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class _DeepSeekV4TargetWidthRoute:
     """One prebound target-forward surface for an exact verify width."""
 
-    target_rows: int
+    expected_physical_rows: int
     forward: Callable[..., Any]
+    _installation_seal: object = field(repr=False)
+
+    def __init__(
+        self,
+        *,
+        factory_seal: object,
+        target_rows: int,
+        forward: Callable[..., Any],
+    ) -> None:
+        if factory_seal is not _FACTORY_SEAL:
+            raise TypeError("adaptive width target routes are factory-only")
+        object.__setattr__(self, "expected_physical_rows", int(target_rows))
+        object.__setattr__(self, "forward", forward)
+        object.__setattr__(self, "_installation_seal", factory_seal)
+
+    @property
+    def target_rows(self) -> int:
+        return self.expected_physical_rows
 
     def __call__(self, input_ids: Any, **kwargs: Any) -> Any:
         return self.forward(input_ids, **kwargs)
 
 
-@dataclass(frozen=True, slots=True)
-class DeepSeekV4AdaptiveWidthPolicy:
+@dataclass(frozen=True, slots=True, init=False)
+class _DeepSeekV4AdaptiveWidthPolicy:
     """The single preregistered policy and its construction-validated surfaces."""
 
     runtime_object_id: int
+    _runtime: Any = field(repr=False)
+    _model: Any = field(repr=False)
+    _capture_forward: Callable[..., Any] = field(repr=False)
+    _capture_forward_function: Callable[..., Any] = field(repr=False)
+    _o_lora_report_json: str = field(repr=False)
+    _installation_seal: object = field(repr=False)
     target_routes: tuple[
-        DeepSeekV4TargetWidthRoute,
-        DeepSeekV4TargetWidthRoute,
-        DeepSeekV4TargetWidthRoute,
+        _DeepSeekV4TargetWidthRoute,
+        _DeepSeekV4TargetWidthRoute,
+        _DeepSeekV4TargetWidthRoute,
     ]
     d1_margin_threshold: float = field(default=D1_MARGIN_THRESHOLD, init=False)
     d2_margin_threshold: float = field(default=D2_MARGIN_THRESHOLD, init=False)
@@ -41,6 +118,39 @@ class DeepSeekV4AdaptiveWidthPolicy:
     verify_strategy: str = field(default="capture_commit", init=False)
     verify_core: str = field(default="stock", init=False)
     mtp_history_policy: str = field(default="committed", init=False)
+
+    def __init__(
+        self,
+        *,
+        factory_seal: object,
+        runtime: Any,
+        capture_forward: Callable[..., Any],
+        capture_forward_function: Callable[..., Any],
+        o_lora_report_json: str,
+        target_routes: tuple[
+            _DeepSeekV4TargetWidthRoute,
+            _DeepSeekV4TargetWidthRoute,
+            _DeepSeekV4TargetWidthRoute,
+        ],
+    ) -> None:
+        if factory_seal is not _FACTORY_SEAL:
+            raise TypeError("adaptive width policies are factory-only")
+        object.__setattr__(self, "runtime_object_id", id(runtime))
+        object.__setattr__(self, "_runtime", runtime)
+        object.__setattr__(self, "_model", runtime.model)
+        object.__setattr__(self, "_capture_forward", capture_forward)
+        object.__setattr__(
+            self, "_capture_forward_function", capture_forward_function
+        )
+        object.__setattr__(self, "_o_lora_report_json", o_lora_report_json)
+        object.__setattr__(self, "_installation_seal", factory_seal)
+        object.__setattr__(self, "target_routes", target_routes)
+        object.__setattr__(self, "d1_margin_threshold", D1_MARGIN_THRESHOLD)
+        object.__setattr__(self, "d2_margin_threshold", D2_MARGIN_THRESHOLD)
+        object.__setattr__(self, "max_speculative_depth", MAX_SPECULATIVE_DEPTH)
+        object.__setattr__(self, "verify_strategy", "capture_commit")
+        object.__setattr__(self, "verify_core", "stock")
+        object.__setattr__(self, "mtp_history_policy", "committed")
 
     def stop_after_d1(self, margin: float) -> bool:
         return float(margin) < self.d1_margin_threshold
@@ -61,8 +171,47 @@ class DeepSeekV4AdaptiveWidthPolicy:
     ) -> None:
         """Reject a launch that differs from the installed policy contract."""
 
-        if id(rt) != self.runtime_object_id:
+        if self._installation_seal is not _FACTORY_SEAL:
+            raise ValueError("adaptive width policy installation seal is invalid")
+        if self._runtime is not rt or id(rt) != self.runtime_object_id:
             raise ValueError("adaptive width policy belongs to a different runtime")
+        if getattr(rt, "model", None) is not self._model:
+            raise ValueError("adaptive width policy model authority changed")
+        model_type = str(getattr(self._model, "model_type", "") or "").lower()
+        if model_type != "deepseek_v4":
+            raise ValueError("adaptive width policy DeepSeek-V4 authority changed")
+        report = getattr(rt, "deepseek_v4_o_lora_report", None)
+        if (
+            _o_lora_fingerprint(report) != _CANONICAL_O_LORA_FINGERPRINT
+            or _serialized_report(report) != self._o_lora_report_json
+        ):
+            raise ValueError("adaptive width policy canonical o-LoRA report changed")
+        current_forward = getattr(rt, "forward_ar_capture", None)
+        if (
+            not callable(current_forward)
+            or getattr(current_forward, "__self__", None) is not rt
+            or getattr(current_forward, "__func__", None)
+            is not self._capture_forward_function
+            or getattr(type(rt), "forward_ar_capture", None)
+            is not self._capture_forward_function
+        ):
+            raise ValueError("adaptive width policy capture-forward authority changed")
+        if (
+            not isinstance(self.target_routes, tuple)
+            or len(self.target_routes) != 3
+            or tuple(route.expected_physical_rows for route in self.target_routes)
+            != _CANONICAL_TARGET_ROWS
+            or any(
+                type(route) is not _DeepSeekV4TargetWidthRoute
+                or route._installation_seal is not _FACTORY_SEAL
+                or route.forward is not self._capture_forward
+                or getattr(route.forward, "__self__", None) is not rt
+                or getattr(route.forward, "__func__", None)
+                is not self._capture_forward_function
+                for route in self.target_routes
+            )
+        ):
+            raise ValueError("adaptive width policy target route authority changed")
         _validate_launch(
             sampler=sampler,
             draft_sampler=draft_sampler,
@@ -71,6 +220,35 @@ class DeepSeekV4AdaptiveWidthPolicy:
             verify_core=verify_core,
             mtp_history_policy=mtp_history_policy,
         )
+
+
+def validate_installed_deepseek_v4_adaptive_width_policy(
+    policy: Any,
+    rt: Any,
+    *,
+    sampler: SamplerConfig,
+    draft_sampler: SamplerConfig,
+    speculative_depth: int,
+    verify_strategy: str,
+    verify_core: str,
+    mtp_history_policy: str,
+) -> None:
+    """Authenticate the installed private type before trusting its methods."""
+
+    if (
+        type(policy) is not _DeepSeekV4AdaptiveWidthPolicy
+        or getattr(policy, "_installation_seal", None) is not _FACTORY_SEAL
+    ):
+        raise ValueError("adaptive width policy must be factory-installed")
+    policy.validate_request(
+        rt,
+        sampler=sampler,
+        draft_sampler=draft_sampler,
+        speculative_depth=speculative_depth,
+        verify_strategy=verify_strategy,
+        verify_core=verify_core,
+        mtp_history_policy=mtp_history_policy,
+    )
 
 
 def _validate_launch(
@@ -96,7 +274,7 @@ def _validate_launch(
         raise ValueError("adaptive width policy requires committed MTP history")
 
 
-def _validate_runtime(rt: Any) -> Callable[..., Any]:
+def _validate_runtime(rt: Any) -> tuple[Callable[..., Any], Callable[..., Any], str]:
     if not bool(getattr(rt, "mtp_enabled", False)):
         raise ValueError("adaptive width policy requires an MTP-enabled runtime")
     model = getattr(rt, "model", None)
@@ -105,34 +283,21 @@ def _validate_runtime(rt: Any) -> Callable[..., Any]:
         raise ValueError("adaptive width policy is only valid for DeepSeek-V4")
 
     report = getattr(rt, "deepseek_v4_o_lora_report", None)
-    census = report.get("callable_census", {}) if isinstance(report, dict) else {}
-    route_ok = bool(
-        isinstance(report, dict)
-        and report.get("mode") == "gather_qmm"
-        and report.get("module_count") == 44
-        and report.get("trunk_module_count") == 43
-        and report.get("mtp_module_count") == 1
-        and report.get("body_direct") == 43
-        and report.get("mtp_stock") == 1
-        and report.get("body_all_mode_matches") is True
-        and report.get("route_plan_matches") is True
-        and census.get("body_route_objects") == 43
-        and census.get("body_route_kind") == "gather_qmm_direct"
-        and census.get("body_callable_class") == "_DirectGatherOLora"
-        and census.get("mtp_route_objects") == 1
-        and census.get("mtp_route_kind") == "dense_bf16_stock_direct"
-        and census.get("mtp_callable_class") == "_DirectDenseMTPOLora"
-        and census.get("total_route_objects") == 44
-        and census.get("unique_route_objects") == 44
-        and census.get("mtp_distinct_type") is True
-    )
-    if not route_ok:
+    if _o_lora_fingerprint(report) != _CANONICAL_O_LORA_FINGERPRINT:
         raise ValueError("adaptive width policy requires the canonical o-LoRA route")
 
     forward = getattr(rt, "forward_ar_capture", None)
-    if not callable(forward):
-        raise ValueError("adaptive width policy requires a callable capture target forward")
-    return forward
+    forward_function = getattr(forward, "__func__", None)
+    if (
+        not callable(forward)
+        or getattr(forward, "__self__", None) is not rt
+        or not callable(forward_function)
+        or getattr(type(rt), "forward_ar_capture", None) is not forward_function
+    ):
+        raise ValueError(
+            "adaptive width policy requires the canonical owned capture target forward"
+        )
+    return forward, forward_function, _serialized_report(report)
 
 
 def install_deepseek_v4_adaptive_width_policy(
@@ -144,7 +309,7 @@ def install_deepseek_v4_adaptive_width_policy(
     verify_strategy: str,
     verify_core: str,
     mtp_history_policy: str,
-) -> DeepSeekV4AdaptiveWidthPolicy:
+) -> _DeepSeekV4AdaptiveWidthPolicy:
     """Validate and bind the only supported adaptive-width configuration."""
 
     resolved_draft_sampler = sampler if draft_sampler is None else draft_sampler
@@ -156,12 +321,20 @@ def install_deepseek_v4_adaptive_width_policy(
         verify_core=verify_core,
         mtp_history_policy=mtp_history_policy,
     )
-    target_forward = _validate_runtime(rt)
+    target_forward, target_forward_function, report_json = _validate_runtime(rt)
     target_routes = tuple(
-        DeepSeekV4TargetWidthRoute(target_rows=rows, forward=target_forward)
-        for rows in (2, 3, 4)
+        _DeepSeekV4TargetWidthRoute(
+            factory_seal=_FACTORY_SEAL,
+            target_rows=rows,
+            forward=target_forward,
+        )
+        for rows in _CANONICAL_TARGET_ROWS
     )
-    return DeepSeekV4AdaptiveWidthPolicy(
-        runtime_object_id=id(rt),
+    return _DeepSeekV4AdaptiveWidthPolicy(
+        factory_seal=_FACTORY_SEAL,
+        runtime=rt,
+        capture_forward=target_forward,
+        capture_forward_function=target_forward_function,
+        o_lora_report_json=report_json,
         target_routes=target_routes,  # type: ignore[arg-type]
     )

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -3681,6 +3681,22 @@ def _sample_from_logits(
     return sample_from_distribution(probs, rng), probs
 
 
+def _greedy_draft_token_and_top2(logits: mx.array) -> tuple[int, float, float]:
+    """Materialize one greedy token and its FP32 top-two values together."""
+
+    row = (
+        logits[:, -1, :][0]
+        if logits.ndim == 3
+        else logits.reshape(-1)
+    ).astype(mx.float32)
+    token_id = mx.argmax(row, axis=-1)
+    top2_values = mx.topk(row, k=2)
+    _eval(token_id, top2_values)
+    token = int(np.asarray(token_id).reshape(-1)[0])
+    top2 = np.asarray(top2_values, dtype=np.float32).reshape(-1)
+    return token, float(top2[-1]), float(top2[-2])
+
+
 def _sample_draft_from_logits(
     logits: mx.array,
     config: SamplerConfig,
@@ -5749,6 +5765,7 @@ def generate_mtpk(
     thinking_guard: ThinkingGuardConfig | None = None,
     vision_splice: Any | None = None,
     constraint: Any | None = None,
+    adaptive_width_policy: Any | None = None,
 ) -> GenerationOutput:
     """Generate with a fixed native-MTP depth.
 
@@ -5893,6 +5910,47 @@ def generate_mtpk(
     _loop_guard_config = loop_guard_config_from_env(
         bool(loop_guard), tokenizer=getattr(rt, "tokenizer", None)
     )
+    if adaptive_width_policy is not None:
+        if adaptive_policy is not None:
+            raise ValueError(
+                "adaptive width policy cannot be combined with another adaptive policy"
+            )
+        if draft_margin_threshold is not None:
+            raise ValueError(
+                "adaptive width policy cannot be combined with draft_margin_threshold"
+            )
+        incompatible_features = {
+            "draft_core": draft_core != "stock",
+            "mtp_corrector": mtp_corrector is not None,
+            "online_hidden_corrector": online_hidden_corrector_alpha != 0.0,
+            "online_correction_cache": online_correction_cache,
+            "prompt_correction_cache": prompt_correction_cache,
+            "adapter_ensemble_q": adapter_ensemble_q,
+            "mtp_topk_reranker": mtp_topk_reranker is not None,
+            "session_bank": session_bank is not None,
+            "vision_splice": vision_splice is not None,
+            "constraint": constraint is not None,
+            "loop_guard": _loop_guard_config.enabled,
+            "thinking_guard": thinking_guard is not None,
+            "compiled_verify": compiled_verify_mode() != "off",
+        }
+        selected_features = [
+            name for name, selected in incompatible_features.items() if selected
+        ]
+        if selected_features:
+            raise ValueError(
+                "adaptive width policy requires its fixed canonical lane; "
+                f"incompatible features: {selected_features}"
+            )
+        adaptive_width_policy.validate_request(
+            rt,
+            sampler=sampler,
+            draft_sampler=draft_sampler,
+            speculative_depth=speculative_depth,
+            verify_strategy=verify_strategy,
+            verify_core=verify_core,
+            mtp_history_policy=mtp_history_policy,
+        )
     if bool(getattr(rt, "a3b_whole_moe_installed", False)):
         os.environ["MTPLX_CURRENT_PREFILL_CONTEXT_TOKENS"] = str(len(prompt_ids))
         whole_moe_prefill_layout = _sustained_prefill_layout()
@@ -5942,6 +6000,98 @@ def generate_mtpk(
     )
 
     rng = np.random.default_rng(seed)
+
+    def _fixed_width_draft_reader(
+        draft_logits: mx.array,
+        *,
+        cycle_depth: int,
+        depth_index: int,
+        need_distribution: bool,
+        decision_margins: list[float],
+    ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+        del cycle_depth, depth_index, decision_margins
+        token, distribution = _sample_draft_from_logits(
+            draft_logits[:, -1, :][0],
+            draft_sampler,
+            rng,
+            need_distribution=need_distribution,
+        )
+        return token, distribution, False
+
+    if adaptive_width_policy is None:
+        adaptive_width_draft_reader = _fixed_width_draft_reader
+        capture_forward_routes = (rt.forward_ar_capture,) * max(
+            1, int(speculative_depth)
+        )
+
+        def record_adaptive_width_event(
+            event: dict[str, Any],
+            *,
+            cycle_depth: int,
+            decision_margins: list[float],
+            selected_draft_depth: int,
+        ) -> None:
+            del event, cycle_depth, decision_margins, selected_draft_depth
+
+    else:
+        adaptive_width_margin_stops = (
+            adaptive_width_policy.stop_after_d1,
+            adaptive_width_policy.stop_after_d2,
+        )
+        adaptive_width_d1_threshold = float(
+            adaptive_width_policy.d1_margin_threshold
+        )
+        adaptive_width_d2_threshold = float(
+            adaptive_width_policy.d2_margin_threshold
+        )
+        adaptive_width_max_depth = int(adaptive_width_policy.max_speculative_depth)
+        capture_forward_routes = adaptive_width_policy.target_routes
+
+        def adaptive_width_draft_reader(
+            draft_logits: mx.array,
+            *,
+            cycle_depth: int,
+            depth_index: int,
+            need_distribution: bool,
+            decision_margins: list[float],
+        ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+            if cycle_depth != adaptive_width_max_depth or depth_index >= 2:
+                return _fixed_width_draft_reader(
+                    draft_logits,
+                    cycle_depth=cycle_depth,
+                    depth_index=depth_index,
+                    need_distribution=need_distribution,
+                    decision_margins=decision_margins,
+                )
+            token, top1, top2 = _greedy_draft_token_and_top2(draft_logits)
+            margin = float(top1 - top2)
+            decision_margins.append(margin)
+            distribution = (
+                SparseDistribution.one_hot(token, int(draft_logits.shape[-1]))
+                if need_distribution
+                else None
+            )
+            return token, distribution, adaptive_width_margin_stops[depth_index](
+                margin
+            )
+
+        def record_adaptive_width_event(
+            event: dict[str, Any],
+            *,
+            cycle_depth: int,
+            decision_margins: list[float],
+            selected_draft_depth: int,
+        ) -> None:
+            event["adaptive_width_policy"] = {
+                "kind": "deepseek_v4_preregistered_max_k3",
+                "eligible_full_k3": cycle_depth == adaptive_width_max_depth,
+                "d1_margin_threshold": adaptive_width_d1_threshold,
+                "d2_margin_threshold": adaptive_width_d2_threshold,
+                "decision_margins": list(decision_margins),
+                "selected_draft_depth": selected_draft_depth,
+                "target_rows": selected_draft_depth + 1,
+            }
+
     if mtp_corrector is not None:
         corrector_variant = getattr(mtp_corrector, "hidden_variant", mtp_hidden_variant)
         if corrector_variant != mtp_hidden_variant:
@@ -7064,6 +7214,7 @@ def generate_mtpk(
             break
 
         cycle_depth = min(planned_depth, max_tokens - len(tokens))
+        adaptive_width_decision_margins: list[float] = []
         draft_tokens: list[int | None] = []
         draft_probs: list[np.ndarray | None] = []
         draft_cache_keys: list[tuple[int, ...]] = []
@@ -7742,6 +7893,7 @@ def generate_mtpk(
                 )
             )
             reranker_info = None
+            adaptive_width_stop = False
             cached_token = (
                 correction_cache.get(cache_key) if cache_enabled_for_depth else None
             )
@@ -7822,13 +7974,17 @@ def generate_mtpk(
                             ),
                         )
                 else:
-                    draft_token, draft_q = _sample_draft_from_logits(
-                        draft_logits[:, -1, :][0],
-                        draft_sampler,
-                        rng,
-                        need_distribution=(
-                            sampler.temperature > 0 and not target_prefix_verify
-                        ),
+                    need_draft_distribution = (
+                        sampler.temperature > 0 and not target_prefix_verify
+                    )
+                    draft_token, draft_q, adaptive_width_stop = (
+                        adaptive_width_draft_reader(
+                            draft_logits,
+                            cycle_depth=cycle_depth,
+                            depth_index=depth_index,
+                            need_distribution=need_draft_distribution,
+                            decision_margins=adaptive_width_decision_margins,
+                        )
                     )
             elapsed_draft = time.perf_counter() - started
             draft_time += elapsed_draft
@@ -7938,6 +8094,9 @@ def generate_mtpk(
             if online_draft_event is not None:
                 draft_event["online_hidden_corrector"] = online_draft_event
             event["drafts"].append(draft_event)
+            if adaptive_width_stop:
+                event["gated_stop_depth"] = depth_index + 1
+                break
             if adaptive_policy is not None and hasattr(
                 adaptive_policy, "should_continue_after_draft"
             ):
@@ -7951,6 +8110,13 @@ def generate_mtpk(
                     event["gated_stop_depth"] = depth_index + 1
                     event["policy_stop"] = policy_continue
                     break
+
+        record_adaptive_width_event(
+            event,
+            cycle_depth=cycle_depth,
+            decision_margins=adaptive_width_decision_margins,
+            selected_draft_depth=len(draft_tokens),
+        )
 
         before_verify = None
         if a3b_target_prefix_route is None:
@@ -8056,7 +8222,8 @@ def generate_mtpk(
                         )
                     )
                 else:
-                    verify_logits, verify_hidden, captures = rt.forward_ar_capture(
+                    capture_forward = capture_forward_routes[len(draft_tokens) - 1]
+                    verify_logits, verify_hidden, captures = capture_forward(
                         verify_input_array,
                         cache=cache,
                         return_hidden=True,

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -31,6 +31,9 @@ from .a3b_compiled_target_prefix import (
 from .a3b_whole_moe import validate_a3b_whole_moe_request
 from .adaptive import AdaptiveDepthPolicy, ExpectedValueDepthPolicy
 from .attention_context import attention_phase
+from .deepseek_v4_adaptive_width import (
+    validate_installed_deepseek_v4_adaptive_width_policy,
+)
 from .progress_heartbeat import tick as _owner_progress_tick
 from .cache_state import (
     detach_array_leaf,
@@ -3713,6 +3716,83 @@ def _sample_draft_from_logits(
     return token, SparseDistribution.one_hot(token, int(logits.shape[-1]))
 
 
+def _fixed_width_draft_reader(
+    draft_logits: mx.array,
+    config: SamplerConfig,
+    rng: np.random.Generator,
+    *,
+    need_distribution: bool,
+) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+    token, distribution = _sample_draft_from_logits(
+        draft_logits[:, -1, :][0],
+        config,
+        rng,
+        need_distribution=need_distribution,
+    )
+    return token, distribution, False
+
+
+def _adaptive_tail_k1_draft_reader(
+    draft_logits: mx.array,
+    config: SamplerConfig,
+    rng: np.random.Generator,
+    *,
+    need_distribution: bool,
+) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+    token, distribution = _sample_draft_from_logits(
+        draft_logits[:, -1, :][0],
+        config,
+        rng,
+        need_distribution=need_distribution,
+    )
+    return token, distribution, False
+
+
+def _adaptive_tail_k2_draft_reader(
+    draft_logits: mx.array,
+    config: SamplerConfig,
+    rng: np.random.Generator,
+    *,
+    need_distribution: bool,
+) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+    token, distribution = _sample_draft_from_logits(
+        draft_logits[:, -1, :][0],
+        config,
+        rng,
+        need_distribution=need_distribution,
+    )
+    return token, distribution, False
+
+
+def _adaptive_full_k3_draft_reader(
+    draft_logits: mx.array,
+    config: SamplerConfig,
+    rng: np.random.Generator,
+    *,
+    depth_index: int,
+    need_distribution: bool,
+    decision_margins: list[float],
+    margin_stops: tuple[Callable[[float], bool], Callable[[float], bool]],
+) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+    if depth_index < 2:
+        token, top1, top2 = _greedy_draft_token_and_top2(draft_logits)
+        margin = float(top1 - top2)
+        decision_margins.append(margin)
+        distribution = (
+            SparseDistribution.one_hot(token, int(draft_logits.shape[-1]))
+            if need_distribution
+            else None
+        )
+        return token, distribution, margin_stops[depth_index](margin)
+    token, distribution = _sample_draft_from_logits(
+        draft_logits[:, -1, :][0],
+        config,
+        rng,
+        need_distribution=need_distribution,
+    )
+    return token, distribution, False
+
+
 def _env_scaled_draft_sampler(
     sampler: SamplerConfig,
     draft_sampler: SamplerConfig | None,
@@ -5942,7 +6022,8 @@ def generate_mtpk(
                 "adaptive width policy requires its fixed canonical lane; "
                 f"incompatible features: {selected_features}"
             )
-        adaptive_width_policy.validate_request(
+        validate_installed_deepseek_v4_adaptive_width_policy(
+            adaptive_width_policy,
             rt,
             sampler=sampler,
             draft_sampler=draft_sampler,
@@ -6001,25 +6082,25 @@ def generate_mtpk(
 
     rng = np.random.default_rng(seed)
 
-    def _fixed_width_draft_reader(
+    def _default_cycle_draft_reader(
         draft_logits: mx.array,
         *,
-        cycle_depth: int,
         depth_index: int,
         need_distribution: bool,
         decision_margins: list[float],
     ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
-        del cycle_depth, depth_index, decision_margins
-        token, distribution = _sample_draft_from_logits(
-            draft_logits[:, -1, :][0],
+        del depth_index, decision_margins
+        return _fixed_width_draft_reader(
+            draft_logits,
             draft_sampler,
             rng,
             need_distribution=need_distribution,
         )
-        return token, distribution, False
 
     if adaptive_width_policy is None:
-        adaptive_width_draft_reader = _fixed_width_draft_reader
+        adaptive_width_cycle_readers = (_default_cycle_draft_reader,) * max(
+            1, int(speculative_depth)
+        )
         capture_forward_routes = (rt.forward_ar_capture,) * max(
             1, int(speculative_depth)
         )
@@ -6047,33 +6128,58 @@ def generate_mtpk(
         adaptive_width_max_depth = int(adaptive_width_policy.max_speculative_depth)
         capture_forward_routes = adaptive_width_policy.target_routes
 
-        def adaptive_width_draft_reader(
+        def adaptive_tail_k1_reader(
             draft_logits: mx.array,
             *,
-            cycle_depth: int,
             depth_index: int,
             need_distribution: bool,
             decision_margins: list[float],
         ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
-            if cycle_depth != adaptive_width_max_depth or depth_index >= 2:
-                return _fixed_width_draft_reader(
-                    draft_logits,
-                    cycle_depth=cycle_depth,
-                    depth_index=depth_index,
-                    need_distribution=need_distribution,
-                    decision_margins=decision_margins,
-                )
-            token, top1, top2 = _greedy_draft_token_and_top2(draft_logits)
-            margin = float(top1 - top2)
-            decision_margins.append(margin)
-            distribution = (
-                SparseDistribution.one_hot(token, int(draft_logits.shape[-1]))
-                if need_distribution
-                else None
+            del depth_index, decision_margins
+            return _adaptive_tail_k1_draft_reader(
+                draft_logits,
+                draft_sampler,
+                rng,
+                need_distribution=need_distribution,
             )
-            return token, distribution, adaptive_width_margin_stops[depth_index](
-                margin
+
+        def adaptive_tail_k2_reader(
+            draft_logits: mx.array,
+            *,
+            depth_index: int,
+            need_distribution: bool,
+            decision_margins: list[float],
+        ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+            del depth_index, decision_margins
+            return _adaptive_tail_k2_draft_reader(
+                draft_logits,
+                draft_sampler,
+                rng,
+                need_distribution=need_distribution,
             )
+
+        def adaptive_full_k3_reader(
+            draft_logits: mx.array,
+            *,
+            depth_index: int,
+            need_distribution: bool,
+            decision_margins: list[float],
+        ) -> tuple[int, np.ndarray | SparseDistribution | None, bool]:
+            return _adaptive_full_k3_draft_reader(
+                draft_logits,
+                draft_sampler,
+                rng,
+                depth_index=depth_index,
+                need_distribution=need_distribution,
+                decision_margins=decision_margins,
+                margin_stops=adaptive_width_margin_stops,
+            )
+
+        adaptive_width_cycle_readers = (
+            adaptive_tail_k1_reader,
+            adaptive_tail_k2_reader,
+            adaptive_full_k3_reader,
+        )
 
         def record_adaptive_width_event(
             event: dict[str, Any],
@@ -7214,6 +7320,7 @@ def generate_mtpk(
             break
 
         cycle_depth = min(planned_depth, max_tokens - len(tokens))
+        cycle_draft_reader = adaptive_width_cycle_readers[cycle_depth - 1]
         adaptive_width_decision_margins: list[float] = []
         draft_tokens: list[int | None] = []
         draft_probs: list[np.ndarray | None] = []
@@ -7978,9 +8085,8 @@ def generate_mtpk(
                         sampler.temperature > 0 and not target_prefix_verify
                     )
                     draft_token, draft_q, adaptive_width_stop = (
-                        adaptive_width_draft_reader(
+                        cycle_draft_reader(
                             draft_logits,
-                            cycle_depth=cycle_depth,
                             depth_index=depth_index,
                             need_distribution=need_draft_distribution,
                             decision_margins=adaptive_width_decision_margins,

--- a/mtplx/models/deepseek_v4.py
+++ b/mtplx/models/deepseek_v4.py
@@ -984,6 +984,177 @@ class _DerivedCache:
         return value
 
 
+class _UninstalledGatherOLora:
+    """Fail-closed placeholder used until post-load route installation."""
+
+    __slots__ = ()
+
+    def __call__(self, _o: mx.array) -> mx.array:
+        raise RuntimeError(
+            "gather_qmm o-LoRA was selected but its post-load route was not installed"
+        )
+
+
+def _o_lora_linear_logical_weight_shape(linear) -> tuple[int, ...]:
+    """Return ``[output, input]`` without materializing a quantized weight."""
+
+    weight_shape = tuple(getattr(getattr(linear, "weight", None), "shape", ()))
+    if len(weight_shape) != 2:
+        return ()
+    if not isinstance(linear, nn.QuantizedLinear):
+        return weight_shape
+    try:
+        bits = int(linear.bits)
+        group_size = int(linear.group_size)
+        scales_shape = tuple(linear.scales.shape)
+    except (AttributeError, TypeError, ValueError):
+        return ()
+    packed_divisor = 32 // bits if bits > 0 and 32 % bits == 0 else 0
+    if not packed_divisor or group_size <= 0 or len(scales_shape) != 2:
+        return ()
+    packed_logical = (weight_shape[0], weight_shape[1] * packed_divisor)
+    scales_logical = (scales_shape[0], scales_shape[1] * group_size)
+    return packed_logical if packed_logical == scales_logical else ()
+
+
+class _DirectGatherOLora:
+    """Prevalidated direct gather route; execution performs no eligibility lookup."""
+
+    __slots__ = (
+        "biases",
+        "bits",
+        "group_size",
+        "groups",
+        "mode",
+        "per_group_input",
+        "rank",
+        "scales",
+        "weight",
+        "wo_b",
+    )
+
+    def __init__(self, attention: "DeepseekV4Attention", quant: tuple) -> None:
+        weight, scales, biases, group_size, bits, mode = quant
+        groups = int(attention.n_groups)
+        rank = int(attention.o_lora_rank)
+        per_group_input = int(
+            attention.n_heads * attention.head_dim // attention.n_groups
+        )
+        output_rows = groups * rank
+        if groups <= 0 or rank <= 0 or per_group_input <= 0:
+            raise ValueError("gather_qmm o-LoRA geometry must be positive")
+        if per_group_input % int(group_size):
+            raise ValueError(
+                "gather_qmm o-LoRA input width is not divisible by group_size"
+            )
+        packed_divisor = 32 // int(bits) if int(bits) and 32 % int(bits) == 0 else 0
+        if not packed_divisor:
+            raise ValueError(f"gather_qmm o-LoRA has unsupported bits={bits!r}")
+        expected_weight = (output_rows, per_group_input // packed_divisor)
+        expected_scales = (output_rows, per_group_input // int(group_size))
+        if tuple(weight.shape) != expected_weight:
+            raise ValueError(
+                f"gather_qmm o-LoRA packed weight shape {tuple(weight.shape)} "
+                f"does not match {expected_weight}"
+            )
+        if tuple(scales.shape) != expected_scales:
+            raise ValueError(
+                f"gather_qmm o-LoRA scale shape {tuple(scales.shape)} "
+                f"does not match {expected_scales}"
+            )
+        if biases is not None and tuple(biases.shape) != expected_scales:
+            raise ValueError(
+                f"gather_qmm o-LoRA bias shape {tuple(biases.shape)} "
+                f"does not match {expected_scales}"
+            )
+        expected_wo_b = (int(attention.dim), output_rows)
+        if _o_lora_linear_logical_weight_shape(attention.wo_b) != expected_wo_b:
+            raise ValueError("gather_qmm o-LoRA wo_b input geometry is invalid")
+        self.groups = groups
+        self.rank = rank
+        self.per_group_input = per_group_input
+        self.weight = weight.reshape(groups, rank, -1)
+        self.scales = scales.reshape(groups, rank, -1)
+        self.biases = (
+            None if biases is None else biases.reshape(groups, rank, -1)
+        )
+        self.group_size = int(group_size)
+        self.bits = int(bits)
+        self.mode = mode
+        self.wo_b = attention.wo_b
+
+    def __call__(self, o: mx.array) -> mx.array:
+        batch, sequence, _ = o.shape
+        rows = batch * sequence
+        x = o.reshape(rows, self.groups, self.per_group_input).swapaxes(0, 1)
+        out = mx.gather_qmm(
+            x,
+            self.weight,
+            self.scales,
+            self.biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+        return self.wo_b(
+            out.swapaxes(0, 1).reshape(
+                batch, sequence, self.groups * self.rank
+            )
+        )
+
+
+class _DirectDenseOLora:
+    """Prebound dense grouped matmul with no storage/cache decision at execution."""
+
+    __slots__ = ("groups", "per_group_input", "rank", "weight", "wo_b")
+
+    def __init__(self, attention: "DeepseekV4Attention", weight: mx.array) -> None:
+        self.groups = int(attention.n_groups)
+        self.rank = int(attention.o_lora_rank)
+        self.per_group_input = int(
+            attention.n_heads * attention.head_dim // attention.n_groups
+        )
+        self.weight = weight.reshape(
+            self.groups, self.rank, self.per_group_input
+        )
+        self.wo_b = attention.wo_b
+
+    def __call__(self, o: mx.array) -> mx.array:
+        batch, sequence, _ = o.shape
+        grouped = o.reshape(
+            batch, sequence, self.groups, self.per_group_input
+        )
+        out = mx.einsum("bsgp,grp->bsgr", grouped, self.weight)
+        return self.wo_b(out.reshape(batch, sequence, self.groups * self.rank))
+
+
+class _DirectCachedOLora(_DirectDenseOLora):
+    """Known quantized body storage, dequantized and captured exactly once."""
+
+    __slots__ = ()
+
+    def __init__(self, attention: "DeepseekV4Attention", quant: tuple) -> None:
+        weight, scales, biases, group_size, bits, mode = quant
+        dense = mx.dequantize(
+            weight,
+            scales,
+            biases,
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+        super().__init__(attention, dense)
+        mx.eval(self.weight)
+        attention._wo_a_cache.put((weight, scales, biases), self.weight)
+
+
+class _DirectDenseMTPOLora(_DirectDenseOLora):
+    """Known dense-BF16 MTP stock math, captured without a quantized lookup."""
+
+    __slots__ = ()
+
+
 @dataclass
 class ModelArgs(BaseModelArgs):
     model_type: str = "deepseek_v4"
@@ -2376,6 +2547,11 @@ class DeepseekV4Attention(nn.Module):
         # are plain (non-array) attributes, so neither reaches the weight tree.
         self.o_lora_mode = _o_lora_mode_from_env()
         self._wo_a_cache = _DerivedCache()
+        self._o_lora_impl = (
+            _UninstalledGatherOLora()
+            if self.o_lora_mode == "gather_qmm"
+            else self._o_lora_dense
+        )
         # How _attend forms the score block (see _ATTN_MODES).
         self.attn_mode = _attn_mode_from_env()
 
@@ -2463,54 +2639,36 @@ class DeepseekV4Attention(nn.Module):
             return dense
         return self._wo_a_cache.put(src, dense)
 
-    def _o_lora_gather_qmm(self, o: mx.array) -> mx.array:
-        """Grouped o-LoRA as a quantised block-diagonal matmul (arm b).
+    def install_o_lora_route(self, mode: str | None = None) -> dict:
+        """Validate and bind one o-LoRA route at an installation boundary."""
+        selected = self.o_lora_mode if mode is None else str(mode)
+        if selected not in _O_LORA_MODES:
+            raise ValueError(f"unsupported o-LoRA route {selected!r}")
+        if selected == "gather_qmm":
+            quant = self._wo_a_quant()
+            if quant is None:
+                raise ValueError(
+                    "gather_qmm o-LoRA requires a quantized wo_a; dense fallback "
+                    "is forbidden"
+                )
+            installed = _DirectGatherOLora(self, quant)
+            direct = True
+        else:
+            installed = self._o_lora_dense
+            direct = False
+        self.o_lora_mode = selected
+        self._o_lora_impl = installed
+        return {
+            "mode": selected,
+            "direct": direct,
+            "groups": int(self.n_groups),
+            "rank": int(self.o_lora_rank),
+            "per_group_input": int(
+                self.n_heads * self.head_dim // self.n_groups
+            ),
+        }
 
-        The ``o_groups`` LoRA groups are ``o_groups`` independent ``[r, per]``
-        matrices, so the projection is one :func:`mx.gather_qmm` over a leading
-        group axis — every row visits every group, and nothing dense is ever
-        materialised.  The reference flags exactly this as the optimisation it did
-        not take ("wo_a is FP8 in checkpoint; could do FP8 einsum here for better
-        perf, but using BF16 for simplicity", model.py L538-539).
-
-        **Calling convention.**  ``x`` must carry the row axis in the *batch* dims
-        with the matmul rows in the last two, i.e. ``[g, rows, per] -> [g, rows,
-        r]``; a flat ``[rows, per]`` broadcasts instead and silently does ``g``
-        times the work while still producing usable-looking numbers.  This box's
-        ledger has been bitten by that twice, which is why the output shape is
-        checked here rather than assumed.
-
-        **Not bit-identical** to :meth:`_wo_a_grouped` + einsum: the quantised
-        kernel dequantises inside the accumulation, so the products are summed in
-        a different order.  Gated on tolerance + argmax stability, default off.
-        """
-        b, s, _ = o.shape
-        g = self.n_groups
-        r = self.o_lora_rank
-        per = self.n_heads * self.head_dim // g
-        w, scales, biases, group_size, bits, mode = self._wo_a_quant()
-        rows = b * s
-        # [b, s, g*per] -> [g, rows, per]: group g owns o's g-th per-wide chunk.
-        x = o.reshape(rows, g, per).swapaxes(0, 1)
-        out = mx.gather_qmm(
-            x,
-            w.reshape(g, r, -1),
-            scales.reshape(g, r, -1),
-            None if biases is None else biases.reshape(g, r, -1),
-            transpose=True,
-            group_size=group_size,
-            bits=bits,
-            mode=mode,
-        )
-        if tuple(out.shape) != (g, rows, r):
-            raise AssertionError(
-                "gather_qmm o-LoRA shape contract broken: expected "
-                f"{(g, rows, r)}, got {tuple(out.shape)} — an x of shape "
-                f"{tuple(x.shape)} was broadcast instead of batched"
-            )
-        return self.wo_b(out.swapaxes(0, 1).reshape(b, s, g * r))
-
-    def _o_lora(self, o: mx.array) -> mx.array:
+    def _o_lora_dense(self, o: mx.array) -> mx.array:
         """Grouped output-LoRA (reference model.py L536-542).
 
         ``o``: ``[b, s, n_heads*head_dim]`` -> reshape ``[b, s, n_groups, per]``;
@@ -2519,8 +2677,6 @@ class DeepseekV4Attention(nn.Module):
 
         See :data:`_O_LORA_MODES` for the three ways ``wo_a`` gets there.
         """
-        if self.o_lora_mode == "gather_qmm" and self._wo_a_quant() is not None:
-            return self._o_lora_gather_qmm(o)
         b, s, _ = o.shape
         g = self.n_groups
         per = self.n_heads * self.head_dim // g
@@ -2531,6 +2687,10 @@ class DeepseekV4Attention(nn.Module):
         out = mx.einsum("bsgp,grp->bsgr", og, w)
         out = out.reshape(b, s, g * r)
         return self.wo_b(out)
+
+    def _o_lora(self, o: mx.array) -> mx.array:
+        """Execute the prebound route with no enabled-path eligibility branch."""
+        return self._o_lora_impl(o)
 
     def _attn_mask(
         self,
@@ -3389,6 +3549,385 @@ class MTPHead(nn.Module):
     def __init__(self, blocks):
         super().__init__()
         self.layers = list(blocks)
+
+
+_O_LORA_BODY_COUNT = 43
+_O_LORA_MTP_COUNT = 1
+_O_LORA_WO_A_LOGICAL_SHAPE = (8192, 4096)
+_O_LORA_WO_A_PACKED_SHAPE = (8192, 512)
+_O_LORA_WO_A_QUANT_AUX_SHAPE = (8192, 64)
+_O_LORA_BODY_WO_B_LOGICAL_SHAPE = (4096, 8192)
+_O_LORA_BODY_WO_B_PACKED_SHAPE = (4096, 1024)
+_O_LORA_BODY_WO_B_QUANT_AUX_SHAPE = (4096, 128)
+_O_LORA_MTP_WO_B_SHAPE = (4096, 8192)
+_O_LORA_ATTENTION_GEOMETRY = {
+    "n_groups": 8,
+    "o_lora_rank": 1024,
+    "n_heads": 64,
+    "head_dim": 512,
+    "dim": 4096,
+    "input_width": 32768,
+    "per_group_input": 4096,
+    "grouped_output_width": 8192,
+}
+_O_LORA_QUANT_FIELDS = ("scales", "biases", "bits", "group_size", "mode")
+_CANONICAL_O_LORA_STORAGE_CONTRACT = {
+    "body": {
+        "count": 43,
+        "attention_geometry": _O_LORA_ATTENTION_GEOMETRY,
+        "wo_a": {
+            "class": "QuantizedLinear",
+            "logical_weight_shape": list(_O_LORA_WO_A_LOGICAL_SHAPE),
+            "packed_weight": {
+                "shape": list(_O_LORA_WO_A_PACKED_SHAPE),
+                "dtype": "uint32",
+            },
+            "scales": {
+                "shape": list(_O_LORA_WO_A_QUANT_AUX_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "biases": {
+                "shape": list(_O_LORA_WO_A_QUANT_AUX_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "bits": 4,
+            "group_size": 64,
+            "mode": "affine",
+            "additive_bias": None,
+        },
+        "wo_b": {
+            "class": "QuantizedLinear",
+            "logical_weight_shape": list(_O_LORA_BODY_WO_B_LOGICAL_SHAPE),
+            "packed_weight": {
+                "shape": list(_O_LORA_BODY_WO_B_PACKED_SHAPE),
+                "dtype": "uint32",
+            },
+            "scales": {
+                "shape": list(_O_LORA_BODY_WO_B_QUANT_AUX_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "biases": {
+                "shape": list(_O_LORA_BODY_WO_B_QUANT_AUX_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "bits": 4,
+            "group_size": 64,
+            "mode": "affine",
+            "additive_bias": None,
+        },
+    },
+    "mtp": {
+        "count": 1,
+        "wo_a": {
+            "class": "Linear",
+            "weight": {
+                "shape": list(_O_LORA_WO_A_LOGICAL_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "additive_bias": None,
+            "no_quant_metadata": True,
+            "absent_quant_fields": list(_O_LORA_QUANT_FIELDS),
+        },
+        "wo_b": {
+            "class": "Linear",
+            "weight": {
+                "shape": list(_O_LORA_MTP_WO_B_SHAPE),
+                "dtype": "bfloat16",
+            },
+            "additive_bias": None,
+            "no_quant_metadata": True,
+            "absent_quant_fields": list(_O_LORA_QUANT_FIELDS),
+        },
+    },
+}
+
+
+def _require_o_lora_array(
+    value, *, label: str, shape: tuple[int, int], dtype
+) -> None:
+    if tuple(getattr(value, "shape", ())) != shape:
+        raise ValueError(
+            f"{label} shape {tuple(getattr(value, 'shape', ()))} does not match {shape}"
+        )
+    if getattr(value, "dtype", None) != dtype:
+        raise ValueError(f"{label} dtype is not {dtype}")
+
+
+def _require_canonical_quantized_linear(
+    linear, *, label: str, logical_shape: tuple[int, int]
+) -> tuple:
+    """Validate exact Q4 storage and derive its logical shape two ways."""
+
+    if not isinstance(linear, nn.QuantizedLinear):
+        raise ValueError(f"{label} must be QuantizedLinear")
+    for attribute, expected in (
+        ("bits", 4),
+        ("group_size", 64),
+        ("mode", "affine"),
+    ):
+        observed = getattr(linear, attribute, None)
+        if observed != expected:
+            raise ValueError(
+                f"{label} {attribute}={observed!r}, expected {expected!r}"
+            )
+
+    weight = getattr(linear, "weight", None)
+    scales = getattr(linear, "scales", None)
+    biases = getattr(linear, "biases", None)
+    weight_shape = tuple(getattr(weight, "shape", ()))
+    scales_shape = tuple(getattr(scales, "shape", ()))
+    biases_shape = tuple(getattr(biases, "shape", ()))
+    if len(weight_shape) != 2:
+        raise ValueError(f"{label} packed weight shape {weight_shape} is not rank 2")
+    if len(scales_shape) != 2:
+        raise ValueError(f"{label} scales shape {scales_shape} is not rank 2")
+
+    packed_divisor = 32 // int(linear.bits)
+    packed_logical = (weight_shape[0], weight_shape[1] * packed_divisor)
+    scales_logical = (
+        scales_shape[0],
+        scales_shape[1] * int(linear.group_size),
+    )
+    expected_output, expected_input = logical_shape
+    if packed_logical[0] != expected_output:
+        raise ValueError(
+            f"{label} packed weight shape {weight_shape} has logical output "
+            f"{packed_logical[0]}, expected {expected_output}"
+        )
+    if packed_logical[1] != expected_input:
+        raise ValueError(
+            f"{label} packed weight shape {weight_shape} has logical input "
+            f"{packed_logical[1]}, expected {expected_input}"
+        )
+    if scales_logical[0] != expected_output:
+        raise ValueError(
+            f"{label} scales shape {scales_shape} has logical output "
+            f"{scales_logical[0]}, expected {expected_output}"
+        )
+    if scales_logical[1] != expected_input:
+        raise ValueError(
+            f"{label} scales shape {scales_shape} has logical input "
+            f"{scales_logical[1]}, expected {expected_input}"
+        )
+    if getattr(weight, "dtype", None) != mx.uint32:
+        raise ValueError(f"{label} packed weight dtype is not {mx.uint32}")
+    if getattr(scales, "dtype", None) != mx.bfloat16:
+        raise ValueError(f"{label} scales dtype is not {mx.bfloat16}")
+    if biases_shape != scales_shape:
+        raise ValueError(
+            f"{label} biases shape {biases_shape} does not match scales shape "
+            f"{scales_shape}"
+        )
+    if getattr(biases, "dtype", None) != mx.bfloat16:
+        raise ValueError(f"{label} biases dtype is not {mx.bfloat16}")
+    if getattr(linear, "bias", None) is not None:
+        raise ValueError(f"{label} additive bias must be absent")
+    return (
+        weight,
+        scales,
+        biases,
+        linear.group_size,
+        linear.bits,
+        linear.mode,
+    )
+
+
+def _require_canonical_dense_linear(
+    linear, *, label: str, shape: tuple[int, int]
+):
+    if not isinstance(linear, nn.Linear) or isinstance(linear, nn.QuantizedLinear):
+        raise ValueError(f"{label} must be a dense nn.Linear, not QuantizedLinear")
+    weight = getattr(linear, "weight", None)
+    _require_o_lora_array(
+        weight,
+        label=f"{label} weight",
+        shape=shape,
+        dtype=mx.bfloat16,
+    )
+    if getattr(linear, "bias", None) is not None:
+        raise ValueError(f"{label} additive bias must be absent")
+    accidental = [
+        attribute
+        for attribute in _O_LORA_QUANT_FIELDS
+        if hasattr(linear, attribute)
+    ]
+    if accidental:
+        raise ValueError(
+            f"{label} must not expose quantized metadata: " + ", ".join(accidental)
+        )
+    return weight
+
+
+def _validate_canonical_o_lora_topology(trunk, mtp) -> tuple[list[tuple], mx.array]:
+    """Fail before timing unless this exact mixed checkpoint layout is loaded.
+
+    The 43 body modules are affine Q4 storage and may take the direct gather
+    route.  The one MTP module is intentionally a dense BF16 linear and must
+    remain an explicit stock route; treating it as an eligible gather module
+    would turn a checkpoint-layout fact into a hot-path fallback.
+    """
+    if len(trunk) != _O_LORA_BODY_COUNT:
+        raise ValueError(f"expected 43 body o-LoRA modules, found {len(trunk)}")
+    if len(mtp) != _O_LORA_MTP_COUNT:
+        raise ValueError(f"expected exactly one MTP o-LoRA module, found {len(mtp)}")
+
+    body_quant = []
+    for index, attention in enumerate(trunk):
+        wo_a = getattr(attention, "wo_a", None)
+        wo_a_label = f"body {index} wo_a"
+        for attribute in ("n_groups", "o_lora_rank", "n_heads", "head_dim", "dim"):
+            observed = getattr(attention, attribute, None)
+            expected = _O_LORA_ATTENTION_GEOMETRY[attribute]
+            if observed != expected:
+                raise ValueError(
+                    f"body {index} attention {attribute}={observed!r}, "
+                    f"expected {expected}"
+                )
+        input_width = int(attention.n_heads) * int(attention.head_dim)
+        per_group_input = input_width // int(attention.n_groups)
+        grouped_output_width = int(attention.n_groups) * int(attention.o_lora_rank)
+        derived_geometry = {
+            "input_width": input_width,
+            "per_group_input": per_group_input,
+            "grouped_output_width": grouped_output_width,
+        }
+        for attribute, observed in derived_geometry.items():
+            expected = _O_LORA_ATTENTION_GEOMETRY[attribute]
+            if observed != expected:
+                raise ValueError(
+                    f"body {index} attention {attribute}={observed}, expected {expected}"
+                )
+        body_quant.append(
+            _require_canonical_quantized_linear(
+                wo_a,
+                label=wo_a_label,
+                logical_shape=_O_LORA_WO_A_LOGICAL_SHAPE,
+            )
+        )
+        _require_canonical_quantized_linear(
+            getattr(attention, "wo_b", None),
+            label=f"body {index} wo_b",
+            logical_shape=(int(attention.dim), grouped_output_width),
+        )
+
+    mtp_weight = _require_canonical_dense_linear(
+        getattr(mtp[0], "wo_a", None),
+        label="MTP wo_a",
+        shape=_O_LORA_WO_A_LOGICAL_SHAPE,
+    )
+    _require_canonical_dense_linear(
+        getattr(mtp[0], "wo_b", None),
+        label="MTP wo_b",
+        shape=_O_LORA_MTP_WO_B_SHAPE,
+    )
+    return body_quant, mtp_weight
+
+
+def install_deepseek_v4_o_lora_routes(
+    model, mode: str | None = None, *, canonical_mixed_route: bool = False
+) -> dict:
+    """Install the canonical 43-Q4-body/one-dense-MTP o-LoRA route.
+
+    Validation and binding are construction-time only.  The direct candidate
+    binds gather on body modules and binds MTP to its stock dense callable;
+    neither branch has a runtime eligibility check or fallback.
+    """
+    trunk = [layer.attn for layer in model.layers]
+    mtp = [block.attn for block in model.mtp_blocks]
+    selected = (
+        str(mode)
+        if mode is not None
+        else _o_lora_mode_from_env()
+    )
+    if selected not in _O_LORA_MODES:
+        raise ValueError(f"unsupported o-LoRA route {selected!r}")
+    if not canonical_mixed_route:
+        reports = [attention.install_o_lora_route(selected) for attention in trunk + mtp]
+        return {
+            "mode": selected,
+            "module_count": len(reports),
+            "trunk_module_count": len(trunk),
+            "mtp_module_count": len(mtp),
+            "all_direct": bool(reports) and all(report["direct"] for report in reports),
+            "all_mode_matches": bool(reports)
+            and all(report["mode"] == selected for report in reports),
+            "modules": reports,
+        }
+    if selected not in {"cached", "gather_qmm"}:
+        raise ValueError(
+            "canonical mixed o-LoRA route supports only cached or gather_qmm"
+        )
+    body_quant, mtp_weight = _validate_canonical_o_lora_topology(trunk, mtp)
+    body_route_type = (
+        _DirectGatherOLora if selected == "gather_qmm" else _DirectCachedOLora
+    )
+    body_impls = [
+        body_route_type(attention, quant)
+        for attention, quant in zip(trunk, body_quant)
+    ]
+    mtp_impls = [_DirectDenseMTPOLora(mtp[0], mtp_weight)]
+    for attention, installed in zip(trunk, body_impls):
+        attention.o_lora_mode = selected
+        attention._o_lora_impl = installed
+    # Dense MTP is always explicitly installed stock.  In the candidate arm this
+    # is deliberately not a fallback from gather_qmm.
+    for attention, installed in zip(mtp, mtp_impls):
+        attention.o_lora_mode = "cached"
+        attention._o_lora_impl = installed
+    body_reports = [
+        {
+            "mode": selected,
+            "direct": selected == "gather_qmm",
+            "callable": type(installed).__name__,
+        }
+        for installed in body_impls
+    ]
+    mtp_reports = [
+        {
+            "mode": "cached",
+            "direct": False,
+            "callable": type(installed).__name__,
+        }
+        for installed in mtp_impls
+    ]
+    reports = body_reports + mtp_reports
+    route_objects = body_impls + mtp_impls
+    callable_census = {
+        "body_route_objects": len(body_impls),
+        "body_route_kind": (
+            "gather_qmm_direct" if selected == "gather_qmm" else "cached_direct"
+        ),
+        "body_callable_class": body_route_type.__name__,
+        "mtp_route_objects": len(mtp_impls),
+        "mtp_route_kind": "dense_bf16_stock_direct",
+        "mtp_callable_class": _DirectDenseMTPOLora.__name__,
+        "total_route_objects": len(route_objects),
+        "unique_route_objects": len({id(installed) for installed in route_objects}),
+        "mtp_distinct_type": bool(body_impls and mtp_impls)
+        and type(mtp_impls[0]) is not type(body_impls[0]),
+    }
+    return {
+        "mode": selected,
+        "module_count": len(reports),
+        "trunk_module_count": len(trunk),
+        "mtp_module_count": len(mtp),
+        "body_direct": sum(report["direct"] for report in body_reports),
+        "mtp_stock": sum(
+            report["mode"] == "cached" and not report["direct"]
+            for report in mtp_reports
+        ),
+        "body_all_mode_matches": bool(body_reports)
+        and all(report["mode"] == selected for report in body_reports),
+        "route_plan_matches": bool(body_reports and mtp_reports)
+        and all(report["mode"] == selected for report in body_reports)
+        and all(
+            report["mode"] == "cached" and not report["direct"]
+            for report in mtp_reports
+        ),
+        "storage_contract": _CANONICAL_O_LORA_STORAGE_CONTRACT,
+        "callable_census": callable_census,
+        "modules": reports,
+    }
 
 
 def is_deepseek_v4_mtp_config(config: dict) -> bool:

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -86,6 +86,7 @@ class MTPLXRuntime:
     mtp_adapter_path: Path | None = None
     mtp_adapter_metadata: dict[str, Any] | None = None
     mtp_adapter_merge_report: dict[str, Any] | None = None
+    deepseek_v4_o_lora_report: dict[str, Any] | None = None
     a3b_compiled_target_prefix_factory: A3BCompiledTargetPrefixFactory | None = None
     a3b_whole_moe_installed: bool = False
     _a3b_whole_moe_request_preflights: dict[str, dict[str, Any]] = field(
@@ -754,6 +755,28 @@ def load(
             adapter_merge_report = merge_installed_mtp_lora_adapters(model)
     elif merge_mtp_adapter:
         raise RuntimeError("merge_mtp_adapter requires mtp_adapter")
+    deepseek_v4_o_lora_report = None
+    if str(config.get("model_type") or "").lower() == "deepseek_v4":
+        from .models.deepseek_v4 import (
+            _o_lora_mode_from_env,
+            install_deepseek_v4_o_lora_routes,
+        )
+
+        selected_o_lora_mode = _o_lora_mode_from_env()
+        canonical_mixed_route = bool(
+            mtp_enabled and selected_o_lora_mode in {"cached", "gather_qmm"}
+        )
+        if not mtp_enabled:
+            # An artifact that declared but did not ship MTP weights already
+            # degraded to AR above. It has no dense MTP module to validate or
+            # route, so bind the trunk's explicit stock/cached construction.
+            selected_o_lora_mode = "cached"
+        deepseek_v4_o_lora_report = install_deepseek_v4_o_lora_routes(
+            model,
+            mode=selected_o_lora_mode,
+            canonical_mixed_route=canonical_mixed_route,
+        )
+        logger.info("[deepseek-v4-o-lora] %s", deepseek_v4_o_lora_report)
     fused_report: list[dict[str, Any]] = []
     if _is_laguna_s_2_1_mlx_4bit_config(config):
         # Env-gated fused decode paths (MTPLX_LAGUNA_*): with no switches set
@@ -779,6 +802,7 @@ def load(
         mtp_adapter_path=adapter_path,
         mtp_adapter_metadata=adapter_metadata,
         mtp_adapter_merge_report=adapter_merge_report,
+        deepseek_v4_o_lora_report=deepseek_v4_o_lora_report,
         a3b_compiled_target_prefix_factory=compiled_target_factory,
         a3b_whole_moe_installed=False,
     )

--- a/scripts/deepseek_v4_adaptive_width_arms.sh
+++ b/scripts/deepseek_v4_adaptive_width_arms.sh
@@ -7,10 +7,13 @@ set -euo pipefail
   exit 1
 }
 WORKTREE=${0:A:h:h}
-VENV=/Users/davidtai/projects/OpenSourceWTF/mtplx-hy3-ssd/.venv/bin/python
-BENCH=/Users/davidtai/projects/OpenSourceWTF/bench/deepseek-v4
-MODEL=/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp
-PROMPT="$BENCH/smoke-2bitdq-20260731-prompt2.txt"
+# The guard wrapper supplies these deployment-specific locations.  Keeping
+# them out of the source makes the exact artifact identity—not one developer's
+# filesystem—the reproducibility contract.
+VENV=${MTPLX_DSV4_PYTHON:-python3}
+BENCH=${MTPLX_DSV4_BENCH_DIR:?set MTPLX_DSV4_BENCH_DIR}
+MODEL=${MTPLX_DSV4_MODEL_PATH:?set MTPLX_DSV4_MODEL_PATH}
+PROMPT=${MTPLX_DSV4_PROMPT_FILE:?set MTPLX_DSV4_PROMPT_FILE}
 PROMPT_SHA256=ee94397faa812c91d5f1a0ee17c5bb6ca6032883653591dd33d4cfddb737ac33
 
 (( $# <= 1 )) || {

--- a/scripts/deepseek_v4_adaptive_width_arms.sh
+++ b/scripts/deepseek_v4_adaptive_width_arms.sh
@@ -1,0 +1,62 @@
+#!/bin/zsh
+# Canonical adaptive-width performance bracket. Invoke only via its wrapper.
+set -euo pipefail
+
+[[ "${MTPLX_DSV4_ADAPTIVE_WIDTH_POSTFLIGHT_WRAPPER:-}" == 1 ]] || {
+  print -u2 'invoke deepseek_v4_adaptive_width_guarded.py, not this child'
+  exit 1
+}
+WORKTREE=${0:A:h:h}
+VENV=/Users/davidtai/projects/OpenSourceWTF/mtplx-hy3-ssd/.venv/bin/python
+BENCH=/Users/davidtai/projects/OpenSourceWTF/bench/deepseek-v4
+MODEL=/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp
+PROMPT="$BENCH/smoke-2bitdq-20260731-prompt2.txt"
+PROMPT_SHA256=ee94397faa812c91d5f1a0ee17c5bb6ca6032883653591dd33d4cfddb737ac33
+
+(( $# <= 1 )) || {
+  print -u2 'invalid bracket tag: expected zero or one argument'
+  exit 1
+}
+TAG=${1:-adaptive-width-policy-$(date -u +%Y%m%dT%H%M%SZ)}
+if [[ -z "$TAG" || "$TAG" == '.' || "$TAG" == '..' ]] ||
+   [[ ! "$TAG" =~ '^[A-Za-z0-9][A-Za-z0-9._-]*$' ]]; then
+  print -u2 'invalid bracket tag: expected a safe basename'
+  exit 1
+fi
+
+GUARD_PIPE_FD=${MTPLX_GUARD_ATTEST_FD:-}
+GUARD_ISSUED=$("$VENV" -u "$WORKTREE/scripts/deepseek_v4_guard_window.py" issue)
+GUARD_RECEIPT=${GUARD_ISSUED%%$'\t'*}
+GUARD_DIGEST=${GUARD_ISSUED#*$'\t'}
+[[ -n "$GUARD_PIPE_FD" && "$GUARD_RECEIPT" != "$GUARD_ISSUED" && ${#GUARD_DIGEST} == 64 ]] || exit 1
+exec {GUARD_PIPE_FD}<&-
+unset MTPLX_GUARD_ATTEST_FD MTPLX_GUARD_ATTEST_NONCE GUARD_ISSUED
+trap '/bin/rm -f -- "$GUARD_RECEIPT"; /bin/rmdir -- "${GUARD_RECEIPT:h}" 2>/dev/null || true' EXIT
+
+[[ -x "$VENV" && -f "$PROMPT" && -d "$MODEL" ]] || exit 1
+[[ -z "$(git -C "$WORKTREE" status --porcelain)" ]] || {
+  print -u2 'worktree is dirty; refusing an unrepeatable bracket'
+  exit 1
+}
+[[ "$(shasum -a 256 "$PROMPT" | awk '{print $1}')" == "$PROMPT_SHA256" ]] || {
+  print -u2 'canonical prompt SHA256 mismatch'
+  exit 1
+}
+
+# Drop inherited selectors. Both context-copy selectors remain absent, which is
+# the canonical default used by every bracket cell.
+for entry in ${(f)"$(env)"}; do
+  name=${entry%%=*}
+  [[ "$name" == MTPLX_* ]] && unset "$name"
+done
+unset MTPLX_CONTEXT_COPY MTPLX_CONTEXT_COPY_TARGET_PREFIX
+export PYTHONNOUSERSITE=1 PYTHONPATH="$WORKTREE/scripts:$WORKTREE" HF_HUB_OFFLINE=1
+export MTPLX_COMPILED_VERIFY=off MTPLX_DSV4_ATTN=fused MTPLX_DSV4_FP32_ACTIVATIONS=0
+export MTPLX_DSV4_HC_COMPILE=1 MTPLX_DSV4_MOE_TAIL=1 MTPLX_DSV4_O_LORA=gather_qmm
+export MTPLX_DSV4_SINKHORN_KERNEL=1 MTPLX_DSV4_GUARD_WINDOW_PATH="$GUARD_RECEIPT"
+export MTPLX_DSV4_GUARD_WINDOW_SHA256="$GUARD_DIGEST"
+
+exec "$VENV" -u "$WORKTREE/scripts/deepseek_v4_mtpk_bench.py" \
+  --adaptive-width-bracket --model "$MODEL" --prompt-file "$PROMPT" \
+  --max-tokens 256 --depths 3 --verify-strategy capture_commit --verify-core stock \
+  --mtp-history-policy committed --warmup-tokens 0 --out "$BENCH/$TAG"

--- a/scripts/deepseek_v4_adaptive_width_guarded.py
+++ b/scripts/deepseek_v4_adaptive_width_guarded.py
@@ -22,6 +22,7 @@ PLIST = Path("/Users/davidtai/Library/LaunchAgents/com.tea.qwen.plist")
 BENCH = Path("/Users/davidtai/projects/OpenSourceWTF/bench/deepseek-v4")
 WRAPPER_ENV = "MTPLX_DSV4_ADAPTIVE_WIDTH_POSTFLIGHT_WRAPPER"
 TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+INVALID_TAG_RECEIPT_PREFIX = "adaptive-width-invalid-tag-"
 REQUIRED_PROBES = (
     "lock_free",
     "wired_limit_mb",
@@ -31,9 +32,28 @@ REQUIRED_PROBES = (
 
 
 def _validate_tag(tag: str) -> str:
-    if tag in {"", ".", ".."} or TAG_PATTERN.fullmatch(tag) is None:
+    if (
+        not isinstance(tag, str)
+        or tag in {"", ".", ".."}
+        or TAG_PATTERN.fullmatch(tag) is None
+    ):
         raise ValueError("invalid bracket tag: expected a safe basename")
     return tag
+
+
+def _tag_sha256(tag: object) -> str:
+    encoded = (
+        tag.encode("utf-8", errors="surrogatepass")
+        if isinstance(tag, str)
+        else repr(tag).encode("utf-8", errors="surrogatepass")
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _invalid_tag_receipt_path(bench_dir: Path, tag: object) -> Path:
+    digest = _tag_sha256(tag)
+    name = f"{INVALID_TAG_RECEIPT_PREFIX}{digest}-pid-{os.getpid()}-postflight.json"
+    return bench_dir / name
 
 
 def _postflight_collector():
@@ -119,18 +139,37 @@ def run(
     postflight_collector=_postflight_collector,
     bench_dir: Path = BENCH,
 ) -> int:
-    tag = _validate_tag(tag)
-    environment = dict(os.environ)
-    environment[WRAPPER_ENV] = "1"
-    child_error = None
+    bench_dir = Path(bench_dir)
+    tag_sha256 = _tag_sha256(tag)
+    tag_validation_error = None
     try:
-        completed = run_command(_command(tag), check=False, env=environment)
-        child_exit_code = int(completed.returncode)
-    except Exception as error:
-        child_exit_code = 1
-        child_error = f"{type(error).__name__}: {error}"
+        valid_tag = _validate_tag(tag)
+    except ValueError as error:
+        valid_tag = None
+        tag_validation_error = f"{type(error).__name__}: {error}"
 
-    primary, primary_sha256, primary_error = _read_primary(bench_dir / f"{tag}.json")
+    child_started = valid_tag is not None
+    child_error = None
+    if child_started:
+        environment = dict(os.environ)
+        environment[WRAPPER_ENV] = "1"
+        try:
+            completed = run_command(_command(valid_tag), check=False, env=environment)
+            child_exit_code = int(completed.returncode)
+        except Exception as error:
+            child_exit_code = 1
+            child_error = f"{type(error).__name__}: {error}"
+        primary, primary_sha256, primary_error = _read_primary(
+            bench_dir / f"{valid_tag}.json"
+        )
+        receipt_path = bench_dir / f"{valid_tag}-postflight.json"
+    else:
+        child_exit_code = None
+        primary = None
+        primary_sha256 = None
+        primary_error = "primary receipt skipped because bracket tag is invalid"
+        receipt_path = _invalid_tag_receipt_path(bench_dir, tag)
+
     try:
         raw_postflight = postflight_collector()
         postflight, postflight_errors = _validate_postflight(raw_postflight)
@@ -139,7 +178,9 @@ def run(
         postflight_errors = [f"{type(error).__name__}: {error}"]
 
     errors = list(postflight_errors)
-    if child_exit_code != 0:
+    if tag_validation_error is not None:
+        errors.append(tag_validation_error)
+    if child_started and child_exit_code != 0:
         errors.append(f"guarded child exited {child_exit_code}")
     if child_error is not None:
         errors.append(child_error)
@@ -149,7 +190,11 @@ def run(
     receipt = {
         "kind": "deepseek_v4_adaptive_width_guarded_postflight",
         "timestamp_utc": datetime.now(UTC).isoformat(),
-        "tag": tag,
+        "tag": valid_tag,
+        "tag_valid": valid_tag is not None,
+        "tag_sha256": tag_sha256,
+        "tag_validation_error": tag_validation_error,
+        "guarded_child_started": child_started,
         "guarded_child_exit_code": child_exit_code,
         "primary_receipt": primary,
         "primary_receipt_sha256": primary_sha256,
@@ -159,7 +204,7 @@ def run(
         "validation_errors": errors,
         "status": status,
     }
-    _write_receipt(bench_dir / f"{tag}-postflight.json", receipt)
+    _write_receipt(receipt_path, receipt)
     return status
 
 

--- a/scripts/deepseek_v4_adaptive_width_guarded.py
+++ b/scripts/deepseek_v4_adaptive_width_guarded.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Run the guarded adaptive-width bracket and persist restoration postflight."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+VENV = Path("/Users/davidtai/projects/OpenSourceWTF/mtplx-hy3-ssd/.venv/bin/python")
+RUN_GUARDED = Path("/Users/davidtai/projects/OpenSourceWTF/bench/laguna/run_guarded.py")
+PLIST = Path("/Users/davidtai/Library/LaunchAgents/com.tea.qwen.plist")
+BENCH = Path("/Users/davidtai/projects/OpenSourceWTF/bench/deepseek-v4")
+WRAPPER_ENV = "MTPLX_DSV4_ADAPTIVE_WIDTH_POSTFLIGHT_WRAPPER"
+TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+REQUIRED_PROBES = (
+    "lock_free",
+    "wired_limit_mb",
+    "quality_models",
+    "quality_ready_chat",
+)
+
+
+def _validate_tag(tag: str) -> str:
+    if tag in {"", ".", ".."} or TAG_PATTERN.fullmatch(tag) is None:
+        raise ValueError("invalid bracket tag: expected a safe basename")
+    return tag
+
+
+def _postflight_collector():
+    path = HERE / "deepseek_v4_moe_tail_guarded_bracket.py"
+    spec = importlib.util.spec_from_file_location("_dsv4_shared_postflight", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    collector = getattr(module, "collect_postflight", None)
+    if not callable(collector):
+        raise TypeError("shared postflight module has no collector")
+    return collector()
+
+
+def _command(tag: str) -> list[str]:
+    return [
+        str(VENV),
+        str(RUN_GUARDED),
+        "--plist",
+        str(PLIST),
+        "--timeout-seconds",
+        "300",
+        "--lock-timeout-seconds",
+        "3600",
+        "--child-timeout-seconds",
+        "7200",
+        "--",
+        "/bin/zsh",
+        str(HERE / "deepseek_v4_adaptive_width_arms.sh"),
+        tag,
+    ]
+
+
+def _write_receipt(path: Path, receipt: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(receipt, sort_keys=True, indent=2) + "\n").encode()
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        os.unlink(temporary)
+        raise
+
+
+def _read_primary(path: Path) -> tuple[dict | None, str | None, str | None]:
+    try:
+        encoded = path.read_bytes()
+        payload = json.loads(encoded)
+        if not isinstance(payload, dict):
+            raise TypeError("primary receipt is not an object")
+        if payload.get("receipt_role") != "adaptive_width_performance_bracket":
+            raise ValueError("primary receipt role is invalid")
+        if payload.get("status") != 0:
+            raise ValueError("primary receipt status is not zero")
+        return payload, hashlib.sha256(encoded).hexdigest(), None
+    except Exception as error:
+        return None, None, f"{type(error).__name__}: {error}"
+
+
+def _validate_postflight(payload) -> tuple[dict, list[str]]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return {}, ["postflight result is not an object"]
+    normalized = {}
+    for name in REQUIRED_PROBES:
+        row = payload.get(name)
+        if not isinstance(row, dict) or type(row.get("ok")) is not bool:
+            errors.append(f"postflight probe {name} is missing or malformed")
+            continue
+        normalized[name] = row
+        if row["ok"] is not True:
+            errors.append(f"postflight probe {name} failed")
+    return normalized, errors
+
+
+def run(
+    tag: str,
+    *,
+    run_command=subprocess.run,
+    postflight_collector=_postflight_collector,
+    bench_dir: Path = BENCH,
+) -> int:
+    tag = _validate_tag(tag)
+    environment = dict(os.environ)
+    environment[WRAPPER_ENV] = "1"
+    child_error = None
+    try:
+        completed = run_command(_command(tag), check=False, env=environment)
+        child_exit_code = int(completed.returncode)
+    except Exception as error:
+        child_exit_code = 1
+        child_error = f"{type(error).__name__}: {error}"
+
+    primary, primary_sha256, primary_error = _read_primary(bench_dir / f"{tag}.json")
+    try:
+        raw_postflight = postflight_collector()
+        postflight, postflight_errors = _validate_postflight(raw_postflight)
+    except Exception as error:
+        postflight = {}
+        postflight_errors = [f"{type(error).__name__}: {error}"]
+
+    errors = list(postflight_errors)
+    if child_exit_code != 0:
+        errors.append(f"guarded child exited {child_exit_code}")
+    if child_error is not None:
+        errors.append(child_error)
+    if primary_error is not None:
+        errors.append(primary_error)
+    status = int(bool(errors))
+    receipt = {
+        "kind": "deepseek_v4_adaptive_width_guarded_postflight",
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+        "tag": tag,
+        "guarded_child_exit_code": child_exit_code,
+        "primary_receipt": primary,
+        "primary_receipt_sha256": primary_sha256,
+        "primary_receipt_error": primary_error,
+        "postflight": postflight,
+        "postflight_ok": not postflight_errors,
+        "validation_errors": errors,
+        "status": status,
+    }
+    _write_receipt(bench_dir / f"{tag}-postflight.json", receipt)
+    return status
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "tag",
+        nargs="?",
+        default=f"adaptive-width-policy-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}",
+    )
+    args = parser.parse_args()
+    return run(args.tag)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deepseek_v4_adaptive_width_guarded.py
+++ b/scripts/deepseek_v4_adaptive_width_guarded.py
@@ -16,10 +16,13 @@ from pathlib import Path
 
 
 HERE = Path(__file__).resolve().parent
-VENV = Path("/Users/davidtai/projects/OpenSourceWTF/mtplx-hy3-ssd/.venv/bin/python")
-RUN_GUARDED = Path("/Users/davidtai/projects/OpenSourceWTF/bench/laguna/run_guarded.py")
-PLIST = Path("/Users/davidtai/Library/LaunchAgents/com.tea.qwen.plist")
-BENCH = Path("/Users/davidtai/projects/OpenSourceWTF/bench/deepseek-v4")
+# Guard deployment locations are supplied by the operator.  These defaults are
+# intentionally relative so an unconfigured checkout fails in the guarded
+# runner rather than encoding a particular developer machine.
+VENV = Path(os.environ.get("MTPLX_DSV4_PYTHON", "python3"))
+RUN_GUARDED = Path(os.environ.get("MTPLX_DSV4_GUARDED_RUNNER", "run_guarded.py"))
+PLIST = Path(os.environ.get("MTPLX_DSV4_QUALITY_PLIST", "com.tea.qwen.plist"))
+BENCH = Path(os.environ.get("MTPLX_DSV4_BENCH_DIR", "bench/deepseek-v4"))
 WRAPPER_ENV = "MTPLX_DSV4_ADAPTIVE_WIDTH_POSTFLIGHT_WRAPPER"
 TAG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 INVALID_TAG_RECEIPT_PREFIX = "adaptive-width-invalid-tag-"

--- a/scripts/deepseek_v4_mtpk_bench.py
+++ b/scripts/deepseek_v4_mtpk_bench.py
@@ -78,6 +78,106 @@ from deepseek_v4_guard_window import load_verified_guard_window  # noqa: E402
 # throughput ~4x and the number would be garbage anyway.
 _PEAK_ABORT_GIB = 108.0
 
+_OFFICIAL_MLX_IDENTITY = {
+    "version": "0.31.2",
+    "core_sha256": "d7bd29fc20b4a08318d21161c3dfb340889cc9454c5e554ad749eb0127cfa2d6",
+    "lib_sha256": "2ee6fbd32ff22e22e1301ebe3c3bece95584104ff9cbc900513d41a095211bbd",
+}
+_CANONICAL_PROMPT_SHA256 = (
+    "ee94397faa812c91d5f1a0ee17c5bb6ca6032883653591dd33d4cfddb737ac33"
+)
+_ADAPTIVE_WIDTH_STAGE4_ENV = {
+    "MTPLX_COMPILED_VERIFY": "off",
+    "MTPLX_DSV4_ATTN": "fused",
+    "MTPLX_DSV4_FP32_ACTIVATIONS": "0",
+    "MTPLX_DSV4_HC_COMPILE": "1",
+    "MTPLX_DSV4_MOE_TAIL": "1",
+    "MTPLX_DSV4_O_LORA": "gather_qmm",
+    "MTPLX_DSV4_SINKHORN_KERNEL": "1",
+}
+_ADAPTIVE_WIDTH_ARTIFACT_IDENTITY = {
+    "config_sha256": "c8ff87fd5ee5c9587d0c937e9bfd3193e1a1621141aa367848a9610b3291fa6f",
+    "index_sha256": "c84d2b369f5d5023d0f2d183fc36a935a3981751414996243b65f069983e43d8",
+    "model_type": "deepseek_v4",
+    "num_hidden_layers": 43,
+    "num_nextn_predict_layers": 1,
+    "body_q2_routed_projections": 129,
+    "body_q2_manifest_tensors": 387,
+    "mtp_manifest_tensors": 35,
+    "index_weight_count": 2645,
+}
+_ADAPTIVE_WIDTH_LOADED_IDENTITY = {
+    "runtime_mtp_enabled": True,
+    "body_layers_loaded": 43,
+    "mtp_blocks_bound": 1,
+    "body_q2_routed_projections": 129,
+    "body_q2_weight_dtype": "uint32",
+    "mtp_mxfp4_routed_projections": 3,
+    "mtp_routed_weight_dtype": "uint32",
+}
+_ADAPTIVE_WIDTH_MOE_TAIL_ROUTE = {
+    "route": "decode_verify_m4",
+    "body_layers_installed": 43,
+    "mtp_layers_stock": 1,
+    "verify_rows": 4,
+    "repair_rows": 1,
+    "topk": 6,
+    "hidden_size": 4096,
+    "kernel_selfcheck_exact": True,
+}
+_ADAPTIVE_WIDTH_O_LORA_ROUTE = {
+    "mode": "gather_qmm",
+    "module_count": 44,
+    "trunk_module_count": 43,
+    "mtp_module_count": 1,
+    "body_direct": 43,
+    "mtp_stock": 1,
+    "body_all_mode_matches": True,
+    "route_plan_matches": True,
+}
+_ADAPTIVE_WIDTH_O_LORA_CENSUS = {
+    "body_route_objects": 43,
+    "body_route_kind": "gather_qmm_direct",
+    "body_callable_class": "_DirectGatherOLora",
+    "mtp_route_objects": 1,
+    "mtp_route_kind": "dense_bf16_stock_direct",
+    "mtp_callable_class": "_DirectDenseMTPOLora",
+    "total_route_objects": 44,
+    "unique_route_objects": 44,
+    "mtp_distinct_type": True,
+}
+_ADAPTIVE_WIDTH_BRACKET_ARMS = (
+    ("K3-PRIMER", False),
+    ("K3-C0", False),
+    ("ADAPTIVE-B", True),
+    ("K3-C1", False),
+)
+_ADAPTIVE_WIDTH_POLICY_RECEIPT = {
+    "kind": "deepseek_v4_preregistered_max_k3",
+    "immutable": True,
+    "d1_margin_threshold": 0.25,
+    "d2_margin_threshold": 1.0,
+    "max_speculative_depth": 3,
+    "target_routes": {"K1": "M2", "K2": "M3", "K3": "M4"},
+    "target_rows": [2, 3, 4],
+}
+_BEHAVIOR_SCALARS = (
+    "generated_tokens",
+    "accepted_drafts",
+    "rejected_drafts",
+    "drafted_tokens",
+    "skipped_drafts",
+    "bonus_tokens",
+    "correction_tokens",
+    "verify_calls",
+    "mtp_forward_calls",
+    "make_mtp_cache_calls",
+    "update_mtp_cache_calls",
+    "mtp_history_append_calls",
+    "forward_ar_hidden_calls",
+    "forward_ar_plain_calls",
+)
+
 
 def _gib(n: int) -> float:
     return n / (1024**3)
@@ -291,6 +391,7 @@ def _run_arm(
     mtp_history_policy: str,
     baseline_tokens: list[int] | None,
     enforce_exact: bool = True,
+    adaptive_width_policy=None,
 ) -> dict:
     from mtplx.generation import generate_ar, generate_mtpk
     from mtplx.sampling import SamplerConfig
@@ -327,6 +428,7 @@ def _run_arm(
                 verify_strategy=verify_strategy,
                 verify_core=verify_core,
                 stop_token_ids=set(),
+                adaptive_width_policy=adaptive_width_policy,
             )
     except Exception:
         error = traceback.format_exc()
@@ -346,6 +448,7 @@ def _run_arm(
         "peak_gib": _gib(peak),
         "active_end_gib": _gib(_active_bytes()),
         "error": error,
+        "adaptive_width_policy_enabled": adaptive_width_policy is not None,
     }
     if out is None:
         return arm
@@ -555,6 +658,417 @@ def _reset_benchmark_state(rt) -> None:
     _reset_peak()
 
 
+def _token_sha256(tokens: list[int]) -> str:
+    encoded = json.dumps(list(tokens), separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _valid_nonnegative_int(value) -> bool:
+    return type(value) is int and value >= 0
+
+
+def _validate_behavior_stats(label: str, stats: object) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(stats, dict):
+        return [f"{label} stats_full is not an object"]
+    for key in _BEHAVIOR_SCALARS:
+        if not _valid_nonnegative_int(stats.get(key)):
+            errors.append(f"{label} has malformed counter {key}")
+    for key in ("accepted_by_depth", "drafted_by_depth"):
+        values = stats.get(key)
+        if (
+            not isinstance(values, list)
+            or len(values) != 3
+            or not all(_valid_nonnegative_int(value) for value in values)
+        ):
+            errors.append(f"{label} has malformed counter {key}")
+    drafted_by_depth = stats.get("drafted_by_depth")
+    if isinstance(drafted_by_depth, list) and all(
+        _valid_nonnegative_int(value) for value in drafted_by_depth
+    ):
+        if sum(drafted_by_depth) != stats.get("drafted_tokens"):
+            errors.append(f"{label} drafted counter sum is inconsistent")
+        if not all(
+            left >= right
+            for left, right in zip(drafted_by_depth, drafted_by_depth[1:])
+        ):
+            errors.append(f"{label} drafted depth histogram is not monotone")
+    if stats.get("generated_tokens") != 256:
+        errors.append(f"{label} did not generate the canonical 256 tokens")
+    if not isinstance(stats.get("events"), list):
+        errors.append(f"{label} events are missing")
+    return errors
+
+
+def _adaptive_width_engagement(arm: dict) -> tuple[dict, list[str]]:
+    errors: list[str] = []
+    stats = arm.get("stats_full")
+    events = stats.get("events", []) if isinstance(stats, dict) else []
+    histogram = {"K1_M2": 0, "K2_M3": 0, "K3_M4": 0}
+    policy_events = 0
+    eligible_events = 0
+    context_copy_events = 0
+    for index, event in enumerate(events):
+        if not isinstance(event, dict):
+            errors.append(f"ADAPTIVE-B event {index} is malformed")
+            continue
+        if "context_copy" in event:
+            context_copy_events += 1
+            if "adaptive_width_policy" in event:
+                errors.append("context-copy event carries adaptive policy metadata")
+            continue
+        policy = event.get("adaptive_width_policy")
+        if not isinstance(policy, dict):
+            if event.get("drafts"):
+                errors.append(f"ADAPTIVE-B event {index} lacks policy engagement")
+            continue
+        policy_events += 1
+        width = policy.get("selected_draft_depth")
+        target_rows = policy.get("target_rows")
+        margins = policy.get("decision_margins")
+        eligible = policy.get("eligible_full_k3")
+        if policy.get("kind") != "deepseek_v4_preregistered_max_k3":
+            errors.append(f"ADAPTIVE-B event {index} has the wrong policy kind")
+        if policy.get("d1_margin_threshold") != 0.25:
+            errors.append(f"ADAPTIVE-B event {index} changed D1")
+        if policy.get("d2_margin_threshold") != 1.0:
+            errors.append(f"ADAPTIVE-B event {index} changed D2")
+        if width not in {1, 2, 3} or target_rows != width + 1:
+            errors.append(f"ADAPTIVE-B event {index} has an invalid target width")
+            continue
+        histogram[("K1_M2", "K2_M3", "K3_M4")[width - 1]] += 1
+        if eligible is True:
+            eligible_events += 1
+            if not isinstance(margins, list) or len(margins) != min(width, 2):
+                errors.append(f"ADAPTIVE-B event {index} has incomplete margins")
+            elif not all(type(value) in {int, float} for value in margins):
+                errors.append(f"ADAPTIVE-B event {index} has malformed margins")
+            if width == 1 and not (float(margins[0]) < 0.25):
+                errors.append(f"ADAPTIVE-B event {index} violates the D1 decision")
+            if width >= 2 and not (float(margins[0]) >= 0.25):
+                errors.append(f"ADAPTIVE-B event {index} violates the D1 tie rule")
+            if width == 2 and not (float(margins[1]) < 1.0):
+                errors.append(f"ADAPTIVE-B event {index} violates the D2 decision")
+            if width == 3 and not (float(margins[1]) >= 1.0):
+                errors.append(f"ADAPTIVE-B event {index} violates the D2 tie rule")
+        elif eligible is not False:
+            errors.append(f"ADAPTIVE-B event {index} lacks an eligibility receipt")
+    if eligible_events <= 0:
+        errors.append("ADAPTIVE-B has no eligible full-K3 policy events")
+    if isinstance(stats, dict):
+        drafted_by_depth = stats.get("drafted_by_depth")
+        expected_drafted = [
+            sum(histogram.values()),
+            histogram["K2_M3"] + histogram["K3_M4"],
+            histogram["K3_M4"],
+        ]
+        if drafted_by_depth != expected_drafted:
+            errors.append("event-derived widths do not match drafted_by_depth")
+        if stats.get("verify_calls") != policy_events + context_copy_events:
+            errors.append("event-derived widths do not cover verify calls")
+    return {
+        "policy_events": policy_events,
+        "eligible_full_k3_events": eligible_events,
+        "context_copy_events": context_copy_events,
+        "event_derived_width_histogram": histogram,
+    }, errors
+
+
+def _token_quality(arms_by_label: dict[str, dict]) -> tuple[dict, list[str]]:
+    errors: list[str] = []
+    controls = [
+        arms_by_label.get("K3-PRIMER", {}).get("tokens"),
+        arms_by_label.get("K3-C0", {}).get("tokens"),
+        arms_by_label.get("K3-C1", {}).get("tokens"),
+    ]
+    candidate = arms_by_label.get("ADAPTIVE-B", {}).get("tokens")
+    if not all(isinstance(tokens, list) and len(tokens) == 256 for tokens in controls):
+        return {"accepted": False, "mode": "invalid_controls"}, [
+            "fixed-K3 controls lack canonical token sequences"
+        ]
+    if controls[0] != controls[1] or controls[1] != controls[2]:
+        return {"accepted": False, "mode": "control_mismatch"}, [
+            "fixed-K3 controls are not token-identical"
+        ]
+    if not isinstance(candidate, list) or len(candidate) != 256:
+        return {"accepted": False, "mode": "invalid_candidate"}, [
+            "adaptive candidate lacks a canonical token sequence"
+        ]
+    control = controls[1]
+    differing = [index for index, pair in enumerate(zip(control, candidate)) if pair[0] != pair[1]]
+    if not differing:
+        return {
+            "accepted": True,
+            "mode": "exact",
+            "control_token_sha256": _token_sha256(control),
+            "candidate_token_sha256": _token_sha256(candidate),
+            "divergent_tokens": 0,
+        }, errors
+    cause = {
+        "continuation_index": 221,
+        "absolute_position": 549,
+        "control_token_id": 14042,
+        "candidate_token_id": 12258,
+        "control_target_gap": 0.25,
+        "candidate_target_gap": 0.0,
+    }
+    approved = (
+        differing[0] == cause["continuation_index"]
+        and control[:221] == candidate[:221]
+        and control[221] == cause["control_token_id"]
+        and candidate[221] == cause["candidate_token_id"]
+    )
+    quality = {
+        "accepted": approved,
+        "mode": "approved_bf16_top2_cause" if approved else "unapproved_divergence",
+        "approved_cause": cause if approved else None,
+        "divergent_tokens": len(differing),
+        "first_divergence_index": differing[0],
+        "control_token_sha256": _token_sha256(control),
+        "candidate_token_sha256": _token_sha256(candidate),
+        "propagated_tail": {
+            "documented": approved,
+            "start_continuation_index": 222,
+            "compared_tokens": len(candidate) - 222,
+            "divergent_tokens": sum(
+                control[index] != candidate[index] for index in range(222, len(candidate))
+            ),
+            "control_tail_sha256": _token_sha256(control[222:]),
+            "candidate_tail_sha256": _token_sha256(candidate[222:]),
+            "human_eval": "deferred",
+        },
+    }
+    if not approved:
+        errors.append("adaptive candidate has an unapproved token divergence")
+    return quality, errors
+
+
+def _adaptive_width_common_errors(common: dict) -> list[str]:
+    errors: list[str] = []
+    source = common.get("source_commit")
+    if not isinstance(source, str) or len(source) != 40 or any(
+        character not in "0123456789abcdef" for character in source
+    ):
+        errors.append("source commit is malformed")
+    expected = {
+        "model_path": "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp",
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 43,
+        "num_nextn_predict_layers": 1,
+        "prompt_tokens": 328,
+        "max_tokens": 256,
+        "depths": [3],
+        "verify_strategy": "capture_commit",
+        "verify_core": "stock",
+        "mtp_history_policy": "committed",
+        "sampling": {"greedy": True, "temperature": 0.0, "stop_token_ids": []},
+        "fp32_activations": False,
+    }
+    for key, value in expected.items():
+        if common.get(key) != value:
+            errors.append(f"{key} is not canonical")
+    prompt = common.get("prompt")
+    if not isinstance(prompt, dict) or prompt.get("sha256") != _CANONICAL_PROMPT_SHA256 or prompt.get("tokens") != 328:
+        errors.append("prompt identity is not canonical")
+    for key, expected_identity in (
+        ("mlx_identity", _OFFICIAL_MLX_IDENTITY),
+        ("artifact_identity", _ADAPTIVE_WIDTH_ARTIFACT_IDENTITY),
+        ("loaded_runtime_identity", _ADAPTIVE_WIDTH_LOADED_IDENTITY),
+        ("launch_mtplx_env", _ADAPTIVE_WIDTH_STAGE4_ENV),
+    ):
+        observed = common.get(key)
+        if not isinstance(observed, dict) or any(
+            observed.get(name) != value for name, value in expected_identity.items()
+        ) or (key == "launch_mtplx_env" and observed != expected_identity):
+            errors.append(f"{key} is not canonical")
+    if common.get("deepseek_v4_moe_tail") != _ADAPTIVE_WIDTH_MOE_TAIL_ROUTE:
+        errors.append("MoE-tail installed route is not canonical")
+    o_lora = common.get("deepseek_v4_o_lora")
+    if (
+        not isinstance(o_lora, dict)
+        or any(
+            o_lora.get(name) != value
+            for name, value in _ADAPTIVE_WIDTH_O_LORA_ROUTE.items()
+        )
+        or o_lora.get("callable_census") != _ADAPTIVE_WIDTH_O_LORA_CENSUS
+    ):
+        errors.append("o-LoRA installed route is not canonical")
+    guard = common.get("guard_window")
+    if not isinstance(guard, dict) or guard.get("verified") is not True:
+        errors.append("guard window is not verified")
+    return errors
+
+
+def _adaptive_width_bracket_receipt(
+    *,
+    common: dict,
+    arms: list[dict],
+    process_pid: int,
+    model_object_id: int,
+    policy_receipt: dict,
+) -> dict:
+    errors = _adaptive_width_common_errors(common)
+    expected_order = [label for label, _enabled in _ADAPTIVE_WIDTH_BRACKET_ARMS]
+    observed_order = [arm.get("label") for arm in arms if isinstance(arm, dict)]
+    if observed_order != expected_order:
+        errors.append("adaptive-width arm order is invalid")
+    if type(process_pid) is not int or process_pid <= 0:
+        errors.append("process identity is invalid")
+    if type(model_object_id) is not int or model_object_id <= 0:
+        errors.append("model object identity is invalid")
+    if policy_receipt != _ADAPTIVE_WIDTH_POLICY_RECEIPT:
+        errors.append("installed adaptive-width policy receipt is invalid")
+
+    arms_by_label = {
+        str(arm.get("label")): arm for arm in arms if isinstance(arm, dict)
+    }
+    for label in expected_order:
+        arm = arms_by_label.get(label)
+        if arm is None:
+            continue
+        if arm.get("error") is not None:
+            errors.append(f"{label} failed")
+        if arm.get("generated_tokens") != 256 or arm.get("finish_reason") != "length":
+            errors.append(f"{label} did not complete the canonical workload")
+        tokens = arm.get("tokens")
+        if not isinstance(tokens, list) or arm.get("token_sha256") != _token_sha256(tokens):
+            errors.append(f"{label} token identity is malformed")
+        errors.extend(_validate_behavior_stats(label, arm.get("stats_full")))
+
+    for label in ("K3-PRIMER", "K3-C0", "K3-C1"):
+        stats = arms_by_label.get(label, {}).get("stats_full", {})
+        events = stats.get("events", []) if isinstance(stats, dict) else []
+        if any(
+            isinstance(event, dict) and "adaptive_width_policy" in event
+            for event in events
+        ):
+            errors.append(f"{label} unexpectedly engaged adaptive width")
+
+    candidate = arms_by_label.get("ADAPTIVE-B", {})
+    engagement, engagement_errors = _adaptive_width_engagement(candidate)
+    errors.extend(engagement_errors)
+    quality, quality_errors = _token_quality(arms_by_label)
+    errors.extend(quality_errors)
+
+    def _tps(label: str) -> float:
+        value = arms_by_label.get(label, {}).get("decode_tokens_per_second")
+        return float(value) if type(value) in {int, float} and value > 0 else 0.0
+
+    c0_tps = _tps("K3-C0")
+    c1_tps = _tps("K3-C1")
+    candidate_tps = _tps("ADAPTIVE-B")
+    if not c0_tps or not c1_tps or not candidate_tps:
+        errors.append("performance cells are missing positive throughput")
+    control_mean = (c0_tps + c1_tps) / 2.0
+    drift_tps = abs(c1_tps - c0_tps)
+    promotion_floor = control_mean + drift_tps
+    performance = {
+        "control_c0_tps": c0_tps,
+        "control_c1_tps": c1_tps,
+        "control_mean_tps": control_mean,
+        "control_drift_tps": drift_tps,
+        "candidate_tps": candidate_tps,
+        "candidate_minus_control_mean_tps": candidate_tps - control_mean,
+        "promotion_floor_tps": promotion_floor,
+        "promotion_pass": candidate_tps > promotion_floor,
+        "reported_below_40_tps": candidate_tps < 40.0,
+    }
+    return {
+        **common,
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "receipt_role": "adaptive_width_performance_bracket",
+        "performance_eligible": True,
+        "single_process_bracket": {
+            "process_pid": process_pid,
+            "model_object_id": model_object_id,
+            "model_load_count": 1,
+            "execution_order": expected_order,
+            "discarded_primer": "K3-PRIMER",
+        },
+        "policy": policy_receipt,
+        "policy_engagement": engagement,
+        "token_quality": quality,
+        "performance": performance,
+        "arms": arms,
+        "validation_errors": errors,
+        "status": int(bool(errors)),
+    }
+
+
+def _installed_policy_receipt(policy) -> dict:
+    rows = [int(route.target_rows) for route in policy.target_routes]
+    return {
+        "kind": "deepseek_v4_preregistered_max_k3",
+        "immutable": bool(
+            getattr(getattr(type(policy), "__dataclass_params__", None), "frozen", False)
+        ),
+        "d1_margin_threshold": float(policy.d1_margin_threshold),
+        "d2_margin_threshold": float(policy.d2_margin_threshold),
+        "max_speculative_depth": int(policy.max_speculative_depth),
+        "target_routes": {"K1": "M2", "K2": "M3", "K3": "M4"},
+        "target_rows": rows,
+    }
+
+
+def _run_adaptive_width_bracket(
+    *,
+    rt,
+    prompt_ids: list[int],
+    args,
+    common_receipt: dict,
+    out_stem: Path,
+) -> int:
+    from mtplx.deepseek_v4_adaptive_width import (
+        install_deepseek_v4_adaptive_width_policy,
+    )
+    from mtplx.sampling import SamplerConfig
+
+    sampler = SamplerConfig(temperature=0.0)
+    policy = install_deepseek_v4_adaptive_width_policy(
+        rt,
+        sampler=sampler,
+        draft_sampler=None,
+        speculative_depth=3,
+        verify_strategy=args.verify_strategy,
+        verify_core=args.verify_core,
+        mtp_history_policy=args.mtp_history_policy,
+    )
+    policy_receipt = _installed_policy_receipt(policy)
+    arms: list[dict] = []
+    for label, enabled in _ADAPTIVE_WIDTH_BRACKET_ARMS:
+        _reset_benchmark_state(rt)
+        arm = _run_arm(
+            rt=rt,
+            label=label,
+            depth=3,
+            prompt_ids=prompt_ids,
+            max_tokens=args.max_tokens,
+            verify_strategy=args.verify_strategy,
+            verify_core=args.verify_core,
+            mtp_history_policy=args.mtp_history_policy,
+            baseline_tokens=None,
+            adaptive_width_policy=policy if enabled else None,
+        )
+        if isinstance(arm.get("tokens"), list):
+            arm["token_sha256"] = _token_sha256(arm["tokens"])
+        arms.append(arm)
+
+    receipt = _adaptive_width_bracket_receipt(
+        common=common_receipt,
+        arms=arms,
+        process_pid=os.getpid(),
+        model_object_id=id(rt.model),
+        policy_receipt=policy_receipt,
+    )
+    _write_pair_receipt(out_stem, receipt, prompt_ids, args.prompt_file)
+    print(f"[adaptive width] wrote {out_stem.with_suffix('.json')}")
+    print(json.dumps(receipt["policy_engagement"], sort_keys=True))
+    print(json.dumps(receipt["token_quality"], sort_keys=True))
+    print(json.dumps(receipt["performance"], sort_keys=True))
+    sys.stdout.flush()
+    return int(receipt["status"])
+
+
 def _write_pair_receipt(stem: Path, receipt: dict, prompt_ids: list[int], prompt_file: str) -> None:
     stem.parent.mkdir(parents=True, exist_ok=True)
     stem.with_suffix(".json").write_text(json.dumps(receipt, indent=2) + "\n")
@@ -693,11 +1207,7 @@ def main() -> int:
         "lib_path": str(mlx_lib_path),
         "lib_sha256": hashlib.sha256(mlx_lib_path.read_bytes()).hexdigest(),
     }
-    required_mlx_identity = {
-        "version": "0.31.2",
-        "core_sha256": "d7bd29fc20b4a08318d21161c3dfb340889cc9454c5e554ad749eb0127cfa2d6",
-        "lib_sha256": "2ee6fbd32ff22e22e1301ebe3c3bece95584104ff9cbc900513d41a095211bbd",
-    }
+    required_mlx_identity = _OFFICIAL_MLX_IDENTITY
     if any(mlx_identity[key] != value for key, value in required_mlx_identity.items()):
         raise RuntimeError(
             f"requires official MLX 0.31.2 binary identity: {mlx_identity}"
@@ -731,6 +1241,11 @@ def main() -> int:
         help="one-load primer/C0/MoE-tail/C1 K3 bracket",
     )
     ap.add_argument(
+        "--adaptive-width-bracket",
+        action="store_true",
+        help="one-load fixed-C0/adaptive-B/fixed-C1 max-K3 bracket",
+    )
+    ap.add_argument(
         "--receipt-role",
         choices=("measurement", "discarded_control_primer"),
         default="measurement",
@@ -758,6 +1273,14 @@ def main() -> int:
         and not key.startswith("MTPLX_GUARD_ATTEST_")
         and not key.startswith("MTPLX_DSV4_GUARD_WINDOW_")
     }
+    if (
+        args.adaptive_width_bracket
+        and launch_mtplx_env != _ADAPTIVE_WIDTH_STAGE4_ENV
+    ):
+        sys.exit(
+            "--adaptive-width-bracket requires the exact seven-variable "
+            f"Stage-4 environment: {launch_mtplx_env}"
+        )
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -845,6 +1368,72 @@ def main() -> int:
         sys.stdout.flush()
 
     after_load_active = _active_bytes()
+
+    if args.adaptive_width_bracket:
+        if args.tiny:
+            sys.exit("--adaptive-width-bracket requires the canonical GPU model")
+        if args.moe_tail_bracket:
+            sys.exit("adaptive-width and MoE-tail bracket modes are exclusive")
+        if list(args.depths) != [3] or args.max_tokens != 256:
+            sys.exit("--adaptive-width-bracket requires --depths 3 --max-tokens 256")
+        if not args.out:
+            sys.exit("--adaptive-width-bracket requires --out")
+        if (
+            args.verify_strategy != "capture_commit"
+            or args.verify_core != "stock"
+            or args.mtp_history_policy != "committed"
+        ):
+            sys.exit(
+                "--adaptive-width-bracket requires capture_commit/stock/committed"
+            )
+        if prompt_identity != {
+            "path": str(prompt_path),
+            "sha256": _CANONICAL_PROMPT_SHA256,
+            "tokens": 328,
+        }:
+            sys.exit(f"canonical prompt identity mismatch: {prompt_identity}")
+        if str(model_path) != "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp":
+            sys.exit(f"canonical model path mismatch: {model_path}")
+        common_receipt = {
+            "harness": "scripts/deepseek_v4_mtpk_bench.py",
+            "source_commit": source_commit,
+            "artifact_identity": artifact_identity,
+            "loaded_runtime_identity": loaded_runtime_identity,
+            "mlx_identity": mlx_identity,
+            "command": ["python", *sys.argv],
+            "host": {
+                "platform": platform.platform(),
+                "mlx_version": mx.__version__,
+                "python": sys.version.split()[0],
+            },
+            "launch_mtplx_env": launch_mtplx_env,
+            "guard_window": guard_window,
+            "model_path": str(model_path),
+            "model_type": config.get("model_type"),
+            "num_hidden_layers": config.get("num_hidden_layers"),
+            "num_nextn_predict_layers": config.get("num_nextn_predict_layers"),
+            "sampling": {"greedy": True, "temperature": 0.0, "stop_token_ids": []},
+            "prompt_file": str(prompt_path),
+            "prompt": prompt_identity,
+            "prompt_tokens": len(prompt_ids),
+            "max_tokens": args.max_tokens,
+            "depths": [3],
+            "verify_strategy": args.verify_strategy,
+            "verify_core": args.verify_core,
+            "mtp_history_policy": args.mtp_history_policy,
+            "fp32_activations": _fp32_activations_env(),
+            "load_seconds": load_seconds,
+            "active_after_load_gib": _gib(after_load_active),
+            "deepseek_v4_moe_tail": moe_tail_report,
+            "deepseek_v4_o_lora": rt.deepseek_v4_o_lora_report,
+        }
+        return _run_adaptive_width_bracket(
+            rt=rt,
+            prompt_ids=prompt_ids,
+            args=args,
+            common_receipt=common_receipt,
+            out_stem=Path(args.out),
+        )
 
     if args.moe_tail_bracket:
         if args.tiny:

--- a/scripts/deepseek_v4_mtpk_bench.py
+++ b/scripts/deepseek_v4_mtpk_bench.py
@@ -851,7 +851,6 @@ def _adaptive_width_common_errors(common: dict) -> list[str]:
     ):
         errors.append("source commit is malformed")
     expected = {
-        "model_path": "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp",
         "model_type": "deepseek_v4",
         "num_hidden_layers": 43,
         "num_nextn_predict_layers": 1,
@@ -1392,8 +1391,6 @@ def main() -> int:
             "tokens": 328,
         }:
             sys.exit(f"canonical prompt identity mismatch: {prompt_identity}")
-        if str(model_path) != "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp":
-            sys.exit(f"canonical model path mismatch: {model_path}")
         common_receipt = {
             "harness": "scripts/deepseek_v4_mtpk_bench.py",
             "source_commit": source_commit,

--- a/tests/test_deepseek_v4_adaptive_width_bracket.py
+++ b/tests/test_deepseek_v4_adaptive_width_bracket.py
@@ -432,3 +432,71 @@ def test_postflight_wrapper_always_writes_and_fails_closed(tmp_path, failure):
     assert status == 1
     receipt = json.loads((tmp_path / f"{tag}-postflight.json").read_text())
     assert receipt["status"] == 1
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ("../../escaped", "", ".", "..", "slash/name", "bad tag"),
+)
+def test_invalid_tag_skips_child_but_collects_postflight_and_writes_safe_receipt(
+    tmp_path, tag
+):
+    wrapper = _wrapper_module()
+    collected = []
+
+    def collect():
+        collected.append(True)
+        return _postflight(True)
+
+    status = wrapper.run(
+        tag,
+        run_command=lambda *_a, **_k: pytest.fail("invalid tag started child"),
+        postflight_collector=collect,
+        bench_dir=tmp_path,
+    )
+
+    digest = hashlib.sha256(tag.encode("utf-8", errors="surrogatepass")).hexdigest()
+    receipts = list(
+        tmp_path.glob(
+            f"adaptive-width-invalid-tag-{digest}-pid-*-postflight.json"
+        )
+    )
+    assert status == 1
+    assert collected == [True]
+    assert len(receipts) == 1
+    assert receipts[0].parent.resolve() == tmp_path.resolve()
+    assert list(tmp_path.iterdir()) == receipts
+    pid_text = receipts[0].name.removeprefix(
+        f"adaptive-width-invalid-tag-{digest}-pid-"
+    ).removesuffix("-postflight.json")
+    assert pid_text.isdecimal()
+    receipt = json.loads(receipts[0].read_text())
+    assert receipt["tag_valid"] is False
+    assert receipt["tag_sha256"] == digest
+    assert receipt["guarded_child_started"] is False
+    assert receipt["guarded_child_exit_code"] is None
+    assert receipt["postflight_ok"] is True
+    assert set(receipt["postflight"]) == set(wrapper.REQUIRED_PROBES)
+    assert receipt["status"] == 1
+
+
+def test_invalid_tag_path_strictly_rejects_malformed_restoration_probe(tmp_path):
+    wrapper = _wrapper_module()
+    probes = _postflight(True)
+    probes["wired_limit_mb"] = {"ok": 1}
+
+    status = wrapper.run(
+        "invalid/tag",
+        run_command=lambda *_a, **_k: pytest.fail("invalid tag started child"),
+        postflight_collector=lambda: probes,
+        bench_dir=tmp_path,
+    )
+
+    receipt_path = next(tmp_path.glob("adaptive-width-invalid-tag-*-postflight.json"))
+    receipt = json.loads(receipt_path.read_text())
+    assert status == 1
+    assert receipt["postflight_ok"] is False
+    assert any(
+        "wired_limit_mb is missing or malformed" in error
+        for error in receipt["validation_errors"]
+    )

--- a/tests/test_deepseek_v4_adaptive_width_bracket.py
+++ b/tests/test_deepseek_v4_adaptive_width_bracket.py
@@ -1,0 +1,434 @@
+"""Fail-closed gates for the canonical adaptive-width performance bracket."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+BENCH_PATH = ROOT / "scripts" / "deepseek_v4_mtpk_bench.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("dsv4_adaptive_width_bench", BENCH_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _token_sha(tokens):
+    return hashlib.sha256(json.dumps(tokens, separators=(",", ":")).encode()).hexdigest()
+
+
+def _control(label, tps=40.0):
+    tokens = list(range(256))
+    tokens[221] = 14042
+    stats = {
+        "events": [
+            {"depth": 3, "drafts": [{}, {}, {}], "gated_stop_depth": None},
+            {"depth": 3, "drafts": [{}, {}, {}], "gated_stop_depth": None},
+        ],
+        "generated_tokens": 256,
+        "accepted_by_depth": [2, 1, 1],
+        "drafted_by_depth": [2, 2, 2],
+        "accepted_drafts": 4,
+        "rejected_drafts": 1,
+        "drafted_tokens": 6,
+        "skipped_drafts": 0,
+        "bonus_tokens": 1,
+        "correction_tokens": 1,
+        "verify_calls": 2,
+        "mtp_forward_calls": 6,
+        "make_mtp_cache_calls": 2,
+        "update_mtp_cache_calls": 2,
+        "mtp_history_append_calls": 2,
+        "forward_ar_hidden_calls": 3,
+        "forward_ar_plain_calls": 0,
+    }
+    return {
+        "label": label,
+        "error": None,
+        "generated_tokens": 256,
+        "finish_reason": "length",
+        "tokens": tokens,
+        "token_sha256": _token_sha(tokens),
+        "decode_tokens_per_second": tps,
+        "stats_full": stats,
+    }
+
+
+def _candidate(tps=42.0, *, tokens=None):
+    if tokens is None:
+        tokens = list(range(256))
+        tokens[221] = 14042
+    else:
+        tokens = list(tokens)
+    events = []
+    for width, margins in ((1, [0.1]), (2, [0.5, 0.5]), (3, [0.5, 1.5])):
+        events.append(
+            {
+                "depth": 3,
+                "drafts": [{}] * width,
+                "gated_stop_depth": width if width < 3 else None,
+                "adaptive_width_policy": {
+                    "kind": "deepseek_v4_preregistered_max_k3",
+                    "eligible_full_k3": True,
+                    "d1_margin_threshold": 0.25,
+                    "d2_margin_threshold": 1.0,
+                    "decision_margins": margins,
+                    "selected_draft_depth": width,
+                    "target_rows": width + 1,
+                },
+            }
+        )
+    stats = {
+        "events": events,
+        "generated_tokens": 256,
+        "accepted_by_depth": [2, 1, 1],
+        "drafted_by_depth": [3, 2, 1],
+        "accepted_drafts": 4,
+        "rejected_drafts": 1,
+        "drafted_tokens": 6,
+        "skipped_drafts": 0,
+        "bonus_tokens": 1,
+        "correction_tokens": 1,
+        "verify_calls": 3,
+        "mtp_forward_calls": 6,
+        "make_mtp_cache_calls": 3,
+        "update_mtp_cache_calls": 3,
+        "mtp_history_append_calls": 3,
+        "forward_ar_hidden_calls": 4,
+        "forward_ar_plain_calls": 0,
+    }
+    return {
+        "label": "ADAPTIVE-B",
+        "error": None,
+        "generated_tokens": 256,
+        "finish_reason": "length",
+        "tokens": tokens,
+        "token_sha256": _token_sha(tokens),
+        "decode_tokens_per_second": tps,
+        "stats_full": stats,
+    }
+
+
+def _policy_receipt():
+    return {
+        "kind": "deepseek_v4_preregistered_max_k3",
+        "immutable": True,
+        "d1_margin_threshold": 0.25,
+        "d2_margin_threshold": 1.0,
+        "max_speculative_depth": 3,
+        "target_routes": {"K1": "M2", "K2": "M3", "K3": "M4"},
+        "target_rows": [2, 3, 4],
+    }
+
+
+def _moe_tail_report():
+    return {
+        "route": "decode_verify_m4",
+        "body_layers_installed": 43,
+        "mtp_layers_stock": 1,
+        "verify_rows": 4,
+        "repair_rows": 1,
+        "topk": 6,
+        "hidden_size": 4096,
+        "kernel_selfcheck_exact": True,
+    }
+
+
+def _o_lora_report():
+    return {
+        "mode": "gather_qmm",
+        "module_count": 44,
+        "trunk_module_count": 43,
+        "mtp_module_count": 1,
+        "body_direct": 43,
+        "mtp_stock": 1,
+        "body_all_mode_matches": True,
+        "route_plan_matches": True,
+        "callable_census": {
+            "body_route_objects": 43,
+            "body_route_kind": "gather_qmm_direct",
+            "body_callable_class": "_DirectGatherOLora",
+            "mtp_route_objects": 1,
+            "mtp_route_kind": "dense_bf16_stock_direct",
+            "mtp_callable_class": "_DirectDenseMTPOLora",
+            "total_route_objects": 44,
+            "unique_route_objects": 44,
+            "mtp_distinct_type": True,
+        },
+    }
+
+
+def _common(bench):
+    return {
+        "source_commit": "a" * 40,
+        "model_path": "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp",
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 43,
+        "num_nextn_predict_layers": 1,
+        "prompt": {"sha256": bench._CANONICAL_PROMPT_SHA256, "tokens": 328},
+        "prompt_tokens": 328,
+        "max_tokens": 256,
+        "depths": [3],
+        "verify_strategy": "capture_commit",
+        "verify_core": "stock",
+        "mtp_history_policy": "committed",
+        "sampling": {"greedy": True, "temperature": 0.0, "stop_token_ids": []},
+        "fp32_activations": False,
+        "mlx_identity": dict(bench._OFFICIAL_MLX_IDENTITY),
+        "artifact_identity": dict(bench._ADAPTIVE_WIDTH_ARTIFACT_IDENTITY),
+        "loaded_runtime_identity": dict(bench._ADAPTIVE_WIDTH_LOADED_IDENTITY),
+        "launch_mtplx_env": dict(bench._ADAPTIVE_WIDTH_STAGE4_ENV),
+        "deepseek_v4_moe_tail": _moe_tail_report(),
+        "deepseek_v4_o_lora": _o_lora_report(),
+        "guard_window": {"verified": True},
+    }
+
+
+def _receipt(bench, *, arms=None, common=None):
+    return bench._adaptive_width_bracket_receipt(
+        common=_common(bench) if common is None else common,
+        arms=arms
+        or [
+            _control("K3-PRIMER", 39.0),
+            _control("K3-C0", 40.0),
+            _candidate(42.0),
+            _control("K3-C1", 40.5),
+        ],
+        process_pid=7,
+        model_object_id=9,
+        policy_receipt=_policy_receipt(),
+    )
+
+
+def test_bracket_constants_pin_the_canonical_full_workload():
+    bench = _module()
+    assert bench._ADAPTIVE_WIDTH_BRACKET_ARMS == (
+        ("K3-PRIMER", False),
+        ("K3-C0", False),
+        ("ADAPTIVE-B", True),
+        ("K3-C1", False),
+    )
+    assert bench._ADAPTIVE_WIDTH_STAGE4_ENV == {
+        "MTPLX_COMPILED_VERIFY": "off",
+        "MTPLX_DSV4_ATTN": "fused",
+        "MTPLX_DSV4_FP32_ACTIVATIONS": "0",
+        "MTPLX_DSV4_HC_COMPILE": "1",
+        "MTPLX_DSV4_MOE_TAIL": "1",
+        "MTPLX_DSV4_O_LORA": "gather_qmm",
+        "MTPLX_DSV4_SINKHORN_KERNEL": "1",
+    }
+
+
+def test_valid_bracket_derives_width_histogram_quality_and_promotion():
+    bench = _module()
+    receipt = _receipt(bench)
+
+    assert receipt["status"] == 0
+    assert receipt["performance_eligible"] is True
+    assert receipt["single_process_bracket"]["model_load_count"] == 1
+    assert receipt["single_process_bracket"]["execution_order"] == [
+        "K3-PRIMER", "K3-C0", "ADAPTIVE-B", "K3-C1"
+    ]
+    assert receipt["policy_engagement"]["event_derived_width_histogram"] == {
+        "K1_M2": 1,
+        "K2_M3": 1,
+        "K3_M4": 1,
+    }
+    assert receipt["token_quality"]["accepted"] is True
+    assert receipt["token_quality"]["mode"] == "exact"
+    assert receipt["performance"]["candidate_tps"] == 42.0
+    assert receipt["performance"]["reported_below_40_tps"] is False
+    assert receipt["performance"]["promotion_pass"] is True
+
+
+def test_below_40_is_reported_without_becoming_a_receipt_failure():
+    bench = _module()
+    arms = [
+        _control("K3-PRIMER", 38.0),
+        _control("K3-C0", 37.0),
+        _candidate(39.0),
+        _control("K3-C1", 37.1),
+    ]
+    receipt = _receipt(bench, arms=arms)
+    assert receipt["status"] == 0
+    assert receipt["performance"]["reported_below_40_tps"] is True
+
+
+def test_only_the_approved_bf16_first_cause_can_justify_a_propagated_tail():
+    bench = _module()
+    tokens = list(range(256))
+    tokens[221] = 12258
+    tokens[222:] = [90000 + index for index in range(34)]
+    arms = [
+        _control("K3-PRIMER"),
+        _control("K3-C0"),
+        _candidate(tokens=tokens),
+        _control("K3-C1"),
+    ]
+    receipt = _receipt(bench, arms=arms)
+    quality = receipt["token_quality"]
+    assert receipt["status"] == 0
+    assert quality["mode"] == "approved_bf16_top2_cause"
+    assert quality["approved_cause"] == {
+        "continuation_index": 221,
+        "absolute_position": 549,
+        "control_token_id": 14042,
+        "candidate_token_id": 12258,
+        "control_target_gap": 0.25,
+        "candidate_target_gap": 0.0,
+    }
+    assert quality["propagated_tail"]["documented"] is True
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("env", "mlx", "artifact", "runtime", "order", "policy", "events", "counter", "control", "quality"),
+)
+def test_bracket_fails_closed_on_identity_engagement_counter_control_or_quality(mutation):
+    bench = _module()
+    common = _common(bench)
+    arms = [
+        _control("K3-PRIMER"),
+        _control("K3-C0"),
+        _candidate(),
+        _control("K3-C1"),
+    ]
+    policy = _policy_receipt()
+    if mutation == "env":
+        common["launch_mtplx_env"]["MTPLX_CONTEXT_COPY"] = "0"
+    elif mutation == "mlx":
+        common["mlx_identity"]["core_sha256"] = "0" * 64
+    elif mutation == "artifact":
+        common["artifact_identity"]["config_sha256"] = "0" * 64
+    elif mutation == "runtime":
+        common["loaded_runtime_identity"]["mtp_blocks_bound"] = 0
+    elif mutation == "order":
+        arms[1], arms[2] = arms[2], arms[1]
+    elif mutation == "policy":
+        policy["d1_margin_threshold"] = 0.5
+    elif mutation == "events":
+        arms[2]["stats_full"]["events"][0].pop("adaptive_width_policy")
+    elif mutation == "counter":
+        arms[2]["stats_full"]["drafted_tokens"] = True
+    elif mutation == "control":
+        arms[1]["stats_full"]["events"][0]["adaptive_width_policy"] = {}
+    else:
+        arms[2]["tokens"][17] = 99999
+    receipt = bench._adaptive_width_bracket_receipt(
+        common=common,
+        arms=arms,
+        process_pid=7,
+        model_object_id=9,
+        policy_receipt=policy,
+    )
+    assert receipt["status"] != 0
+    assert receipt["validation_errors"]
+
+
+@pytest.mark.parametrize("route", ("moe_tail", "o_lora"))
+def test_bracket_fails_closed_on_installed_route_receipts(route):
+    bench = _module()
+    common = _common(bench)
+    if route == "moe_tail":
+        common["deepseek_v4_moe_tail"]["body_layers_installed"] = 42
+    else:
+        common["deepseek_v4_o_lora"]["callable_census"]["mtp_route_kind"] = "stock"
+
+    receipt = _receipt(bench, common=common)
+
+    assert receipt["status"] != 0
+    assert any(
+        route.replace("_", "-") in error.lower()
+        for error in receipt["validation_errors"]
+    )
+
+
+def test_guard_child_has_exact_selector_cleanup_and_canonical_command():
+    child = (ROOT / "scripts" / "deepseek_v4_adaptive_width_arms.sh").read_text()
+    assert "for entry in ${(f)\"$(env)\"}" in child
+    assert "unset MTPLX_CONTEXT_COPY MTPLX_CONTEXT_COPY_TARGET_PREFIX" in child
+    assert "--adaptive-width-bracket" in child
+    assert "--max-tokens 256 --depths 3" in child
+    assert "--verify-strategy capture_commit --verify-core stock" in child
+    assert "--mtp-history-policy committed" in child
+
+
+def _wrapper_module():
+    path = ROOT / "scripts" / "deepseek_v4_adaptive_width_guarded.py"
+    spec = importlib.util.spec_from_file_location("dsv4_adaptive_width_wrapper", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _postflight(ok=True):
+    return {
+        key: {"ok": ok}
+        for key in (
+            "lock_free",
+            "wired_limit_mb",
+            "quality_models",
+            "quality_ready_chat",
+        )
+    }
+
+
+def test_postflight_wrapper_requires_child_receipt_and_all_restoration_probes(tmp_path):
+    wrapper = _wrapper_module()
+    tag = "adaptive-width-test"
+    primary = {"status": 0, "receipt_role": "adaptive_width_performance_bracket"}
+    (tmp_path / f"{tag}.json").write_text(json.dumps(primary))
+    seen = {}
+
+    def fake_run(command, **kwargs):
+        seen["command"] = command
+        seen["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    status = wrapper.run(
+        tag,
+        run_command=fake_run,
+        postflight_collector=lambda: _postflight(True),
+        bench_dir=tmp_path,
+    )
+
+    assert status == 0
+    assert seen["env"]["MTPLX_DSV4_ADAPTIVE_WIDTH_POSTFLIGHT_WRAPPER"] == "1"
+    receipt = json.loads((tmp_path / f"{tag}-postflight.json").read_text())
+    assert receipt["postflight_ok"] is True
+    assert receipt["primary_receipt"]["status"] == 0
+    assert receipt["status"] == 0
+
+
+@pytest.mark.parametrize("failure", ("child", "missing", "malformed", "probe"))
+def test_postflight_wrapper_always_writes_and_fails_closed(tmp_path, failure):
+    wrapper = _wrapper_module()
+    tag = f"adaptive-width-{failure}"
+    if failure != "missing":
+        primary = (
+            {"status": 1, "receipt_role": "adaptive_width_performance_bracket"}
+            if failure == "malformed"
+            else {"status": 0, "receipt_role": "adaptive_width_performance_bracket"}
+        )
+        (tmp_path / f"{tag}.json").write_text(json.dumps(primary))
+    probes = _postflight(failure != "probe")
+    status = wrapper.run(
+        tag,
+        run_command=lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1 if failure == "child" else 0
+        ),
+        postflight_collector=lambda: probes,
+        bench_dir=tmp_path,
+    )
+    assert status == 1
+    receipt = json.loads((tmp_path / f"{tag}-postflight.json").read_text())
+    assert receipt["status"] == 1

--- a/tests/test_deepseek_v4_adaptive_width_bracket.py
+++ b/tests/test_deepseek_v4_adaptive_width_bracket.py
@@ -170,7 +170,8 @@ def _o_lora_report():
 def _common(bench):
     return {
         "source_commit": "a" * 40,
-        "model_path": "/Users/davidtai/models/DeepSeek-V4-Flash-2bit-DQ-mtp",
+        # The artifact identity—not the developer's checkout path—is canonical.
+        "model_path": "/models/DeepSeek-V4-Flash-2bit-DQ-mtp",
         "model_type": "deepseek_v4",
         "num_hidden_layers": 43,
         "num_nextn_predict_layers": 1,
@@ -360,6 +361,16 @@ def test_guard_child_has_exact_selector_cleanup_and_canonical_command():
     assert "--max-tokens 256 --depths 3" in child
     assert "--verify-strategy capture_commit --verify-core stock" in child
     assert "--mtp-history-policy committed" in child
+
+
+def test_published_adaptive_bracket_has_no_developer_absolute_paths():
+    paths = (
+        ROOT / "scripts" / "deepseek_v4_adaptive_width_arms.sh",
+        ROOT / "scripts" / "deepseek_v4_adaptive_width_guarded.py",
+        BENCH_PATH,
+    )
+    developer_home = f"/{'Users'}/{'davidtai'}"
+    assert all(developer_home not in path.read_text() for path in paths)
 
 
 def _wrapper_module():

--- a/tests/test_deepseek_v4_adaptive_width_policy.py
+++ b/tests/test_deepseek_v4_adaptive_width_policy.py
@@ -1,0 +1,296 @@
+"""Contracts for the preregistered DeepSeek-V4 adaptive max-K3 policy."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import inspect
+
+import pytest
+
+pytest.importorskip("mlx.core")
+import mlx.core as mx  # noqa: E402
+
+from mtplx import generation
+from mtplx.deepseek_v4_adaptive_width import (  # noqa: E402
+    D1_MARGIN_THRESHOLD,
+    D2_MARGIN_THRESHOLD,
+    DeepSeekV4AdaptiveWidthPolicy,
+    MAX_SPECULATIVE_DEPTH,
+    install_deepseek_v4_adaptive_width_policy,
+)
+from mtplx.sampling import SamplerConfig  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _cpu_default_device(monkeypatch):
+    previous = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    monkeypatch.setenv("MTPLX_CONTEXT_COPY", "0")
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY", "off")
+    try:
+        yield
+    finally:
+        mx.set_default_device(previous)
+
+
+def _canonical_route_report() -> dict:
+    return {
+        "mode": "gather_qmm",
+        "module_count": 44,
+        "trunk_module_count": 43,
+        "mtp_module_count": 1,
+        "body_direct": 43,
+        "mtp_stock": 1,
+        "body_all_mode_matches": True,
+        "route_plan_matches": True,
+        "callable_census": {
+            "body_route_objects": 43,
+            "body_route_kind": "gather_qmm_direct",
+            "body_callable_class": "_DirectGatherOLora",
+            "mtp_route_objects": 1,
+            "mtp_route_kind": "dense_bf16_stock_direct",
+            "mtp_callable_class": "_DirectDenseMTPOLora",
+            "total_route_objects": 44,
+            "unique_route_objects": 44,
+            "mtp_distinct_type": True,
+        },
+    }
+
+
+def _tiny_runtime_and_prompt():
+    from test_deepseek_v4_spec import _prompt, _runtime
+
+    rt = _runtime(vocab=8)
+    rt.deepseek_v4_o_lora_report = _canonical_route_report()
+    return rt, _prompt(17, vocab=8)
+
+
+def _install(rt, *, sampler=None, draft_sampler=None, depth=3):
+    return install_deepseek_v4_adaptive_width_policy(
+        rt,
+        sampler=sampler or SamplerConfig(temperature=0.0),
+        draft_sampler=draft_sampler,
+        speculative_depth=depth,
+        verify_strategy="capture_commit",
+        verify_core="stock",
+        mtp_history_policy="committed",
+    )
+
+
+def _adaptive(rt, prompt, *, policy, max_tokens=16, stop_token_ids=None):
+    return generation.generate_mtpk(
+        rt,
+        prompt,
+        max_tokens=max_tokens,
+        sampler=SamplerConfig(temperature=0.0),
+        speculative_depth=3,
+        verify_strategy="capture_commit",
+        verify_core="stock",
+        mtp_history_policy="committed",
+        stop_token_ids=set() if stop_token_ids is None else stop_token_ids,
+        adaptive_width_policy=policy,
+    )
+
+
+def test_policy_is_frozen_preregistered_and_ties_continue_deeper():
+    rt, _ = _tiny_runtime_and_prompt()
+    policy = _install(rt)
+
+    assert D1_MARGIN_THRESHOLD == 0.25
+    assert D2_MARGIN_THRESHOLD == 1.0
+    assert MAX_SPECULATIVE_DEPTH == 3
+    assert policy.d1_margin_threshold == 0.25
+    assert policy.d2_margin_threshold == 1.0
+    assert policy.max_speculative_depth == 3
+    assert policy.stop_after_d1(0.249999) is True
+    assert policy.stop_after_d1(0.25) is False
+    assert policy.stop_after_d2(0.999999) is True
+    assert policy.stop_after_d2(1.0) is False
+    with pytest.raises(FrozenInstanceError):
+        policy.d1_margin_threshold = 0.5
+    parameters = inspect.signature(DeepSeekV4AdaptiveWidthPolicy).parameters
+    assert "d1_margin_threshold" not in parameters
+    assert "d2_margin_threshold" not in parameters
+    assert "max_speculative_depth" not in parameters
+
+
+@pytest.mark.parametrize(
+    ("target_temp", "draft_temp", "depth", "match"),
+    [
+        (0.2, 0.0, 3, "greedy target"),
+        (0.0, 0.2, 3, "greedy draft"),
+        (0.0, 0.0, 2, "max-K3"),
+        (0.0, 0.0, 4, "max-K3"),
+    ],
+)
+def test_install_rejects_temperature_and_non_k3(target_temp, draft_temp, depth, match):
+    rt, _ = _tiny_runtime_and_prompt()
+    with pytest.raises(ValueError, match=match):
+        _install(
+            rt,
+            sampler=SamplerConfig(temperature=target_temp),
+            draft_sampler=SamplerConfig(temperature=draft_temp),
+            depth=depth,
+        )
+
+
+def test_install_fails_closed_on_runtime_identity_and_route_plan():
+    rt, _ = _tiny_runtime_and_prompt()
+    rt.model.model_type = "not_deepseek_v4"
+    with pytest.raises(ValueError, match="DeepSeek-V4"):
+        _install(rt)
+
+    rt, _ = _tiny_runtime_and_prompt()
+    rt.deepseek_v4_o_lora_report["mtp_stock"] = 0
+    with pytest.raises(ValueError, match="o-LoRA route"):
+        _install(rt)
+
+
+def test_greedy_token_and_fp32_top2_share_one_eval_without_hidden(monkeypatch):
+    original_eval = generation._eval
+    calls = []
+
+    def audited_eval(*values, **kwargs):
+        calls.append(values)
+        return original_eval(*values, **kwargs)
+
+    monkeypatch.setattr(generation, "_eval", audited_eval)
+    logits = mx.array([[[1.0, 4.0, 3.25, -2.0]]], dtype=mx.float16)
+    hidden = mx.zeros((1, 1, 32), dtype=mx.float32)
+
+    token, top1, top2 = generation._greedy_draft_token_and_top2(logits)
+
+    assert (token, top1, top2) == pytest.approx((1, 4.0, 3.25))
+    assert len(calls) == 1
+    assert len(calls[0]) == 2
+    assert all(value is not hidden for value in calls[0])
+    assert calls[0][0].ndim == 0
+    assert tuple(calls[0][1].shape) == (2,)
+    assert calls[0][1].dtype == mx.float32
+
+
+def test_selected_width_mix_uses_one_target_verify_per_cycle(monkeypatch):
+    rt, prompt = _tiny_runtime_and_prompt()
+    policy = _install(rt)
+    original = generation._greedy_draft_token_and_top2
+    margins = iter((0.10, 0.50, 0.50, 0.50, 1.50) * 20)
+
+    def scripted_margin(logits):
+        token, top1, _top2 = original(logits)
+        margin = next(margins)
+        return token, top1, top1 - margin
+
+    monkeypatch.setattr(generation, "_greedy_draft_token_and_top2", scripted_margin)
+    out = _adaptive(rt, prompt, policy=policy, max_tokens=24)
+    policy_events = [
+        event["adaptive_width_policy"]
+        for event in out.stats.events
+        if "adaptive_width_policy" in event
+    ]
+    widths = [event["selected_draft_depth"] for event in policy_events]
+
+    assert {1, 2, 3} <= set(widths)
+    assert len(widths) == out.stats.verify_calls
+    assert sum(width == 1 for width in widths) == out.stats.drafted_by_depth[0] - out.stats.drafted_by_depth[1]
+    assert sum(width == 2 for width in widths) == out.stats.drafted_by_depth[1] - out.stats.drafted_by_depth[2]
+    assert sum(width == 3 for width in widths) == out.stats.drafted_by_depth[2]
+    assert all(event["target_rows"] == event["selected_draft_depth"] + 1 for event in policy_events)
+
+
+def test_target_corrections_preserve_authoritative_ar_sequence(monkeypatch):
+    rt, prompt = _tiny_runtime_and_prompt()
+    from mtplx.generation import generate_ar
+
+    baseline = generate_ar(
+        rt,
+        prompt,
+        max_tokens=32,
+        sampler=SamplerConfig(temperature=0.0),
+        stop_token_ids=set(),
+    )
+    policy = _install(rt)
+    original = generation._greedy_draft_token_and_top2
+    monkeypatch.setattr(
+        generation,
+        "_greedy_draft_token_and_top2",
+        lambda logits: (lambda row: (row[0], row[1], row[1] - 0.10))(original(logits)),
+    )
+    out = _adaptive(rt, prompt, policy=policy, max_tokens=32)
+
+    assert out.stats.rejected_drafts > 0
+    assert out.tokens == baseline.tokens
+
+
+def test_terminal_primary_never_enters_adaptive_draft_path(monkeypatch):
+    rt, prompt = _tiny_runtime_and_prompt()
+    from mtplx.generation import generate_ar
+
+    baseline = generate_ar(
+        rt,
+        prompt,
+        max_tokens=1,
+        sampler=SamplerConfig(temperature=0.0),
+        stop_token_ids=set(),
+    )
+    policy = _install(rt)
+    monkeypatch.setattr(
+        generation,
+        "_greedy_draft_token_and_top2",
+        lambda *_args, **_kwargs: pytest.fail("terminal cycle must not draft"),
+    )
+    out = _adaptive(
+        rt,
+        prompt,
+        policy=policy,
+        max_tokens=8,
+        stop_token_ids={baseline.tokens[0]},
+    )
+
+    assert out.tokens == [baseline.tokens[0]]
+    assert out.finish_reason == "stop"
+    assert out.stats.verify_calls == 0
+
+
+def test_default_fixed_k3_remains_argmax_only(monkeypatch):
+    def fail_if_policy_helper(*_args, **_kwargs):
+        raise AssertionError("ordinary fixed K3 must remain argmax-only")
+
+    monkeypatch.setattr(
+        generation, "_greedy_draft_token_and_top2", fail_if_policy_helper
+    )
+    rt, prompt = _tiny_runtime_and_prompt()
+    out = generation.generate_mtpk(
+        rt,
+        prompt,
+        max_tokens=8,
+        sampler=SamplerConfig(temperature=0.0),
+        speculative_depth=3,
+        verify_strategy="capture_commit",
+        verify_core="stock",
+        mtp_history_policy="committed",
+        stop_token_ids=set(),
+    )
+
+    assert out.tokens
+    assert not any("adaptive_width_policy" in event for event in out.stats.events)
+
+
+def test_policy_source_has_no_environment_reads_fallback_or_mutable_counters():
+    import mtplx.deepseek_v4_adaptive_width as policy_module
+
+    source = inspect.getsource(policy_module)
+    forbidden = (
+        "os.environ",
+        "getenv(",
+        "fallback",
+        "diagnostic_counters",
+        "try:",
+    )
+    assert all(fragment not in source for fragment in forbidden)
+
+
+def test_decode_loop_uses_prebound_policy_surfaces():
+    source = inspect.getsource(generation.generate_mtpk)
+    decode_loop = source.split("while len(tokens) < max_tokens:", 1)[1]
+
+    assert "adaptive_width_policy" not in decode_loop

--- a/tests/test_deepseek_v4_adaptive_width_policy.py
+++ b/tests/test_deepseek_v4_adaptive_width_policy.py
@@ -14,7 +14,6 @@ from mtplx import generation
 from mtplx.deepseek_v4_adaptive_width import (  # noqa: E402
     D1_MARGIN_THRESHOLD,
     D2_MARGIN_THRESHOLD,
-    DeepSeekV4AdaptiveWidthPolicy,
     MAX_SPECULATIVE_DEPTH,
     install_deepseek_v4_adaptive_width_policy,
 )
@@ -108,10 +107,100 @@ def test_policy_is_frozen_preregistered_and_ties_continue_deeper():
     assert policy.stop_after_d2(1.0) is False
     with pytest.raises(FrozenInstanceError):
         policy.d1_margin_threshold = 0.5
-    parameters = inspect.signature(DeepSeekV4AdaptiveWidthPolicy).parameters
+    parameters = inspect.signature(type(policy)).parameters
     assert "d1_margin_threshold" not in parameters
     assert "d2_margin_threshold" not in parameters
     assert "max_speculative_depth" not in parameters
+
+
+def test_policy_type_is_private_and_factory_only():
+    rt, _ = _tiny_runtime_and_prompt()
+    policy = _install(rt)
+
+    assert type(policy).__name__.startswith("_")
+    with pytest.raises(TypeError):
+        type(policy)(
+            runtime_object_id=id(rt),
+            target_routes=policy.target_routes,
+        )
+
+
+def test_hand_forged_policy_object_fails_before_prefill(monkeypatch):
+    rt, prompt = _tiny_runtime_and_prompt()
+
+    class ForgedPolicy:
+        d1_margin_threshold = 0.25
+        d2_margin_threshold = 1.0
+        max_speculative_depth = 3
+        target_routes = (lambda *_a, **_k: None,) * 3
+
+        def validate_request(self, *_args, **_kwargs):
+            return None
+
+        def stop_after_d1(self, margin):
+            return margin < 0.25
+
+        def stop_after_d2(self, margin):
+            return margin < 1.0
+
+    monkeypatch.setattr(
+        generation,
+        "restore_or_prefill_prompt_state",
+        lambda *_a, **_k: pytest.fail("forged object reached prefill"),
+    )
+
+    with pytest.raises(ValueError, match="factory-installed"):
+        generation.generate_mtpk(
+            rt,
+            prompt,
+            max_tokens=4,
+            sampler=SamplerConfig(temperature=0.0),
+            speculative_depth=3,
+            verify_strategy="capture_commit",
+            verify_core="stock",
+            mtp_history_policy="committed",
+            stop_token_ids=set(),
+            adaptive_width_policy=ForgedPolicy(),
+        )
+
+
+@pytest.mark.parametrize(
+    "forgery",
+    ("runtime_id", "capture_callable", "physical_rows", "gather_report"),
+)
+def test_forged_policy_authority_fails_before_prefill(monkeypatch, forgery):
+    rt, prompt = _tiny_runtime_and_prompt()
+    policy = _install(rt)
+    selected_rt = rt
+    if forgery == "runtime_id":
+        selected_rt, _ = _tiny_runtime_and_prompt()
+        selected_rt.deepseek_v4_o_lora_report = _canonical_route_report()
+        object.__setattr__(policy, "runtime_object_id", id(selected_rt))
+    elif forgery == "capture_callable":
+        object.__setattr__(policy.target_routes[0], "forward", lambda *_a, **_k: None)
+    elif forgery == "physical_rows":
+        object.__setattr__(policy.target_routes[1], "expected_physical_rows", 4)
+    else:
+        rt.deepseek_v4_o_lora_report["callable_census"]["mtp_route_kind"] = "stock"
+
+    monkeypatch.setattr(
+        generation,
+        "restore_or_prefill_prompt_state",
+        lambda *_a, **_k: pytest.fail("forgery reached prefill"),
+    )
+    with pytest.raises(ValueError, match="adaptive width policy"):
+        generation.generate_mtpk(
+            selected_rt,
+            prompt,
+            max_tokens=4,
+            sampler=SamplerConfig(temperature=0.0),
+            speculative_depth=3,
+            verify_strategy="capture_commit",
+            verify_core="stock",
+            mtp_history_policy="committed",
+            stop_token_ids=set(),
+            adaptive_width_policy=policy,
+        )
 
 
 @pytest.mark.parametrize(
@@ -251,6 +340,75 @@ def test_terminal_primary_never_enters_adaptive_draft_path(monkeypatch):
     assert out.stats.verify_calls == 0
 
 
+@pytest.mark.parametrize(
+    ("max_tokens", "draft_depth", "physical_rows"),
+    ((2, 1, [2]), (3, 2, [3, 2])),
+)
+def test_terminal_tail_readers_are_explicit_and_target_correct(
+    monkeypatch, max_tokens, draft_depth, physical_rows
+):
+    rt, prompt = _tiny_runtime_and_prompt()
+    from mtplx.generation import generate_ar
+
+    baseline = generate_ar(
+        rt,
+        prompt,
+        max_tokens=max_tokens,
+        sampler=SamplerConfig(temperature=0.0),
+        stop_token_ids=set(),
+    )
+    captured_rows = []
+    runtime_type = type(rt)
+    original_capture = runtime_type.forward_ar_capture
+
+    def audited_capture(self, input_ids, **kwargs):
+        captured_rows.append(int(input_ids.shape[1]))
+        return original_capture(self, input_ids, **kwargs)
+
+    monkeypatch.setattr(runtime_type, "forward_ar_capture", audited_capture)
+    policy = _install(rt)
+    original_sample = generation._sample_draft_from_logits
+
+    def force_wrong_draft(logits, config, rng, *, need_distribution):
+        _token, _distribution = original_sample(
+            logits,
+            config,
+            rng,
+            need_distribution=need_distribution,
+        )
+        wrong_token = (int(baseline.tokens[1]) + 1) % int(logits.shape[-1])
+        return wrong_token, None
+
+    monkeypatch.setattr(generation, "_sample_draft_from_logits", force_wrong_draft)
+    monkeypatch.setattr(
+        generation,
+        "_fixed_width_draft_reader",
+        lambda *_a, **_k: pytest.fail("adaptive tail used fixed-reader fallback"),
+        raising=False,
+    )
+
+    out = _adaptive(rt, prompt, policy=policy, max_tokens=max_tokens)
+    policy_events = [
+        event["adaptive_width_policy"]
+        for event in out.stats.events
+        if "adaptive_width_policy" in event
+    ]
+
+    assert out.tokens == baseline.tokens
+    assert out.stats.rejected_drafts >= 1
+    assert captured_rows == physical_rows
+    assert policy_events
+    assert all(event["eligible_full_k3"] is False for event in policy_events)
+    assert policy_events[0]["selected_draft_depth"] == draft_depth
+    assert all(event["decision_margins"] == [] for event in policy_events)
+    correction = next(
+        event["drafts"][0]["correction"]
+        for event in out.stats.events
+        if event.get("rejected_at_depth") == 1
+    )
+    assert correction == baseline.tokens[1]
+
+
 def test_default_fixed_k3_remains_argmax_only(monkeypatch):
     def fail_if_policy_helper(*_args, **_kwargs):
         raise AssertionError("ordinary fixed K3 must remain argmax-only")
@@ -294,3 +452,11 @@ def test_decode_loop_uses_prebound_policy_surfaces():
     decode_loop = source.split("while len(tokens) < max_tokens:", 1)[1]
 
     assert "adaptive_width_policy" not in decode_loop
+
+
+def test_enabled_readers_have_no_fixed_reader_fallback():
+    source = inspect.getsource(generation.generate_mtpk)
+    enabled_setup = source.split("else:\n        adaptive_width_margin_stops", 1)[1]
+    enabled_setup = enabled_setup.split("if mtp_corrector is not None:", 1)[0]
+
+    assert "_fixed_width_draft_reader" not in enabled_setup

--- a/tests/test_deepseek_v4_o_lora.py
+++ b/tests/test_deepseek_v4_o_lora.py
@@ -129,7 +129,7 @@ def _tokens(seq_len, batch=1, seed=1234):
 
 def _set_mode(model, mode):
     for layer in model.layers:
-        layer.attn.o_lora_mode = mode
+        layer.attn.install_o_lora_route(mode)
 
 
 def _decode(model, ids, prompt_len):
@@ -165,7 +165,9 @@ def test_unknown_mode_is_rejected_loudly(monkeypatch):
 def test_attention_picks_the_mode_up_at_construction(monkeypatch):
     monkeypatch.setenv("MTPLX_DSV4_O_LORA", "gather_qmm")
     _, model = _seeded_model()
-    assert [l.attn.o_lora_mode for l in model.layers] == ["gather_qmm"] * len(RATIOS)
+    assert [layer.attn.o_lora_mode for layer in model.layers] == [
+        "gather_qmm"
+    ] * len(RATIOS)
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +186,7 @@ def test_cached_dequant_is_bit_identical():
     _set_mode(model, "dequant")
     ref = model(ids)
     mx.eval(ref)
-    assert all(l.attn._wo_a_cache.value is None for l in model.layers), (
+    assert all(layer.attn._wo_a_cache.value is None for layer in model.layers), (
         "the dequant arm must not populate the cache, or it is not a control")
 
     _set_mode(model, "cached")
@@ -192,7 +194,7 @@ def test_cached_dequant_is_bit_identical():
     second = model(ids)         # serves from cache
     mx.eval(first, second)
 
-    assert all(l.attn._wo_a_cache.value is not None for l in model.layers), (
+    assert all(layer.attn._wo_a_cache.value is not None for layer in model.layers), (
         "cache never populated — the gate would be vacuous")
     assert mx.array_equal(ref, first), "cached first call is not bit-identical"
     assert mx.array_equal(ref, second), "cached cache-hit call is not bit-identical"
@@ -219,9 +221,9 @@ def test_cache_is_reused_not_rebuilt():
     ids = _tokens(20)
     _set_mode(model, "cached")
     model(ids)
-    held = [l.attn._wo_a_cache.value for l in model.layers]
+    held = [layer.attn._wo_a_cache.value for layer in model.layers]
     model(ids)
-    again = [l.attn._wo_a_cache.value for l in model.layers]
+    again = [layer.attn._wo_a_cache.value for layer in model.layers]
     assert all(a is b for a, b in zip(held, again))
 
 
@@ -232,7 +234,7 @@ def test_cache_is_invalidated_when_the_weights_are_rebound():
     ids = _tokens(20)
     _set_mode(model, "cached")
     model(ids)
-    stale = [l.attn._wo_a_cache.value for l in model.layers]
+    stale = [layer.attn._wo_a_cache.value for layer in model.layers]
 
     # Rebind scales only — the packed weight object stays the same, which is
     # exactly what a dtype cast or a partial reload does.
@@ -245,7 +247,7 @@ def test_cache_is_invalidated_when_the_weights_are_rebound():
     ref = model(ids)
     mx.eval(got, ref)
     assert mx.array_equal(ref, got), "stale dense cache served after a weight rebind"
-    fresh = [l.attn._wo_a_cache.value for l in model.layers]
+    fresh = [layer.attn._wo_a_cache.value for layer in model.layers]
     assert all(a is not b for a, b in zip(stale, fresh))
 
 
@@ -265,21 +267,20 @@ def test_cache_never_reaches_the_weight_tree():
     model.load_weights(tree_flatten(model.parameters()), strict=True)
 
 
-def test_unquantised_wo_a_is_untouched_by_the_cache():
-    """The M2/parity path has a plain nn.Linear: nothing to dequantise, nothing
-    cached, and all three modes agree bit-for-bit."""
+def test_unquantised_wo_a_rejects_gather_at_installation():
+    """An enabled gather route cannot silently execute the dense implementation."""
     _, model = _seeded_model()
     ids = _tokens(20)
     outs = []
-    for mode in D._O_LORA_MODES:
+    for mode in ("cached", "dequant"):
         _set_mode(model, mode)
         out = model(ids)
         mx.eval(out)
         outs.append(out)
-    assert all(l.attn._wo_a_cache.value is None for l in model.layers)
+    with pytest.raises(ValueError, match="quantized"):
+        _set_mode(model, "gather_qmm")
+    assert all(layer.attn._wo_a_cache.value is None for layer in model.layers)
     assert mx.array_equal(outs[0], outs[1])
-    assert mx.array_equal(outs[0], outs[2]), (
-        "gather_qmm must fall back to the dense path when wo_a is not quantised")
 
 
 # ---------------------------------------------------------------------------
@@ -311,17 +312,60 @@ def test_gather_qmm_calling_convention_shapes():
         assert rel < 1e-3, f"rows={rows} grouped qmm rel={rel:.3e}"
 
 
-def test_gather_qmm_output_shape_is_checked_not_assumed(monkeypatch):
-    """The ledger trap: a broadcast instead of a batched call still returns usable
-    numbers.  The guard has to fire, so it is tested by forcing a wrong shape."""
+def test_gather_qmm_is_prebound_and_never_rechecks_or_falls_back(monkeypatch):
     _, model = _quantized_model()
     attn = model.layers[0].attn
     o = mx.random.normal((1, 3, N_HEADS * HEAD_DIM))
+    receipt = attn.install_o_lora_route("gather_qmm")
+    assert receipt["direct"] is True
+    installed = attn._o_lora_impl
     monkeypatch.setattr(
-        D.mx, "gather_qmm", lambda *a, **k: mx.zeros((3, O_GROUPS, O_RANK))
+        attn,
+        "_wo_a_quant",
+        lambda: (_ for _ in ()).throw(AssertionError("hot eligibility lookup")),
     )
-    with pytest.raises(AssertionError, match="shape contract"):
-        attn._o_lora_gather_qmm(o)
+    got = attn._o_lora(o)
+    mx.eval(got)
+    assert attn._o_lora_impl is installed
+    assert tuple(got.shape) == (1, 3, DIM)
+
+
+def test_gather_route_preserves_and_calls_a_real_quantized_wo_b():
+    _, model = _seeded_model(o_lora_rank=16)
+    nn.quantize(
+        model,
+        group_size=GROUP_SIZE,
+        bits=BITS,
+        class_predicate=lambda path, _module: path.endswith(
+            ("attn.wo_a", "attn.wo_b")
+        ),
+    )
+    mx.eval(model.parameters())
+    attn = model.layers[0].attn
+    assert isinstance(attn.wo_a, nn.QuantizedLinear)
+    assert isinstance(attn.wo_b, nn.QuantizedLinear)
+    stock_wo_b = attn.wo_b
+    assert getattr(stock_wo_b, "bias", None) is None
+    stock_storage = (
+        stock_wo_b.weight,
+        stock_wo_b.scales,
+        stock_wo_b.biases,
+        stock_wo_b.bits,
+        stock_wo_b.group_size,
+        stock_wo_b.mode,
+    )
+    assert D._o_lora_linear_logical_weight_shape(stock_wo_b) == (DIM, 32)
+
+    receipt = attn.install_o_lora_route("gather_qmm")
+    assert receipt["direct"] is True
+    assert attn._o_lora_impl.wo_b is stock_wo_b
+    result = attn._o_lora(mx.random.normal((1, 3, N_HEADS * HEAD_DIM)))
+    mx.eval(result)
+    assert tuple(result.shape) == (1, 3, DIM)
+    assert stock_wo_b.weight is stock_storage[0]
+    assert stock_wo_b.scales is stock_storage[1]
+    assert stock_wo_b.biases is stock_storage[2]
+    assert (stock_wo_b.bits, stock_wo_b.group_size, stock_wo_b.mode) == stock_storage[3:]
 
 
 def test_gather_qmm_matches_the_cached_arm_within_tolerance():
@@ -365,9 +409,9 @@ def test_gather_qmm_precision_drops_at_bf16_and_that_is_arm_bs_open_risk():
     mx.random.seed(3)
     o = (mx.random.normal((1, 140, N_HEADS * HEAD_DIM)) * 0.5).astype(mx.bfloat16)
 
-    attn.o_lora_mode = "cached"
+    attn.install_o_lora_route("cached")
     ref = attn._o_lora(o)
-    attn.o_lora_mode = "gather_qmm"
+    attn.install_o_lora_route("gather_qmm")
     got = attn._o_lora(o)
     mx.eval(ref, got)
     assert ref.dtype == got.dtype == mx.bfloat16
@@ -413,12 +457,322 @@ def _quantized_mtp_model(seed=0):
 
 
 def _attentions(model):
-    return [l.attn for l in model.layers] + [b.attn for b in model.mtp_blocks]
+    return [layer.attn for layer in model.layers] + [
+        block.attn for block in model.mtp_blocks
+    ]
 
 
 def _set_mode_everywhere(model, mode):
     for attn in _attentions(model):
-        attn.o_lora_mode = mode
+        attn.install_o_lora_route(mode)
+
+
+class _O_LoraArrayMeta:
+    def __init__(self, shape, dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+
+class _CanonicalQuantizedLinear:
+    pass
+
+
+class _CanonicalDenseLinear:
+    pass
+
+
+class _CanonicalBodyWOA(_CanonicalQuantizedLinear):
+    def __init__(self):
+        self.weight = _O_LoraArrayMeta((8192, 512), mx.uint32)
+        self.scales = _O_LoraArrayMeta((8192, 64), mx.bfloat16)
+        self.biases = _O_LoraArrayMeta((8192, 64), mx.bfloat16)
+        self.bits = 4
+        self.group_size = 64
+        self.mode = "affine"
+        self.bias = None
+
+
+class _CanonicalBodyWOB(_CanonicalQuantizedLinear):
+    def __init__(self):
+        self.weight = _O_LoraArrayMeta((4096, 1024), mx.uint32)
+        self.scales = _O_LoraArrayMeta((4096, 128), mx.bfloat16)
+        self.biases = _O_LoraArrayMeta((4096, 128), mx.bfloat16)
+        self.bits = 4
+        self.group_size = 64
+        self.mode = "affine"
+        self.bias = None
+
+
+class _CanonicalMTPWOA(_CanonicalDenseLinear):
+    def __init__(self):
+        self.weight = _O_LoraArrayMeta((8192, 4096), mx.bfloat16)
+        self.bias = None
+
+
+class _CanonicalMTPWOB(_CanonicalDenseLinear):
+    def __init__(self):
+        self.weight = _O_LoraArrayMeta((4096, 8192), mx.bfloat16)
+        self.bias = None
+
+
+class _RouteFakeAttention:
+    def __init__(self, wo_a, wo_b):
+        self.wo_a = wo_a
+        self.wo_b = wo_b
+        self.n_groups = 8
+        self.o_lora_rank = 1024
+        self.n_heads = 64
+        self.head_dim = 512
+        self.dim = 4096
+        self.o_lora_mode = None
+        self._o_lora_impl = None
+
+
+class _RouteBox:
+    def __init__(self, wo_a, wo_b):
+        self.attn = _RouteFakeAttention(wo_a, wo_b)
+
+
+def _canonical_route_model(*, body_count=43, mtp_count=1):
+    class FakeModel:
+        layers = [
+            _RouteBox(_CanonicalBodyWOA(), _CanonicalBodyWOB())
+            for _ in range(body_count)
+        ]
+        mtp_blocks = [
+            _RouteBox(_CanonicalMTPWOA(), _CanonicalMTPWOB())
+            for _ in range(mtp_count)
+        ]
+
+    return FakeModel()
+
+
+class _FakeCachedBodyRoute:
+    def __init__(self, attention, quant):
+        self.attention = attention
+        self.quant = quant
+        self.wo_b = attention.wo_b
+
+
+class _FakeGatherBodyRoute:
+    def __init__(self, attention, quant):
+        self.attention = attention
+        self.quant = quant
+        self.wo_b = attention.wo_b
+
+
+class _FakeDenseMTPRoute:
+    def __init__(self, attention, weight):
+        self.attention = attention
+        self.weight = weight
+        self.wo_b = attention.wo_b
+
+
+_FakeCachedBodyRoute.__name__ = "_DirectCachedOLora"
+_FakeGatherBodyRoute.__name__ = "_DirectGatherOLora"
+_FakeDenseMTPRoute.__name__ = "_DirectDenseMTPOLora"
+
+
+def _patch_canonical_route_types(monkeypatch):
+    monkeypatch.setattr(D.nn, "QuantizedLinear", _CanonicalQuantizedLinear)
+    monkeypatch.setattr(D.nn, "Linear", _CanonicalDenseLinear)
+    monkeypatch.setattr(D, "_DirectCachedOLora", _FakeCachedBodyRoute)
+    monkeypatch.setattr(D, "_DirectGatherOLora", _FakeGatherBodyRoute)
+    monkeypatch.setattr(D, "_DirectDenseMTPOLora", _FakeDenseMTPRoute)
+
+
+def test_model_installer_prebinds_43_body_gathers_and_explicit_mtp_stock(monkeypatch):
+    _patch_canonical_route_types(monkeypatch)
+    model = _canonical_route_model()
+    original_body_wo_b = [box.attn.wo_b for box in model.layers]
+    original_mtp_wo_b = model.mtp_blocks[0].attn.wo_b
+    report = D.install_deepseek_v4_o_lora_routes(
+        model, mode="gather_qmm", canonical_mixed_route=True
+    )
+    body = [box.attn for box in model.layers]
+    mtp = model.mtp_blocks[0].attn
+    assert report["trunk_module_count"] == 43
+    assert report["mtp_module_count"] == 1
+    assert report["module_count"] == 44
+    assert report["body_direct"] == 43
+    assert report["mtp_stock"] == 1
+    assert all(isinstance(attention._o_lora_impl, _FakeGatherBodyRoute) for attention in body)
+    assert isinstance(mtp._o_lora_impl, _FakeDenseMTPRoute)
+    assert all(
+        attention._o_lora_impl.wo_b is original
+        for attention, original in zip(body, original_body_wo_b)
+    )
+    assert mtp._o_lora_impl.wo_b is original_mtp_wo_b
+    assert report["callable_census"] == {
+        "body_route_objects": 43,
+        "body_route_kind": "gather_qmm_direct",
+        "body_callable_class": "_DirectGatherOLora",
+        "mtp_route_objects": 1,
+        "mtp_route_kind": "dense_bf16_stock_direct",
+        "mtp_callable_class": "_DirectDenseMTPOLora",
+        "total_route_objects": 44,
+        "unique_route_objects": 44,
+        "mtp_distinct_type": True,
+    }
+    assert report["storage_contract"] == D._CANONICAL_O_LORA_STORAGE_CONTRACT
+    assert report["storage_contract"]["body"]["wo_b"] == {
+        "class": "QuantizedLinear",
+        "logical_weight_shape": [4096, 8192],
+        "packed_weight": {"shape": [4096, 1024], "dtype": "uint32"},
+        "scales": {"shape": [4096, 128], "dtype": "bfloat16"},
+        "biases": {"shape": [4096, 128], "dtype": "bfloat16"},
+        "bits": 4,
+        "group_size": 64,
+        "mode": "affine",
+        "additive_bias": None,
+    }
+    assert report["storage_contract"]["mtp"]["wo_a"]["weight"] == {
+        "shape": [8192, 4096],
+        "dtype": "bfloat16",
+    }
+    assert report["storage_contract"]["mtp"]["wo_b"]["weight"] == {
+        "shape": [4096, 8192],
+        "dtype": "bfloat16",
+    }
+
+
+def _mutate_body_wo_b_logical_output(model):
+    wo_b = model.layers[0].attn.wo_b
+    wo_b.weight.shape = (4095, 1024)
+    wo_b.scales.shape = (4095, 128)
+    wo_b.biases.shape = (4095, 128)
+
+
+def _mutate_body_wo_b_logical_input(model):
+    wo_b = model.layers[0].attn.wo_b
+    wo_b.weight.shape = (4096, 1016)
+    wo_b.scales.shape = (4096, 127)
+    wo_b.biases.shape = (4096, 127)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    (
+        (lambda model: model.layers.pop(), "expected 43 body"),
+        (lambda model: setattr(model.layers[0].attn, "wo_a", _CanonicalMTPWOA()), "body 0"),
+        (lambda model: setattr(model.layers[0].attn.wo_a.weight, "dtype", mx.bfloat16), "weight dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_a.weight, "shape", (8192, 513)), "weight shape"),
+        (lambda model: setattr(model.layers[0].attn.wo_a.scales, "dtype", mx.float32), "scales dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_a.biases, "shape", (8192, 63)), "biases shape"),
+        (lambda model: setattr(model.layers[0].attn.wo_a.biases, "dtype", mx.float32), "biases dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_a, "bits", 8), "bits"),
+        (lambda model: setattr(model.layers[0].attn.wo_a, "group_size", 32), "group_size"),
+        (lambda model: setattr(model.layers[0].attn.wo_a, "mode", "mxfp4"), "mode"),
+        (lambda model: setattr(model.layers[0].attn, "n_groups", 4), "n_groups"),
+        (lambda model: setattr(model.layers[0].attn, "o_lora_rank", 512), "o_lora_rank"),
+        (lambda model: setattr(model.layers[0].attn, "n_heads", 32), "n_heads"),
+        (lambda model: setattr(model.layers[0].attn, "head_dim", 256), "head_dim"),
+        (lambda model: setattr(model.layers[0].attn, "dim", 2048), "dim"),
+        (lambda model: setattr(model.layers[0].attn, "wo_b", _CanonicalMTPWOB()), "body 0 wo_b"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.weight, "shape", (4096, 1023)), "wo_b.*weight.*shape"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.weight, "dtype", mx.bfloat16), "wo_b.*weight.*dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.scales, "shape", (4096, 127)), "wo_b.*scales.*shape"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.scales, "dtype", mx.float32), "wo_b.*scales.*dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.biases, "shape", (4096, 127)), "wo_b.*biases.*shape"),
+        (lambda model: setattr(model.layers[0].attn.wo_b.biases, "dtype", mx.float32), "wo_b.*biases.*dtype"),
+        (lambda model: setattr(model.layers[0].attn.wo_b, "bits", 8), "wo_b.*bits"),
+        (lambda model: setattr(model.layers[0].attn.wo_b, "group_size", 32), "wo_b.*group_size"),
+        (lambda model: setattr(model.layers[0].attn.wo_b, "mode", "mxfp4"), "wo_b.*mode"),
+        (lambda model: setattr(model.layers[0].attn.wo_b, "bias", _O_LoraArrayMeta((4096,), mx.bfloat16)), "wo_b.*additive bias"),
+        (_mutate_body_wo_b_logical_output, "wo_b.*logical output"),
+        (_mutate_body_wo_b_logical_input, "wo_b.*logical input"),
+        (lambda model: setattr(model.mtp_blocks[0].attn, "wo_a", _CanonicalBodyWOA()), "MTP"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_a.weight, "dtype", mx.float32), "MTP wo_a weight dtype"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_a.weight, "shape", (8192, 4095)), "MTP wo_a weight shape"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_a, "bias", _O_LoraArrayMeta((8192,), mx.bfloat16)), "MTP wo_a additive bias"),
+        (lambda model: setattr(model.mtp_blocks[0].attn, "wo_b", _CanonicalBodyWOB()), "MTP wo_b"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_b.weight, "dtype", mx.float32), "MTP wo_b weight dtype"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_b.weight, "shape", (4096, 8191)), "MTP wo_b weight shape"),
+        (lambda model: setattr(model.mtp_blocks[0].attn.wo_b, "bias", _O_LoraArrayMeta((4096,), mx.bfloat16)), "MTP wo_b additive bias"),
+        (lambda model: model.mtp_blocks.pop(), "expected exactly one MTP"),
+    ),
+)
+def test_model_installer_rejects_noncanonical_mixed_storage(monkeypatch, mutate, match):
+    _patch_canonical_route_types(monkeypatch)
+    model = _canonical_route_model()
+    mutate(model)
+    with pytest.raises(ValueError, match=match):
+        D.install_deepseek_v4_o_lora_routes(
+            model, mode="gather_qmm", canonical_mixed_route=True
+        )
+    assert all(box.attn._o_lora_impl is None for box in model.layers + model.mtp_blocks)
+
+
+def test_model_installer_rejects_mtp_quant_metadata(monkeypatch):
+    _patch_canonical_route_types(monkeypatch)
+    model = _canonical_route_model()
+    model.mtp_blocks[0].attn.wo_a.scales = _O_LoraArrayMeta((8192, 64), mx.bfloat16)
+    with pytest.raises(ValueError, match="must not expose quantized metadata"):
+        D.install_deepseek_v4_o_lora_routes(
+            model, mode="gather_qmm", canonical_mixed_route=True
+        )
+    assert all(box.attn._o_lora_impl is None for box in model.layers + model.mtp_blocks)
+
+
+def test_geometry_failure_binds_no_partial_route(monkeypatch):
+    _patch_canonical_route_types(monkeypatch)
+    model = _canonical_route_model()
+    model.layers[-1].attn.wo_b.weight.shape = (4096, 1023)
+    with pytest.raises(ValueError, match="wo_b.*weight.*shape"):
+        D.install_deepseek_v4_o_lora_routes(
+            model, mode="gather_qmm", canonical_mixed_route=True
+        )
+    assert all(box.attn._o_lora_impl is None for box in model.layers + model.mtp_blocks)
+
+
+def test_model_installer_routes_cached_after_validating_mixed_topology(monkeypatch):
+    _patch_canonical_route_types(monkeypatch)
+    model = _canonical_route_model()
+    report = D.install_deepseek_v4_o_lora_routes(
+        model, mode="cached", canonical_mixed_route=True
+    )
+    assert report["body_direct"] == 0
+    assert report["mtp_stock"] == 1
+    assert all(
+        isinstance(box.attn._o_lora_impl, _FakeCachedBodyRoute)
+        for box in model.layers
+    )
+    assert isinstance(model.mtp_blocks[0].attn._o_lora_impl, _FakeDenseMTPRoute)
+    assert report["callable_census"]["body_route_kind"] == "cached_direct"
+
+
+def test_prebound_body_and_mtp_routes_never_recheck_quant_metadata(monkeypatch):
+    _, quantized = _quantized_model()
+    body = quantized.layers[0].attn
+    quant = body._wo_a_quant()
+    body_cached = D._DirectCachedOLora(body, quant)
+    body_gather = D._DirectGatherOLora(body, quant)
+
+    _, dense = _seeded_model(num_nextn_predict_layers=1)
+    mtp = dense.mtp_blocks[0].attn
+    mtp_stock = D._DirectDenseMTPOLora(mtp, mtp.wo_a.weight)
+    monkeypatch.setattr(
+        body,
+        "_wo_a_quant",
+        lambda: (_ for _ in ()).throw(AssertionError("body hot metadata check")),
+    )
+    monkeypatch.setattr(
+        mtp,
+        "_wo_a_quant",
+        lambda: (_ for _ in ()).throw(AssertionError("MTP hot metadata check")),
+    )
+
+    body_input = mx.random.normal((1, 3, N_HEADS * HEAD_DIM))
+    mtp_input = mx.random.normal((1, 3, N_HEADS * HEAD_DIM))
+    body._o_lora_impl = body_cached
+    cached_output = body._o_lora(body_input)
+    body._o_lora_impl = body_gather
+    gather_output = body._o_lora(body_input)
+    mtp._o_lora_impl = mtp_stock
+    mtp_output = mtp._o_lora(mtp_input)
+    outputs = [cached_output, gather_output, mtp_output]
+    mx.eval(*outputs)
+    assert all(tuple(output.shape) == (1, 3, DIM) for output in outputs)
 
 
 def _mtp_inputs(args, seq=9, seed=7):

--- a/tests/test_runtime_deepseek_v4_o_lora.py
+++ b/tests/test_runtime_deepseek_v4_o_lora.py
@@ -1,0 +1,115 @@
+"""Runtime construction coverage for the canonical DeepSeek-V4 o-LoRA route."""
+
+from __future__ import annotations
+
+from mtplx import runtime
+from mtplx.models import deepseek_v4 as D
+from tests.test_deepseek_v4_o_lora import (
+    _FakeCachedBodyRoute,
+    _FakeDenseMTPRoute,
+    _FakeGatherBodyRoute,
+    _canonical_route_model,
+    _patch_canonical_route_types,
+)
+
+
+def test_runtime_load_installs_canonical_mixed_o_lora_route(monkeypatch, tmp_path):
+    """The real runtime load flow prebinds Q4 body gathers plus dense MTP stock."""
+
+    _patch_canonical_route_types(monkeypatch)
+    monkeypatch.setattr(D, "_DirectCachedOLora", _FakeCachedBodyRoute)
+    monkeypatch.setattr(D, "_DirectGatherOLora", _FakeGatherBodyRoute)
+    monkeypatch.setattr(D, "_DirectDenseMTPOLora", _FakeDenseMTPRoute)
+    monkeypatch.setenv("MTPLX_DSV4_O_LORA", "gather_qmm")
+    model = _canonical_route_model()
+    config = {"model_type": "deepseek_v4", "num_nextn_predict_layers": 1}
+    monkeypatch.setattr(runtime, "load_config", lambda _path: config)
+    monkeypatch.setattr(runtime, "_load_base_model", lambda *_args: (model, object()))
+    monkeypatch.setattr(runtime, "_load_runtime_metadata", lambda _path: {})
+    monkeypatch.setattr(runtime, "mtp_weights_present_on_disk", lambda *_args: False)
+    monkeypatch.setattr(runtime, "validate_mtp_support", lambda _model: True)
+
+    monkeypatch.setattr(D, "configure_deepseek_v4_moe_tail", lambda *_args: None)
+    monkeypatch.setattr(D, "is_deepseek_v4_mtp_config", lambda _config: True)
+    monkeypatch.setattr(D, "inject_deepseek_v4_mtp_support", lambda *_args: True)
+
+    import mtplx.a3b_compiled_target_prefix as target_prefix
+    import mtplx.a3b_whole_moe as whole_moe
+    import mtplx.attention_split as attention_split
+    import mtplx.gdn_capture as gdn_capture
+    import mtplx.kernel_selfcheck as kernel_selfcheck
+    import mtplx.native_mlp as native_mlp
+    import mtplx.nax_verify as nax_verify
+    import mtplx.qwen_row_owned_router as row_owned
+
+    monkeypatch.setattr(attention_split, "configure_split_full_attention", lambda *_: None)
+    monkeypatch.setattr(native_mlp, "configure_native_mlp", lambda *_: None)
+    monkeypatch.setattr(nax_verify, "nax_env_enabled", lambda: False)
+    monkeypatch.setattr(whole_moe, "prepare_a3b_whole_moe", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(row_owned, "prepare_qwen_row_owned_routers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(gdn_capture, "prepare_a3b_gdn_postconv", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(kernel_selfcheck, "maybe_run_model_selfcheck", lambda *_: None)
+    monkeypatch.setattr(target_prefix, "prepare_a3b_compiled_target_prefix", lambda *_args, **_kwargs: None)
+
+    loaded = runtime.load(tmp_path, mtp=True)
+
+    assert loaded.model is model
+    assert loaded.deepseek_v4_o_lora_report["body_direct"] == 43
+    assert loaded.deepseek_v4_o_lora_report["mtp_stock"] == 1
+    assert all(
+        isinstance(box.attn._o_lora_impl, _FakeGatherBodyRoute) for box in model.layers
+    )
+    assert isinstance(model.mtp_blocks[0].attn._o_lora_impl, _FakeDenseMTPRoute)
+    assert not any(
+        isinstance(box.attn._o_lora_impl, _FakeCachedBodyRoute) for box in model.layers
+    )
+
+
+def test_runtime_load_preserves_ar_only_degrade_without_canonical_mixed_route(
+    monkeypatch, tmp_path
+):
+    model = _canonical_route_model(mtp_count=0)
+    config = {"model_type": "deepseek_v4", "num_nextn_predict_layers": 1}
+    calls = []
+    monkeypatch.setenv("MTPLX_DSV4_O_LORA", "gather_qmm")
+    monkeypatch.setattr(runtime, "load_config", lambda _path: config)
+    monkeypatch.setattr(runtime, "_load_base_model", lambda *_args: (model, object()))
+    monkeypatch.setattr(runtime, "_load_runtime_metadata", lambda _path: {})
+    monkeypatch.setattr(runtime, "mtp_weights_present_on_disk", lambda *_args: False)
+
+    monkeypatch.setattr(D, "configure_deepseek_v4_moe_tail", lambda *_args: None)
+    monkeypatch.setattr(D, "is_deepseek_v4_mtp_config", lambda _config: True)
+    monkeypatch.setattr(D, "inject_deepseek_v4_mtp_support", lambda *_args: False)
+    monkeypatch.setattr(
+        D,
+        "install_deepseek_v4_o_lora_routes",
+        lambda _model, **kwargs: calls.append(kwargs)
+        or {"mode": kwargs.get("mode"), "canonical_mixed_route": False},
+    )
+
+    import mtplx.a3b_compiled_target_prefix as target_prefix
+    import mtplx.a3b_whole_moe as whole_moe
+    import mtplx.attention_split as attention_split
+    import mtplx.gdn_capture as gdn_capture
+    import mtplx.kernel_selfcheck as kernel_selfcheck
+    import mtplx.native_mlp as native_mlp
+    import mtplx.nax_verify as nax_verify
+    import mtplx.qwen_row_owned_router as row_owned
+
+    monkeypatch.setattr(attention_split, "configure_split_full_attention", lambda *_: None)
+    monkeypatch.setattr(native_mlp, "configure_native_mlp", lambda *_: None)
+    monkeypatch.setattr(nax_verify, "nax_env_enabled", lambda: False)
+    monkeypatch.setattr(whole_moe, "prepare_a3b_whole_moe", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(row_owned, "prepare_qwen_row_owned_routers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(gdn_capture, "prepare_a3b_gdn_postconv", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(kernel_selfcheck, "maybe_run_model_selfcheck", lambda *_: None)
+    monkeypatch.setattr(target_prefix, "prepare_a3b_compiled_target_prefix", lambda *_args, **_kwargs: None)
+
+    loaded = runtime.load(tmp_path, mtp=True)
+
+    assert loaded.mtp_enabled is False
+    assert calls == [{"mode": "cached", "canonical_mixed_route": False}]
+    assert loaded.deepseek_v4_o_lora_report == {
+        "mode": "cached",
+        "canonical_mixed_route": False,
+    }


### PR DESCRIPTION
## What changed

Adds the fixed DeepSeek-V4 max-K3 adaptive verification policy. The installed lane prebinds exact M2/M3/M4 verifier routes and contracts after low draft margins while retaining the existing target authority and `capture_commit`/stock/committed-history contract. The benchmark wrapper is portable: deployment locations are explicit operator configuration, while artifact, topology, route, and MLX identity checks remain fail-closed.

## Why

On the canonical single-load, primed 328-token → 256-generated K3 bracket this is a relative workload winner: 38.0405936601 tok/s versus a 36.7252878598 tok/s two-control mean (+1.3153058003 tok/s, +3.58%). It does **not** reach the 40 tok/s target; it remains 1.9594 tok/s short.

## How to verify

```sh
uv run --extra dev pytest -q tests/test_deepseek_v4_*.py tests/test_runtime_deepseek_v4_o_lora.py tests/test_generation_sustained.py tests/test_context_copy_stats.py
uv run --extra dev ruff check mtplx/deepseek_v4_adaptive_width.py mtplx/generation.py scripts/deepseek_v4_adaptive_width_guarded.py scripts/deepseek_v4_mtpk_bench.py tests/test_deepseek_v4_adaptive_width_bracket.py tests/test_deepseek_v4_adaptive_width_policy.py
```

For the production bracket, use `scripts/deepseek_v4_adaptive_width_guarded.py` inside the existing exclusive-GPU/service restoration workflow and provide `MTPLX_DSV4_PYTHON`, `MTPLX_DSV4_GUARDED_RUNNER`, `MTPLX_DSV4_QUALITY_PLIST`, `MTPLX_DSV4_BENCH_DIR`, `MTPLX_DSV4_MODEL_PATH`, and `MTPLX_DSV4_PROMPT_FILE`.

## Notable decisions

- Stacked on #223 (O-LoRA gather); #216 is already merged.
- The source intentionally has no developer-machine absolute paths; model artifact/config identity, not path spelling, is the canonical guard.
- The full receipt reports an allowed BF16 M3-width near-tie at generated index 6 (603 → 305) and its propagated tail. HumanEval is deferred by explicit policy; this PR does not claim quality equivalence.
- The detailed benchmark receipt and restoration evidence are in the PR comment.