### PR TITLE
Release 2.5.2: settle the compiled growth handoff and raise the MLX floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable user-facing changes to MTPLX. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.5.2] - 2026-08-04
+
+Hotfix for a long-response slowdown that shipped in 2.5.1 with Optimized
+Speed V2 as the recommended coding model.
+
+### Fixed
+
+- Long single responses no longer slow down and stutter partway through. The
+  compiled verifier hands generation to the eager path after its growth
+  reserve is exhausted, and that handoff carried unfinished GPU work into the
+  rest of the response. Every later token paid for the old work, so decode
+  throughput fell steadily on responses past a few thousand tokens. The
+  reported 12,000-token response opened at 59 tokens per second and
+  ended near 30. With the fix, the same seeded generation no longer
+  decays: the closing windows now run as fast as or faster than the
+  early ones.
+- The handoff now settles all cache and recurrent state exactly once at the
+  ownership boundary and releases the compiled references before eager
+  decoding continues. Handoff telemetry is exposed in the compiled verifier
+  stats.
+
+### Changed
+
+- The minimum MLX version is now 0.32. Fresh installs already resolved MLX
+  0.32.0; existing runtime environments could stay on 0.31.2 indefinitely
+  because dependency upgrades only run when the declared floor requires
+  them. Long-generation runs consistently read faster on the 0.32 stack,
+  and existing installs now converge to what new installs already run.
+
+### Compatibility
+
+- Model catalogs, defaults, sampler settings, memory policy, and the 2.5.1
+  V2 recommendation are unchanged.
+
 ## [2.5.1] - 2026-08-03
 
 Optimized Speed V2 is now the recommended Qwen 3.6 27B model for coding on

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 repository-code: "https://github.com/youssofal/mtplx"
 url: "https://github.com/youssofal/mtplx"
 license: Apache-2.0
-version: 2.5.1
+version: 2.5.2
 abstract: "Native MTP speculative decoding for Qwen3-Next on Apple Silicon, using built-in MTP heads with math-correct rejection sampling and an OpenAI/Anthropic-compatible serving surface."
 keywords:
   - speculative decoding

--- a/docs/releases/v2.5.2.md
+++ b/docs/releases/v2.5.2.md
@@ -1,0 +1,59 @@
+# MTPLX 2.5.2
+
+MTPLX 2.5.2 is a hotfix for a long-response slowdown in 2.5.1.
+
+## What was wrong
+
+2.5.1 made Qwen 3.6 27B Optimized Speed V2 the recommended coding model. On
+long single responses, users saw generation start fast and then fall off and
+stutter for the rest of the answer. A 12,000-token response that opened near
+60 tokens per second could end near 30.
+
+The cause was in the speculative decoding engine, not the model. The compiled
+verifier reserves room for a fixed number of generated tokens. When a response
+runs past that reserve, MTPLX deliberately moves verification to the regular
+eager path for the rest of the response. That transition had a bug: it
+restored the cache containers but did not settle the GPU work still scheduled
+by the compiled path. Every later verification step then had to absorb the old
+dependency chain, which grew the cost of each step and produced the visible
+slowdown and stutter.
+
+Short responses and agent tool turns never cross the reserve, which is why the
+release testing for 2.5.1 missed it.
+
+## What is fixed
+
+The transition now settles all cache and recurrent state exactly once at the
+ownership boundary, then releases every compiled reference before eager
+decoding continues. The transition is visible in the compiled verifier stats
+so this cannot regress silently again.
+
+On the reported prompt, run to 12,288 output tokens with a pinned seed so
+both builds generate the same tokens, 2.5.1 decodes its final windows 17
+percent slower than its early windows on a fresh server, and field reports
+on live app servers showed the same decay reaching roughly half the opening
+speed. The fixed build inverts the shape: its closing 256-token window runs
+as fast as or faster than its opening ones, and the state settle at the
+transition costs about 3 milliseconds once per response. Output tokens,
+acceptance counters, and peak memory are identical between the two builds.
+
+## Faster MLX for existing installs
+
+The minimum MLX version is now 0.32. Fresh installs already resolved MLX
+0.32.0, but existing runtime environments could stay on 0.31.2 indefinitely
+because dependency upgrades only run when the declared floor requires them.
+Our 12,000-token generation runs consistently read faster on the 0.32
+stack. Raising the floor converges every install to the stack that new
+installs already run.
+
+## Scope
+
+This release contains the handoff fix, its regression tests, and the MLX
+floor raise. Model catalogs, defaults, sampler settings, memory policy, and
+the 2.5.1 V2 recommendation are unchanged.
+
+## Upgrade
+
+- **App**: Sparkle offers 2.5.2 (build 25200).
+- **pip**: `pip install -U mtplx`
+- **Homebrew**: `brew upgrade mtplx`

