### PR TITLE
profiles: sustained/turbo set a batched target-distribution lane they also disable; allow operator override

### DIFF
--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -55,6 +55,10 @@ PROFILE_ENV_USER_OVERRIDE_KEYS = frozenset(
         # config being shipped), not only on profiles that leave the env
         # unset. Same operator-A/B precedent as DONATION/MAX_CONTEXT.
         "MTPLX_COMPILED_VERIFY",
+        # Batched target-distribution lane is dead under the profile
+        # defaults; operators need launch-env A/B (generation.py:9298, :9403).
+        "MTPLX_LAZY_TARGET_DISTRIBUTIONS",
+        "MTPLX_BATCH_TARGET_ARRAYS",
         # Background warmup ladder (F6, 2026-08-16): operators sweep the
         # rung list per machine/benchmark; an explicit env must beat the
         # turbo default below, same precedent as the chunk-size knobs.


### PR DESCRIPTION
**Type:** config bug fix, zero hot-path lines, byte-identical output.

**Problem:** The `sustained` and `turbo` profiles set `MTPLX_BATCH_TARGET_ARRAYS=1` and `MTPLX_LAZY_TARGET_DISTRIBUTIONS=1` together, but every batched-build site is gated on `not lazy_target_distributions`, so the batched lane is unreachable. The profile applier also stomps an operator override of either key, so it cannot be A/B'd from the launch env.

**Evidence:** +1.70% at temperature 1.0 with the lane enabled (n=10 per arm, 4 arms), byte-identical output, `tok/cycle` and `accepted_by_depth` unchanged.

**Fix:** Add both keys to `PROFILE_ENV_USER_OVERRIDE_KEYS`; defaults unchanged.

## Details

Both keys ship as `"1"` in `NATIVE_MTP_60_FAST_PATH_ENV`, which `SUSTAINED_PREFILL_ENV` splats (`profiles.py:251`) and `TURBO_PROFILE` merges (`profiles.py:521`):

```python
# profiles.py:158 (2.9.0)
"MTPLX_BATCH_TARGET_ARRAYS": "1",        # enabled
"MTPLX_LAZY_TARGET_DISTRIBUTIONS": "1",  # and this disables it
```

`_batch_target_arrays_enabled()` is only consulted inside blocks guarded by that flag:

```python
# generation.py:9297-9310 and 9402-9411 (2.9.0)
    and not lazy_target_distributions     # always False under turbo/sustained
    ...
    if _batch_target_arrays_enabled():
        target_distribution_batch = _batched_distributions_from_mlx_logits(...)
```

So `MTPLX_BATCH_TARGET_ARRAYS=1` is dead configuration on both profiles, and every `temperature > 0` accept row takes the per-row lazy path. It is not operator-recoverable either: `MTPLX_LAZY_TARGET_DISTRIBUTIONS` is absent from `PROFILE_ENV_USER_OVERRIDE_KEYS` (`profiles.py:26`), the set consulted at `profiles.py:682` that lets a launch env beat a profile default, so an exported `0` is stomped back to `1`. (`MODEL_RUNTIME_ENV_OVERRIDE_KEYS` at `profiles.py:167` holds both keys but is a different mechanism, consumed at `profiles.py:210` for per-model runtime env.)

Line numbers are from the extracted `mtplx-2.9.0-py3-none-any.whl` tree, where `PROFILE_ENV_USER_OVERRIDE_KEYS` ends with `MTPLX_COMPILED_VERIFY` / `MTPLX_WARMUP_LADDER` and contains neither key.

Measurement: M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), 5 prompts x 400 tokens x 2 reps, n=10 per arm, ABBA-interleaved, same-window controls. Temperature 1.0; a temp-0 capture cannot observe this, since the lane only exists on the sampled path.

| arm | `MTPLX_LAZY_TARGET_DISTRIBUTIONS` | tok/s | verify ms/call |
|---|---|---:|---:|
| a1 | 1 (profile default) | 44.09 | 68.23 |
| a2 | 1 (profile default) | 44.07 | n/a |
| b1 | 0 | 44.79 | 67.05 |
| b2 | 0 | 44.86 | 66.96 |

+0.75 tok/s = +1.70%. The two `1` arms agree to 0.02 tok/s and the two `0` arms to 0.07, about 10x below the effect. `tok/cycle` = 3.268 and `accepted_by_depth` = 0.889 / 0.762 / 0.622 in all four arms, so no acceptance was traded. Every prompt improves: code 45.7 to 46.4, math 46.4 to 47.2, prose 33.2 to 33.5, json 48.6 to 49.5, reason 46.1 to 47.0. A fixed-seed capture at temperature 1.0 is byte-identical on code, json and prose; both lanes build the same supports and consume the same RNG draws in the same order.

## Optional follow-up

Flipping `"MTPLX_LAZY_TARGET_DISTRIBUTIONS"` to `"0"` in `NATIVE_MTP_60_FAST_PATH_ENV` (`profiles.py:158`) captures the +1.70% for every `turbo`/`sustained` user, which is upstream's call since it changes shipped profile behaviour.

## Validation

- `MTPLX_LAZY_TARGET_DISTRIBUTIONS=0` with `--profile turbo`: `/health` `profile_env_status` lists the override, so the deviation is announced rather than silent.
- Fixed-seed capture at temperature 1.0, on and off: byte-identical. Temperature 0 A/B: neutral, the lane is unreachable there.
- `tok/cycle` and `accepted_by_depth` unchanged; movement there should block the merge.

