### PR TITLE
fix: keep vision towers through forge and repair the blind Qwen 3.8 publishes (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable user-facing changes to MTPLX. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The Qwen 3.8 Hugging Face artifacts can see again (#263).** All six
+  published 3.8 repos (Bare Speed, Optimized Speed, Optimized Quality and
+  their FP16 siblings) shipped without their vision towers: the forge
+  `mlx_lm.convert` lane serializes only the text model, so the 333
+  `model.visual.*` tensors, `vision_config`, and the preprocessor sidecars
+  were silently dropped. The repos were re-published on 2026-08-15 with the
+  official bf16 tower grafted back as an index-registered
+  `model-vision.safetensors` (byte-for-byte from `Qwen/Qwen3.8-27B`; language
+  and MTP tensors untouched). Existing installs pick the delta up with
+  `mtplx pull`; images, `/health` `vision.enabled`, prompt caching with
+  images, and MTP decode were verified on all six builds. Thanks to
+  @kjellix for the report and the proven graft procedure.
+- **Forge keeps vision towers from now on.** `mtplx forge build` grafts the
+  source's vision tower, `vision_config`, and preprocessor sidecars into the
+  converted artifact on every lane (`mtplx/vision_graft.py`), and fails
+  closed when a source that declares `vision_config` would produce a blind
+  artifact. A repair script for already-forged artifacts ships as
+  `scripts/graft_vision_tower.py`, and the pillar gate now asserts
+  `vision.enabled` before the vision-cache check so a blind build fails
+  loudly with the real cause.
+- **`mtplx pull` no longer corrupts files that changed upstream.** The
+  progress downloader treated a size-mismatched *complete* local file as a
+  resumable partial and byte-range-appended the remote tail onto the old
+  content — updating a repo in place (for example the restored 3.8 vision
+  indexes) corrupted `config.json` and `model.safetensors.index.json` and
+  left the local copy unloadable until re-downloaded. Stale files are now
+  discarded and re-fetched whole; genuine `*.incomplete` partials still
+  resume. **Users on ≤2.7.1 should upgrade before pulling repaired repos**;
+  a failed pull from an older build is recovered by deleting the corrupt
+  `config.json` + `model.safetensors.index.json` and pulling again.
+
 ## [2.7.1] - 2026-08-15
 
 Clears the 2.7.0 known-issues list: `xhigh` is now selectable everywhere it is

--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Models/MTPLXModelOption.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Models/MTPLXModelOption.swift
@@ -420,7 +420,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Bare Speed",
             ],
             // Exact byte sum of the published HF repo files (2026-08-15 tree API).
-            sizeBytes: 16_002_648_138,
+            sizeBytes: 16_924_164_062,
             // Measured 2026-08-14: request-log MLX high-water 19.6 GiB during
             // quiet-window 2.4k-context serving (boot + Flappy arms + rung).
             peakMemoryGiB: 20.0,
@@ -442,7 +442,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Qwen 3.8 Optimized Speed",
             ],
             // Exact byte sum of the published HF repo files (2026-08-15 tree API).
-            sizeBytes: 20_392_433_868,
+            sizeBytes: 21_313_949_792,
             // Measured 2026-08-14: request-log MLX high-water 24.6 GiB during
             // quiet-window 2.4k-context serving (boot + Flappy arms + rung).
             peakMemoryGiB: 25.0,
@@ -464,7 +464,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Qwen 3.8 Optimized Quality",
             ],
             // Exact byte sum of the published HF repo files (2026-08-15 tree API).
-            sizeBytes: 29_449_324_149,
+            sizeBytes: 30_370_840_073,
             // Measured 2026-08-14: request-log MLX high-water 32.9 GiB during
             // quiet-window 2.4k-context serving (boot + Flappy arms + rung).
             peakMemoryGiB: 33.0,
@@ -493,7 +493,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Bare Speed FP16",
             ],
             // Exact byte sum of the local sibling at build time (2026-08-15).
-            sizeBytes: 16_003_127_584,
+            sizeBytes: 16_924_647_669,
             // Same packs and tensor bytes as the parent; peak carried over.
             peakMemoryGiB: 20.0,
             recommendedFor: [.legacyApple]
@@ -514,7 +514,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Qwen 3.8 Optimized Speed FP16",
             ],
             // Exact byte sum of the local sibling at build time (2026-08-15).
-            sizeBytes: 20_392_914_234,
+            sizeBytes: 21_314_434_309,
             // Same packs and tensor bytes as the parent; peak carried over.
             peakMemoryGiB: 25.0,
             recommendedFor: [.legacyApple]
@@ -535,7 +535,7 @@ public struct MTPLXModelOption: Codable, Equatable, Identifiable, Sendable {
                 "Qwen 3.8 Optimized Quality FP16",
             ],
             // Exact byte sum of the local sibling at build time (2026-08-15).
-            sizeBytes: 29_449_805_992,
+            sizeBytes: 30_371_326_040,
             // Same packs and tensor bytes as the parent; peak carried over.
             peakMemoryGiB: 33.0,
             recommendedFor: [.legacyApple]

--- a/mtplx/commands/forge.py
+++ b/mtplx/commands/forge.py
@@ -1028,6 +1028,9 @@ def _cmd_build(args: Any) -> int:
     if _cancel_requested(args.run_id):
         raise ForgeError("forge cancelled", code=130)
 
