### PR TITLE
Hold the background warmup ladder while a request is in flight

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -20692,9 +20692,29 @@ class _BackgroundWarmup:
         return cls.IDLE_GRACE_S
 
     def _foreground_quiet_for_s(self) -> float:
-        last = float(getattr(self.state, "last_request_at", 0.0) or 0.0)
+        # last_request_at is stamped when a request COMPLETES, so a request
+        # that has arrived and is still generating leaves it untouched --
+        # 0.0 on a daemon that has not finished one yet, which read as
+        # "infinitely quiet" and admitted a warm rung against live traffic.
+        # That is the post-restart window an operator actually types into
+        # (a UI that restarts the engine on a config change is typed into
+        # immediately afterwards), so the very first request of a serve was
+        # the one most likely to be warmed over. Model work in flight or
+        # queued is zero quiet; only then does the completion stamp decide.
+        state = self.state
+        try:
+            if state.has_foreground():
+                return 0.0
+        except BaseException:
+            pass
+        try:
+            if _foreground_model_work_pending(state):
+                return 0.0
+        except BaseException:
+            pass
+        last = float(getattr(state, "last_request_at", 0.0) or 0.0)
         if last <= 0.0:
-            # No request has ever landed (fresh boot): warm immediately.
+            # Nothing has ever run and nothing is running: warm immediately.
             return float("inf")
         return max(0.0, time.time() - last)
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -20462,7 +20462,14 @@ def _run_generation(
             else (getattr(out, "finish_reason", None) or "stop")
         )
         _record_request_metrics(state, dict(envelope))
