### PR TITLE
Fix Gemma 4 session cache across rewritten conversation turns

### DIFF
--- a/mtplx/backends/gemma4_assistant.py
+++ b/mtplx/backends/gemma4_assistant.py
@@ -2523,6 +2523,23 @@ def _gemma4_prefill_prompt(
     )
 
 
+def _clone_gemma4_prompt_cache(
+    runtime: Gemma4AssistantRuntime,
+    cache: list[Any],
+) -> list[Any]:
+    """Retain the pre-decode cache before sliding layers evict its history."""
+
+    from mtplx.cache_state import restore_cache, snapshot_cache_lazy_hybrid
+
+    clone = runtime.make_cache()
+    restore_cache(
+        clone,
+        snapshot_cache_lazy_hybrid(cache),
+        clone_states=False,
+    )
+    return clone
+
+
 def _restore_or_prefill_gemma4_prompt(
     runtime: Gemma4AssistantRuntime,
     prompt_ids: list[int],
@@ -2575,6 +2592,99 @@ def _restore_or_prefill_gemma4_prompt(
         policy_fingerprint=session_policy_fingerprint,
     )
     if restored is None:
+        candidates = getattr(session_bank, "near_prefix_candidates", None)
+        restore_prefix = getattr(session_bank, "restore_entry_prefix_cache", None)
+        if callable(candidates) and callable(restore_prefix):
+            try:
+                near_matches = candidates(
+                    prompt_ids,
+                    model_path=str(runtime.model_path),
+                    mtp_enabled=bool(runtime.mtp_enabled),
+                    hidden_variant="gemma4_pre_norm",
+                    template_hash=session_template_hash,
+                    mtp_history_policy=GEMMA4_SESSION_STATE_POLICY,
+                    draft_head_identity=session_draft_head_identity,
+                    policy_fingerprint=session_policy_fingerprint,
+                )
+            except Exception:
+                near_matches = []
+            for entry, matched in near_matches:
+                matched = int(matched)
+                if (
+                    matched < 2
+                    or matched >= int(getattr(entry, "prefix_len", 0) or 0)
+                    or matched >= len(prompt_ids)
+                    or str(getattr(entry, "model_path", ""))
+                    != str(runtime.model_path)
+                    or bool(getattr(entry, "mtp_enabled", False))
+                    != bool(runtime.mtp_enabled)
+                    or getattr(entry, "hidden_variant", None) != "gemma4_pre_norm"
+                    or (
+                        session_template_hash is not None
+                        and getattr(entry, "template_hash", None)
+                        != session_template_hash
+                    )
+                    or getattr(entry, "mtp_history_policy", None)
+                    != GEMMA4_SESSION_STATE_POLICY
+                    or (
+                        session_draft_head_identity is not None
+                        and getattr(entry, "draft_head_identity", None)
+                        != session_draft_head_identity
+                    )
+                    or (
+                        session_policy_fingerprint is not None
+                        and getattr(entry, "policy_fingerprint", None)
+                        != session_policy_fingerprint
+                    )
+                ):
+                    continue
+                try:
+                    prefix_restore = restore_prefix(
+                        runtime,
+                        entry,
+                        matched,
+                        mode=session_restore_mode,
+                        full_boundary=True,
+                    )
+                except Exception:
+                    prefix_restore = None
+                if prefix_restore is None:
+                    continue
+                boundary_hidden = None
+                if len(prefix_restore) == 5:
+                    cache, _history, storage_mode, restore_point, boundary_hidden = (
+                        prefix_restore
+                    )
+                elif len(prefix_restore) == 4:
+                    cache, _history, storage_mode, restore_point = prefix_restore
+                else:
+                    cache, _history, storage_mode = prefix_restore
+                    restore_point = matched
+                restore_point = int(restore_point)
+                prefill_start = restore_point
+                if prefill_start < 0 or prefill_start >= len(prompt_ids):
+                    continue
+                output, _suffix_elapsed = _gemma4_prefill_prompt(
+                    runtime,
+                    list(prompt_ids[prefill_start:]),
+                    cache=cache,
+                    phase="prefill",
+                )
+                entry.hits += 1
+                entry.last_access_s = time.time()
+                return Gemma4PromptState(
+                    cache=cache,
+                    logits=output.logits[:, -1, :],
+                    hidden=output.hidden[:, -1:, :],
+                    shared_kv_states=output.shared_kv_states,
+                    kv_offset=int(output.cache_offset),
+                    prompt_eval_time_s=time.perf_counter() - started,
+                    cached_tokens=restore_point,
+                    suffix_tokens=len(prompt_ids) - restore_point,
+                    cache_hit=True,
+                    cache_miss_reason=None,
+                    restore_mode=f"block_prefix_{storage_mode}",
+                )
         return cold_prefill(getattr(session_bank, "last_miss_reason", None))
 
     suffix = list(prompt_ids[restored.entry.prefix_len :])
@@ -2715,6 +2825,13 @@ def generate_gemma4_ar(
         except Exception:
             pass
     cache = prompt_state.cache
+    prompt_boundary_cache = (
+        _clone_gemma4_prompt_cache(runtime, cache) if capture_final_state else None
+    )
+    prompt_boundary_extra_state = _gemma4_session_extra_state(
+        shared_kv_states=prompt_state.shared_kv_states,
+        kv_offset=int(prompt_state.kv_offset),
+    )
     logits = prompt_state.logits
     hidden = prompt_state.hidden
     shared_kv_states = prompt_state.shared_kv_states
@@ -2806,6 +2923,10 @@ def generate_gemma4_ar(
             safe_to_commit=not pending_token_needs_commit,
             finish_reason=finish_reason,
             extra_state=extra_state,
+            prompt_boundary_cache=prompt_boundary_cache,
+            prompt_boundary_logits=prompt_state.logits,
+            prompt_boundary_hidden=prompt_state.hidden,
+            prompt_boundary_extra_state=prompt_boundary_extra_state,
         )
     stats = GenerationStats(
         mode="ar",
@@ -2959,6 +3080,13 @@ def generate_gemma4_assistant(
         except Exception:
             pass
     cache = prompt_state.cache
+    prompt_boundary_cache = (
+        _clone_gemma4_prompt_cache(runtime, cache) if capture_final_state else None
+    )
+    prompt_boundary_extra_state = _gemma4_session_extra_state(
+        shared_kv_states=prompt_state.shared_kv_states,
+        kv_offset=int(prompt_state.kv_offset),
+    )
 
     tokens: list[int] = []
     stats_depth = max_block_size if adaptive_draft else block_size
@@ -3332,6 +3460,10 @@ def generate_gemma4_assistant(
                 shared_kv_states=shared_kv_states,
                 kv_offset=int(kv_offset),
             ),
+            prompt_boundary_cache=prompt_boundary_cache,
+            prompt_boundary_logits=prompt_state.logits,
+            prompt_boundary_hidden=prompt_state.hidden,
+            prompt_boundary_extra_state=prompt_boundary_extra_state,
         )
     return GenerationOutput(
         tokens=tokens,

--- a/mtplx/chat_encoding.py
+++ b/mtplx/chat_encoding.py
@@ -230,6 +230,14 @@ def encode_gemma4_messages(
         if role == "assistant":
             role = "model"
             content = strip_gemma4_thinking_text(content)
+            reasoning = _content_to_text(
+                item.get("reasoning_content") or item.get("reasoning")
+            )
+            if enable_thinking and reasoning:
+                content = (
+                    f"{GEMMA4_THINK_OPEN}{GEMMA4_THOUGHT_PREFIX}"
+                    f"{reasoning}{GEMMA4_THINK_CLOSE}{content}"
+                )
             tool_call_text = _gemma4_tool_calls_text(item.get("tool_calls"))
             if tool_call_text:
                 content = (

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -2466,6 +2466,12 @@ class GenerationFinalState:
     mtp_history_window_tokens: int = 0
     mtp_history_position_base: int = 0
     extra_state: dict[str, Any] | None = None
+    # Optional pre-decode state for backends whose rolling cache cannot safely
+    # reconstruct an earlier prompt boundary from the generated tail.
+    prompt_boundary_cache: list[Any] | None = None
+    prompt_boundary_logits: Any | None = None
+    prompt_boundary_hidden: Any | None = None
+    prompt_boundary_extra_state: dict[str, Any] | None = None
 
 
 def _finish_reason_from_tokens(

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -12078,6 +12078,10 @@ _COMMITTED_TURN_OPEN = "<|im_start|>assistant\n"
 _COMMITTED_TURN_CLOSE = "<|im_end|>"
 _COMMITTED_THINK_OPEN = "<think>\n"
 _COMMITTED_THINK_CLOSE = "</think>"
+_COMMITTED_GEMMA4_TURN_OPEN = "<|turn>model\n"
+_COMMITTED_GEMMA4_TURN_CLOSE = "<turn|>"
+_COMMITTED_GEMMA4_THINK_OPEN = "<|channel>thought\n"
+_COMMITTED_GEMMA4_THINK_CLOSE = "<channel|>"
 
 
 def _committed_reasoning_canonicalization_enabled() -> bool:
@@ -12109,16 +12113,25 @@ def _committed_assistant_turns(
     calls (identical visible text, different call → the committed reasoning
     argues for the OLD call and must not be substituted). Parsing is
     marker-based on the same template specials the boundary helpers above
-    rely on.
+    rely on. Gemma 4 uses model turns and native channel markers instead of
+    ChatML assistant turns and ``<think>`` tags; both shapes reduce to this
+    same positional representation.
     """
+    gemma4 = _COMMITTED_GEMMA4_TURN_OPEN in committed_text
+    turn_open = _COMMITTED_GEMMA4_TURN_OPEN if gemma4 else _COMMITTED_TURN_OPEN
+    turn_close = _COMMITTED_GEMMA4_TURN_CLOSE if gemma4 else _COMMITTED_TURN_CLOSE
+    think_open = _COMMITTED_GEMMA4_THINK_OPEN if gemma4 else _COMMITTED_THINK_OPEN
+    think_close = (
+        _COMMITTED_GEMMA4_THINK_CLOSE if gemma4 else _COMMITTED_THINK_CLOSE
+    )
     turns: list[tuple[str | None, str, str]] = []
     search_from = 0
     while True:
-        turn_at = committed_text.find(_COMMITTED_TURN_OPEN, search_from)
+        turn_at = committed_text.find(turn_open, search_from)
         if turn_at < 0:
             break
-        body_start = turn_at + len(_COMMITTED_TURN_OPEN)
-        turn_end = committed_text.find(_COMMITTED_TURN_CLOSE, body_start)
+        body_start = turn_at + len(turn_open)
+        turn_end = committed_text.find(turn_close, body_start)
         body = (
             committed_text[body_start:turn_end]
             if turn_end >= 0
@@ -12126,15 +12139,20 @@ def _committed_assistant_turns(
         )
         think_interior: str | None = None
         content_part = body
-        if body.startswith(_COMMITTED_THINK_OPEN):
-            close_at = body.find(_COMMITTED_THINK_CLOSE, len(_COMMITTED_THINK_OPEN))
+        if body.startswith(think_open):
+            close_at = body.find(think_close, len(think_open))
             if close_at >= 0:
-                interior = body[len(_COMMITTED_THINK_OPEN) : close_at]
+                interior = body[len(think_open) : close_at]
                 # The template re-renders '<think>\n' + rc|trim + '\n</think>':
                 # a generated interior of the shape '{rc}\n' round-trips
                 # byte-exactly with rc stripped of the single trailing newline.
-                think_interior = interior[:-1] if interior.endswith("\n") else interior
-                content_part = body[close_at + len(_COMMITTED_THINK_CLOSE) :]
+                if gemma4:
+                    think_interior = interior
+                else:
+                    think_interior = (
+                        interior[:-1] if interior.endswith("\n") else interior
+                    )
+                content_part = body[close_at + len(think_close) :]
         markup_at = content_part.find("<tool_call")
         if markup_at >= 0:
             gate = content_part[:markup_at].strip()
@@ -12916,10 +12934,17 @@ def _encode_messages_uncached(
     # turn from scratch). Committed-think substitution still overwrites covered
     # turns inside _message_to_template_dict, so KV-exact bytes win wherever
     # they exist. Thinking-off and strip keep their pinned legacy renders.
-    include_reasoning = scoped_reasoning_history or (
-        preserve_reasoning_history
-        and enable_thinking
-        and not strip_assistant_reasoning_history
+    gemma4_encoding = is_gemma4_tokenizer(tokenizer)
+    include_reasoning = (
+        scoped_reasoning_history
+        or (
+            preserve_reasoning_history
+            and enable_thinking
+            and not strip_assistant_reasoning_history
+        )
+        # Gemma 4's direct encoder needs the echoed reasoning to reproduce the
+        # committed token stream even when the general preserve mode is off.
+        or (gemma4_encoding and not strip_assistant_reasoning_history)
     )
     prepared_messages: list[dict[str, Any]] = []
     for message in messages:
@@ -12962,7 +12987,7 @@ def _encode_messages_uncached(
             template_observability["native_agent_tail_contract_active"] = bool(
                 native_tail_added
             )
-    if is_gemma4_tokenizer(tokenizer):
+    if gemma4_encoding:
         if template_observability is not None:
             template_observability["backend_chat_encoding"] = "gemma4"
         native_tools = (
@@ -19749,12 +19774,6 @@ def _generation_final_postcommit_compatibility(
             "mode": "unsafe",
             "reason": "stats_footer_in_assistant_history",
         }
-    if _reasoning_parser_for_state(state) == "gemma4" and thinking_enabled:
-        return {
-            "safe": False,
-            "mode": "unsafe",
-            "reason": "gemma4_reasoning_history_retokenize",
-        }
     final_state = generated.get("_final_state")
     if final_state is None:
         return {
@@ -19861,6 +19880,96 @@ def _generation_final_postcommit_compatibility(
     }
 
 
+def _generation_final_bank_metadata(
+    state: ServerState,
+    final_state: Any,
+    *,
+    token_count: int,
+) -> dict[str, Any]:
+    backend_id = str(
+        getattr(getattr(state, "backend_descriptor", None), "backend_id", "")
+        or getattr(getattr(state, "runtime", None), "backend_id", "")
+    )
+    if backend_id == GEMMA4_BACKEND:
+        return {
+            "hidden_variant": "gemma4_pre_norm",
+            "mtp_history_policy": "assistant_shared_kv",
+            "mtp_history_snapshot": None,
+            "mtp_snapshot_epoch": None,
+        }
+    mtp_snapshot = (
+        snapshot_cache(final_state.final_committed_mtp_cache)
+        if final_state.final_committed_mtp_cache is not None
+        else None
+    )
+    return {
+        "hidden_variant": "post_norm",
+        "mtp_history_policy": "committed",
+        "mtp_history_snapshot": mtp_snapshot,
+        "mtp_snapshot_epoch": token_count if mtp_snapshot is not None else None,
+    }
+
+
+def _generation_final_prompt_boundary_available(
+    state: ServerState,
+    final_state: Any,
+) -> bool:
+    backend_id = str(
+        getattr(getattr(state, "backend_descriptor", None), "backend_id", "")
+        or getattr(getattr(state, "runtime", None), "backend_id", "")
+    )
+    return bool(
+        backend_id == GEMMA4_BACKEND
+        and getattr(final_state, "prompt_boundary_cache", None) is not None
+        and getattr(final_state, "prompt_boundary_logits", None) is not None
+        and getattr(final_state, "prompt_boundary_hidden", None) is not None
+        and isinstance(
+            getattr(final_state, "prompt_boundary_extra_state", None),
+            dict,
+        )
+    )
+
+
+def _generation_final_bank_commit_safe(state: ServerState, final_state: Any) -> bool:
+    return bool(
+        getattr(final_state, "safe_to_commit", False)
+        or _generation_final_prompt_boundary_available(state, final_state)
+    )
+
+
+def _generation_final_bank_values(
+    state: ServerState,
+    final_state: Any,
+    *,
+    prompt_ids: Sequence[int],
+    final_token_ids: Sequence[int],
+) -> dict[str, Any]:
+    backend_id = str(
+        getattr(getattr(state, "backend_descriptor", None), "backend_id", "")
+        or getattr(getattr(state, "runtime", None), "backend_id", "")
+    )
+    prompt_cache = getattr(final_state, "prompt_boundary_cache", None)
+    if backend_id == GEMMA4_BACKEND and prompt_cache is not None:
+        return {
+            "token_ids": [int(token) for token in prompt_ids],
+            "cache": prompt_cache,
+            "logits": getattr(final_state, "prompt_boundary_logits", None),
+            "hidden": getattr(final_state, "prompt_boundary_hidden", None),
+            "extra_state": getattr(
+                final_state,
+                "prompt_boundary_extra_state",
+                None,
+            ),
+        }
+    return {
+        "token_ids": [int(token) for token in final_token_ids],
+        "cache": final_state.final_trunk_cache,
+        "logits": final_state.final_logits,
+        "hidden": final_state.final_hidden,
+        "extra_state": getattr(final_state, "extra_state", None),
+    }
+
+
 def _store_generation_final_history_snapshot(
     state: ServerState,
     *,
@@ -19906,15 +20015,25 @@ def _store_generation_final_history_snapshot(
         strip_tool_call_preamble_text=strip_tool_call_preamble_text,
         session=session,
     )
-    if not bool(compatibility.get("safe")):
+    final_state = generated.get("_final_state")
+    prompt_boundary_safe = bool(
+        final_state is not None
+        and _generation_final_prompt_boundary_available(state, final_state)
+    )
+    if not bool(compatibility.get("safe")) and not prompt_boundary_safe:
         return {
             "stored": False,
             "mode": compatibility.get("mode", "unsafe"),
             "reason": compatibility.get("reason", "unsafe_history"),
             "elapsed_s": time.perf_counter() - started,
         }
-    final_state = generated["_final_state"]
-    token_ids = [int(token) for token in compatibility["token_ids"]]
+    bank_values = _generation_final_bank_values(
+        state,
+        final_state,
+        prompt_ids=prompt_ids,
+        final_token_ids=compatibility.get("token_ids") or prompt_ids,
+    )
+    token_ids = bank_values.pop("token_ids")
     acquired = state.lock.acquire(blocking=False)
     if not acquired:
         return {
@@ -19924,28 +20043,22 @@ def _store_generation_final_history_snapshot(
             "elapsed_s": time.perf_counter() - started,
         }
     try:
-        mtp_snapshot = (
-            snapshot_cache(final_state.final_committed_mtp_cache)
-            if final_state.final_committed_mtp_cache is not None
-            else None
+        bank_metadata = _generation_final_bank_metadata(
+            state,
+            final_state,
+            token_count=len(token_ids),
         )
         entry = state.sessions.bank.put(
             runtime=state.runtime,
             token_ids=token_ids,
-            cache=final_state.final_trunk_cache,
-            logits=final_state.final_logits,
-            hidden=final_state.final_hidden,
-            hidden_variant="post_norm",
             keep_live_ref=bool(keep_live_ref),
             session_id=session_id,
             template_hash=state.template_hash,
-            mtp_history_policy="committed",
             draft_head_identity=state.draft_head_identity,
             policy_fingerprint=policy_fingerprint,
-            mtp_history_snapshot=mtp_snapshot,
             snapshot_epoch=len(token_ids),
-            mtp_snapshot_epoch=len(token_ids) if mtp_snapshot is not None else None,
-            extra_state=getattr(final_state, "extra_state", None),
+            **bank_values,
+            **bank_metadata,
         )
     finally:
         state.lock.release()
@@ -19958,12 +20071,28 @@ def _store_generation_final_history_snapshot(
         }
     return {
         "stored": True,
-        "mode": compatibility["mode"],
-        "reason": compatibility["reason"],
+        "mode": (
+            "generation_prompt_boundary"
+            if prompt_boundary_safe
+            else compatibility["mode"]
+        ),
+        "reason": (
+            (
+                "prompt_boundary_retained"
+                if compatibility.get("safe")
+                else "prompt_boundary_before_unsafe_history"
+            )
+            if prompt_boundary_safe
+            else compatibility["reason"]
+        ),
         "prefix_len": entry.prefix_len,
         "nbytes": entry.nbytes,
         "elapsed_s": time.perf_counter() - started,
-        "history_suffix_tokens": int(compatibility.get("history_suffix_tokens") or 0),
+        "history_suffix_tokens": (
+            0
+            if prompt_boundary_safe
+            else int(compatibility.get("history_suffix_tokens") or 0)
+        ),
         "token_hash": entry.token_hash,
     }
 
@@ -22651,34 +22780,33 @@ def _run_generation(
             and session_bank is not None
             and session_id is not None
             and final_state is not None
-            and final_state.safe_to_commit
+            and _generation_final_bank_commit_safe(state, final_state)
             and final_commit_prompt_ids is not None
         ):
             final_token_ids = list(final_commit_prompt_ids) + list(out.tokens)
-            mtp_snapshot = (
-                snapshot_cache(final_state.final_committed_mtp_cache)
-                if final_state.final_committed_mtp_cache is not None
-                else None
+            bank_values = _generation_final_bank_values(
+                state,
+                final_state,
+                prompt_ids=final_commit_prompt_ids,
+                final_token_ids=final_token_ids,
+            )
+            bank_token_ids = bank_values.pop("token_ids")
+            bank_metadata = _generation_final_bank_metadata(
+                state,
+                final_state,
+                token_count=len(bank_token_ids),
             )
             session_bank.put(
                 runtime=state.runtime,
-                token_ids=final_token_ids,
-                cache=final_state.final_trunk_cache,
-                logits=final_state.final_logits,
-                hidden=final_state.final_hidden,
-                hidden_variant="post_norm",
+                token_ids=bank_token_ids,
                 keep_live_ref=bool(session_keep_live_ref),
                 session_id=session_id,
                 template_hash=session_template_hash,
-                mtp_history_policy="committed",
                 draft_head_identity=session_draft_head_identity,
                 policy_fingerprint=session_policy_fingerprint,
-                mtp_history_snapshot=mtp_snapshot,
-                snapshot_epoch=len(final_token_ids),
-                mtp_snapshot_epoch=len(final_token_ids)
-                if mtp_snapshot is not None
-                else None,
-                extra_state=getattr(final_state, "extra_state", None),
+                snapshot_epoch=len(bank_token_ids),
+                **bank_values,
+                **bank_metadata,
             )
             stats["sessionbank_snapshot_bytes"] = int(
                 getattr(session_bank, "last_put_nbytes", 0) or 0
@@ -29267,6 +29395,24 @@ def create_app(state: ServerState) -> FastAPI:
                 strip_tool_call_preamble_text=opencode_client,
                 session=session,
             )
+            final_state = generated.get("_final_state")
+            if final_state is not None and _generation_final_prompt_boundary_available(
+                state,
+                final_state,
+            ):
+                generated["stats"]["session_postcommit_snapshot"] = {
+                    "stored": True,
+                    "mode": "generation_prompt_boundary",
+                    "reason": (
+                        "prompt_boundary_retained"
+                        if compatibility.get("safe")
+                        else "prompt_boundary_before_unsafe_history"
+                    ),
+                    "prefix_len": len(prompt_ids),
+                    "elapsed_s": time.perf_counter() - started,
+                    "history_suffix_tokens": 0,
+                }
+                return
             if compatibility.get("safe"):
                 generated["stats"]["session_postcommit_snapshot"] = {
                     "stored": True,

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -1468,6 +1468,7 @@ class SessionBank:
         cache_factory: Callable[[], list[Any]] | None = None,
         mtp_cache_factory: Callable[[], list[Any]] | None = None,
         served_out: dict[str, Any] | None = None,
+        full_boundary: bool = False,
     ) -> tuple[list[Any], list[Any] | None, str] | None:
         """Restore a cached entry to an earlier safe prefix boundary.
 
@@ -1533,13 +1534,12 @@ class SessionBank:
 
         actual_restore_mode = "clone"
         mtp_history_trim_tokens = max(0, int(entry.prefix_len) - restore_point)
-        # Boundary restores land the KV at the full boundary (no seed forward
-        # will run — it would advance recurrent state past the captured
-        # boundary a second time). Non-boundary restores keep the seed-forward
+        # Boundary restores and callers with complete attention-only state land
+        # the KV at the full boundary. Other consumers keep the seed-forward
         # slot semantics.
         trim_to_target = (
             (lambda c: _trim_cache_ref_to_tokens(c, restore_point))
-            if boundary_snapshot is not None
+            if boundary_snapshot is not None or full_boundary
             else (lambda c: _trim_cache_ref_to_prefix(c, restore_point))
         )
         # Passive-probe maintenance splits: CPU-side perf_counter spans only,

--- a/tests/test_gemma4_session_cache.py
+++ b/tests/test_gemma4_session_cache.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from types import SimpleNamespace
+
+import mtplx.backends.gemma4_assistant as gemma4
+from mtplx.backends.descriptors import descriptor_for_backend_id
+from mtplx.server import openai
+from mtplx.session_bank import SessionBank
+
+
+class _GemmaTokenizer:
+    bos_token = "<bos>"
+    model_specific_special_tokens = {
+        "think_token": "<|think|>",
+        "soc_token": "<|channel>",
+        "eoc_token": "<channel|>",
+    }
+
+    def encode(self, text, **_kwargs):
+        return [ord(char) for char in str(text)]
+
+    def decode(self, token_ids, **_kwargs):
+        return "".join(chr(int(token)) for token in token_ids)
+
+
+class _RecordingBank:
+    def __init__(self) -> None:
+        self.puts: list[dict] = []
+
+    def put(self, **kwargs):
+        self.puts.append(kwargs)
+        return SimpleNamespace(
+            prefix_len=len(kwargs["token_ids"]),
+            nbytes=123,
+            token_hash="gemma4-test-prefix",
+        )
+
+
+def _postcommit_state(tokenizer: _GemmaTokenizer, bank: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        args=SimpleNamespace(
+            reasoning_parser="gemma4",
+            strip_assistant_reasoning_history=False,
+        ),
+        backend_descriptor=descriptor_for_backend_id("gemma4_assistant"),
+        runtime=SimpleNamespace(
+            tokenizer=tokenizer,
+            model_path=Path("models/gemma4"),
+            mtp_enabled=True,
+        ),
+        sessions=SimpleNamespace(bank=bank),
+        template_hash="gemma4-template",
+        draft_head_identity="gemma4-assistant-head",
+        lock=Lock(),
+    )
+
+
+def test_gemma4_reasoning_history_is_token_identical_and_uses_native_bank_state():
+    tokenizer = _GemmaTokenizer()
+    bank = _RecordingBank()
+    state = _postcommit_state(tokenizer, bank)
+    messages = [openai.ChatMessage(role="user", content="Explain the result.")]
+    prompt_ids = openai._encode_messages(
+        tokenizer,
+        messages,
+        enable_thinking=True,
+        add_generation_prompt=True,
+    )
+    reasoning = "Check the invariant first."
+    content = "The invariant holds."
+    generated_ids = tokenizer.encode(
+        f"<|channel>thought\n{reasoning}<channel|>{content}<turn|>"
+    )
+    generated = {
+        "tokens": generated_ids,
+        "_final_state": SimpleNamespace(
+            final_trunk_cache=["gemma4-cache"],
+            final_logits="gemma4-logits",
+            final_hidden="gemma4-pre-norm-hidden",
+            final_committed_mtp_cache=None,
+            generated_token_ids=tuple(generated_ids),
+            safe_to_commit=False,
+            finish_reason="stop",
+            extra_state={
+                "gemma4_shared_kv_states": {"layer": "shared-kv"},
+                "gemma4_kv_offset": len(prompt_ids) + len(generated_ids),
+                "gemma4_session_state_policy": "assistant_shared_kv",
+            },
+            prompt_boundary_cache=["gemma4-prompt-cache"],
+            prompt_boundary_logits="gemma4-prompt-logits",
+            prompt_boundary_hidden="gemma4-prompt-pre-norm-hidden",
+            prompt_boundary_extra_state={
+                "gemma4_shared_kv_states": {"layer": "prompt-shared-kv"},
+                "gemma4_kv_offset": len(prompt_ids),
+                "gemma4_session_state_policy": "assistant_shared_kv",
+            },
+        ),
+    }
+
+    echoed_history_ids = openai._encode_messages(
+        tokenizer,
+        [
+            *messages,
+            openai.ChatMessage(
+                role="assistant",
+                content=content,
+                reasoning_content=reasoning,
+            ),
+        ],
+        enable_thinking=True,
+        add_generation_prompt=False,
+    )
+    committed_ids = prompt_ids + generated_ids
+
+    assert echoed_history_ids[: len(committed_ids)] == committed_ids
+    assert openai._generation_final_bank_commit_safe(
+        state,
+        generated["_final_state"],
+    )
+
+    result = openai._store_generation_final_history_snapshot(
+        state,
+        session_id="gemma4-session",
+        prompt_ids=prompt_ids,
+        generated=generated,
+        messages=messages,
+        assistant_content=content,
+        thinking_enabled=True,
+        policy_fingerprint="gemma4-policy",
+    )
+
+    assert result["stored"] is True
+    assert result["mode"] == "generation_prompt_boundary"
+    assert result["reason"] == "prompt_boundary_before_unsafe_history"
+    assert result["prefix_len"] == len(prompt_ids)
+    assert result["history_suffix_tokens"] == 0
+    assert bank.puts[0]["hidden_variant"] == "gemma4_pre_norm"
+    assert bank.puts[0]["mtp_history_policy"] == "assistant_shared_kv"
+    assert bank.puts[0]["mtp_history_snapshot"] is None
+    assert bank.puts[0]["token_ids"] == prompt_ids
+    assert bank.puts[0]["cache"] == ["gemma4-prompt-cache"]
+    assert bank.puts[0]["logits"] == "gemma4-prompt-logits"
+    assert bank.puts[0]["hidden"] == "gemma4-prompt-pre-norm-hidden"
+    assert (
+        bank.puts[0]["extra_state"]
+        == generated["_final_state"].prompt_boundary_extra_state
+    )
+
+
+class _TokenCache:
+    def __init__(self, token_ids: list[int] | None = None) -> None:
+        self.token_ids = list(token_ids or [])
+        self.offset = len(self.token_ids)
+
+    @property
+    def state(self):
+        raise RuntimeError("live reference only")
+
+    def is_trimmable(self) -> bool:
+        return True
+
+    def trim(self, count: int) -> int:
+        count = int(count)
+        if count:
+            del self.token_ids[-count:]
+        self.offset = len(self.token_ids)
+        return count
+
+
+class _GemmaRuntime:
+    model_path = Path("models/gemma4")
+    mtp_enabled = True
+
+    def __init__(self) -> None:
+        self.target = SimpleNamespace(cache_offset=lambda cache: cache[0].offset)
+
+    def make_cache(self):
+        return [_TokenCache()]
+
+
+class _SliceValue:
+    def __init__(self, kind: str, prompt: tuple[int, ...]) -> None:
+        self.kind = kind
+        self.prompt = prompt
+
+    def __getitem__(self, _key):
+        return self
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, _SliceValue)
+            and self.kind == other.kind
+            and self.prompt == other.prompt
+        )
+
+
+def test_gemma4_two_turn_memory_rewrite_restores_common_prefix_with_cold_parity(
+    monkeypatch,
+):
+    tokenizer = _GemmaTokenizer()
+    stable_context = "stable project context " * 35
+    first_messages = [
+        openai.ChatMessage(role="system", content=stable_context),
+        openai.ChatMessage(
+            role="user",
+            content="<memory_context>volatile one</memory_context>\nFirst question",
+        ),
+    ]
+    first_prompt = openai._encode_messages(
+        tokenizer,
+        first_messages,
+        enable_thinking=True,
+        add_generation_prompt=True,
+    )
+    reasoning = "Use the stable context."
+    content = "First answer."
+    first_generated = tokenizer.encode(
+        f"<|channel>thought\n{reasoning}<channel|>{content}<turn|>"
+    )
+    committed_ids = first_prompt + first_generated
+
+    second_messages = [
+        openai.ChatMessage(role="system", content=stable_context),
+        openai.ChatMessage(role="user", content="First question"),
+        openai.ChatMessage(
+            role="assistant",
+            content=content,
+            reasoning_content=reasoning,
+        ),
+        openai.ChatMessage(
+            role="user",
+            content="<memory_context>volatile two</memory_context>\nSecond question",
+        ),
+    ]
+    second_prompt = openai._encode_messages(
+        tokenizer,
+        second_messages,
+        enable_thinking=True,
+        add_generation_prompt=True,
+    )
+    common = openai._common_prefix_len(committed_ids, second_prompt)
+    assert common > 512
+    assert common < len(first_prompt)
+
+    runtime = _GemmaRuntime()
+    bank = SessionBank(max_entries=2, max_bytes=1024, per_session_max_bytes=512)
+    entry = bank.put(
+        runtime=runtime,
+        token_ids=first_prompt,
+        cache=[_TokenCache(first_prompt)],
+        logits=("stored", len(first_prompt)),
+        hidden=("stored", len(first_prompt)),
+        hidden_variant="gemma4_pre_norm",
+        keep_live_ref=True,
+        session_id="gemma4-session",
+        template_hash="gemma4-template",
+        mtp_history_policy="assistant_shared_kv",
+        draft_head_identity="gemma4-assistant-head",
+        policy_fingerprint="gemma4-policy",
+        snapshot_epoch=len(first_prompt),
+        nbytes_override=1024,
+        extra_state={
+            "gemma4_shared_kv_states": {"stored": True},
+            "gemma4_kv_offset": len(first_prompt),
+            "gemma4_session_state_policy": "assistant_shared_kv",
+        },
+    )
+    assert entry is not None and entry.live_ref_only
+
+    prefill_calls = []
+
+    def fake_prefill(_runtime, prompt_ids, *, cache, phase):
+        assert phase == "prefill"
+        prefill_calls.append(tuple(prompt_ids))
+        cache[0].token_ids.extend(int(token) for token in prompt_ids)
+        cache[0].offset = len(cache[0].token_ids)
+        full_prompt = tuple(cache[0].token_ids)
+        return (
+            SimpleNamespace(
+                logits=_SliceValue("logits", full_prompt),
+                hidden=_SliceValue("hidden", full_prompt),
+                shared_kv_states={"prompt": full_prompt},
+                cache_offset=len(full_prompt),
+            ),
+            0.01,
+        )
+
+    monkeypatch.setattr(gemma4, "_gemma4_prefill_prompt", fake_prefill)
+    cold = gemma4._restore_or_prefill_gemma4_prompt(
+        runtime,
+        second_prompt,
+        require_shared_kv=True,
+    )
+    warm = gemma4._restore_or_prefill_gemma4_prompt(
+        runtime,
+        second_prompt,
+        session_bank=bank,
+        session_restore_mode="reference",
+        session_template_hash="gemma4-template",
+        session_draft_head_identity="gemma4-assistant-head",
+        session_policy_fingerprint="gemma4-policy",
+        require_shared_kv=True,
+    )
+
+    assert warm.cache_hit is True
+    assert warm.cached_tokens == common
+    assert warm.suffix_tokens == len(second_prompt) - common
+    assert warm.logits == cold.logits
+    assert warm.hidden == cold.hidden
+    assert warm.shared_kv_states == cold.shared_kv_states
+    assert warm.kv_offset == cold.kv_offset == len(second_prompt)
+    assert prefill_calls == [
+        tuple(second_prompt),
+        tuple(second_prompt[common:]),
+    ]


### PR DESCRIPTION
## Summary

- reconstruct Gemma 4 assistant reasoning from `reasoning_content` using its native channel markers, so echoed assistant history retokenizes to the committed stream
- retain the pre-decode Gemma 4 prompt boundary and store it with the backend's expected pre-norm hidden state and shared-KV metadata
- restore the longest compatible common prefix when clients rewrite a prior volatile memory suffix, then prefill only the divergent tail
- cover native reasoning token identity and a two-turn memory rewrite with warm/cold state parity

## Verification

- `python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py` — 268 passed
- focused Gemma/server/session-cache regression set — 375 passed
- `python -m build` — sdist and wheel built successfully
- `scripts/fresh_venv_smoke.sh` — passed
- Ruff and `git diff --check` — passed
- full `python -m pytest -q` — only five pre-existing exact-float failures in `tests/test_graphbank_compiled_verify.py`; the same five failures reproduce from clean upstream commit `f52f9be`

## Benchmark Evidence

Measured 2026-08-17 on commit `a233e9a`:

- hardware: Apple M4 Max, 128 GB, macOS 26.5.2
- model: local Gemma 4 31B QAT target/assistant pair; target mixed 4-bit/8-bit QAT (MLP projections 8-bit), assistant 4-bit
- runtime: resolved `sustained` profile, MTP generation, reasoning on, SSD session cache off, default Apple fan control
- sampler: temperature 0, seed 1729, max 128 tokens; each compared completion used 53 tokens
- workload: second OpenAI-format turn removes the prior user's volatile `<memory_context>`, echoes assistant `reasoning_content` plus `content`, and injects a new memory block on the current user turn

| Run | Prompt | Cached | New prefill | Prompt eval | Wall |
| --- | ---: | ---: | ---: | ---: | ---: |
| Warm rewritten turn | 1,705 | 1,610 | 95 | 0.519 s | 2.028 s |
| Cold control | 1,705 | 0 | 1,705 | 8.436 s | 9.944 s |
| Warm exact repeat | 1,705 | 1,705 | 0 | 0.0001 s | 1.545 s |

The rewritten warm turn was 4.9x faster end-to-end than cold; the exact repeat was 6.44x faster. The complete returned message, including both `reasoning_content` and visible `content`, matched the cold control exactly in both warm cases.