+    _ensure_vision_tower(source_path, destination)
+    _validate_vision_payload(source_path, destination)
+
     _calibrate_sidecar(
         source_path,
         destination,
@@ -1765,6 +1768,51 @@ def _validate_mtp_sidecar_payload(destination: Path) -> dict[str, Any] | None:
     config["mtplx_mtp_payload_audit"] = audit
     atomic_write_json(config_path, config)
     return audit
+
+
+def _ensure_vision_tower(source: Path, destination: Path) -> None:
+    """Restore the vision tower that text-only convert lanes drop.
+
+    ``mlx_lm.convert`` serializes only the text model, so multimodal sources
+    lose their vision tensors, ``vision_config``, and preprocessor sidecars
+    (issue #263). Graft them back from the source directory. A no-op for
+    text-only sources and for lanes (mirror, compressed-tensors) that already
+    preserved the tower.
+    """
+    if not source.is_dir():
+        return
+    from mtplx.vision_graft import VisionGraftError, graft_vision_tower
+
+    try:
+        report = graft_vision_tower(source, destination, verify_load=True)
+    except VisionGraftError as exc:
+        raise ForgeError(f"vision tower graft failed: {exc}") from exc
+    if report.get("status") == "grafted":
+        _err(
+            f"[forge] restored vision tower: {report.get('tensors')} tensors "
+            f"({report.get('bytes')} bytes) in {report.get('vision_file')}"
+        )
+
+
+def _validate_vision_payload(source: Path, destination: Path) -> None:
+    """Fail closed when a multimodal source produced a blind artifact."""
+    if not source.is_dir():
+        return
+    try:
+        source_config = _load_json(source / "config.json")
+    except Exception:
+        return
+    if not isinstance(source_config, dict) or not isinstance(
+        source_config.get("vision_config"), dict
+    ):
+        return
+    from mtplx.vision import vision_spec_for_model_dir
+
+    if vision_spec_for_model_dir(destination) is None:
+        raise ForgeError(
+            "source declares vision_config but the forged artifact resolves no "
+            "vision tower; the convert lane dropped it (issue #263)"
+        )
 
 
 def _audit_mtp_sidecar_payload(mtp_path: Path) -> dict[str, Any]:
@@ -2922,6 +2970,9 @@ def _stamp_runtime_metadata(
         metadata["mtp_sidecar"] = inspection.mtp.sidecar_format
     else:
         metadata.setdefault("mtp_sidecar", "mtp.safetensors")
+    vision_stamp = _vision_metadata_stamp(model_path)
+    if vision_stamp is not None:
+        metadata["vision"] = vision_stamp
     metadata["base_trunk"] = source_repo
     metadata.setdefault("artifact_role", "forge-local")
     metadata["forge_provenance"] = {
@@ -2937,6 +2988,32 @@ def _stamp_runtime_metadata(
         "published_to_hf": None,
     }
     return metadata
+
+
+def _vision_metadata_stamp(model_path: Path) -> dict[str, Any] | None:
+    """Provenance for artifacts that carry a vision tower, or None."""
+    from mtplx.vision import resolve_vision_prefix
+
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.exists():
+        return None
+    try:
+        index = _load_json(index_path)
+    except Exception:
+        return None
+    weight_map = index.get("weight_map") if isinstance(index, dict) else None
+    if not isinstance(weight_map, dict):
+        return None
+    prefix = resolve_vision_prefix(weight_map)
+    if prefix is None:
+        return None
+    vision_keys = [key for key in weight_map if str(key).startswith(prefix)]
+    shards = sorted({str(weight_map[key]) for key in vision_keys})
+    return {
+        "tensor_count": len(vision_keys),
+        "prefix": prefix,
+        "shards": shards,
+    }
 
 
 def _speed_evidence(rows: list[dict[str, Any]]) -> dict[str, Any]:

--- a/mtplx/diagnostics.py
+++ b/mtplx/diagnostics.py
@@ -26,7 +26,7 @@ from mtplx.profiles import DEFAULT_HF_MODEL_ID, DEFAULT_PROFILE_NAME
 
 
 GIB = 1024**3
-DEFAULT_SPEED_MODEL_SIZE_BYTES = 20_392_433_868  # Qwen3.8-27B Optimized Speed (Hub bytes)
+DEFAULT_SPEED_MODEL_SIZE_BYTES = 21_313_949_792  # Qwen3.8-27B Optimized Speed (Hub bytes, incl. restored vision tower #263)
 MIN_RECOMMENDED_MEMORY_BYTES = 48 * GIB
 SUPPORT_MACOS_MAJOR = 14
 SUPPORT_PYTHON = (3, 11)

--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -637,10 +637,12 @@ def _download_repo_file(
 
     partial = target.with_name(target.name + ".incomplete")
     if target.exists():
-        if not partial.exists():
-            target.replace(partial)
-        else:
-            target.unlink()
+        # A size-mismatched final file is a stale version of a file that
+        # changed upstream (e.g. a repaired index gaining vision entries),
+        # not an interrupted download. Resuming from it would append the
+        # remote tail onto old content and corrupt the file, so discard it.
+        # Only a leftover *.incomplete partial may be range-resumed.
+        target.unlink()
     existing = partial.stat().st_size if partial.exists() else 0
     if expected_size is not None and existing > expected_size:
         partial.unlink()

--- a/mtplx/model_catalog.py
+++ b/mtplx/model_catalog.py
@@ -128,8 +128,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Bare-Speed",
         # Exact byte sum of the published HF repo files (2026-08-15 tree API;
-        # three trunk shards + bf16 MTP sidecar + tokenizer + card).
-        size_bytes=16_002_648_138,
+        # three trunk shards + bf16 MTP sidecar + restored bf16 vision tower
+        # (#263) + tokenizer + card).
+        size_bytes=16_924_164_062,
         # Measured 2026-08-14: request-log MLX high-water 19.6 GiB during
         # quiet-window 2.4k-context serving (boot + Flappy arms + rung).
         peak_memory_gib=20.0,
@@ -150,8 +151,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed",
         # Exact byte sum of the published HF repo files (2026-08-15 tree API;
-        # module_overrides recipe, 5.807 bits/weight, bf16 MTP sidecar).
-        size_bytes=20_392_433_868,
+        # module_overrides recipe, 5.807 bits/weight, bf16 MTP sidecar,
+        # restored bf16 vision tower (#263)).
+        size_bytes=21_313_949_792,
         # Measured 2026-08-14: request-log MLX high-water 24.6 GiB during
         # quiet-window 2.4k-context serving (boot + Flappy arms + rung).
         peak_memory_gib=25.0,
@@ -169,8 +171,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
             "8-bit dynamic quant. Good coding speeds and perfect quality."
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality",
-        # Exact byte sum of the published HF repo files (2026-08-15 tree API).
-        size_bytes=29_449_324_149,
+        # Exact byte sum of the published HF repo files (2026-08-15 tree API;
+        # includes the restored bf16 vision tower, #263).
+        size_bytes=30_370_840_073,
         # Measured 2026-08-14: request-log MLX high-water 32.9 GiB during
         # quiet-window 2.4k-context serving (boot + Flappy arms + rung).
         peak_memory_gib=33.0,
@@ -193,8 +196,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
             "coding tasks. FP16 build for M1 and M2 Macs."
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Bare-Speed-FP16",
-        # Exact byte sum of the local sibling at build time (2026-08-15).
-        size_bytes=16_003_127_584,
+        # Exact byte sum of the published HF repo files (2026-08-15 tree API;
+        # includes the restored bf16 vision tower, #263).
+        size_bytes=16_924_647_669,
         # Same packs and tensor bytes as the parent; peak carried over.
         peak_memory_gib=20.0,
         recommended_tiers=frozenset({LEGACY_TIER}),
@@ -213,8 +217,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
             "FP16 build for M1 and M2 Macs. Recommended."
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed-FP16",
-        # Exact byte sum of the local sibling at build time (2026-08-15).
-        size_bytes=20_392_914_234,
+        # Exact byte sum of the published HF repo files (2026-08-15 tree API;
+        # includes the restored bf16 vision tower, #263).
+        size_bytes=21_314_434_309,
         # Same packs and tensor bytes as the parent; peak carried over.
         peak_memory_gib=25.0,
         recommended_tiers=frozenset({LEGACY_TIER}),
@@ -232,8 +237,9 @@ OFFICIAL_CATALOG: tuple[CatalogModel, ...] = (
             "FP16 build for M1 and M2 Macs."
         ),
         hf_model_id="Youssofal/Qwen3.8-27B-MTPLX-Optimized-Quality-FP16",
-        # Exact byte sum of the local sibling at build time (2026-08-15).
-        size_bytes=29_449_805_992,
+        # Exact byte sum of the published HF repo files (2026-08-15 tree API;
+        # includes the restored bf16 vision tower, #263).
+        size_bytes=30_371_326_040,
         # Same packs and tensor bytes as the parent; peak carried over.
         peak_memory_gib=33.0,
         recommended_tiers=frozenset({LEGACY_TIER}),

--- a/mtplx/vision_graft.py
+++ b/mtplx/vision_graft.py
@@ -1,0 +1,372 @@
+"""Vision-tower graft: restore official vision weights into forged artifacts.
+
+The ``mlx_lm.convert`` forge lane serializes only the text model, so
+multimodal sources lose their vision tower, ``vision_config``, and the
+preprocessor sidecars (issue #263). This module grafts them back from the
+original source checkpoint without touching language or MTP tensors:
+
+- copies the vision tensors byte-for-byte (no dequant round-trip) into a
+  ``model-vision.safetensors`` shard, renaming ``model.visual.*`` to
+  ``vision_tower.*`` on the way out,
+- registers the tensors in ``model.safetensors.index.json`` (the runtime
+  discovers vision weights only through the index weight_map),
+- restores ``vision_config`` into ``config.json``,
+- copies / synthesizes the preprocessor sidecars.
+
+Shared by the one-off repair script ``scripts/graft_vision_tower.py`` and
+the forge pipeline (``_ensure_vision_tower`` in ``mtplx/commands/forge.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from mtplx.vision import resolve_vision_prefix, vision_spec_for_model_dir
+
+VISION_FILE = "model-vision.safetensors"
+
+_VISION_SIDECAR_FILES = (
+    "preprocessor_config.json",
+    "video_preprocessor_config.json",
+    "processor_config.json",
+)
+
+# Top-level config.json token ids the vision splice relies on. Copied from
+# the source only when the destination does not already carry them.
+_VISION_TOKEN_ID_KEYS = (
+    "image_token_id",
+    "video_token_id",
+    "vision_start_token_id",
+    "vision_end_token_id",
+)
+
+_DTYPE_BITS = {
+    "BOOL": 8,
+    "U8": 8,
+    "I8": 8,
+    "F8_E4M3": 8,
+    "F8_E5M2": 8,
+    "I16": 16,
+    "U16": 16,
+    "F16": 16,
+    "BF16": 16,
+    "I32": 32,
+    "U32": 32,
+    "F32": 32,
+    "I64": 64,
+    "U64": 64,
+    "F64": 64,
+}
+
+
+class VisionGraftError(RuntimeError):
+    """Raised when a vision graft cannot be performed consistently."""
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    tmp.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp, path)
+
+
+def _read_safetensors_header(path: Path) -> tuple[int, dict[str, Any]]:
+    with path.open("rb") as handle:
+        header_size_raw = handle.read(8)
+        if len(header_size_raw) != 8:
+            raise VisionGraftError(f"{path.name} is not a valid safetensors file")
+        header_size = int.from_bytes(header_size_raw, "little")
+        try:
+            header = json.loads(handle.read(header_size).decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise VisionGraftError(
+                f"{path.name} has invalid safetensors metadata: {exc}"
+            ) from exc
+    if not isinstance(header, dict):
+        raise VisionGraftError(f"{path.name} has invalid safetensors metadata")
+    return header_size, header
+
+
+def _tensor_parameters(info: dict[str, Any]) -> int:
+    count = 1
+    for dim in info.get("shape") or []:
+        count *= int(dim)
+    return count
+
+
+def _rename_vision_key(key: str) -> str:
+    if key.startswith("model.visual."):
+        return "vision_tower." + key[len("model.visual.") :]
+    return key
+
+
+def _normalize_vision_config(vision_config: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(vision_config)
+    if normalized.get("model_type") == "qwen3_5_vision":
+        normalized["model_type"] = "qwen3_5"
+    normalized.pop("dtype", None)
+    return normalized
+
+
+def _collect_vision_tensors(
+    source: Path, weight_map: dict[str, str], prefix: str
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Return ``(source_key, output_key, shard_name, tensor_info)`` tuples,
+    sorted by output key for a deterministic sidecar layout."""
+    by_file: dict[str, list[str]] = {}
+    for key, shard in weight_map.items():
+        if key.startswith(prefix):
+            by_file.setdefault(str(shard), []).append(str(key))
+
+    tensors: list[tuple[str, str, str, dict[str, Any]]] = []
+    for shard_name, keys in by_file.items():
+        shard = source / shard_name
+        if not shard.is_file():
+            raise VisionGraftError(
+                f"source shard {shard_name} referenced by the index is missing"
+            )
+        _, header = _read_safetensors_header(shard)
+        for key in keys:
+            info = header.get(key)
+            if not isinstance(info, dict):
+                raise VisionGraftError(f"vision tensor {key} missing from {shard_name}")
+            offsets = info.get("data_offsets")
+            if (
+                not isinstance(offsets, list)
+                or len(offsets) != 2
+                or not all(isinstance(item, int) for item in offsets)
+                or offsets[0] < 0
+                or offsets[1] < offsets[0]
+            ):
+                raise VisionGraftError(
+                    f"vision tensor {key} has invalid safetensors offsets in {shard_name}"
+                )
+            if not isinstance(info.get("dtype"), str) or not isinstance(
+                info.get("shape"), list
+            ):
+                raise VisionGraftError(
+                    f"vision tensor {key} has invalid safetensors metadata in {shard_name}"
+                )
+            tensors.append((key, _rename_vision_key(key), shard_name, info))
+    tensors.sort(key=lambda item: item[1])
+    return tensors
+
+
+def _write_vision_sidecar(
+    source: Path,
+    tensors: list[tuple[str, str, str, dict[str, Any]]],
+    target: Path,
+) -> None:
+    header: dict[str, Any] = {"__metadata__": {"format": "mlx"}}
+    offset = 0
+    for _, output_key, _, info in tensors:
+        start, end = info["data_offsets"]
+        length = end - start
+        header[output_key] = {
+            "dtype": info["dtype"],
+            "shape": info["shape"],
+            "data_offsets": [offset, offset + length],
+        }
+        offset += length
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+
+    tmp = target.with_name(f".{target.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    handles: dict[str, Any] = {}
+    header_sizes: dict[str, int] = {}
+    try:
+        with tmp.open("wb") as out:
+            out.write(len(encoded).to_bytes(8, "little"))
+            out.write(encoded)
+            for source_key, _, shard_name, info in tensors:
+                handle = handles.get(shard_name)
+                if handle is None:
+                    handle = (source / shard_name).open("rb")
+                    handles[shard_name] = handle
+                    header_sizes[shard_name], _ = _read_safetensors_header(
+                        source / shard_name
+                    )
+                header_size = header_sizes[shard_name]
+                start, end = info["data_offsets"]
+                handle.seek(8 + header_size + start)
+                payload = handle.read(end - start)
+                if len(payload) != end - start:
+                    raise VisionGraftError(
+                        f"vision tensor {source_key} payload is truncated in {shard_name}"
+                    )
+                out.write(payload)
+        os.replace(tmp, target)
+    finally:
+        for handle in handles.values():
+            handle.close()
+        if tmp.exists():
+            tmp.unlink()
+
+
+def _copy_vision_sidecars(source: Path, destination: Path) -> list[str]:
+    copied: list[str] = []
+    for name in _VISION_SIDECAR_FILES:
+        src = source / name
+        if src.is_file():
+            shutil.copy2(src, destination / name)
+            copied.append(name)
+    if "processor_config.json" not in copied:
+        from mtplx.compressed_tensors import _processor_config_fallback
+
+        _processor_config_fallback(destination)
+        if (destination / "processor_config.json").exists():
+            copied.append("processor_config.json")
+    return copied
+
+
+def _verify_strict_load(destination: Path) -> None:
+    # Bypass mtplx.vision.load_vision_tower so the module-level cache never
+    # serves a pre-graft tower for the same path.
+    from mtplx.vision.qwen3_vl_tower import Qwen3VLVisionTower
+
+    Qwen3VLVisionTower.from_model_dir(str(destination))
+
+
+def graft_vision_tower(
+    source: Path | str,
+    destination: Path | str,
+    *,
+    dry_run: bool = False,
+    verify_load: bool = True,
+) -> dict[str, Any]:
+    """Graft the vision tower from ``source`` into ``destination``.
+
+    Idempotent: a destination whose index already resolves a vision prefix
+    is left untouched, and a text-only source is a no-op. Returns a report
+    dict whose ``status`` is one of ``grafted``, ``already-present``,
+    ``no-vision-in-source``, or ``dry-run``.
+    """
+    source = Path(source)
+    destination = Path(destination)
+    report: dict[str, Any] = {
+        "source": str(source),
+        "destination": str(destination),
+        "vision_file": VISION_FILE,
+    }
+
+    # A destination without a (well-formed) weight index cannot register
+    # vision tensors; artifact completeness is enforced elsewhere (forge
+    # verification, _validate_vision_payload), so this is a no-op here.
+    dest_index_path = destination / "model.safetensors.index.json"
+    if not dest_index_path.is_file():
+        report["status"] = "no-destination-index"
+        return report
+    dest_index = _load_json(dest_index_path)
+    dest_weight_map = dest_index.get("weight_map")
+    if not isinstance(dest_weight_map, dict):
+        report["status"] = "no-destination-index"
+        return report
+    if resolve_vision_prefix(dest_weight_map) is not None:
+        report["status"] = "already-present"
+        return report
+
+    source_index_path = source / "model.safetensors.index.json"
+    if not source_index_path.is_file():
+        report["status"] = "no-vision-in-source"
+        return report
+    source_index = _load_json(source_index_path)
+    source_weight_map = source_index.get("weight_map")
+    if not isinstance(source_weight_map, dict):
+        report["status"] = "no-vision-in-source"
+        return report
+    prefix = resolve_vision_prefix(source_weight_map)
+    if prefix is None:
+        report["status"] = "no-vision-in-source"
+        return report
+
+    source_config = _load_json(source / "config.json")
+    source_vision_config = source_config.get("vision_config")
+    if not isinstance(source_vision_config, dict):
+        raise VisionGraftError(
+            f"{source} carries vision tensors but no vision_config; refusing an "
+            "inconsistent graft"
+        )
+    if not (source / "preprocessor_config.json").is_file():
+        raise VisionGraftError(
+            f"{source} has no preprocessor_config.json; the runtime cannot decode "
+            "images without it"
+        )
+
+    tensors = _collect_vision_tensors(source, source_weight_map, prefix)
+    collisions = [key for _, key, _, _ in tensors if key in dest_weight_map]
+    if collisions:
+        raise VisionGraftError(
+            f"destination index already maps {len(collisions)} vision keys "
+            f"(e.g. {collisions[0]})"
+        )
+    vision_bytes = sum(
+        info["data_offsets"][1] - info["data_offsets"][0] for _, _, _, info in tensors
+    )
+    vision_parameters = sum(_tensor_parameters(info) for _, _, _, info in tensors)
+    report.update(
+        {
+            "prefix": prefix,
+            "tensors": len(tensors),
+            "bytes": vision_bytes,
+            "parameters": vision_parameters,
+        }
+    )
+
+    if dry_run:
+        report["status"] = "dry-run"
+        return report
+
+    _write_vision_sidecar(source, tensors, destination / VISION_FILE)
+
+    for _, output_key, _, _ in tensors:
+        dest_weight_map[output_key] = VISION_FILE
+    metadata = dest_index.get("metadata")
+    if isinstance(metadata, dict):
+        if isinstance(metadata.get("total_size"), (int, float)):
+            metadata["total_size"] = int(metadata["total_size"]) + vision_bytes
+        if isinstance(metadata.get("total_parameters"), (int, float)):
+            metadata["total_parameters"] = (
+                int(metadata["total_parameters"]) + vision_parameters
+            )
+    _atomic_write_json(dest_index_path, dest_index)
+
+    config_path = destination / "config.json"
+    config = _load_json(config_path)
+    config["vision_config"] = _normalize_vision_config(source_vision_config)
+    for key in _VISION_TOKEN_ID_KEYS:
+        if key not in config and key in source_config:
+            config[key] = source_config[key]
+    _atomic_write_json(config_path, config)
+
+    report["sidecars"] = _copy_vision_sidecars(source, destination)
+
+    spec = vision_spec_for_model_dir(destination)
+    if spec is None:
+        raise VisionGraftError(
+            f"graft finished but {destination} still resolves no vision spec"
+        )
+    grafted_index = _load_json(dest_index_path)
+    grafted_keys = [
+        key
+        for key, shard in grafted_index["weight_map"].items()
+        if shard == VISION_FILE
+    ]
+    if len(grafted_keys) != len(tensors):
+        raise VisionGraftError(
+            f"index registers {len(grafted_keys)} vision tensors, expected {len(tensors)}"
+        )
+    if verify_load:
+        _verify_strict_load(destination)
+    report["verified"] = {"spec": True, "strict_load": bool(verify_load)}
+    report["status"] = "grafted"
+    return report

--- a/scripts/graft_vision_tower.py
+++ b/scripts/graft_vision_tower.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Restore a dropped vision tower into a forged MTPLX artifact (issue #263).
+
+Copies the vision tensors byte-for-byte from the original multimodal source
+checkpoint into ``model-vision.safetensors``, registers them in the
+destination's ``model.safetensors.index.json``, restores ``vision_config``
+in ``config.json``, and copies the preprocessor sidecars. Language and MTP
+tensors are never touched.
+
+Example:
+    python3 scripts/graft_vision_tower.py \
+        --source ~/.mtplx/models/Qwen--Qwen3.8-27B \
+        --target ~/.mtplx/models/Qwen3.8-27B-MTPLX-Optimized-Speed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mtplx.vision_graft import VisionGraftError, graft_vision_tower  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--source",
+        required=True,
+        type=Path,
+        help="original multimodal checkpoint directory (vision donor)",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        type=Path,
+        help="forged artifact directory to repair",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be grafted without writing anything",
+    )
+    parser.add_argument(
+        "--no-verify-load",
+        action="store_true",
+        help="skip the strict tower load after grafting (saves ~1 GB of RAM)",
+    )
+    args = parser.parse_args()
+
+    try:
+        report = graft_vision_tower(
+            args.source.expanduser(),
+            args.target.expanduser(),
+            dry_run=args.dry_run,
+            verify_load=not args.no_verify_load,
+        )
+    except VisionGraftError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] in ("grafted", "already-present", "dry-run") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pillar_gate_qa.py
+++ b/scripts/pillar_gate_qa.py
@@ -147,6 +147,22 @@ class Client:
 
 
 def gate_vision_cache(client: Client, report: dict[str, Any]) -> bool:
+    # Preflight: a blind artifact (dropped vision tower, issue #263) must fail
+    # this gate loudly with the real cause, not a confusing mid-gate HTTP 400.
+    with urllib.request.urlopen(client.base_url + "/health", timeout=15) as resp:
+        health = json.loads(resp.read())
+    vision_enabled = bool((health.get("vision") or {}).get("enabled"))
+    if not vision_enabled:
+        report["vision_cache"] = {
+            "health_vision_enabled": False,
+            "fail_reason": (
+                "served model reports vision.enabled=false: the artifact has "
+                "no vision tower (issue #263 class of miss)"
+            ),
+            "pass": False,
+        }
+        return False
+
     msgs = build_context(9000)
     r1 = client.chat(msgs, max_tokens=250)
     msgs.append({"role": "assistant", "content": r1["text"] or "(styles)"})

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2409,6 +2409,91 @@ def test_pull_refreshes_when_remote_index_changed(monkeypatch, tmp_path):
     assert hf_loader._local_matches_remote_index(local, "org/repo", None) is True
 
 
+class _FakeHubResponse:
+    def __init__(self, headers: dict, remote_content: bytes):
+        range_header = headers.get("Range")
+        if range_header:
+            offset = int(range_header.split("=")[1].rstrip("-"))
+            self.payload = remote_content[offset:]
+            self.status_code = 206
+        else:
+            self.payload = remote_content
+            self.status_code = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def iter_content(self, chunk_size):
+        yield self.payload
+
+
+def _run_download_repo_file(monkeypatch, destination, remote_content: bytes, filename: str):
+    from mtplx import hf_loader
+
+    seen_headers: list[dict] = []
+
+    def fake_stream(session, url, headers):
+        seen_headers.append(dict(headers))
+        return _FakeHubResponse(headers, remote_content)
+
+    monkeypatch.setattr(hf_loader, "_open_hub_stream", fake_stream)
+    repo_file = hf_loader.RepoFile(path=filename, size_bytes=len(remote_content))
+    hf_loader._download_repo_file(
+        repo_file,
+        repo_id="org/repo",
+        revision=None,
+        destination=destination,
+        session=None,
+        hf_hub_url=lambda repo_id, filename, revision=None: "https://example.invalid/f",
+        build_hf_headers=lambda token=None: {},
+        hf_raise_for_status=lambda response: None,
+        callback=None,
+        total_bytes=None,
+        started_at=0.0,
+        progress_interval_s=3600.0,
+        last_emit_at=0.0,
+        last_emit_size=0,
+    )
+    return seen_headers
+
+
+def test_download_repo_file_discards_stale_complete_file(monkeypatch, tmp_path):
+    # A file that changed upstream (a repaired index/config gaining vision
+    # entries, issue #263) must be re-fetched from scratch. Range-resuming
+    # from the stale *complete* local copy appends the remote tail onto old
+    # content and corrupts the JSON — the upgrade rehearsal caught exactly
+    # this, leaving the local model unloadable.
+    old_content = b'{"old": true}' + b" " * 8
+    new_content = b'{"new": true, "vision": "restored"}' + b" " * 32
+    destination = tmp_path / "model"
+    destination.mkdir()
+    (destination / "config.json").write_bytes(old_content)
+
+    seen = _run_download_repo_file(monkeypatch, destination, new_content, "config.json")
+
+    assert (destination / "config.json").read_bytes() == new_content
+    assert all("Range" not in headers for headers in seen)
+    assert not (destination / "config.json.incomplete").exists()
+
+
+def test_download_repo_file_still_resumes_incomplete_partial(monkeypatch, tmp_path):
+    # Genuine interrupted downloads (*.incomplete staging files) must keep
+    # their byte-range resume.
+    new_content = b'{"new": true, "vision": "restored"}' + b" " * 32
+    destination = tmp_path / "model"
+    destination.mkdir()
+    (destination / "config.json.incomplete").write_bytes(new_content[:11])
+
+    seen = _run_download_repo_file(monkeypatch, destination, new_content, "config.json")
+
+    assert (destination / "config.json").read_bytes() == new_content
+    assert any(headers.get("Range") == "bytes=11-" for headers in seen)
+    assert not (destination / "config.json.incomplete").exists()
+
+
 def test_served_public_ids_resolve_to_first_party_repos():
     """The exact ids /v1/models advertises must resolve for serve/run/pull.
 

--- a/tests/test_compressed_tensors.py
+++ b/tests/test_compressed_tensors.py
@@ -547,3 +547,27 @@ def test_nvfp4_converter_preserves_glm_key_layout(tmp_path):
     assert report["audit"]["passed"] is True
     assert f"{prefix}.weight" in index["weight_map"]
     assert f"language_model.{prefix}.weight" not in index["weight_map"]
+
+
+def test_mlx_key_preserves_vision_tower_prefixes():
+    # The model.visual.* -> vision_tower.* remap is what keeps multimodal
+    # checkpoints sighted through the compressed-tensors lane (issue #263).
+    from mtplx.compressed_tensors import _mlx_key
+
+    assert (
+        _mlx_key("model.visual.blocks.0.attn.qkv.weight")
+        == "vision_tower.blocks.0.attn.qkv.weight"
+    )
+    assert (
+        _mlx_key("model.visual.patch_embed.proj.weight")
+        == "vision_tower.patch_embed.proj.weight"
+    )
+    assert (
+        _mlx_key("vision_tower.merger.linear_fc1.weight")
+        == "vision_tower.merger.linear_fc1.weight"
+    )
+    assert (
+        _mlx_key("model.language_model.layers.0.mlp.gate_proj.weight")
+        == "language_model.model.layers.0.mlp.gate_proj.weight"
+    )
+    assert _mlx_key("lm_head.weight") == "language_model.lm_head.weight"

--- a/tests/test_forge_cli.py
+++ b/tests/test_forge_cli.py
@@ -2211,3 +2211,181 @@ def test_publish_reads_one_token_line_and_keeps_artifacts_secret_free(tmp_path, 
     assert "hf_secret" not in publish_json
     assert "hf_secret" not in runtime_json
     assert json.loads(runtime_json)["forge_provenance"]["published_to_hf"]["repo"] == "owner/Fixture-MTPLX-Speed"
+
+
+def _tiny_vision_config() -> dict:
+    return {
+        "model_type": "qwen3_5",
+        "depth": 1,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_heads": 2,
+        "out_hidden_size": 4,
+        "patch_size": 2,
+        "spatial_merge_size": 2,
+        "temporal_patch_size": 1,
+        "in_channels": 3,
+        "num_position_embeddings": 4,
+        "deepstack_visual_indexes": [],
+    }
+
+
+def _write_multimodal_source(source: Path) -> dict[str, object]:
+    """Synthetic multimodal checkpoint: language + model.visual.* weights.
+
+    The vision weights are dumped from a real (miniature) tower so the
+    graft's strict verification load has an exact key/shape match.
+    """
+    from mlx.utils import tree_flatten
+
+    from mtplx.vision.qwen3_vl_tower import Qwen3VLVisionConfig, Qwen3VLVisionTower
+
+    vision_config = _tiny_vision_config()
+    tower = Qwen3VLVisionTower(Qwen3VLVisionConfig.from_dict(vision_config))
+    tensors: dict[str, object] = {
+        "model.visual." + name: value for name, value in tree_flatten(tower.parameters())
+    }
+    tensors["model.language_model.layers.0.self_attn.q_proj.weight"] = mx.zeros(
+        (2, 2), dtype=mx.bfloat16
+    )
+    _write_json(
+        source / "config.json",
+        {
+            "model_type": "qwen3_5",
+            "vision_config": vision_config,
+            "image_token_id": 248056,
+            "video_token_id": 248057,
+            "vision_start_token_id": 248053,
+            "vision_end_token_id": 248054,
+        },
+    )
+    _write_json(
+        source / "model.safetensors.index.json",
+        {"weight_map": {key: "model.safetensors" for key in tensors}},
+    )
+    mx.save_safetensors(str(source / "model.safetensors"), tensors)
+    _write_json(source / "preprocessor_config.json", {"patch_size": 2, "merge_size": 2})
+    _write_json(source / "video_preprocessor_config.json", {"patch_size": 2})
+    return tensors
+
+
+def _write_text_only_destination(destination: Path) -> None:
+    _write_json(destination / "config.json", {"model_type": "qwen3_5"})
+    _write_json(
+        destination / "model.safetensors.index.json",
+        {
+            "metadata": {"total_size": 8},
+            "weight_map": {
+                "language_model.model.layers.0.self_attn.q_proj.weight": "model-00001-of-00001.safetensors"
+            },
+        },
+    )
+    mx.save_safetensors(
+        str(destination / "model-00001-of-00001.safetensors"),
+        {
+            "language_model.model.layers.0.self_attn.q_proj.weight": mx.zeros(
+                (2, 2), dtype=mx.bfloat16
+            )
+        },
+    )
+
+
+def test_forge_preserves_vision_tower(tmp_path):
+    from mtplx.vision_graft import graft_vision_tower
+
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    source_tensors = _write_multimodal_source(source)
+    _write_text_only_destination(destination)
+
+    forge._ensure_vision_tower(source, destination)
+
+    index = json.loads(
+        (destination / "model.safetensors.index.json").read_text(encoding="utf-8")
+    )
+    vision_keys = [
+        key for key in index["weight_map"] if key.startswith("vision_tower.")
+    ]
+    expected = sum(1 for key in source_tensors if key.startswith("model.visual."))
+    assert len(vision_keys) == expected
+    assert all(
+        index["weight_map"][key] == "model-vision.safetensors" for key in vision_keys
+    )
+    assert index["metadata"]["total_size"] > 8
+
+    config = json.loads((destination / "config.json").read_text(encoding="utf-8"))
+    assert isinstance(config.get("vision_config"), dict)
+    assert config["image_token_id"] == 248056
+    assert (destination / "model-vision.safetensors").exists()
+    assert (destination / "preprocessor_config.json").exists()
+    assert (destination / "video_preprocessor_config.json").exists()
+
+    grafted = mx.load(str(destination / "model-vision.safetensors"))
+    assert sorted(grafted) == sorted(
+        "vision_tower." + key[len("model.visual.") :]
+        for key in source_tensors
+        if key.startswith("model.visual.")
+    )
+
+    # The fail-closed validator must accept the repaired artifact.
+    forge._validate_vision_payload(source, destination)
+
+    # Provenance stamp resolves the grafted tower.
+    stamp = forge._vision_metadata_stamp(destination)
+    assert stamp == {
+        "tensor_count": expected,
+        "prefix": "vision_tower.",
+        "shards": ["model-vision.safetensors"],
+    }
+
+    # Idempotent: a second pass must be a no-op.
+    report = graft_vision_tower(source, destination)
+    assert report["status"] == "already-present"
+
+
+def test_forge_vision_noop_for_text_only_source(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    _write_json(source / "config.json", {"model_type": "qwen3_5"})
+    _write_json(
+        source / "model.safetensors.index.json",
+        {"weight_map": {"model.layers.0.self_attn.q_proj.weight": "model.safetensors"}},
+    )
+    _write_text_only_destination(destination)
+    index_before = (destination / "model.safetensors.index.json").read_text(
+        encoding="utf-8"
+    )
+    config_before = (destination / "config.json").read_text(encoding="utf-8")
+
+    forge._ensure_vision_tower(source, destination)
+    forge._validate_vision_payload(source, destination)
+
+    assert not (destination / "model-vision.safetensors").exists()
+    assert (destination / "model.safetensors.index.json").read_text(
+        encoding="utf-8"
+    ) == index_before
+    assert (destination / "config.json").read_text(encoding="utf-8") == config_before
+    assert forge._vision_metadata_stamp(destination) is None
+
+
+def test_forge_vision_validation_fails_closed_on_blind_artifact(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    # Source declares vision_config, but its index carries no vision tensors,
+    # so the graft cannot restore anything: the build must fail, not ship blind.
+    _write_json(
+        source / "config.json",
+        {"model_type": "qwen3_5", "vision_config": _tiny_vision_config()},
+    )
+    _write_json(
+        source / "model.safetensors.index.json",
+        {"weight_map": {"model.layers.0.self_attn.q_proj.weight": "model.safetensors"}},
+    )
+    _write_text_only_destination(destination)
+
+    forge._ensure_vision_tower(source, destination)
+    with pytest.raises(forge.ForgeError, match="vision"):
+        forge._validate_vision_payload(source, destination)


### PR DESCRIPTION
## Summary

Fixes #263 — `forge build` silently drops the vision tower on the `mlx_lm.convert` lane, which shipped all six Qwen 3.8 repos (and the 3.6 V2 rebuilds) blind.

- **Artifact repair (already live on the Hub):** all six `Youssofal/Qwen3.8-27B-MTPLX-*` repos were re-published on 2026-08-15 with the official bf16 tower grafted back as an index-registered `model-vision.safetensors` (333 tensors, byte-for-byte from `Qwen/Qwen3.8-27B`), restored `vision_config`, and the preprocessor sidecars. One atomic commit per repo; language + MTP tensors untouched. Existing installs sync the delta via `mtplx pull`.
- **Permanent forge fix:** new `mtplx/vision_graft.py` shared core; `_ensure_vision_tower` runs after every convert lane in `forge build`, and `_validate_vision_payload` fails closed when a source that declares `vision_config` would forge blind. Repair CLI: `scripts/graft_vision_tower.py`. Runtime metadata now stamps the vision payload.
- **Pull-corruption fix (found rehearsing the user upgrade):** the structured-progress downloader promoted a size-mismatched *complete* file to a range-resumed partial, appending the remote tail onto stale content — corrupting `config.json` / `model.safetensors.index.json` whenever a repo changed in place. Stale files are now discarded and re-fetched whole; genuine `*.incomplete` partials still resume. **This means ≤2.7.1 CLIs corrupt those two JSONs when pulling the repaired repos (loud failure, recoverable by deleting the two files and re-pulling) — a 2.7.2 cut with this fix should ship promptly.**
- **Gates:** pillar gate asserts `/health` `vision.enabled` before `gate_vision_cache`; forge regression tests (graft, no-op for text-only, fail-closed on blind artifact), `_mlx_key` vision-prefix unit test, and two downloader tests (stale-complete re-fetch, `.incomplete` resume).
- **Catalog:** the six Qwen 3.8 `size_bytes` (Python catalog + Swift mirror + diagnostics default) now match the post-repair Hub byte sums.

## Verification

- Graft self-verifies: `vision_spec_for_model_dir` + strict tower load; all six builds carry the identical `model-vision.safetensors` (sha256 `964bef26…`).
- Optimized Speed: `/health` `vision.enabled: true` + `generation_mode: mtp`; real image round-trip described a synthetic test image exactly; `pillar_gate_qa.py` vision_cache gate passed (14,596/15,589 tokens cached post-image, alias bar enforced); text regression clean. Desktop app QA via Computer Use: paperclip offered images, attached PNG answered correctly at 45 tok/s.
- Other five builds: health + image round-trip each (all PASS, bf16 tower on FP16 siblings confirmed working).
- Upgrade rehearsal: stale pre-repair install → `mtplx pull` (fixed CLI) fetched only the delta in 32 s and produced byte-identical files to the publisher copies; fresh 21.3 GB download also verified.
- `tests/test_forge_cli.py`, `test_compressed_tensors.py`, `test_vision_tower.py`, `test_artifacts.py`, `test_vision_session_cache.py`, `test_vision_restore_span_guard.py`, `test_model_catalog.py`, `test_metal_memory_caps.py` all green.

## Follow-ups

- Cut v2.7.2 so users pull the repaired repos with the fixed downloader (`docs/releases/v2.7.2.md` required by `release_macos_v1.sh`).
- The 3.6 V2 pair (`Optimized-Speed-V2` / `-Quality-V2`) is still blind; `scripts/graft_vision_tower.py` applies as-is.