### PR TITLE
Fix markdown-table <br> cell overflow

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Chat/Primitives/AssistantMarkdownView.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Chat/Primitives/AssistantMarkdownView.swift
@@ -511,12 +511,26 @@ private struct AssistantTableView: View {
     }
 
     private static func inline(_ text: String) -> AttributedString {
-        (try? AttributedString(
-            markdown: text,
+        // Models (notably thinking-mode) emit <br> for in-cell line breaks in
+        // markdown tables. cmark hands raw HTML back as literal tag text, so
+        // the cell would render "<br>" verbatim AND keep the whole cell as one
+        // unbreakable token that overflows the fixed column frame into its
+        // neighbour (the "pile of overlapping text"). Convert <br> variants to
+        // real newlines at this single choke point so cells wrap. Comparison
+        // operators ("a < b") are untouched: the pattern requires "br".
+        // ponytail: <br> only — other raw tags (<b>, <span>) would still show
+        // raw; strip-all mangles "<"/">", add a tag allowlist if they appear.
+        let readable = text.replacingOccurrences(
+            of: #"<br\s*/?>"#,
+            with: "\n",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        return (try? AttributedString(
+            markdown: readable,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .inlineOnlyPreservingWhitespace
             )
-        )) ?? AttributedString(text)
+        )) ?? AttributedString(readable)
     }
 }
 


### PR DESCRIPTION
Fixes #272.

*(This PR originally also carried an unrelated Profile sampling-presets feature. That has been dropped — this PR is now the bug fix alone. The branch name is a leftover from that earlier scope.)*

## Bug: markdown-table `<br>` cell overflow

Models (notably thinking-mode) emit `<br>` for in-cell line breaks in markdown tables. `AssistantMarkdownView.inline(_:)` hands the raw cell substring to Foundation's `AttributedString(markdown:)`, which returns raw-HTML nodes as **literal tag text** — so the cell rendered `<br>` verbatim *and* kept the whole cell as one unbreakable token that overflowed the fixed column frame into its neighbour (the "pile of overlapping text").

Both symptoms trace to that one mechanism in one function — the single choke point every table cell routes through.

## Fix

Normalize `<br>` variants to real newlines at that choke point, before markdown attribution, so cells wrap:

```swift
let readable = text.replacingOccurrences(
    of: #"<br\s*/?>"#,
    with: "\n",
    options: [.regularExpression, .caseInsensitive]
)
```

Comparison operators (`a < b`) are untouched — the pattern requires the literal `br`.

**Known ceiling, marked with a deliberate `ponytail:` comment:** other raw tags (`<b>`, `<span>`) would still render raw. A blanket tag-strip was rejected because it mangles bare `<`/`>` (verified: `a < b and c > d` → `a  d`). If those tags show up in practice, the follow-up is a tag allowlist at the same choke point.

## Proof

- Verified before/after against the real `AttributedString(markdown:)` API:
  - before: `"foo<br>bar<br>baz"` → `"foo<br>bar<br>baz"` (one unbreakable line, literal tags)
  - after: `"foo<br>bar<br>baz"` → `"foo\nbar\nbaz"` (three wrappable lines, no tags)
- `swift build` clean on this branch, no new warnings in the touched file.
- `swift test`: 574 tests, 0 failures. (A timing-sensitive daemon-supervisor test in `MTPLXAppCore` flakes under the full run on this machine but passes in isolation, with and without this change; it is unreachable from this view-only diff.)
