### PR TITLE
fix(forge): honor quantize:false module overrides

### DIFF
--- a/mtplx/commands/forge_mixed_convert.py
+++ b/mtplx/commands/forge_mixed_convert.py
@@ -10,7 +10,9 @@ params (``True`` from the predicate).
 
 The predicate is called by ``mlx_lm.utils.quantize_model`` with
 ``(path, module)``; returning a dict routes those params to ``to_quantized``
-and records the per-module entry in ``config["quantization"]``.
+and records the per-module entry in ``config["quantization"]``. An override
+with ``"quantize": false`` returns ``False`` so sensitive modules remain in
+their source precision.
 """
 
 from __future__ import annotations
@@ -18,7 +20,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from typing import Any, Callable
 
 _LAYER_INDEX_RE = re.compile(r"\.layers\.(\d+)\.")
@@ -26,7 +27,9 @@ _LAYER_INDEX_RE = re.compile(r"\.layers\.(\d+)\.")
 
 def build_predicate(recipe: dict[str, Any]) -> Callable[[str, Any], bool | dict[str, Any]]:
     body_mode = str(recipe.get("body_mode") or "affine")
-    overrides: list[tuple[str, frozenset[int] | None, dict[str, Any]]] = []
+    overrides: list[
+        tuple[str, frozenset[int] | None, bool | dict[str, Any]]
+    ] = []
     for entry in recipe.get("module_overrides") or []:
         if not isinstance(entry, dict):
             raise SystemExit("module_overrides entries must be objects")
@@ -37,11 +40,15 @@ def build_predicate(recipe: dict[str, Any]) -> Callable[[str, Any], bool | dict[
         layer_set = (
             frozenset(int(index) for index in raw_layers) if raw_layers is not None else None
         )
-        params = {
-            "bits": int(entry.get("bits") or 8),
-            "group_size": int(entry.get("group_size") or 64),
-            "mode": str(entry.get("mode") or body_mode),
-        }
+        params: bool | dict[str, Any]
+        if entry.get("quantize") is False:
+            params = False
+        else:
+            params = {
+                "bits": int(entry.get("bits") or 8),
+                "group_size": int(entry.get("group_size") or 64),
+                "mode": str(entry.get("mode") or body_mode),
+            }
         overrides.append((suffix, layer_set, params))
 
     def predicate(path: str, module: Any) -> bool | dict[str, Any]:
@@ -53,7 +60,7 @@ def build_predicate(recipe: dict[str, Any]) -> Callable[[str, Any], bool | dict[
                 match = _LAYER_INDEX_RE.search(path)
                 if match is None or int(match.group(1)) not in layer_set:
                     continue
-            return dict(params)
+            return dict(params) if isinstance(params, dict) else params
         return True
 
     return predicate

--- a/tests/test_forge_mixed_convert.py
+++ b/tests/test_forge_mixed_convert.py
@@ -46,6 +46,24 @@ def test_predicate_unmatched_module_uses_body() -> None:
     assert predicate("language_model.model.layers.5.self_attn.q_proj", None) is True
 
 
+def test_predicate_quantize_false_preserves_source_precision() -> None:
+    recipe = {
+        "body_mode": "affine",
+        "module_overrides": [
+            {
+                "suffix": "linear_attn.in_proj_a",
+                "quantize": False,
+            }
+        ],
+    }
+    predicate = build_predicate(recipe)
+    assert (
+        predicate("language_model.model.layers.5.linear_attn.in_proj_a", None)
+        is False
+    )
+    assert predicate("language_model.model.layers.5.mlp.gate_proj", None) is True
+
+
 def test_predicate_prefix_agnostic() -> None:
     predicate = build_predicate(SPEED_RECIPE)
     assert predicate("model.layers.3.linear_attn.out_proj", None) == {


### PR DESCRIPTION
## Summary

Forge's mixed-precision converter currently turns every matching `module_overrides` entry into a quantization-parameter dictionary. An entry such as:

```json
{"suffix": "linear_attn.in_proj_a", "quantize": false}
```

therefore ignores the exclusion and silently falls through to the default 8-bit override values.

This change makes `build_predicate` return the literal `False` value expected by `mlx_lm.utils.quantize_model` when a matching override explicitly sets `"quantize": false`. The matched module stays at source precision; ordinary mixed-precision overrides, layer filtering, first-match precedence, and body fallback behavior are unchanged.

The converter docstring now records the exclusion contract, and the regression test verifies both the excluded path and an unmatched body path.

## Why this matters

Hybrid recipes use source-precision exclusions for numerically sensitive projections while quantizing the rest of the trunk. Before this fix, those recipes completed without an error but produced q8 tensors for the modules that were intended to remain BF16, changing both model size and the requested quality/performance tradeoff.

## Verification

- `uv run --frozen --extra dev ruff check mtplx/commands/forge_mixed_convert.py tests/test_forge_mixed_convert.py` — passed
- `uv run --frozen --extra dev pytest -q tests/test_forge_mixed_convert.py` — 10 passed
- `MTPLX_CONFIG=<isolated-empty-path> uv run --frozen --extra dev pytest -q tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py` — 268 passed
- `uv run --frozen --extra dev python -m build` — sdist and wheel built
- `scripts/hygiene_scan.sh` — passed
- `scripts/fresh_venv_smoke.sh` — passed

A real Qwen 3.8 27B conversion was also structurally inspected: all 96 requested recurrent-projection exclusions remained BF16, none gained quantization scale/bias tensors or quantization-config entries, and the other 234 mixed-precision overrides were still applied.
