### PR TITLE
Correct the 2.5.1 cache wording

### DIFF
--- a/docs/releases/v2.5.1.md
+++ b/docs/releases/v2.5.1.md
@@ -36,8 +36,9 @@ pull requests are broad or experimental, while the active cache and
 cross-hardware performance issues need their own measured work. No unrelated
 architecture change was pulled into 2.5.1.
 
-Runtime kernels, sampler defaults, cache behavior, and speculative depth are
-unchanged from 2.5.0.
+Runtime kernels, sampler defaults, and speculative depth are unchanged from
+2.5.0. The release also fixes a cold-cache bookkeeping race so flushes wait
+for in-flight writes and eviction decisions use a coherent disk snapshot.
 
 ## Upgrade
 


### PR DESCRIPTION
The release notes said cache behavior was entirely unchanged, but 2.5.1 includes the focused cold-cache bookkeeping race fix from the tested release commit. This docs-only correction states the exact boundary without changing the release artifact or runtime.