### PR TITLE
perf(mtp): combine greedy token and confidence reads in opt-in lanes

### DIFF
--- a/mtplx/benchmarks/runners/mtp_adaptive.py
+++ b/mtplx/benchmarks/runners/mtp_adaptive.py
@@ -8,7 +8,11 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from mtplx.benchmarks.runners.mtp_depth_sweep import _rate_by_depth, _sum_lists
+from mtplx.benchmarks.runners.mtp_depth_sweep import (
+    _rate_by_depth,
+    _sum_draft_core,
+    _sum_lists,
+)
 from mtplx.benchmarks.schema import encode_prompt_case, load_prompt_suite
 from mtplx.benchmarks.validators.basic import (
     validate_json_text,
@@ -223,6 +227,7 @@ def run_mtp_adaptive(
                 "commit_time_s": out.stats.commit_time_s,
                 "capture_commit_time_s": out.stats.capture_commit_time_s,
                 "bonus_time_s": out.stats.bonus_time_s,
+                "draft_core": out.stats.draft_core,
                 "bonus_tokens": out.stats.bonus_tokens,
                 "correction_tokens": out.stats.correction_tokens,
                 "verify_calls": out.stats.verify_calls,
@@ -316,6 +321,7 @@ def run_mtp_adaptive(
             "commit_time_s": sum(row["commit_time_s"] for row in rows),
             "capture_commit_time_s": sum(row["capture_commit_time_s"] for row in rows),
             "bonus_time_s": sum(row["bonus_time_s"] for row in rows),
+            "draft_core": _sum_draft_core([row["draft_core"] for row in rows]),
             "bonus_tokens": sum(row["bonus_tokens"] for row in rows),
             "correction_tokens": sum(row["correction_tokens"] for row in rows),
             "verify_calls": sum(row["verify_calls"] for row in rows),

--- a/mtplx/benchmarks/runners/mtp_depth_grid.py
+++ b/mtplx/benchmarks/runners/mtp_depth_grid.py
@@ -8,6 +8,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+from mtplx.benchmarks.runners.mtp_depth_sweep import _sum_draft_core
 from mtplx.benchmarks.schema import encode_prompt_case, load_prompt_suite
 from mtplx.benchmarks.validators.basic import (
     validate_json_text,
@@ -217,6 +218,7 @@ def run_mtp_depth_policy_grid(
                     "verify_time_s": out.stats.verify_time_s,
                     "draft_time_s": out.stats.draft_time_s,
                     "target_forward_time_s": out.stats.target_forward_time_s,
+                    "draft_core": out.stats.draft_core,
                     "model_path_tok_s": (
                         out.stats.generated_tokens
                         / (out.stats.target_forward_time_s + out.stats.draft_time_s)
@@ -278,6 +280,9 @@ def run_mtp_depth_policy_grid(
                         "verify_time_s": sum(row["verify_time_s"] for row in rows),
                         "draft_time_s": sum(row["draft_time_s"] for row in rows),
                         "target_forward_time_s": sum(row["target_forward_time_s"] for row in rows),
+                        "draft_core": _sum_draft_core(
+                            [row["draft_core"] for row in rows]
+                        ),
                         "validations_passed": sum(1 for v in validations if v["passed"]),
                         "validations_total": len(validations),
                         "peak_memory_bytes": max([row["peak_memory_bytes"] for row in rows] or [0]),

--- a/mtplx/benchmarks/runners/mtp_depth_sweep.py
+++ b/mtplx/benchmarks/runners/mtp_depth_sweep.py
@@ -853,6 +853,14 @@ def _sum_draft_core(values: list[dict[str, object]]) -> dict[str, object]:
         "device_d2_compile_time_s": sum(
             float(value.get("device_d2_compile_time_s", 0.0) or 0.0) for value in values
         ),
+        "greedy_confidence_sync_calls": sum(
+            int(value.get("greedy_confidence_sync_calls", 0) or 0)
+            for value in values
+        ),
+        "greedy_confidence_token_reuses": sum(
+            int(value.get("greedy_confidence_token_reuses", 0) or 0)
+            for value in values
+        ),
     }
 
 

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -4362,20 +4362,90 @@ def _sample_from_logits(
     return sample_from_distribution(probs, rng), probs
 
 
+def _greedy_draft_token_and_top_values(
+    logits: mx.array,
+    *,
+    topk: int,
+) -> tuple[int, np.ndarray]:
+    """Materialize greedy argmax and FP32 top-k values with one synchronization."""
+
+    row = logits[:, -1, :][0] if logits.ndim == 3 else logits.reshape(-1)
+    # Keep argmax separate because top-k indices need not preserve first-index ties.
+    token_id = mx.argmax(row, axis=-1)
+    k = max(2, min(int(topk), int(row.shape[-1])))
+    top_values = mx.topk(row.astype(mx.float32), k=k)
+    _eval(token_id, top_values)
+    token = int(np.asarray(token_id).reshape(-1)[0])
+    values = np.asarray(top_values, dtype=np.float32).reshape(-1)
+    return token, values
+
+
 def _greedy_draft_token_and_top2(logits: mx.array) -> tuple[int, float, float]:
     """Materialize one greedy token and its FP32 top-two values together."""
 
-    row = (
-        logits[:, -1, :][0]
-        if logits.ndim == 3
-        else logits.reshape(-1)
-    ).astype(mx.float32)
-    token_id = mx.argmax(row, axis=-1)
-    top2_values = mx.topk(row, k=2)
-    _eval(token_id, top2_values)
-    token = int(np.asarray(token_id).reshape(-1)[0])
-    top2 = np.asarray(top2_values, dtype=np.float32).reshape(-1)
+    token, top2 = _greedy_draft_token_and_top_values(logits, topk=2)
     return token, float(top2[-1]), float(top2[-2])
+
+
+def _confidence_metrics_from_top_values(
+    top_values: mx.array | np.ndarray,
+) -> dict[str, float]:
+    values = np.sort(np.asarray(top_values, dtype=np.float32).reshape(-1))
+    if values.size < 2:
+        return {"top2_margin": 0.0, "top1_prob_topk": 1.0, "entropy_topk": 0.0}
+    descending = values[::-1].astype(np.float64)
+    shifted = descending - float(descending[0])
+    exp_values = np.exp(shifted)
+    probabilities = exp_values / float(np.sum(exp_values))
+    entropy = -float(
+        np.sum(probabilities * np.log(np.maximum(probabilities, 1e-30)))
+    )
+    return {
+        "top2_margin": float(values[-1] - values[-2]),
+        "top1_prob_topk": float(probabilities[0]),
+        "entropy_topk": entropy,
+    }
+
+
+def _greedy_draft_token_and_metrics(
+    logits: mx.array,
+    *,
+    need_distribution: bool,
+    topk: int = 8,
+) -> tuple[int, SparseDistribution | None, dict[str, float]]:
+    """Build the greedy proposal and its confidence metrics with one sync."""
+
+    row = logits[:, -1, :][0] if logits.ndim == 3 else logits.reshape(-1)
+    token, top_values = _greedy_draft_token_and_top_values(row, topk=topk)
+    distribution = (
+        SparseDistribution.one_hot(token, int(row.shape[-1]))
+        if need_distribution
+        else None
+    )
+    return token, distribution, _confidence_metrics_from_top_values(top_values)
+
+
+def _can_combine_greedy_draft_read(
+    draft_sampler: SamplerConfig,
+    *,
+    confidence_metrics_required: bool,
+    adaptive_width_policy: Any | None,
+    target_prefix_route: Any | None,
+    correction_cache_enabled: bool,
+    adapter_ensemble_q: bool,
+    mtp_topk_reranker: Any | None,
+) -> bool:
+    """Limit the joint read to greedy opt-in confidence lanes."""
+
+    return bool(
+        confidence_metrics_required
+        and draft_sampler.temperature <= 0
+        and adaptive_width_policy is None
+        and target_prefix_route is None
+        and not correction_cache_enabled
+        and not adapter_ensemble_q
+        and mtp_topk_reranker is None
+    )
 
 
 def _sample_draft_from_logits(
@@ -4897,19 +4967,7 @@ def _draft_confidence_metrics(logits: mx.array, *, topk: int = 8) -> dict[str, f
     k = max(2, min(int(topk), int(logits.shape[-1])))
     top_values = mx.topk(logits.astype(mx.float32), k)
     _eval(top_values)
-    values = np.sort(np.asarray(top_values, dtype=np.float32).reshape(-1))
-    if values.size < 2:
-        return {"top2_margin": 0.0, "top1_prob_topk": 1.0, "entropy_topk": 0.0}
-    descending = values[::-1].astype(np.float64)
-    shifted = descending - float(descending[0])
-    exp_values = np.exp(shifted)
-    probs = exp_values / float(np.sum(exp_values))
-    entropy = -float(np.sum(probs * np.log(np.maximum(probs, 1e-30))))
-    return {
-        "top2_margin": float(values[-1] - values[-2]),
-        "top1_prob_topk": float(probs[0]),
-        "entropy_topk": entropy,
-    }
+    return _confidence_metrics_from_top_values(top_values)
 
 
 def _top2_margin(logits: mx.array) -> float:
@@ -7492,6 +7550,8 @@ def generate_mtpk(
     device_core_compile_time = 0.0
     device_core_calls = 0
     device_core_fallbacks = 0
+    greedy_confidence_sync_calls = 0
+    greedy_confidence_token_reuses = 0
     streamed_token_count = 0
     mtp_history_materialize_every = max(
         0,
@@ -8222,6 +8282,22 @@ def generate_mtpk(
         # continuation predictiveness and can cost more to verify than they commit,
         # while grounded re-emission matches into the prompt (see the PR benchmarks).
         ccopy_index.sync(prompt_ids)
+    wants_policy_metrics = bool(
+        getattr(adaptive_policy, "wants_draft_metrics", False)
+    )
+    combine_greedy_draft_read = _can_combine_greedy_draft_read(
+        draft_sampler,
+        confidence_metrics_required=(
+            draft_margin_threshold is not None or wants_policy_metrics
+        ),
+        adaptive_width_policy=adaptive_width_policy,
+        target_prefix_route=a3b_target_prefix_route,
+        correction_cache_enabled=(
+            online_correction_cache or prompt_correction_cache
+        ),
+        adapter_ensemble_q=adapter_ensemble_q,
+        mtp_topk_reranker=mtp_topk_reranker,
+    )
     # Close the pre-first-token setup span here: everything from the
     # restore/prefill return to this point (prompt-prefix bank commit,
     # graphbank/policy/sampler construction) is setup wall time that
@@ -9190,14 +9266,22 @@ def generate_mtpk(
                     position_offset=draft_position_offset,
                 )
                 draft_logits, draft_hidden_next = draft_result
-            wants_policy_metrics = bool(
-                getattr(adaptive_policy, "wants_draft_metrics", False)
-            )
-            draft_metrics = (
-                _draft_confidence_metrics(draft_logits[:, -1, :][0])
-                if draft_margin_threshold is not None or wants_policy_metrics
-                else {}
-            )
+            prepared_greedy_draft: tuple[int, SparseDistribution | None] | None = None
+            if combine_greedy_draft_read:
+                draft_token, draft_q, draft_metrics = _greedy_draft_token_and_metrics(
+                    draft_logits,
+                    need_distribution=(
+                        sampler.temperature > 0 and not target_prefix_verify
+                    ),
+                )
+                greedy_confidence_sync_calls += 1
+                prepared_greedy_draft = (draft_token, draft_q)
+            else:
+                draft_metrics = (
+                    _draft_confidence_metrics(draft_logits[:, -1, :][0])
+                    if draft_margin_threshold is not None or wants_policy_metrics
+                    else {}
+                )
             margin = draft_metrics.get("top2_margin")
             if (
                 draft_margin_threshold is not None
@@ -9317,14 +9401,16 @@ def generate_mtpk(
                     need_draft_distribution = (
                         sampler.temperature > 0 and not target_prefix_verify
                     )
-                    draft_token, draft_q, adaptive_width_stop = (
-                        cycle_draft_reader(
+                    if prepared_greedy_draft is not None:
+                        draft_token, draft_q = prepared_greedy_draft
+                        greedy_confidence_token_reuses += 1
+                    else:
+                        draft_token, draft_q, adaptive_width_stop = cycle_draft_reader(
                             draft_logits,
                             depth_index=depth_index,
                             need_distribution=need_draft_distribution,
                             decision_margins=adaptive_width_decision_margins,
                         )
-                    )
             elapsed_draft = time.perf_counter() - started
             draft_time += elapsed_draft
             if trace.enabled:
@@ -11064,6 +11150,8 @@ def generate_mtpk(
             "device_calls": device_core_calls,
             "device_fallbacks": device_core_fallbacks,
             "device_compile_time_s": device_core_compile_time,
+            "greedy_confidence_sync_calls": greedy_confidence_sync_calls,
+            "greedy_confidence_token_reuses": greedy_confidence_token_reuses,
         },
         owned_recurrent_state=owned_recurrent_state_stats(cache),
         owned_attn_kv=tail_owned_attention_kv_stats(cache),

--- a/tests/test_expected_value_greedy.py
+++ b/tests/test_expected_value_greedy.py
@@ -1,0 +1,99 @@
+"""Greedy draft contracts used by expected-value depth selection."""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mtplx.adaptive import ExpectedValueDepthPolicy
+from mtplx.generation import _draft_confidence_metrics, _sample_draft_from_logits
+from mtplx.sampling import SamplerConfig, SparseDistribution
+
+
+@pytest.fixture(autouse=True)
+def _cpu_device():
+    previous = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    try:
+        yield
+    finally:
+        mx.set_default_device(previous)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.float32])
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1.0, 4.0, 3.25, -2.0, 0.5, 2.0, -1.0, 0.0, 1.5],
+        [2.0, 2.0, 1.0, -1.0, 0.0, 0.5, 1.5, -3.0, 0.25],
+    ],
+)
+def test_confidence_metrics_match_fp32_top8(values, dtype):
+    logits = mx.array(values, dtype=dtype)
+
+    metrics = _draft_confidence_metrics(logits, topk=8)
+
+    rounded = np.asarray(logits.astype(mx.float32), dtype=np.float32)
+    top_values = np.sort(rounded)[-8:]
+    shifted = top_values[::-1].astype(np.float64) - float(top_values[-1])
+    exp_values = np.exp(shifted)
+    probabilities = exp_values / float(np.sum(exp_values))
+    expected_entropy = -float(
+        np.sum(probabilities * np.log(np.maximum(probabilities, 1e-30)))
+    )
+
+    assert metrics["top2_margin"] == pytest.approx(
+        float(top_values[-1] - top_values[-2])
+    )
+    assert metrics["top1_prob_topk"] == pytest.approx(float(probabilities[0]))
+    assert metrics["entropy_topk"] == pytest.approx(expected_entropy)
+
+
+@pytest.mark.parametrize("need_distribution", [False, True])
+def test_greedy_draft_reader_preserves_first_maximum(need_distribution):
+    logits = mx.array([1.0, 4.0, 3.25, -2.0, 4.0], dtype=mx.float16)
+
+    token, distribution = _sample_draft_from_logits(
+        logits,
+        SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        np.random.default_rng(7),
+        need_distribution=need_distribution,
+    )
+
+    assert token == 1
+    if need_distribution:
+        assert isinstance(distribution, SparseDistribution)
+        assert distribution.vocab_size == 5
+        np.testing.assert_array_equal(distribution.token_ids, np.array([1]))
+        np.testing.assert_array_equal(distribution.probs, np.array([1.0]))
+    else:
+        assert distribution is None
+
+
+def test_confidence_metrics_preserve_expected_value_decision():
+    metrics = _draft_confidence_metrics(
+        mx.array([0.0, 1.0, 3.5, 2.0, -1.0, 0.25, 0.5, 1.5]),
+        topk=8,
+    )
+    policy = ExpectedValueDepthPolicy(
+        max_depth=3,
+        base_depth=2,
+        warmup_full_depth_cycles=0,
+        exploration_interval=0,
+    )
+    policy._attempt_counts[2] = 1
+    policy._cycles_observed = 1
+
+    decision = policy.should_continue_after_draft(
+        drafted_depth=2,
+        max_depth=3,
+        draft_metrics=metrics,
+    )
+
+    assert math.isfinite(float(decision["confidence_factor"]))
+    assert decision["drafted_depth"] == 2
+    assert decision["next_depth"] == 3
+    assert decision["reason"] in {"ev_pass", "ev_fail"}

--- a/tests/test_expected_value_greedy.py
+++ b/tests/test_expected_value_greedy.py
@@ -8,8 +8,14 @@ import mlx.core as mx
 import numpy as np
 import pytest
 
+import mtplx.generation as generation
 from mtplx.adaptive import ExpectedValueDepthPolicy
-from mtplx.generation import _draft_confidence_metrics, _sample_draft_from_logits
+from mtplx.generation import (
+    _can_combine_greedy_draft_read,
+    _draft_confidence_metrics,
+    _greedy_draft_token_and_metrics,
+    _sample_draft_from_logits,
+)
 from mtplx.sampling import SamplerConfig, SparseDistribution
 
 
@@ -97,3 +103,237 @@ def test_confidence_metrics_preserve_expected_value_decision():
     assert decision["drafted_depth"] == 2
     assert decision["next_depth"] == 3
     assert decision["reason"] in {"ev_pass", "ev_fail"}
+
+
+@pytest.mark.parametrize("need_distribution", [False, True])
+def test_combined_greedy_read_matches_separate_operations(need_distribution):
+    logits = mx.array(
+        [1.0, 4.0, 3.25, -2.0, 4.0, 2.0, -1.0, 0.0, 1.5],
+        dtype=mx.float16,
+    )
+    sampler = SamplerConfig(temperature=0.0, top_p=1.0, top_k=0)
+    expected_token, expected_distribution = _sample_draft_from_logits(
+        logits,
+        sampler,
+        np.random.default_rng(7),
+        need_distribution=need_distribution,
+    )
+    expected_metrics = _draft_confidence_metrics(logits)
+
+    token, distribution, metrics = _greedy_draft_token_and_metrics(
+        logits.reshape(1, 1, -1),
+        need_distribution=need_distribution,
+    )
+
+    assert token == expected_token == 1
+    assert metrics == expected_metrics
+    if need_distribution:
+        assert isinstance(distribution, SparseDistribution)
+        np.testing.assert_array_equal(
+            distribution.token_ids,
+            expected_distribution.token_ids,
+        )
+        np.testing.assert_array_equal(
+            distribution.probs,
+            expected_distribution.probs,
+        )
+    else:
+        assert distribution is expected_distribution is None
+
+
+def test_combined_greedy_read_uses_one_sync(monkeypatch):
+    original_eval = generation._eval
+    evaluations = []
+
+    def audited_eval(*values, **kwargs):
+        evaluations.append(values)
+        return original_eval(*values, **kwargs)
+
+    monkeypatch.setattr(generation, "_eval", audited_eval)
+
+    token, _, _ = _greedy_draft_token_and_metrics(
+        mx.array([[[1.0, 4.0, 3.25, -2.0]]], dtype=mx.float16),
+        need_distribution=False,
+    )
+
+    assert token == 1
+    assert len(evaluations) == 1
+    assert len(evaluations[0]) == 2
+    assert evaluations[0][0].ndim == 0
+    assert tuple(evaluations[0][1].shape) == (4,)
+    assert evaluations[0][1].dtype == mx.float32
+
+
+def _combined_read_kwargs() -> dict:
+    return {
+        "confidence_metrics_required": True,
+        "adaptive_width_policy": None,
+        "target_prefix_route": None,
+        "correction_cache_enabled": False,
+        "adapter_ensemble_q": False,
+        "mtp_topk_reranker": None,
+    }
+
+
+def test_combined_greedy_read_accepts_opt_in_confidence_lane():
+    assert _can_combine_greedy_draft_read(
+        SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        **_combined_read_kwargs(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("confidence_metrics_required", False),
+        ("adaptive_width_policy", object()),
+        ("target_prefix_route", object()),
+        ("correction_cache_enabled", True),
+        ("adapter_ensemble_q", True),
+        ("mtp_topk_reranker", object()),
+    ],
+)
+def test_combined_greedy_read_rejects_alternate_selectors(option, value):
+    options = _combined_read_kwargs()
+    options[option] = value
+
+    assert not _can_combine_greedy_draft_read(
+        SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        **options,
+    )
+
+
+def test_combined_greedy_read_requires_greedy_draft_sampler():
+    assert not _can_combine_greedy_draft_read(
+        SamplerConfig(temperature=0.7, top_p=0.9, top_k=20),
+        **_combined_read_kwargs(),
+    )
+
+
+def test_expected_value_generation_preserves_control_trace(monkeypatch):
+    from test_generation_sustained import AcceptingTinyMTPModel, _runtime
+
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY", "off")
+    monkeypatch.setenv("MTPLX_CONTEXT_COPY", "0")
+
+    def run_once():
+        return generation.generate_mtpk(
+            _runtime(AcceptingTinyMTPModel()),
+            [0],
+            max_tokens=8,
+            sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+            speculative_depth=3,
+            verify_strategy="batched",
+            mtp_history_policy="cycle",
+            stop_token_ids=set(),
+            adaptive_policy=ExpectedValueDepthPolicy(max_depth=3, base_depth=2),
+        )
+
+    original_combined_read = generation._greedy_draft_token_and_metrics
+    combined_calls = 0
+
+    def audited_combined_read(*args, **kwargs):
+        nonlocal combined_calls
+        combined_calls += 1
+        return original_combined_read(*args, **kwargs)
+
+    monkeypatch.setattr(
+        generation,
+        "_greedy_draft_token_and_metrics",
+        audited_combined_read,
+    )
+    combined = run_once()
+    assert combined_calls > 0
+    assert (
+        combined.stats.draft_core["greedy_confidence_sync_calls"]
+        == combined_calls
+    )
+    assert (
+        combined.stats.draft_core["greedy_confidence_token_reuses"]
+        == combined_calls
+    )
+
+    monkeypatch.setattr(
+        generation,
+        "_can_combine_greedy_draft_read",
+        lambda *_args, **_kwargs: False,
+    )
+    control = run_once()
+    assert control.stats.draft_core["greedy_confidence_sync_calls"] == 0
+    assert control.stats.draft_core["greedy_confidence_token_reuses"] == 0
+
+    def policy_trace(output):
+        return [
+            {
+                "depth": draft["depth"],
+                "token": draft["token"],
+                "top2_margin": draft.get("top2_margin"),
+                "top1_prob_topk": draft.get("top1_prob_topk"),
+                "entropy_topk": draft.get("entropy_topk"),
+                "policy_continue": draft.get("policy_continue"),
+            }
+            for event in output.stats.events
+            for draft in event.get("drafts", [])
+        ]
+
+    assert combined.tokens == control.tokens
+    assert combined.stats.drafted_by_depth == control.stats.drafted_by_depth
+    assert combined.stats.accepted_by_depth == control.stats.accepted_by_depth
+    assert combined.stats.rejected_drafts == control.stats.rejected_drafts
+    assert policy_trace(combined) == policy_trace(control)
+
+
+@pytest.mark.parametrize(
+    ("threshold", "expect_full_reuse"),
+    [(0.0, True), (100.0, False)],
+)
+def test_margin_lane_reports_joint_read_engagement(
+    monkeypatch,
+    threshold,
+    expect_full_reuse,
+):
+    from test_generation_sustained import AcceptingTinyMTPModel, _runtime
+
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY", "off")
+    monkeypatch.setenv("MTPLX_CONTEXT_COPY", "0")
+
+    output = generation.generate_mtpk(
+        _runtime(AcceptingTinyMTPModel()),
+        [0],
+        max_tokens=8,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        speculative_depth=3,
+        verify_strategy="batched",
+        mtp_history_policy="cycle",
+        stop_token_ids=set(),
+        draft_margin_threshold=threshold,
+    )
+
+    calls = output.stats.draft_core["greedy_confidence_sync_calls"]
+    reuses = output.stats.draft_core["greedy_confidence_token_reuses"]
+    assert calls > 0
+    if expect_full_reuse:
+        assert reuses == calls
+    else:
+        assert 0 < reuses < calls
+
+
+def test_default_greedy_lane_reports_no_confidence_sync_engagement(monkeypatch):
+    from test_generation_sustained import AcceptingTinyMTPModel, _runtime
+
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY", "off")
+    monkeypatch.setenv("MTPLX_CONTEXT_COPY", "0")
+
+    output = generation.generate_mtpk(
+        _runtime(AcceptingTinyMTPModel()),
+        [0],
+        max_tokens=8,
+        sampler=SamplerConfig(temperature=0.0, top_p=1.0, top_k=0),
+        speculative_depth=3,
+        verify_strategy="batched",
+        mtp_history_policy="cycle",
+        stop_token_ids=set(),
+    )
+
+    assert output.stats.draft_core["greedy_confidence_sync_calls"] == 0
+    assert output.stats.draft_core["greedy_confidence_token_reuses"] == 0

--- a/tests/test_greedy_confidence_runner_telemetry.py
+++ b/tests/test_greedy_confidence_runner_telemetry.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mtplx.benchmarks.runners import mtp_adaptive, mtp_depth_grid
+from mtplx.benchmarks.schema import PromptCase
+
+
+def _runtime() -> SimpleNamespace:
+    return SimpleNamespace(
+        tokenizer=object(),
+        contract=SimpleNamespace(
+            base_hidden_variant="pre_norm",
+            hidden_variant="post_norm",
+            concat_order="base_then_mtp",
+        ),
+        mtp_adapter_metadata=None,
+        mtp_adapter_merge_report=None,
+    )
+
+
+def _output(sync_calls: int, token_reuses: int) -> SimpleNamespace:
+    stats = SimpleNamespace(
+        generated_tokens=2,
+        elapsed_s=1.0,
+        tok_s=2.0,
+        accepted_drafts=1,
+        rejected_drafts=0,
+        drafted_tokens=1,
+        accepted_by_depth=[1, 0],
+        drafted_by_depth=[1, 0],
+        verify_time_s=0.2,
+        draft_time_s=0.1,
+        target_forward_time_s=0.2,
+        snapshot_time_s=0.0,
+        accept_time_s=0.0,
+        rollback_time_s=0.0,
+        repair_time_s=0.0,
+        commit_time_s=0.0,
+        capture_commit_time_s=0.0,
+        bonus_time_s=0.0,
+        draft_core={
+            "requested": "stock",
+            "greedy_confidence_sync_calls": sync_calls,
+            "greedy_confidence_token_reuses": token_reuses,
+        },
+        bonus_tokens=0,
+        correction_tokens=0,
+        verify_calls=1,
+        peak_memory_bytes=1024,
+        graphbank={},
+        events=[{}],
+    )
+    return SimpleNamespace(tokens=[1, 2], text="safe output", stats=stats)
+
+
+def _prompt_cases() -> list[PromptCase]:
+    return [
+        PromptCase(id="one", category="general", prompt="one", max_tokens=2),
+        PromptCase(id="two", category="general", prompt="two", max_tokens=2),
+    ]
+
+
+def test_adaptive_runner_exposes_greedy_confidence_counters(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    outputs = iter([_output(3, 2), _output(4, 4)])
+    monkeypatch.setattr(mtp_adaptive, "load", lambda *_args, **_kwargs: _runtime())
+    monkeypatch.setattr(
+        mtp_adaptive,
+        "load_prompt_suite",
+        lambda *_args, **_kwargs: _prompt_cases(),
+    )
+    monkeypatch.setattr(
+        mtp_adaptive,
+        "encode_prompt_case",
+        lambda *_args, **_kwargs: [1],
+    )
+    monkeypatch.setattr(
+        mtp_adaptive,
+        "generate_mtpk",
+        lambda *_args, **_kwargs: next(outputs),
+    )
+
+    result = mtp_adaptive.run_mtp_adaptive(
+        tmp_path / "model",
+        tmp_path / "suite.jsonl",
+        max_depth=2,
+        policy_kind="expected_value",
+        temperature=0.0,
+        draft_temperature=0.0,
+    )
+
+    assert result["rows"][0]["draft_core"]["greedy_confidence_sync_calls"] == 3
+    assert result["summary"]["draft_core"]["greedy_confidence_sync_calls"] == 7
+    assert result["summary"]["draft_core"]["greedy_confidence_token_reuses"] == 6
+
+
+def test_margin_grid_exposes_greedy_confidence_counters(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    outputs = iter([_output(3, 2), _output(4, 4)])
+    monkeypatch.setattr(mtp_depth_grid, "load", lambda *_args, **_kwargs: _runtime())
+    monkeypatch.setattr(
+        mtp_depth_grid,
+        "load_prompt_suite",
+        lambda *_args, **_kwargs: _prompt_cases(),
+    )
+    monkeypatch.setattr(
+        mtp_depth_grid,
+        "encode_prompt_case",
+        lambda *_args, **_kwargs: [1],
+    )
+    monkeypatch.setattr(
+        mtp_depth_grid,
+        "generate_mtpk",
+        lambda *_args, **_kwargs: next(outputs),
+    )
+
+    result = mtp_depth_grid.run_mtp_depth_policy_grid(
+        tmp_path / "model",
+        tmp_path / "suite.jsonl",
+        depth=2,
+        thresholds=[0.5],
+        min_depths=[0],
+        temperature=0.0,
+        draft_temperature=0.0,
+    )
+
+    cell = result["grid"][0]
+    assert cell["rows"][0]["draft_core"]["greedy_confidence_sync_calls"] == 3
+    assert cell["summary"]["draft_core"]["greedy_confidence_sync_calls"] == 7
+    assert cell["summary"]["draft_core"]["greedy_confidence_token_reuses"] == 6

--- a/tests/test_mtp_depth_sweep.py
+++ b/tests/test_mtp_depth_sweep.py
@@ -88,3 +88,24 @@ def test_depth_sweep_passes_merge_mtp_adapter_to_runtime(monkeypatch, tmp_path) 
     assert result["mtp_adapter_kind"] == "c4_mtp_lora_adapter"
     assert result["mtp_adapter_merged"] is True
     assert result["mtp_adapter_merge_report"] == {"merged": 1, "targets": [{"target": "fc"}]}
+
+
+def test_sum_draft_core_preserves_greedy_confidence_counters() -> None:
+    summary = mtp_depth_sweep._sum_draft_core(
+        [
+            {
+                "requested": "stock",
+                "greedy_confidence_sync_calls": 3,
+                "greedy_confidence_token_reuses": 2,
+            },
+            {
+                "requested": "stock",
+                "greedy_confidence_sync_calls": 4,
+                "greedy_confidence_token_reuses": 4,
+            },
+            {"requested": "stock"},
+        ]
+    )
+
+    assert summary["greedy_confidence_sync_calls"] == 7
+    assert summary["greedy_confidence_token_reuses"] == 6


### PR DESCRIPTION
## Summary

MTPLX 2.9.2 can keep the ordinary greedy draft chain on device. This patch
does not engage on that default lane. It targets only opt-in lanes that still
need host-visible confidence metrics: `draft_margin_threshold` and adaptive
policies that declare `wants_draft_metrics`.

For an eligible regular greedy selector, the patch queues argmax and the FP32
top-eight read before one synchronization, then reuses the selected token after
the shared materialization. Adaptive-width routing, target-prefix routing,
correction caches, adapter ensembles, reranking, and stochastic draft sampling
retain their existing readers. No default changes.

Two counters expose the engagement under `stats.draft_core`:

- `greedy_confidence_sync_calls` counts joint token/metric reads.
- `greedy_confidence_token_reuses` counts reads whose prepared token was
  consumed. A margin gate can read the metrics and stop before token selection,
  so the two counters are intentionally distinct.

The depth-sweep, adaptive-policy, and margin-grid benchmark artifacts preserve
the counters both per row and in their aggregate summaries.

The tests cover first-index tie handling, one-hot proposals, confidence values,
selector eligibility, ExpectedValue engagement and token reuse, both outcomes
of the margin gate, zero engagement on the default greedy lane, and counter
propagation through all three benchmark reports.

## Verification

- PR-focused confidence/runner suite: 38 passed.
- Required `CONTRIBUTING.md` smoke trio: 273 passed.
- Full Python suite: 4,376 passed, 26 skipped, 0 failed.
- Ruff on every changed Python file, `compileall`, and `git diff --check`:
  passed.
- Wheel and sdist build: passed; both artifacts passed `twine check`.
- `scripts/fresh_venv_smoke.sh`: passed.

## Benchmark Evidence

Measured on 2026-08-28 after rebasing onto current `main` at `e07224a`
(v2.9.2 plus its follow-up fixes). Prepared local head: `5551ee0`.

- Hardware: Apple M5 Max, 128 GB unified memory.
- Software: macOS 26.5.2, Python 3.13.13, MLX 0.32.0.
- Model: Qwen3.8-27B MTPLX Optimized Quality; affine Q8, group size 64,
  with one BF16 MTP layer.
- Measured lane: ExpectedValue D3, batched stock verification, persistent draft
  cache, cycle MTP history.
- Sampler: temperature 0, top-p 1, top-k 0; 64 generated tokens per run.

This benchmark measures the adaptive confidence lane. The 2.9.2 default greedy
chain is intentionally ineligible for this patch and is covered by a zero-counter
test rather than included in the performance claim. The margin lane is covered
for engagement semantics but was not used for the throughput headline.

The comparison used one loaded runtime and three prompt classes. Each arm had
one warmup per prompt, followed by 10 measured pairs per prompt. A/B order
alternated by block, prompt order rotated by block, and external wall time was
bracketed by MLX synchronization. The control forced separate token and metric
reads while leaving the model state and remaining decode path unchanged. All
66 runs produced identical token, policy, control, and work fingerprints across
the two arms.

- Paired geometric mean: **+0.559%** end-to-end throughput.
- Shared-block bootstrap 95% CI: **+0.401% to +0.704%**.
- Per-prompt paired deltas: code **+0.353%**, JSON/tool **+0.740%**, creative
  prose **+0.584%**.
- First and second halves: **+0.374%** and **+0.744%**.
- Control-first and candidate-first strata: **+0.588%** and **+0.530%**.
- Median draft-phase time fell by **7.22% to 8.33%**, depending on the prompt.
- Measured engagement: candidate **1,860 joint reads / 1,860 token reuses**;
  control **0 / 0**.

The post-benchmark follow-up only preserves those counters in benchmark JSON
summaries; the measured `mtplx/generation.py` hot path is byte-identical in the
prepared head.