-        state.last_request_at = time.time()
+        if not bool((request_observability or {}).get("warmup")):
+            # Warming generations are not user requests: the same filter the
+            # dashboard gauge applies. Stamping this clock from a warm rung
+            # made the ladder defer against its own output (rung 512 finishes,
+            # rung 2560 then waits out a full idle grace) and made /health
+            # report seconds_since_last_request as if a user had just been
+            # served on a daemon nobody has touched.
+            state.last_request_at = time.time()
         state.requests_completed += 1
         _dashboard_record_completion(state, envelope=envelope, stats=stats)
         last = {

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -20468,9 +20468,12 @@ def _run_generation(
             # made the ladder defer against its own output (rung 512 finishes,
             # rung 2560 then waits out a full idle grace) and made /health
             # report seconds_since_last_request as if a user had just been
-            # served on a daemon nobody has touched.
+            # served on a daemon nobody has touched. The counter moves with
+            # the clock so the two /health fields cannot disagree, and so the
+            # max-idle watchdog does not read warming as user traffic and
+            # hold the fans at performance.
             state.last_request_at = time.time()
-        state.requests_completed += 1
+            state.requests_completed += 1
         _dashboard_record_completion(state, envelope=envelope, stats=stats)
         last = {
             "text": out.text,
@@ -20698,6 +20701,28 @@ class _BackgroundWarmup:
                 return cls.IDLE_GRACE_S
         return cls.IDLE_GRACE_S
 
+    def _foreground_busy(self) -> bool:
+        """True while a real request is generating or queued for the model.
+
+        Only sound at step admission. The warming generation itself calls
+        ``begin_foreground`` for the whole rung, so ``has_foreground()``
+        reads zero here but non-zero once the rung is running: a caller
+        that re-checked from inside a rung would see warmup's own work as
+        live traffic and defer the ladder forever. That is why the sibling
+        ``_ForegroundYield`` reads the scheduler queues instead — it runs
+        during the rung, this runs before it.
+        """
+        state = self.state
+        try:
+            if state.has_foreground():
+                return True
+        except BaseException:
+            pass
+        try:
+            return bool(_foreground_model_work_pending(state))
+        except BaseException:
+            return False
+
     def _foreground_quiet_for_s(self) -> float:
         # last_request_at is stamped when a request COMPLETES, so a request
         # that has arrived and is still generating leaves it untouched --
@@ -20706,22 +20731,12 @@ class _BackgroundWarmup:
         # That is the post-restart window an operator actually types into
         # (a UI that restarts the engine on a config change is typed into
         # immediately afterwards), so the very first request of a serve was
-        # the one most likely to be warmed over. Model work in flight or
-        # queued is zero quiet; only then does the completion stamp decide.
-        state = self.state
-        try:
-            if state.has_foreground():
-                return 0.0
-        except BaseException:
-            pass
-        try:
-            if _foreground_model_work_pending(state):
-                return 0.0
-        except BaseException:
-            pass
-        last = float(getattr(state, "last_request_at", 0.0) or 0.0)
+        # the one most likely to be warmed over. In-flight and queued work
+        # is _foreground_busy's answer, and it holds the ladder whatever the
+        # grace is; this measures the completion stamp alone.
+        last = float(getattr(self.state, "last_request_at", 0.0) or 0.0)
         if last <= 0.0:
-            # Nothing has ever run and nothing is running: warm immediately.
+            # Nothing has ever completed: no traffic to stay clear of.
             return float("inf")
         return max(0.0, time.time() - last)
 
@@ -20757,10 +20772,15 @@ class _BackgroundWarmup:
             self._finish()
             return
         grace = self._idle_grace_s()
-        quiet = self._foreground_quiet_for_s()
-        if quiet < grace:
-            # Recently-served traffic: hold the plan without burning GPU or
-            # the resubmit budget, and re-check when the grace can be met.
+        busy = self._foreground_busy()
+        quiet = 0.0 if busy else self._foreground_quiet_for_s()
+        if busy or quiet < grace:
+            # Live or recently-served traffic: hold the plan without burning
+            # GPU or the resubmit budget, and re-check when the grace can be
+            # met. Busy is its own branch, not a zero folded into the grace
+            # comparison: MTPLX_WARMUP_IDLE_GRACE_S=0 is how an operator says
+            # "do not wait between turns", and it must not also hand a warm
+            # rung a request that is still generating.
             step = self.steps[index]
             if step.get("state") in ("pending", "yielded", "waiting_idle"):
                 step["state"] = "waiting_idle"

--- a/tests/test_background_warmup.py
+++ b/tests/test_background_warmup.py
@@ -120,11 +120,11 @@ def test_foreground_yield_shim_reads_scheduler_queues():
     assert server._ForegroundYield(state).is_set() is False
 
 
-def _deferral_probe(monkeypatch, state, scheduler):
+def _deferral_probe(monkeypatch, state, scheduler, grace: str = "90"):
     """Run one warmup plan with timers faked; report whether any rung
     actually generated and what the first step's published state is."""
     monkeypatch.setenv("MTPLX_WARMUP_LADDER", "16")
-    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", "90")
+    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", grace)
     monkeypatch.setattr(server, "_prewarm_gqa_packed_pipelines", lambda: True)
     generations: list[int] = []
     monkeypatch.setattr(
@@ -389,6 +389,37 @@ def test_background_warmup_defers_while_a_request_is_in_flight(monkeypatch):
     assert status_host["background"]["steps"][0]["state"] == "waiting_idle"
     assert status_host["background"]["resubmits"] == 0
     assert len(timers) == 1
+
+
+def test_background_warmup_holds_a_live_request_even_at_zero_grace(monkeypatch):
+    """MTPLX_WARMUP_IDLE_GRACE_S=0 drops the between-turns wait, not the
+    live-traffic guard.
+
+    Expressing "busy" as zero quiet made the hold collapse at grace 0
+    (``0.0 < 0.0`` is False), so the one knob an operator reaches for when
+    warm rungs are not running also handed them a request that was still
+    generating -- the exact starvation the guard exists to prevent.
+    """
+    scheduler = FakeScheduler()
+    state = make_state(scheduler)
+    state.last_request_at = 0.0
+    state.foreground_active = 1  # a real request is generating right now
+    generations, status_host, timers = _deferral_probe(
+        monkeypatch, state, scheduler, grace="0"
+    )
+    assert generations == [], "warming generated against a live request at grace 0"
+    assert status_host["background"]["steps"][0]["state"] == "waiting_idle"
+    assert status_host["background"]["resubmits"] == 0
+    assert len(timers) == 1
+    wait_s, fn, args = timers[0]
+    assert wait_s >= 1.0  # _defer_step floors the re-check, never a hot loop
+    # The request finishes and nothing else is queued: zero grace means the
+    # plan runs on the very next admission, with no wait to serve out.
+    state.foreground_active = 0
+    fn(*args)
+    scheduler.drain()
+    assert generations == [16]
+    assert status_host["background"]["state"] == "done"
 
 
 def test_background_warmup_defers_while_foreground_is_queued(monkeypatch):

--- a/tests/test_background_warmup.py
+++ b/tests/test_background_warmup.py
@@ -71,12 +71,17 @@ def make_state(scheduler: FakeScheduler | None = None, **args_overrides):
     )
     for key, value in args_overrides.items():
         setattr(args, key, value)
-    return SimpleNamespace(
+    state = SimpleNamespace(
         args=args,
         model_scheduler=scheduler or FakeScheduler(),
         runtime=SimpleNamespace(tokenizer=FakeTokenizer()),
         context_window=262144,
+        foreground_active=0,
     )
+    # Mirrors ServerState.has_foreground: non-zero while a request is being
+    # served, independent of the completion stamp in last_request_at.
+    state.has_foreground = lambda: state.foreground_active > 0
+    return state
 
 
 def test_background_warmup_enabled_env(monkeypatch):
@@ -356,3 +361,78 @@ def test_dashboard_record_completion_skips_warmup_rows():
         stats={},
     )
     assert "lifetime" in calls and "rolling" in calls
+
+
+def _deferral_probe(monkeypatch, state, scheduler):
+    """Run one warmup plan with timers faked; report whether any rung
+    actually generated and what the first step's published state is."""
+    monkeypatch.setenv("MTPLX_WARMUP_LADDER", "16")
+    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", "90")
+    monkeypatch.setattr(server, "_prewarm_gqa_packed_pipelines", lambda: True)
+    generations: list[int] = []
+    monkeypatch.setattr(
+        server,
+        "_run_generation",
+        lambda _state, prompt_ids, **kwargs: generations.append(len(prompt_ids))
+        or {"tok_s": 1.0},
+    )
+    timers: list[tuple[float, object, tuple]] = []
+
+    class FakeTimer:
+        def __init__(self, interval, fn, args=()):
+            timers.append((interval, fn, tuple(args)))
+            self.daemon = False
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
+    status_host: dict = {}
+    warming = server._BackgroundWarmup(state, status_host, [1, 2, 3])
+    warming.submit(0)
+    scheduler.drain()
+    return generations, status_host, timers
+
+
+def test_background_warmup_defers_while_a_request_is_in_flight(monkeypatch):
+    """A request that has ARRIVED but not finished must hold the ladder.
+
+    last_request_at is stamped at completion, so a daemon that has not
+    completed a request yet still reads 0.0 while one is generating. That
+    read as "infinitely quiet" and let a warm rung run against live
+    traffic -- and because a UI that restarts the engine on a config change
+    is typed into immediately afterwards, the very first request of a serve
+    was the one most likely to be warmed over.
+    """
+    scheduler = FakeScheduler()
+    state = make_state(scheduler)
+    state.last_request_at = 0.0  # nothing has COMPLETED yet
+    state.foreground_active = 1  # ...but a real request is generating now
+    generations, status_host, timers = _deferral_probe(monkeypatch, state, scheduler)
+    assert generations == [], "warming generated while a request was in flight"
+    assert status_host["background"]["steps"][0]["state"] == "waiting_idle"
+    assert status_host["background"]["resubmits"] == 0
+    assert len(timers) == 1
+
+
+def test_background_warmup_defers_while_foreground_is_queued(monkeypatch):
+    """Foreground work queued on the scheduler counts as busy at admission
+    time, not only once it starts executing."""
+    scheduler = FakeScheduler()
+    scheduler.foreground_busy = True
+    state = make_state(scheduler)
+    state.last_request_at = 0.0
+    generations, status_host, _ = _deferral_probe(monkeypatch, state, scheduler)
+    assert generations == [], "warming generated while foreground work was queued"
+    assert status_host["background"]["steps"][0]["state"] == "waiting_idle"
+
+
+def test_background_warmup_still_warms_a_genuinely_idle_fresh_daemon(monkeypatch):
+    """The guard must not cost the case it exists for: nothing running and
+    nothing ever completed still warms immediately."""
+    scheduler = FakeScheduler()
+    state = make_state(scheduler)
+    state.last_request_at = 0.0
+    generations, status_host, _ = _deferral_probe(monkeypatch, state, scheduler)
+    assert generations == [16]
+    assert status_host["background"]["state"] == "done"

--- a/tests/test_background_warmup.py
+++ b/tests/test_background_warmup.py
@@ -120,6 +120,37 @@ def test_foreground_yield_shim_reads_scheduler_queues():
     assert server._ForegroundYield(state).is_set() is False
 
 
+def _deferral_probe(monkeypatch, state, scheduler):
+    """Run one warmup plan with timers faked; report whether any rung
+    actually generated and what the first step's published state is."""
+    monkeypatch.setenv("MTPLX_WARMUP_LADDER", "16")
+    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", "90")
+    monkeypatch.setattr(server, "_prewarm_gqa_packed_pipelines", lambda: True)
+    generations: list[int] = []
+    monkeypatch.setattr(
+        server,
+        "_run_generation",
+        lambda _state, prompt_ids, **kwargs: generations.append(len(prompt_ids))
+        or {"tok_s": 1.0},
+    )
+    timers: list[tuple[float, object, tuple]] = []
+
+    class FakeTimer:
+        def __init__(self, interval, fn, args=()):
+            timers.append((interval, fn, tuple(args)))
+            self.daemon = False
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
+    status_host: dict = {}
+    warming = server._BackgroundWarmup(state, status_host, [1, 2, 3])
+    warming.submit(0)
+    scheduler.drain()
+    return generations, status_host, timers
+
+
 def test_background_warmup_runs_all_steps_and_publishes_done(monkeypatch):
     scheduler = FakeScheduler()
     state = make_state(scheduler)
@@ -158,31 +189,7 @@ def test_background_warmup_defers_while_foreground_recent(monkeypatch):
     scheduler = FakeScheduler()
     state = make_state(scheduler)
     state.last_request_at = _time.time()  # a response just finished
-    monkeypatch.setenv("MTPLX_WARMUP_LADDER", "16")
-    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", "90")
-    monkeypatch.setattr(server, "_prewarm_gqa_packed_pipelines", lambda: True)
-    generations: list[int] = []
-    monkeypatch.setattr(
-        server,
-        "_run_generation",
-        lambda _state, prompt_ids, **kwargs: generations.append(len(prompt_ids))
-        or {"tok_s": 1.0},
-    )
-    timers: list[tuple[float, object, tuple]] = []
-
-    class FakeTimer:
-        def __init__(self, interval, fn, args=()):
-            timers.append((interval, fn, tuple(args)))
-            self.daemon = False
-
-        def start(self):
-            pass
-
-    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
-    status_host: dict = {}
-    warming = server._BackgroundWarmup(state, status_host, [1, 2, 3])
-    warming.submit(0)
-    scheduler.drain()
+    generations, status_host, timers = _deferral_probe(monkeypatch, state, scheduler)
     # No model work ran; the plan is waiting for idle, budget untouched.
     assert generations == []
     assert status_host["background"]["steps"][0]["state"] == "waiting_idle"
@@ -361,37 +368,6 @@ def test_dashboard_record_completion_skips_warmup_rows():
         stats={},
     )
     assert "lifetime" in calls and "rolling" in calls
-
-
-def _deferral_probe(monkeypatch, state, scheduler):
-    """Run one warmup plan with timers faked; report whether any rung
-    actually generated and what the first step's published state is."""
-    monkeypatch.setenv("MTPLX_WARMUP_LADDER", "16")
-    monkeypatch.setenv("MTPLX_WARMUP_IDLE_GRACE_S", "90")
-    monkeypatch.setattr(server, "_prewarm_gqa_packed_pipelines", lambda: True)
-    generations: list[int] = []
-    monkeypatch.setattr(
-        server,
-        "_run_generation",
-        lambda _state, prompt_ids, **kwargs: generations.append(len(prompt_ids))
-        or {"tok_s": 1.0},
-    )
-    timers: list[tuple[float, object, tuple]] = []
-
-    class FakeTimer:
-        def __init__(self, interval, fn, args=()):
-            timers.append((interval, fn, tuple(args)))
-            self.daemon = False
-
-        def start(self):
-            pass
-
-    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
-    status_host: dict = {}
-    warming = server._BackgroundWarmup(state, status_host, [1, 2, 3])
-    warming.submit(0)
-    scheduler.drain()
-    return generations, status_host, timers
 
 
 def test_background_warmup_defers_while_a_request_is_in_flight(monkeypatch):


### PR DESCRIPTION
Branch: `q6-lane/warmup-inflight-foreground-yield` (3 commits, base `main` @ 90d8c4b)
Files: `mtplx/server/openai.py`, `tests/test_background_warmup.py`

## What is wrong

`_BackgroundWarmup._foreground_quiet_for_s` decides whether a warm rung may be
admitted, and it reads only `state.last_request_at`. That field is stamped when a
request **completes** (five assignment sites, all on completion or cancellation
paths). A request that has arrived and is still generating therefore leaves it
untouched, and on a daemon that has not completed a request yet it is still
`0.0`, which the function reads as "no request has ever landed" and reports as
infinite quiet:

```python
def _foreground_quiet_for_s(self) -> float:
    last = float(getattr(self.state, "last_request_at", 0.0) or 0.0)
    if last <= 0.0:
        # No request has ever landed (fresh boot): warm immediately.
        return float("inf")
    return max(0.0, time.time() - last)
```

The comment says "landed". The field means "finished". Everything follows from
that gap.

## Why this window is the worst one

The failure is worst exactly where it is most visible. A control UI that
restarts the engine on a configuration change is typed into immediately
afterwards, so the very first request of a serve is both the one that has not
completed yet and the one most likely to be warmed over. Under the turbo
profile's eight-rung ladder (`512,1024,2048,2560,4096,8192,16384,32768`) a
single rung is tens of seconds of background prefill on a 27B, so the operator's
first request shares the GPU with a rung that the 90 second idle grace was
supposed to have held back.

Observed on a 27B (Qwen3.8-27B, 6-bit, M3 Max) from the server's own request
log, real non-warmup rows recorded while the ladder was walking:

```
{'prompt_tokens': 2622,  'completion_tokens': 28, 'decode_tok_s': 0.75}
{'prompt_tokens': 2622,  'completion_tokens': 0,  'decode_tok_s': 0.0}
{'prompt_tokens': 11459, 'completion_tokens': 0,  'decode_tok_s': 0.0}
```

The per-chunk `_ForegroundYield` abort still works and still bounds the damage
once a rung is running. It cannot help with a rung that should never have been
admitted.

## The change

Model work that is in flight or queued holds the ladder as its own admission
condition, whatever the grace is. Only when nothing is running does the
completion stamp decide.

Four details worth reviewing:

- The busy check (`_foreground_busy`) runs at **step admission**, in
  `_run_step_inner`, before the warming generation begins. At that moment
  `has_foreground()` counts only real requests, which is why this code can use
  it where the `_ForegroundYield` shim documents that it deliberately cannot
  (the shim runs inside the warming generation, which has incremented the
  counter itself via `_run_generation_dispatched`).
- The queued half goes through the same `_foreground_model_work_pending` helper
  the yield shim uses, so foreground work that is queued but not yet executing
  also holds the ladder.
- Busy is its own branch, not a zero folded into the grace comparison.
  `MTPLX_WARMUP_IDLE_GRACE_S=0` is how an operator says "do not wait between
  turns", and expressing busy as zero quiet would collapse the hold there
  (`0.0 < 0.0` is False) and hand a warm rung a request that is still
  generating.
- The completion stamp itself is now gated on the same
  `request_observability["warmup"]` filter `_dashboard_record_completion`
  already applies, so a warming generation no longer writes `last_request_at`
  or `requests_completed`. Before this, a rung's own completion made the next
  rung read quiet as roughly zero and park for the full 90 second grace, and
  `/health` reported `seconds_since_last_request` as if a user had just been
  served on an untouched daemon. `last_request_at` means "a user request
  completed"; warmup was writing it. The counter moves with the clock so the
  two `/health` fields cannot disagree.

`last_request_started_at` is deliberately **not** used as the anchor even though
`_smart_fan_activity_probe` pairs it with `last_request_at`: warming generations
go through `begin_foreground` too, so that field is set by the warmup itself and
using it would make every rung after the first defer forever.

## Verification

Four added to `tests/test_background_warmup.py`:

- `test_background_warmup_defers_while_a_request_is_in_flight` (fails before)
- `test_background_warmup_holds_a_live_request_even_at_zero_grace` (fails
  before)
- `test_background_warmup_defers_while_foreground_is_queued` (fails before)
- `test_background_warmup_still_warms_a_genuinely_idle_fresh_daemon` (passes
  before and after, so the guard is shown not to cost the case it exists for)

`make_state` gains the `foreground_active` counter and the `has_foreground`
accessor a real `ServerState` carries, and the shared `_deferral_probe`
helper replaces a verbatim copy of the same setup in the existing
foreground-recent test.

The warmup-stamp half of the change has no direct test: every test in this
file fakes `_run_generation` (the real one needs a model runtime), so no
harness can observe the stamp. The closest pinned evidence is the existing
`test_dashboard_record_completion_skips_warmup_rows`, which asserts the
identical warmup filter on the sibling call in the same function.

```
$ python -m pytest tests/test_background_warmup.py -q
................                                                         [100%]
16 passed

$ git checkout main -- mtplx/server/openai.py && python -m pytest tests/test_background_warmup.py -q
FAILED tests/test_background_warmup.py::test_background_warmup_defers_while_a_request_is_in_flight
FAILED tests/test_background_warmup.py::test_background_warmup_holds_a_live_request_even_at_zero_grace
FAILED tests/test_background_warmup.py::test_background_warmup_defers_while_foreground_is_queued
3 failed, 13 passed
```

## Residual, stated plainly

A request is only counted from `begin_foreground`, so the 100 to 200 ms of
handler Python between arrival and dispatch (tokenize, chat-template render) is
still a window in which a rung can be admitted. Closing that needs an arrival
stamp that warming cannot set, which is a larger change; the per-chunk yield
already bounds that case to one warming chunk, which is what it was designed
for. This change closes the unbounded case.

If a code path ever leaked `begin_foreground` without its matching
`end_foreground`, warming would stop rather than misfire. Every site pairs them
in a `finally`, so this is a degradation mode, not a new failure mode.