--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -963,7 +963,7 @@ def _compiled_verify_growth_reserve() -> int:
     Sized so a typical agent tool round (40-500 generated tokens) completes
     inside one stable leaf shape: one trace per (length, capacity) class,
     zero mid-round retraces. Long generations exceed the grant and demote to
-    eager for the request remainder, which measured flat vs eager-only.
+    eager for the request remainder.
     """
 
     raw = str(os.environ.get("MTPLX_COMPILED_VERIFY_GROWTH_RESERVE", "512")).strip()
@@ -1191,6 +1191,9 @@ class CompiledVerifyBank:
             "parity2_divergent_calls": 0,
             "parity2_first_divergence": None,
             "growth_demotions": 0,
+            "growth_handoff_materializations": 0,
+            "growth_handoff_state_leaves": 0,
+            "growth_handoff_materialize_time_s": 0.0,
         }
 
     # -- public API ---------------------------------------------------------
@@ -1516,6 +1519,49 @@ class CompiledVerifyBank:
             pass
         return _finish()
 
+    def _materialize_growth_handoff_state(self, cache: Any) -> int:
+        """Settle compiled state before the eager tail takes ownership.
+
+        Compiled dispatch schedules every output asynchronously. Merely
+        replacing the tensor-offset cache containers leaves their KV and
+        recurrent leaves attached to that deferred graph. The eager tail then
+        inherits the compiled dependency chain, so long generations pay the
+        old work through later verify-output evaluations instead of crossing a
+        clean ownership boundary.
+
+        Growth demotion is a once-per-request transition. Evaluate the current
+        state exactly once here, while the compiled state spec is still valid,
+        then let ``demote`` replace the containers and release compiled refs.
+        """
+        state = self._read_state_leaves(cache)
+        if state is None:
+            raise RuntimeError(
+                "compiled verify growth handoff has incomplete cache state"
+            )
+        leaves: list[mx.array] = []
+        seen: set[int] = set()
+        for leaf in state:
+            if not isinstance(leaf, mx.array):
+                continue
+            identity = id(leaf)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            leaves.append(leaf)
+        started = time.perf_counter()
+        if leaves:
+            mx.eval(*leaves)
+        self.stats["growth_handoff_materializations"] = (
+            int(self.stats.get("growth_handoff_materializations", 0)) + 1
+        )
+        self.stats["growth_handoff_state_leaves"] = (
+            int(self.stats.get("growth_handoff_state_leaves", 0)) + len(leaves)
+        )
+        self.stats["growth_handoff_materialize_time_s"] = float(
+            self.stats.get("growth_handoff_materialize_time_s", 0.0)
+        ) + (time.perf_counter() - started)
+        return len(leaves)
+
     def demote(self, cache: Any) -> int:
         """Restore stock containers for every tensor-offset adapter in place.
 
@@ -1540,6 +1586,8 @@ class CompiledVerifyBank:
             self.stats["demotions"] += count
             # Container identity changed; compiled closures bound the old
             # shadow, which no longer mirrors the cache list.
+            self._clear_shadow_leaf_refs()
+            self._held_state_refs.clear()
             self._shadow = None
             self._shadow_signature = None
             self._spec = None
@@ -1620,6 +1668,7 @@ class CompiledVerifyBank:
                 self.stats["growth_demotions"] = (
                     int(self.stats.get("growth_demotions", 0)) + 1
                 )
