### PR TITLE
Speculative draft: run the greedy MTP chain on device, one host sync per cycle

### DIFF
--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -8699,7 +8699,100 @@ def generate_mtpk(
                     "requested": "device",
                     "reason": "ineligible_contract",
                 }
-        for depth_index in range(0 if used_device_core else cycle_depth):
+        _greedy_chain_used = False
+        if (
+            not used_device_core
+            and cycle_depth > 0
+            and draft_sampler.temperature <= 0
+            and sampler.temperature <= 0
+            and a3b_target_prefix_route is None
+            and _cc_draft_source_token is None
+            and constraint is None
+            and draft_margin_threshold is None
+            and adaptive_policy is None
+            and adaptive_width_policy is None
+            and mtp_corrector is None
+            and mtp_topk_reranker is None
+            and not adapter_ensemble_q
+            and not online_hidden_enabled
+            and not correction_cache_enabled
+            and not online_correction_cache
+            and not prompt_correction_cache
+            and not target_prefix_verify
+            and not _penalties_active
+            and not _steer_active
+            and mtp_cache is not None
+            and mtp_cache_policy == "persistent"
+            and _mtp_history_uses_committed_cache(mtp_history_policy)
+            and str(
+                os.environ.get("MTPLX_GREEDY_DRAFT_CHAIN", "1")
+            ).strip().lower()
+            not in {"0", "off", "false", "no"}
+        ):
+            _chain_started = time.perf_counter()
+            _chain_seed = int(next_token)
+            _chain_tok = mx.array([[_chain_seed]])
+            _chain_hidden = draft_hidden
+            _chain_pending: list[mx.array] = []
+            _chain_offsets: list[int | None] = []
+            for _chain_depth in range(cycle_depth):
+                _chain_offset = mtp_position_offset_for_cache(mtp_cache)
+                _chain_offsets.append(_chain_offset)
+                _chain_logits, _chain_hidden_next = rt.draft_mtp(
+                    _chain_hidden,
+                    _chain_tok,
+                    mtp_cache=mtp_cache,
+                    return_hidden=True,
+                    mtp_hidden_variant=mtp_hidden_variant,
+                    mtp_depth=_chain_depth + 1,
+                    position_offset=_chain_offset,
+                )
+                _chain_arg = mx.argmax(_chain_logits[:, -1, :][0], axis=-1)
+                _chain_pending.append(_chain_arg)
+                _chain_tok = _chain_arg.reshape(1, 1).astype(mx.int32)
+                _chain_hidden = _chain_hidden_next[:, -1:, :]
+                draft_hidden_for_update.append(_chain_hidden)
+            _eval(*_chain_pending, _chain_hidden)
+            _chain_tokens = [int(a.item()) for a in _chain_pending]
+            _chain_elapsed = time.perf_counter() - _chain_started
+            draft_time += _chain_elapsed
+            for _chain_index, _chain_token in enumerate(_chain_tokens):
+                _chain_source = (
+                    _chain_seed
+                    if _chain_index == 0
+                    else _chain_tokens[_chain_index - 1]
+                )
+                draft_hidden_update_keys.append(
+                    (_chain_index + 1, _chain_source)
+                    if online_hidden_corrector_key == "token"
+                    else _chain_index + 1
+                )
+                draft_tokens.append(_chain_token)
+                draft_probs.append(None)
+                drafted += 1
+                drafted_by_depth[_chain_index] += 1
+                _chain_event = {
+                    "depth": _chain_index + 1,
+                    "token": int(_chain_token),
+                    "timing_s": {
+                        "draft": _chain_elapsed
+                        if _chain_index == len(_chain_tokens) - 1
+                        else 0.0
+                    },
+                    "mtp_corrector": None,
+                    "draft_core": "greedy-chain",
+                }
+                if _chain_offsets[_chain_index] is not None:
+                    _chain_event["position_offset"] = int(
+                        _chain_offsets[_chain_index]
+                    )
+                event["drafts"].append(_chain_event)
+            draft_hidden = _chain_hidden
+            next_token = _chain_tokens[-1]
+            _greedy_chain_used = True
+        for depth_index in range(
+            0 if (used_device_core or _greedy_chain_used) else cycle_depth
+        ):
             source_token = int(next_token)
             step_mtp_cache = (
                 mtp_cache if mtp_cache_policy == "persistent" else rt.make_mtp_cache()


### PR DESCRIPTION
**Type:** perf, bit-identical (scheduling only)

**Problem:** each draft step calls `_sample_draft_from_logits`, which blocks the host twice (`_eval(logits)`, then `argmax(...).item()`), so a draft cycle costs 2*depth blocking host syncs. Those host values are not needed until the chain ends: the next MTP step consumes the token as a device array, and under greedy `need_distribution` is `False`, so the per-draft distribution is already `None`.

**Evidence:** +2.8% decode (43.05 to 44.27 tok/s) sequential A/B, +1.5% marginal, draft time 2.21 to 1.86 ms per drafted token, byte-identical output, `accepted_by_depth` unchanged.

**Fix:** run the whole greedy MTP chain on device and take one `_eval` at the end, 6 host round trips to 1 at depth 3. Guarded to plain greedy drafting, everything else falls through to the stock loop. Off-switch: `MTPLX_GREEDY_DRAFT_CHAIN=0`.

## Details

```python
_chain_tok = mx.array([[int(next_token)]])
for _chain_depth in range(cycle_depth):
    _chain_logits, _chain_hidden_next = rt.draft_mtp(
        _chain_hidden, _chain_tok, ..., mtp_depth=_chain_depth + 1, ...)
    _chain_arg = mx.argmax(_chain_logits[:, -1, :][0], axis=-1)   # stays on device
    _chain_pending.append(_chain_arg)
    _chain_tok = _chain_arg.reshape(1, 1).astype(mx.int32)        # feeds the next step
    _chain_hidden = _chain_hidden_next[:, -1:, :]
_eval(*_chain_pending, _chain_hidden)                             # one host round trip
_chain_tokens = [int(a.item()) for a in _chain_pending]
```

Forwards, reduction and tie-breaking are unchanged; only the host read moves. Timing is billed to the last depth, as the existing device-core lane already does, so `event["drafts"]` keeps its shape, with `draft_core: "greedy-chain"` as the discriminator. `draft_probs` is appended as `None`, matching the stock greedy path.

**Eligibility (one guard).** Both samplers at `temperature <= 0`, persistent `mtp_cache`, committed-cache MTP history policy, and none of: constraint, draft-margin threshold, adaptive or width policy, MTP corrector, top-k reranker, adapter ensemble, online-hidden, correction caches, target-prefix verify, penalties, steering. Anything else falls through to the stock loop untouched.

| metric | before | after | delta |
|---|---:|---:|---|
| tok/s (greedy, 5-prompt mean) | 43.05 | 44.27 | +1.22 (+2.8%) |
| draft_time / drafted_token | 2.21 ms | 1.86 ms | -0.35 ms/tok (-1.05 ms/cycle) |
| accept time | 0.29 ms | 0.24 ms | -0.05 ms |
| verify_fwd / call | 41.74 ms | 41.28 ms | -0.46 ms |
| `accepted_by_depth` | n/a | n/a | unchanged |

+2.8% is the sequential A/B against a build without other host-sync work; +1.5% (0.66 tok/s off 44.28) is the marginal value measured by disabling only this change once that work is present, since the two remove some of the same stalls.

**Not present in 2.9.0.** Extracted `mtplx-2.9.0-py3-none-any.whl`: the loop is still `for depth_index in range(0 if used_device_core else cycle_depth):` (`generation.py:8702`), with no batched or deferred variant. The `used_device_core` / `draft_core == "device"` lane (`generation.py:8588`) is a different mechanism (compiled device core, own eligibility contract) and does not cover the host drafting path this patch targets. The new lane is gated behind `not used_device_core` and only extends that skip condition.

The removed cost is host/device synchronisation, not arithmetic, so it is not M2-specific and should pay off more on faster GPUs and at deeper drafts (5 of 6 syncs removed at depth 3).

## Protocol

M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), 5 prompts x 400 tokens x 2 reps, n=10 per arm, ABBA-interleaved, same-window controls, noise floor 0.00-0.03 tok/s.
Model `Qwen3.8-27B-MTPLX-Optimized-Speed-FP16`, `--profile turbo`, draft depth 3, greedy (temperature 0, seed 0); `decode_tok_s` read from the server's `mtplx_stats` envelope, headline is the unweighted mean of the 10 values.

## Validation

* Fixed-seed greedy capture with the chain on and off: byte-identical output. Primary gate, the change claims bit-identity.
* `accepted_by_depth` and tok/cycle unchanged, which catches a silent acceptance collapse.
* Fall-through: constraint, `temperature > 0`, MTP corrector, non-persistent `mtp_cache`; `draft_core` must not be `"greedy-chain"` and results must match stock.

Not measured on a non-Apple backend, nor above draft depth 3 (the shipped descriptor caps `maximum=3`).

