### PR TITLE
Speculative accept: batch the greedy argmax host round trips

### DIFF
--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -7189,6 +7189,8 @@ def generate_mtpk(
     accept_probability_sum_by_depth = [0.0 for _ in range(speculative_depth)]
     deferred_correction_repairs = 0
     pending_primary: int | None = None
+    _known_primary_next: int | None = None
+    _known_primary_hits = 0
     online_hidden_deltas: dict[object, mx.array] = {}
     online_hidden_update_counts: dict[object, int] = {}
     online_hidden_apply_counts: dict[object, int] = {}
@@ -8015,6 +8017,8 @@ def generate_mtpk(
                 append_event({"step": len(tokens), "constraint_stop": True})
                 break
         primary_already_emitted = pending_primary is not None
+        # Consume and clear: an earlier cycle's row must not reach other logits.
+        _known_primary, _known_primary_next = _known_primary_next, None
         if pending_primary is None:
             primary_row = logits[0]
             if constraint is not None:
@@ -8023,15 +8027,35 @@ def generate_mtpk(
                 # Speculative windows are handled by the legality clamp below
                 # instead of per-row masks (see #186 phase 3).
                 primary_row = constraint.mask_logits_row(primary_row)
-            primary, _ = _sample_from_logits(
-                primary_row,
-                sampler,
-                rng,
-                token_counts=Counter(tokens) if _penalties_active else None,
-                penalty_overlay=(
-                    _steer_overlay(tokens) if _steer_active else None
-                ),
+            _known_primary_usable = (
+                _known_primary is not None
+                and constraint is None
+                and sampler.temperature <= 0
+                and not _penalties_active
+                and not _steer_active
             )
+            if _known_primary_usable and not _env_truthy(
+                "MTPLX_KNOWN_PRIMARY_ASSERT"
+            ):
+                primary = int(_known_primary)
+                _known_primary_hits += 1
+            else:
+                primary, _ = _sample_from_logits(
+                    primary_row,
+                    sampler,
+                    rng,
+                    token_counts=Counter(tokens) if _penalties_active else None,
+                    penalty_overlay=(
+                        _steer_overlay(tokens) if _steer_active else None
+                    ),
+                )
+                if _known_primary_usable:
+                    _known_primary_hits += 1
+                    if int(_known_primary) != int(primary):
+                        raise RuntimeError(
+                            "known-primary self-check failed: published "
+                            f"{int(_known_primary)} != sampled {int(primary)}"
+                        )
             if first_primary_sample_time_s == 0.0:
                 # First primary token sampled: any lazy tail forced by
                 # touching the seed logits has just been paid. Passive read.
@@ -10210,6 +10234,17 @@ def generate_mtpk(
             repair_logits[:, -1, :],
             repair_hidden[:, -1:, :],
         )
+        # Capture/trim commits only: `logits` is verify_logits[:, accepted_count, :].
+        if (
+            (committed_from_capture or committed_from_trim)
+            and rejection_correction is None
+            and constraint is None
+            and _batched_target_tokens is not None
+            and len(_batched_target_tokens) > accepted_count
+            and str(os.environ.get("MTPLX_KNOWN_PRIMARY_CARRYOVER", "1")).strip().lower()
+            not in {"0", "off", "false", "no"}
+        ):
+            _known_primary_next = int(_batched_target_tokens[accepted_count])
         maybe_rebase_decode_state(cache_committed_token_count)
         maybe_eval_state_roots(event, cache_committed_token_count)
         append_event(event)
@@ -10310,6 +10345,12 @@ def generate_mtpk(
             )
 
     emit_trace(force=True, final=True)
+    if _known_primary_hits and _env_truthy("MTPLX_KNOWN_PRIMARY_STATS"):
+        print(
+            f"[mtplx] known-primary cycles: {_known_primary_hits} / {step}",
+            file=sys.stderr,
+            flush=True,
+        )
     compiled_verify_report: dict[str, Any] | None = None
     if a3b_target_prefix_route is not None:
         compiled_verify_report = a3b_target_prefix_route.final_report(

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -9454,6 +9454,30 @@ def generate_mtpk(
             if constraint is not None
             else None
         )
+        _batched_target_tokens: list[int] | None = None
+        if (
+            sampler.temperature <= 0
+            and not _penalties_active
+            and not _steer_active
+            and len(draft_tokens) > 0
+            and int(verify_logits.shape[1]) >= len(draft_tokens)
+            and str(
+                os.environ.get("MTPLX_BATCHED_GREEDY_ACCEPT", "1")
+            ).strip().lower()
+            not in {"0", "off", "false", "no"}
+        ):
+            _batched_rows = len(draft_tokens)
+            if (
+                int(verify_logits.shape[1]) > len(draft_tokens)
+                and str(
+                    os.environ.get("MTPLX_BATCHED_ACCEPT_BONUS_ROW", "1")
+                ).strip().lower()
+                not in {"0", "off", "false", "no"}
+            ):
+                _batched_rows += 1
+            _batched_target_tokens = mx.argmax(
+                verify_logits[0, :_batched_rows, :], axis=-1
+            ).tolist()
         for depth_index, draft_token in enumerate(draft_tokens):
             target_logits_for_draft = verify_logits[:, depth_index, :]
             if _steer_active:
@@ -9471,16 +9495,19 @@ def generate_mtpk(
                 _working_counts.update(draft_tokens[:depth_index])
             target_p_for_cache = None
             if sampler.temperature <= 0:
-                _greedy_row = target_logits_for_draft[0]
-                if _penalties_active or _row_guard_overlay:
-                    _greedy_row = apply_penalties_mlx(
-                        _greedy_row,
-                        _working_counts if _penalties_active else None,
-                        sampler.presence_penalty,
-                        sampler.frequency_penalty,
-                        penalty_overlay=_row_guard_overlay,
-                    )
-                target_token = int(mx.argmax(_greedy_row, axis=-1).item())
+                if _batched_target_tokens is not None:
+                    target_token = int(_batched_target_tokens[depth_index])
+                else:
+                    _greedy_row = target_logits_for_draft[0]
+                    if _penalties_active or _row_guard_overlay:
+                        _greedy_row = apply_penalties_mlx(
+                            _greedy_row,
+                            _working_counts if _penalties_active else None,
+                            sampler.presence_penalty,
+                            sampler.frequency_penalty,
+                            penalty_overlay=_row_guard_overlay,
+                        )
+                    target_token = int(mx.argmax(_greedy_row, axis=-1).item())
                 accepted_now = draft_token == target_token
                 accept_prob = 1.0 if accepted_now else 0.0
                 correction = target_token
@@ -9831,6 +9858,14 @@ def generate_mtpk(
                         target_distributions[len(draft_tokens)],
                         rng,
                     )
+                elif (
+                    _batched_target_tokens is not None
+                    and len(_batched_target_tokens) > len(draft_tokens)
+                    and not lazy_bonus_verify
+                    and not _penalties_active
+                    and not _steer_active
+                ):
+                    bonus = int(_batched_target_tokens[len(draft_tokens)])
                 else:
                     started_bonus_distribution = time.perf_counter()
                     # all-accept bonus: tokens already includes the committed block,

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -7569,6 +7569,7 @@ def generate_mtpk(
         nonlocal target_time, draft_time
         nonlocal state_rebase_tokens_since, state_rebase_observed_tokens
         nonlocal state_rebase_events, state_rebase_time_s
+        nonlocal _batched_target_tokens, _known_primary_next
         if state_rebase_every <= 0 or current_tokens <= 0:
             return
         if current_tokens < state_rebase_observed_tokens:
@@ -7606,6 +7607,9 @@ def generate_mtpk(
         hidden = rebased.hidden
         mtp_history_cache = rebased.committed_mtp_cache
         trace_current_mtp_cache = mtp_history_cache
+        # Rows argmaxed from the pre-rebase verify logits are stale now.
+        _batched_target_tokens = None
+        _known_primary_next = None
         target_time += max(
             0.0, rebased.prompt_eval_time_s - rebased.prompt_mtp_history_time_s
         )


### PR DESCRIPTION
**Type:** perf, bit-identical by construction.

**Problem:** the speculative accept loop reduces one row at a time, calling `int(mx.argmax(_greedy_row, axis=-1).item())` once per drafted token over an already materialised `verify_logits`. At depth 3 that is up to 4 serial lazy-scalar syncs per cycle, each a full pipeline drain, with no data dependency between them.

**Evidence:** accept time 0.683 to 0.292 ms/cycle; +0.68%, +0.50% and +0.15% tok/s across the three parts. Output byte-identical, `tok/cycle` and `accepted_by_depth` unchanged to the last digit.

**Fix:** hoist one batched argmax above the loop and index it (commit 1). Commit 2 reuses the already-reduced boundary row as the next cycle's primary on reject commits. Off-switches: `MTPLX_BATCHED_GREEDY_ACCEPT=0`, `MTPLX_BATCHED_ACCEPT_BONUS_ROW=0`, `MTPLX_KNOWN_PRIMARY_CARRYOVER=0`.

## Details

**Commit 1, batched accept argmax.** One reduction above the loop covers every accept row, plus the bonus row when it exists (on a full accept, 53% of cycles here, `logits` was assigned `verify_logits[:, len(draft_tokens), :]` two branches earlier, so it is another row of the same tensor):

```python
_batched_rows = len(draft_tokens)
if int(verify_logits.shape[1]) > len(draft_tokens) and _bonus_row_enabled():
    _batched_rows += 1
_batched_target_tokens = mx.argmax(
    verify_logits[0, :_batched_rows, :], axis=-1
).tolist()
```

The loop reads `_batched_target_tokens[depth_index]`, the bonus branch `_batched_target_tokens[len(draft_tokens)]`: up to 5 serial round trips become one. Gated on `temperature <= 0 and not _penalties_active and not _steer_active`, since those paths apply a per-row overlay before the reduction; their code is kept verbatim in the `else` branch. The bonus row also requires `not lazy_bonus_verify`.

**Commit 2, known-primary carry-over.** On a reject cycle committing from the capture or trim lane, the repair `logits` is `verify_logits[:, committed_prefix_len - 1, :]`, and `committed_prefix_len - 1 == accepted_count`, a row commit 1 already reduced. The next cycle re-samples its primary from that row via `_sample_from_logits`: two more round trips. Commit 2 publishes `_batched_target_tokens[accepted_count]` instead, guarded on capture or trim commit, `rejection_correction is None`, `constraint is None`. It is consumed once and cleared (`_known_primary, _known_primary_next = _known_primary_next, None`), so a published row can never reach a `logits` from elsewhere, and is used only at `temperature <= 0` with no penalties or steering. The standard-reforward lane rebuilds `repair_logits` from a fresh `forward_ar` and publishes nothing.

**Batched accept**, `Qwen3.8-27B-MTPLX-Optimized-Speed-FP16`, `--profile turbo`, depth 3:

| metric | before | after |
|---|---:|---:|
| tok/s (greedy) | 42.81 | 43.09 |
| accept / verify call (code/json/prose) | 0.73 / 0.75 / 0.57 ms | 0.293 / 0.295 / 0.289 ms |
| accept (cycle table) | 0.683 ms | 0.292 ms |
| verify total | 67.57 ms | 67.56 ms |
| tok/cycle | 3.081 | 3.081 (unchanged) |

+0.30 tok/s (+0.68%). Accept time is the cleaner signal, 2.3x lower, larger than the headline share because accept is a small part of a 67 ms cycle.

**Bonus row**, same model:

| arm | `MTPLX_BATCHED_ACCEPT_BONUS_ROW` | tok/s | verify ms/call | draft/tok |
|---|---|---:|---:|---:|
| off_a / off_b | `0` | 44.16 / 44.20 | 66.83 | 1.851 |
| on_a / on_b | `1` | 44.38 / 44.38 | 66.78 | 1.840 / 1.842 |

+0.22 tok/s (+0.50%). ON arms agree to 0.00 tok/s, OFF to 0.04. `tok/cycle` 3.175 identical, `accepted_by_depth` 0.869/0.721/0.593 identical to the last digit. Every prompt improves: code 45.9 to 46.0, math 47.1 to 47.4, prose 32.6 to 32.7, json 49.3 to 49.6, reason 45.9 to 46.2.

**Known-primary carry-over**, `Qwen3.8-27B-MTPLX-OSmid-FP16`, `--profile turbo`, depth 3, pooled across 13 arms:

| condition | arms | pooled tok/s |
|---|---:|---:|
| control | 6 | 46.093 |
| carry-over | 7 | 46.161 |

+0.068 tok/s (+0.15%), every candidate arm above every control arm (control spread 46.060 to 46.125). Clean re-run block: control 46.08 / 46.08 vs carry-over 46.15 / 46.19. At temperature 1.0, -0.03%: the guard makes it a no-op. Publish rate 245 of 497 cycles (49.3%), matching the ~47% predicted. `verify ms/call` unchanged (64.61 to 64.58); it removes host latency only. Small, and proposed because it is free and exact, not because it is large.

**Exactness.** Greedy output is byte-identical with each part on or off: 3 fixed prompts, `enable_thinking=false`, temp 0, seed 0, 300 tokens, full text compared character by character (not a prefix), in all 13 carry-over arms and against the reference capture, plus 300/300 MMLU items byte-identical with the carry-over on vs off. `MTPLX_KNOWN_PRIMARY_ASSERT=1` runs the sample anyway and raises on disagreement: a full arm gave 245 published cycles and zero disagreements, with `tok/cycle` 3.210 and `accepted_by_depth` 0.878/0.743/0.598 identical to the digit in all sixteen arms.

**2.9.0.** None of this is in 2.9.0: the region 2.7.1:7455-9797 is byte-identical to 2.9.0:7847-10189 (2343 lines, zero diff), the anchors moved by a constant +392 lines.

## Protocol

M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), 5 prompts x 400 tokens x 2 reps, n=10 per arm, ABBA-interleaved, same-window controls, noise floor 0.00-0.03 tok/s.

Prompts are code, math, prose, json and reason; `scripts/bench_speed.py` reads `decode_tok_s` from `mtplx_stats`, greedy (temp 0, seed 0), unweighted mean over the 10 values.

## Validation

1. Fixed-seed greedy capture on/off: byte-identical output for all three parts, with `tok/cycle` and `accepted_by_depth` unchanged to the last digit.
2. A full arm with `MTPLX_KNOWN_PRIMARY_ASSERT=1`: zero disagreements (245/245 here).
3. Fall-through (`temperature > 0`, presence/frequency penalties, steering overlay, active constraint, and the standard-reforward reject lane) matches stock exactly.

Commit 1 stands alone: most of the win, no cross-cycle state, and no state carried across loop iterations, which is the only new hazard commit 2 introduces.



Rebase interaction: maybe_rebase_decode_state replaces the logits with a fresh prefill, so a row argmaxed from the earlier verify_logits must not be used after it runs. The rebase invalidates both cached values, so neither the bonus row nor the carry-over can return an outdated row. state_rebase_every defaults to 0, and none of the numbers here turn it on.