+                self._materialize_growth_handoff_state(cache)
                 self.demote(cache)
                 return "growth_budget_exhausted"
         if failures:

--- a/mtplx/version.py
+++ b/mtplx/version.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "2.5.1"
-DISPLAY_VERSION = "2.5.1"
+__version__ = "2.5.2"
+DISPLAY_VERSION = "2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mtplx"
-version = "2.5.1"
+version = "2.5.2"
 description = "Native MTP speculative decoding for Qwen3-Next on Apple Silicon."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -21,7 +21,12 @@ dependencies = [
   # 0.32.0 exactness-gated 2026-07-11: byte-identical greedy 128-tok output
   # vs 0.31.3 on Optimized-Speed q4 turbo D3 (same 34 verify calls), and 103
   # kernel/paged-verifier/graphbank/sustained tests green under 0.32.0.
-  "mlx>=0.31,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  # Floor raised to 0.32 in 2.5.2: fresh installs already resolve 0.32.0,
+  # but existing venvs sat on 0.31.2 forever because the app bootstrapper's
+  # -U uses pip's only-if-needed strategy. Raising the floor converges every
+  # install to the stack new installs already run (and the 2026-08-04
+  # long-generation runs consistently read faster on 0.32.0).
+  "mlx>=0.32,<0.33; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "mlx-lm>=0.31,<0.32; sys_platform == 'darwin' and platform_machine == 'arm64'",
   # transformers 5.13.0 changed AutoTokenizer.register to require a config
   # class as the key; mlx-lm 0.31.x still registers by name

--- a/tests/test_graphbank_compiled_verify.py
+++ b/tests/test_graphbank_compiled_verify.py
@@ -649,12 +649,57 @@ def test_unbounded_request_budget_clamps_to_env_ceiling_and_demotes(monkeypatch)
     assert stats["request_max_tokens"] == 262_133
     assert stats["calls"] == 1024
     assert stats["growth_demotions"] == 1
+    assert stats["growth_handoff_materializations"] == 1
+    assert stats["growth_handoff_state_leaves"] == 3
+    assert stats["growth_handoff_materialize_time_s"] >= 0.0
     assert stats["fallback_reasons"].get("growth_budget_exhausted", 0) > 0
     assert stats["compiled_calls"] + stats["fallback_calls"] == 1024
     assert stats["parity_failures"] == 0
     # Demoted back to stock entries; the eager path finished the request.
     assert type(cache[0]) is KVCache
     assert cache[0].offset == 1027
+
+
+def test_growth_handoff_settles_hybrid_state_and_releases_compiled_refs(monkeypatch):
+    """Growth demotion must hand eager mode evaluated, independently owned state."""
+
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_PREWARM", "0")
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_GROWTH_RESERVE", "6")
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_BOUNDARY", "none")
+    rt = ToyHybridRuntime()
+    cache = rt.make_cache()
+    cache[1].step = 4
+    rt.forward_ar_capture(mx.array([[0, 1, 2]]), cache=cache, return_hidden=True)
+    bank = CompiledVerifyBank(rt, request_max_tokens=262_133)
+
+    real_eval = mx.eval
+    evaluated_batch_sizes: list[int] = []
+
+    def recording_eval(*leaves):
+        evaluated_batch_sizes.append(len(leaves))
+        return real_eval(*leaves)
+
+    monkeypatch.setattr(mx, "eval", recording_eval)
+    for token_index in range(16):
+        logits, hidden, _ = bank.forward_ar_capture(
+            mx.array([[token_index % rt.V]]),
+            cache=cache,
+            return_hidden=True,
+        )
+        mx.eval(logits, hidden)
+
+    stats = bank.to_dict()
+    assert stats["growth_demotions"] == 1
+    assert stats["growth_handoff_materializations"] == 1
+    # Two recurrent leaves plus dense K, V, and tensor offset.
+    assert stats["growth_handoff_state_leaves"] == 5
+    assert 5 in evaluated_batch_sizes
+    assert type(cache[1]) is KVCache
+    assert cache[1].offset == 19
+    assert bank._held_state_refs == []
+    assert bank._shadow is None
+    assert bank._spec is None
+    assert bank._compiled == {}
 
 
 def test_env_reserve_raises_ceiling_for_known_budget_runs(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -634,32 +634,40 @@ wheels = [
 
 [[package]]
 name = "mlx"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/89/1e77ec3ff380e8fb9e7258047374d31452a0f9828a0e370f127b07dd8288/mlx-0.31.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4a3f181b367d404e44a6bd68ef5eb573930809ac60cacd51d0c851c629b1b651", size = 586911, upload-time = "2026-04-22T03:14:29.675Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/41/c1907f05f8a3fc54025fb78ad68d3c4a4b931664d03c0a24f7f431cc4087/mlx-0.31.2-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:70297cbef7479429f69c966bfed10da20a6f0c2aa997eec2b4f6ba1a07caf2ef", size = 586915, upload-time = "2026-04-22T03:14:31.403Z" },
-    { url = "https://files.pythonhosted.org/packages/97/b0/61ac2c14773c786fecbda28067b0207a0c654cb4d10c548808c51284d700/mlx-0.31.2-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:c0ff158b7ac93a4b5659adbc70053498b30a5964fc45f78596398e056a96c36a", size = 587030, upload-time = "2026-04-22T03:14:32.961Z" },
-    { url = "https://files.pythonhosted.org/packages/de/53/e12feb7078ee472983555fcb1da4749a2bbbc8fc5b29b78c205b96d37d1e/mlx-0.31.2-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:cd5d42b0b2bee7efe1b0680a7e302943dd33b92c879cffa0358ffdb5a4a8d27b", size = 652994, upload-time = "2026-04-22T03:14:34.691Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/40/f92c8cdc9595bf24c7e483a3156bfe0cc99a5cf5545d8dba8e7fe000c10b/mlx-0.31.2-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:b368f7ede4238cc44076e4843820338c453c21ee50bd3ee26d4b182c179fd8e1", size = 692086, upload-time = "2026-04-22T03:14:36.45Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/c3/00664239a98e8bd614733c4182cd402d2bacad2d7f79eca66562ac406870/mlx-0.31.2-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:117c7583cae0ca107cd53c591cc34f8e75f97a505aa47088844b7dc0fc69dc67", size = 627863, upload-time = "2026-04-22T03:14:43.326Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7b/af6cd73a79772af6f19eab2cb4c48eda23a9294d1650a4c1269a9996e532/mlx-0.31.2-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:99572133181481640a8bf8d449daf083816d0af3ee050c8adfc5bf45ceca91c6", size = 685090, upload-time = "2026-04-22T03:14:45.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/19/aca251d4c5f3532ce9c2c1e95ad76740d9c6c298f406f62d992f465b9be0/mlx-0.31.2-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:cd1f4189e5f1bc68735f44eb63ce98ae09d66ac75d7ab5b15a41afae7e9f0513", size = 627843, upload-time = "2026-04-22T03:14:51.351Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2b/b89364883b98f21c2fe29e52d4ac8bc2fa2fe0d79293b36ec421efc1854a/mlx-0.31.2-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:53c8d57ffa9ce77f8355663be05014c0dd37280e57f19126fb0a24389a30684b", size = 685064, upload-time = "2026-04-22T03:14:52.75Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
-    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a4/e822202dd2e4e7d08671f2ecf7b6500af74f5bad5ceb27086b1aa6902f3a/mlx-0.31.2-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:e81798c610f95a09c642c89214ba5c23b72ce18ce4728184aceabe7eddca33d7", size = 630473, upload-time = "2026-04-22T03:14:58.985Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6f/da48d2d7a76e644d35438ef6f33c68755fdd382e2c546fd1804ccba01d04/mlx-0.31.2-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:69fbc94bf53607a75af9eb3e22c354738a6fe4e25aa4e2b20934b009a4bba1f3", size = 685459, upload-time = "2026-04-22T03:15:00.45Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c7/cb62301b01dbccd66b256cab0c98fc29e7533dd76aa599fe44c1bb1f4168/mlx-0.32.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:72c605368d145c756877057d7e3c54f169c9899fe1f83232bfb3a6342561e234", size = 562792, upload-time = "2026-07-07T17:55:35.24Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/c2eba5bb18c94a9fe1b5d6599f18ba2ef5de2d8b42439716d9241ab196c4/mlx-0.32.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0a0e38a409b9cae29647ec9e75ce9747b224ce7e5d91adbfad7eac37b6118ffd", size = 562792, upload-time = "2026-07-07T17:55:36.876Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/43/5b481bfb8f1234153fd8fef9dcacfe34860b0934eb507c0eb811ba599afe/mlx-0.32.0-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:2a180cd39ac68b397b85cc4658d0b8e0ab58166c2549fc9ab2ca5f99d15ef0c3", size = 562776, upload-time = "2026-07-07T17:55:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9d/6b424d7a457baf5da788d881f9c3e908e44473e89544acee77962868d8f6/mlx-0.32.0-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:4c8925d9d22d57b26885cb0858d2d4463d7526b17363c166820db5ea949731ad", size = 647901, upload-time = "2026-07-07T17:55:39.774Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0e/6e264023c3432b83b32fbf9f2a1365f8f0a9c5e67ed1684330ecbd5faf63/mlx-0.32.0-cp311-cp311-manylinux_2_35_x86_64.whl", hash = "sha256:5d5041205173e44f176d00b8119e7db7802c298a0f845486f0281c45122646ed", size = 682331, upload-time = "2026-07-07T17:55:41.101Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/1b/51094ba6fb0e77bc41c5edeb581d1bac115cf98621590b4965fe2b1bc77d/mlx-0.32.0-cp311-cp311-win_amd64.whl", hash = "sha256:2f41445eb4b5c5bfe44f6635d0be3564485bd983de405772f7e4f17fbd6e3a9b", size = 558359, upload-time = "2026-07-07T17:55:42.542Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f3/4e2c03db1185ff2e1bc755ca1c6a25ec38c65f5f7239e6542a4ca525e42f/mlx-0.32.0-cp311-cp311-win_arm64.whl", hash = "sha256:b0fdec519890dd3aa295920940356295012dea3a0390f229cd08d72890888427", size = 542720, upload-time = "2026-07-07T17:55:43.89Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a6/489176d8a2a06137a299910057cc44dc3fccfb73151f7562fea2b75894d9/mlx-0.32.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ea5a594355c89c0095eaba413fd39d4caa8642fa13432dfb0c9354d141046467", size = 558889, upload-time = "2026-07-07T17:55:45.268Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/5d1f1cb1b073c39c822e0c0be1e68f4ced6fd32ab15cf8bb1f448028842c/mlx-0.32.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5f778001562ccce26cf6e5be1050d2afc78e2902bad206201ab9f5a6d0f886a", size = 558890, upload-time = "2026-07-07T17:55:46.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/01/02110ceacf4efd00ec172f60b4cd42c8b1509ac50ffa65a6a77d723133aa/mlx-0.32.0-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:8dfb577faa4dc413cfd0d6eb78f230d3b3b6169df4473e84408abdeb21346e9d", size = 558856, upload-time = "2026-07-07T17:55:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/b16b7ab2670edf0f8f2cdeb2b6b3d5ab27a749b31ed74cb6825958ca0892/mlx-0.32.0-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:50bc29bfaf31dff5138a472b56963bd6ece0fa67800c6c382745aaa41126d01f", size = 617769, upload-time = "2026-07-07T17:55:49.596Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ef/c326e05070f35c43a9775ce9dceaf155c8a9b2706a4c52d64e8999d4929a/mlx-0.32.0-cp312-cp312-manylinux_2_35_x86_64.whl", hash = "sha256:78804098c9f64978b6048ffdfd78689b9e06efa2a530c541d0bd73ce44d2f589", size = 675402, upload-time = "2026-07-07T17:55:51.148Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e9/04cd133d18b4da1c00515c595c1cb6de7e2534938d2c3de2f3f2301c3466/mlx-0.32.0-cp312-cp312-win_amd64.whl", hash = "sha256:13ac6469479cda4bfd6954e0b574b92930b87073f7c79be121a68b31a3a6c596", size = 558048, upload-time = "2026-07-07T17:55:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f6/f27397f44c84138bcae00592a377fc5b1fc79d1dbfa820c1af20042f4c33/mlx-0.32.0-cp312-cp312-win_arm64.whl", hash = "sha256:7c8d3a7b506ab45b3f7976495126c16830d988ec53289134b2bb64dae1efb835", size = 543631, upload-time = "2026-07-07T17:55:53.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/be/ddc888d4a20c7602da06ad1a244f495010c6c7d2457f6253e8fa3c99ceea/mlx-0.32.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:abb786ee1e9638759be82583222fc7d09c5650ef90ad2b7c5da7d1931a8676dc", size = 558795, upload-time = "2026-07-07T17:55:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b9/4f0ae7785fdb3fa7e44434908d832cbc7a9a1e096d046ac6fe953812c52c/mlx-0.32.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:deb284f3a5cd0c3e87bed80c2bee9dcbf946bdad44d75592f6fb784da878c1c0", size = 558799, upload-time = "2026-07-07T17:55:56.844Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a8/7bc999ce5d09dfac8961dcda4ed47e173fca2857492f34599b237380f20d/mlx-0.32.0-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:4192a2d02014a13a6a1030bf13dfb4e4fe05ec3ffa47678ee37da29111e25cb1", size = 558786, upload-time = "2026-07-07T17:55:58.272Z" },
+    { url = "https://files.pythonhosted.org/packages/83/cf/90980e28e6adaaf47d7951604ff2ac4ceb3952040f941bececb9b7a07a4c/mlx-0.32.0-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:102043c6455fe0939509c1e96caec4678f51e241981238da97c83beeed5653f6", size = 617228, upload-time = "2026-07-07T17:55:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fa/e3608936caa02ebf7fc645e3289134918facb0cff6dcb563d51996a5b70e/mlx-0.32.0-cp313-cp313-manylinux_2_35_x86_64.whl", hash = "sha256:e5cdb9bf7c1a9320827a65f7ed63e3742d5b9280d31affc0c277e77982d465ae", size = 675294, upload-time = "2026-07-07T17:56:00.993Z" },
+    { url = "https://files.pythonhosted.org/packages/65/96/4979a82390a69e7ff48a43d3ea5cac222ae6bc41c2ba56550f6f5bd416b3/mlx-0.32.0-cp313-cp313-win_amd64.whl", hash = "sha256:9fea39d8ecf1d08e5c3d5d70936d5a1ca6b890353c1b0b96c4e6232349d48e36", size = 558017, upload-time = "2026-07-07T17:56:02.307Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/1b2a1e3b60fce6bd61ca8af3ccfe0da30f42184352a70123870fd960ce0d/mlx-0.32.0-cp313-cp313-win_arm64.whl", hash = "sha256:df6fa6785fb7a6f8d8e3e91c41074c885aa253b09c2b69e3c4d4f905e3c457e3", size = 543559, upload-time = "2026-07-07T17:56:03.644Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/5e49c183f9024f86dc1f038866ccd743aaec1fe412a7e7dc76fec9271f48/mlx-0.32.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2ee79b1f8c2c2a329afc95ece7dce0be798d43f3de771a6370d2b9f9702bbd9a", size = 561387, upload-time = "2026-07-07T17:56:05.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/33/e3d7f7a18331523762e9968b6716e81514649af81ffd9ba4364e3df95823/mlx-0.32.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:e0db558267bb2d13fac4f85674456adbe0f085c570b9219e03d4e95fdc11c4d0", size = 561389, upload-time = "2026-07-07T17:56:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/58/bd847d3fed65296573a4bb3399adde6934c0a718813b5636000d7d1b4063/mlx-0.32.0-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:23e83c8e74a23156696e9f9905d16a17b7d27b5a596c1bc0f720a98df1c5aadf", size = 561392, upload-time = "2026-07-07T17:56:08.237Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f3/0c3c8bb11362a97ebc6407a1c3e24a45de470e9326ef53dcc96e83263e84/mlx-0.32.0-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:253c5d20c573b277fc64a3eec491984e7ad4c64f9b246c1b3fee903b7d1db824", size = 618758, upload-time = "2026-07-07T17:56:09.729Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/94/61b29c561045576e78d6f992c22d0bb301e8e6eec65588560f942d59c88d/mlx-0.32.0-cp314-cp314-manylinux_2_35_x86_64.whl", hash = "sha256:4edffbdb1f7c185e35dc4e48611966d012b1dda9225a0dabd0fbd31651374a71", size = 675130, upload-time = "2026-07-07T17:56:11.059Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fe/5a0dd8784e0335aa7d472365177a6a13245b4aa28cf102c9bac6d65675c8/mlx-0.32.0-cp314-cp314-win_amd64.whl", hash = "sha256:f67557bd9ce31cbb519b39e9455b19cca698eb153ab6f4deef5b4d5509d94df3", size = 572405, upload-time = "2026-07-07T17:56:12.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/26/f9efe51f7f32afc7da95fc832cc3e2744f9284b846e0e18ebd98b6bd2458/mlx-0.32.0-cp314-cp314-win_arm64.whl", hash = "sha256:13f793c354ea9dc589bbd113f4b7d299900fb440199bbb403546845852b2499b", size = 558174, upload-time = "2026-07-07T17:56:13.694Z" },
 ]
 
 [[package]]
@@ -682,12 +690,12 @@ wheels = [
 
 [[package]]
 name = "mlx-metal"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
-    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
 ]
 
 [[package]]
@@ -701,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "mtplx"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -742,7 +750,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.136" },
     { name = "huggingface-hub", specifier = ">=0.36" },
     { name = "llguidance", marker = "extra == 'server'", specifier = ">=1.7" },
-    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31,<0.33" },
+    { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.32,<0.33" },
     { name = "mlx-lm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=0.31,<0.32" },
     { name = "nanobind", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=2" },
     { name = "numpy", specifier = ">=2" },


### PR DESCRIPTION
## Summary

Hotfix for the 2.5.1 long-response slowdown on Optimized Speed V2.

Long unbounded responses cross the compiled verifier's 512-token growth
reserve and hand verification to the eager path for the rest of the response.
The handoff restored the cache containers but did not settle the GPU work the
compiled path had scheduled, so every later verify step absorbed the old
dependency chain. On the reported 12k-token generation, decode opened at 59
tok/s and ended near 30, with 215 of 312 seconds spent in verify hidden-state
evaluation.

The fix settles all cache and recurrent state exactly once at the growth
ownership boundary, clears shadow and held references before eager takes
ownership, and exposes handoff telemetry in the compiled verifier stats.

## Evidence

- Field repro and root cause: request-log records show the collapse
  with acceptance at 96/89/80 and zero fallbacks; `growth_demotions=1` on
  every affected request.
- Controlled runs on the same V2 artifact, verified max fans, pinned seed,
  identical 12,288-token trajectories: 2.5.1 decodes its final 256-token
  window 17% slower than its early windows on a fresh server (live app
  servers reported roughly half the opening speed); the fixed build's
  closing windows run as fast as or faster than its opening ones. Output
  tokens, acceptance counters, and peak memory are identical across builds.
- Handoff engagement is proven live: exactly one materialization per long
  request, settled in single-digit milliseconds.

## Verification

- `tests/test_graphbank_compiled_verify.py`: 55 passed (includes a new
  synthetic hybrid growth-handoff regression and a pinned single-handoff
  exactness test).
- `tests/test_server_openai.py`: 281 passed.
- Compiled wiring + sustained integration: 41 passed, 1 skipped.
- Ruff clean, wheel/sdist build clean.

## Also in this release

The MLX floor moves to `>=0.32`. Fresh installs already resolve mlx 0.32.0
(exactness-gated 2026-07-11), but existing runtime venvs never left 0.31.2
because the bootstrapper upgrades with pip's only-if-needed strategy. The
floor raise converges every install to the stack new installs already run.

## Scope

The once-per-request growth handoff, the MLX floor, and release metadata.
Normal compiled ticks, short requests, model policies, catalogs, and sampler
are untouched.
