### PR TITLE
Opt-in FR-Spec reduced-vocabulary draft LM head

### DIFF
--- a/mtplx/draft_lm_head.py
+++ b/mtplx/draft_lm_head.py
@@ -303,6 +303,15 @@ def _install_draft_lm_head(rt: Any, *, bits: int, group_size: int, mode: str) ->
                 group_size=group_size,
                 mode=mode,
             )
+            # opt-in reduced-vocab draft head, active only via MTPLX_DRAFT_VOCAB_IDS
+            try:
+                from .reduced_vocab_draft import (
+                    maybe_wrap_draft_head as _mtplx_ext_wrap,
+                )
+
+                draft_head = _mtplx_ext_wrap(text, draft_head)
+            except Exception:  # pragma: no cover - never fail the load
+                pass
             layer.shared_head_head = draft_head
             reports.append({"layer": idx, **report})
         text._mtplx_step_mtp_draft_shared_heads = {
@@ -345,5 +354,25 @@ def _install_draft_lm_head(rt: Any, *, bits: int, group_size: int, mode: str) ->
         )
     else:
         raise AttributeError("model has no lm_head and does not tie output projection to embeddings")
+    try:
+        from .reduced_vocab_draft import maybe_wrap_draft_head as _mtplx_ext_wrap
+
+        _mtplx_ext_head = _mtplx_ext_wrap(text, draft_head)
+    except Exception as _mtplx_ext_exc:  # pragma: no cover - never fail the load
+        import sys as _mtplx_ext_sys
+
+        print(
+            f"[reduced-vocab] hook failed: {_mtplx_ext_exc!r}",
+            file=_mtplx_ext_sys.stderr,
+            flush=True,
+        )
+        _mtplx_ext_head = draft_head
+    if _mtplx_ext_head is not draft_head:
+        draft_head = _mtplx_ext_head
+        if isinstance(report, dict):
+            report = dict(report)
+            report["reduced_vocab"] = dict(
+                getattr(text, "_mtplx_reduced_vocab", {}) or {}
+            )
     text._mtplx_draft_lm_head = draft_head
     return report

--- a/mtplx/reduced_vocab_draft.py
+++ b/mtplx/reduced_vocab_draft.py
@@ -1,0 +1,450 @@
+"""FR-Spec (arXiv:2502.14856) reduced-vocabulary draft LM head.
+
+Restricts the draft-only LM head to a frequency-ranked token subset S.
+Speculative sampling is exact for any proposal q and the draft head never
+feeds the verify/target logits, so the output distribution is unchanged.
+The subset is an exact row slice of weight/scales/biases with no
+re-quantization, so logits on S are bit-identical to the full head's.
+
+``MTPLX_DRAFT_VOCAB_IDS`` (path to an ``.npy`` integer array of ids) is what
+activates the feature.  ``MTPLX_DRAFT_VOCAB_MODE`` selects ``full``
+(default: full-vocabulary-shaped row with a sentinel outside S, drop-in) or
+``compact`` (``|S|``-shaped rows plus sampler shims).
+``MTPLX_DRAFT_VOCAB_NEG`` picks the sentinel, ``MTPLX_DRAFT_VOCAB_KEEP_BASE``
+keeps the full head alive for A/B tests instead of freeing it (~0.7 GB), and
+``MTPLX_DRAFT_VOCAB_DEBUG`` prints a one-line install report.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "ReducedVocabDraftHead",
+    "build_reduced_head",
+    "load_subset_ids",
+    "slice_head_rows",
+    "maybe_wrap_draft_head",
+    "install_compact_shims",
+    "env_config",
+]
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in _TRUE
+
+
+def env_config() -> dict[str, Any]:
+    """Resolve the reduced-vocab configuration from the environment."""
+    ids_path = (os.environ.get("MTPLX_DRAFT_VOCAB_IDS") or "").strip()
+    mode = (os.environ.get("MTPLX_DRAFT_VOCAB_MODE") or "full").strip().lower()
+    if mode not in {"full", "compact"}:
+        raise ValueError(
+            f"MTPLX_DRAFT_VOCAB_MODE must be 'full' or 'compact', got {mode!r}"
+        )
+    return {
+        "enabled": bool(ids_path),
+        "ids_path": ids_path,
+        "mode": mode,
+        "neg": (os.environ.get("MTPLX_DRAFT_VOCAB_NEG") or "finite").strip().lower(),
+        "keep_base": _env_flag("MTPLX_DRAFT_VOCAB_KEEP_BASE", False),
+        "debug": _env_flag("MTPLX_DRAFT_VOCAB_DEBUG", False),
+    }
+
+
+def load_subset_ids(path: str, *, vocab_size: int | None = None) -> np.ndarray:
+    """Load, validate, de-duplicate and sort a token-id subset from ``.npy``."""
+    ids = np.load(path)
+    ids = np.asarray(ids).reshape(-1)
+    if not np.issubdtype(ids.dtype, np.integer):
+        raise ValueError(f"{path}: subset ids must be an integer array, got {ids.dtype}")
+    ids = np.unique(ids.astype(np.int64))
+    if ids.size == 0:
+        raise ValueError(f"{path}: empty token-id subset")
+    if int(ids[0]) < 0:
+        raise ValueError(f"{path}: negative token id {int(ids[0])}")
+    if vocab_size is not None and int(ids[-1]) >= int(vocab_size):
+        raise ValueError(
+            f"{path}: token id {int(ids[-1])} >= vocab_size {int(vocab_size)}"
+        )
+    return ids.astype(np.int32)
+
+
+def _neg_sentinel(dtype: Any, spec: str) -> float:
+    """Masking value that survives the samplers' ``* (1 / temperature)`` scaling."""
+    import mlx.core as mx
+
+    if spec == "inf":
+        return -float("inf")
+    if spec != "finite":
+        try:
+            return float(spec)
+        except ValueError as exc:  # pragma: no cover - operator error
+            raise ValueError(
+                "MTPLX_DRAFT_VOCAB_NEG must be 'finite', 'inf' or a float"
+            ) from exc
+    if dtype == mx.float16:
+        return -6.0e4          # fp16 max magnitude is 65504
+    return -1.0e30
+
+
+def _is_array(value: Any) -> bool:
+    import mlx.core as mx
+
+    return isinstance(value, mx.array)
+
+
+def slice_head_rows(base: Any, ids: Any, *, vocab_size: int) -> Any:
+    """Copy of ``base`` keeping only output rows ``ids``.  ``base`` is not mutated."""
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    cls = type(base)
+    sub = cls.__new__(cls)
+    nn.Module.__init__(sub)
+
+    for key, value in base.items():
+        if _is_array(value):
+            if value.ndim >= 1 and int(value.shape[0]) == int(vocab_size):
+                sub[key] = value[ids]
+            else:
+                sub[key] = value
+        elif isinstance(value, nn.Module):
+            sub[key] = slice_head_rows(value, ids, vocab_size=vocab_size)
+        else:
+            sub[key] = value
+
+    for key, value in vars(base).items():
+        if key in {"_no_grad", "_training"}:
+            continue
+        try:
+            object.__setattr__(sub, key, value)
+        except Exception:  # pragma: no cover - exotic descriptors
+            pass
+
+    try:
+        sub.freeze(recurse=True)
+    except Exception:  # pragma: no cover - older mlx
+        pass
+    mx.eval(sub.parameters())
+    return sub
+
+
+def _row_count(module: Any, *, vocab_size: int) -> int:
+    """Output-row count of a sliced module, or -1 when no weight is found."""
+    import mlx.nn as nn
+
+    weight = None
+    if "weight" in module:
+        weight = module["weight"]
+    else:
+        for value in module.values():
+            if isinstance(value, nn.Module) and "weight" in value:
+                weight = value["weight"]
+                break
+    if weight is None:
+        return -1
+    return int(weight.shape[0])
+
+
+def _make_head_class():
+    """Build the head class lazily so importing this file needs no MLX."""
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    _HAS_PUT_ALONG = hasattr(mx, "put_along_axis")
+
+    class ReducedVocabDraftHead(nn.Module):
+        """Draft LM head restricted to a fixed token subset S.
+
+        ``mode="full"`` returns ``(..., V)`` logits with a sentinel outside S,
+        a drop-in for every MTPLX draft consumer.  ``mode="compact"`` returns
+        ``(..., |S|)`` and requires :func:`install_compact_shims`.
+        """
+
+        def __init__(
+            self,
+            head: Any,
+            ids: np.ndarray,
+            *,
+            vocab_size: int,
+            mode: str = "full",
+            neg: str = "finite",
+            base: Any = None,
+        ):
+            super().__init__()
+            self.head = head
+            object.__setattr__(self, "_ids_np", np.asarray(ids, dtype=np.int64))
+            object.__setattr__(self, "_ids", mx.array(np.asarray(ids, dtype=np.int32)))
+            object.__setattr__(self, "_vocab_size", int(vocab_size))
+            object.__setattr__(self, "_subset_size", int(len(ids)))
+            object.__setattr__(self, "_mode", str(mode))
+            object.__setattr__(self, "_neg_spec", str(neg))
+            object.__setattr__(self, "_base", base)
+            object.__setattr__(self, "_neg_cache", {})
+            object.__setattr__(self, "_idx_cache", {})
+            mx.eval(self._ids)
+
+        @property
+        def vocab_size(self) -> int:
+            return self._vocab_size
+
+        @property
+        def subset_size(self) -> int:
+            return self._subset_size
+
+        @property
+        def mode(self) -> str:
+            return self._mode
+
+        @property
+        def subset_ids(self) -> np.ndarray:
+            return self._ids_np
+
+        # forwarded so server.openai._draft_head_identity fingerprints two
+        # different subsets differently
+        @property
+        def weight(self):
+            return self.head.weight
+
+        @property
+        def scales(self):
+            return self.head.scales
+
+        @property
+        def biases(self):
+            return self.head.biases
+
+        @property
+        def bias(self):
+            return self.head.bias
+
+        def _sentinel(self, dtype):
+            cache = self._neg_cache
+            value = cache.get(dtype)
+            if value is None:
+                value = _neg_sentinel(dtype, self._neg_spec)
+                cache[dtype] = value
+            return value
+
+        def _scatter_index(self, shape):
+            cache = self._idx_cache
+            idx = cache.get(shape)
+            if idx is None:
+                idx = mx.broadcast_to(
+                    self._ids.reshape((1,) * (len(shape) - 1) + (self._subset_size,)),
+                    shape,
+                )
+                cache[shape] = idx
+            return idx
+
+        def __call__(self, x):
+            y = self.head(x)
+            if self._mode == "compact":
+                return y
+            full_shape = tuple(y.shape[:-1]) + (self._vocab_size,)
+            out = mx.full(full_shape, self._sentinel(y.dtype), dtype=y.dtype)
+            if _HAS_PUT_ALONG:
+                idx = self._scatter_index(tuple(y.shape))
+                return mx.put_along_axis(out, idx, y.astype(out.dtype), axis=-1)
+            out[..., self._ids] = y.astype(out.dtype)
+            return out
+
+        def _extra_repr(self) -> str:  # pragma: no cover - cosmetic
+            return (
+                f"subset={self._subset_size}, vocab={self._vocab_size}, "
+                f"mode={self._mode}"
+            )
+
+    return ReducedVocabDraftHead
+
+
+_HEAD_CLASS: Any = None
+
+
+def _head_class():
+    global _HEAD_CLASS
+    if _HEAD_CLASS is None:
+        _HEAD_CLASS = _make_head_class()
+    return _HEAD_CLASS
+
+
+def __getattr__(name: str):
+    if name == "ReducedVocabDraftHead":
+        return _head_class()
+    raise AttributeError(name)
+
+
+def build_reduced_head(
+    base: Any,
+    ids: Any,
+    *,
+    mode: str = "full",
+    neg: str = "finite",
+    keep_base: bool = False,
+) -> Any:
+    """Slice ``base`` down to rows ``ids`` and wrap it in a reduced head."""
+    import mlx.core as mx
+
+    vocab_size = _base_vocab_size(base)
+    if isinstance(ids, str):
+        ids_np = load_subset_ids(ids, vocab_size=vocab_size)
+    else:
+        ids_np = np.unique(np.asarray(ids).reshape(-1).astype(np.int64)).astype(np.int32)
+    if int(ids_np[-1]) >= vocab_size:
+        raise ValueError(
+            f"token id {int(ids_np[-1])} out of range for vocab_size {vocab_size}"
+        )
+    idx = mx.array(ids_np.astype(np.int32))
+    sliced = slice_head_rows(base, idx, vocab_size=vocab_size)
+    rows = _row_count(sliced, vocab_size=vocab_size)
+    if rows not in (-1, int(ids_np.size)):
+        raise RuntimeError(
+            f"row slice produced {rows} rows, expected {int(ids_np.size)}"
+        )
+    head_cls = _head_class()
+    return head_cls(
+        sliced,
+        ids_np,
+        vocab_size=vocab_size,
+        mode=mode,
+        neg=neg,
+        base=base if keep_base else None,
+    )
+
+
+def _base_vocab_size(base: Any) -> int:
+    import mlx.nn as nn
+
+    if "weight" in base:
+        return int(base["weight"].shape[0])
+    for value in base.values():
+        if isinstance(value, nn.Module) and "weight" in value:
+            return int(value["weight"].shape[0])
+    raise TypeError(f"cannot determine vocab size of draft head {type(base)!r}")
+
+
+def maybe_wrap_draft_head(text_model: Any, base: Any) -> Any:
+    """Return a reduced head when the env asks for one, else ``base``.
+
+    Safe to call unconditionally: returns ``base`` untouched when
+    ``MTPLX_DRAFT_VOCAB_IDS`` is unset or on any recoverable failure.
+    """
+    cfg = env_config()
+    if not cfg["enabled"] or base is None:
+        return base
+    try:
+        vocab_size = _base_vocab_size(base)
+        ids = load_subset_ids(cfg["ids_path"], vocab_size=vocab_size)
+        head = build_reduced_head(
+            base,
+            ids,
+            mode=cfg["mode"],
+            neg=cfg["neg"],
+            keep_base=cfg["keep_base"],
+        )
+    except Exception as exc:
+        print(
+            f"[reduced-vocab] DISABLED: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return base
+    if cfg["mode"] == "compact":
+        install_compact_shims(head)
+    if text_model is not None:
+        try:
+            object.__setattr__(text_model, "_mtplx_reduced_vocab", {
+                "ids_path": cfg["ids_path"],
+                "subset_size": int(head.subset_size),
+                "vocab_size": int(head.vocab_size),
+                "mode": cfg["mode"],
+                "neg": cfg["neg"],
+            })
+        except Exception:
+            pass
+    print(
+        "[reduced-vocab] draft head restricted to "
+        f"{head.subset_size}/{head.vocab_size} ids "
+        f"({100.0 * head.subset_size / head.vocab_size:.1f}%), mode={cfg['mode']}, "
+        f"neg={cfg['neg']}, ids={cfg['ids_path']}",
+        file=sys.stderr,
+        flush=True,
+    )
+    return head
+
+
+_COMPACT_INSTALLED = False
+
+
+def compact_shims_installed() -> bool:
+    """Whether :func:`install_compact_shims` has patched the host draft samplers."""
+
+    return bool(_COMPACT_INSTALLED)
+
+
+def install_compact_shims(head: Any) -> None:
+    """Patch the MTPLX host draft samplers for ``mode="compact"``.
+
+    Compact rows make every sampler output a subset index rather than a
+    vocabulary id.  Only the stock host draft path is remapped; the compiled
+    device draft cores and the adaptive-width / reranker / a3b-prefix readers
+    are hard-disabled because they consume those raw indices directly.
+    """
+    global _COMPACT_INSTALLED
+    if _COMPACT_INSTALLED:
+        return
+
+    import mtplx.generation as gen
+    from mtplx.sampling import SparseDistribution
+
+    ids_np = np.asarray(head.subset_ids, dtype=np.int64)
+    vocab_size = int(head.vocab_size)
+
+    original_sample = gen._sample_draft_from_logits
+
+    def _sample_draft_from_logits(logits, config, rng, *, need_distribution):
+        token, dist = original_sample(
+            logits, config, rng, need_distribution=need_distribution
+        )
+        token = int(ids_np[int(token)])
+        if isinstance(dist, SparseDistribution):
+            dist = SparseDistribution(
+                ids_np[np.asarray(dist.token_ids, dtype=np.int64)],
+                np.asarray(dist.probs, dtype=np.float64),
+                vocab_size,
+            )
+        elif dist is not None:
+            dense = np.zeros(vocab_size, dtype=np.float64)
+            dense[ids_np] = np.asarray(dist, dtype=np.float64)
+            dist = dense
+        return token, dist
+
+    def _unsupported(*_args, **_kwargs):
+        raise RuntimeError(
+            "MTPLX_DRAFT_VOCAB_MODE=compact supports only the stock host "
+            "draft core; use MTPLX_DRAFT_VOCAB_MODE=full for the device "
+            "draft cores, adaptive-width readers and a3b prefix route."
+        )
+
+    gen._sample_draft_from_logits = _sample_draft_from_logits
+    gen._greedy_draft_token_and_top2 = _unsupported
+    gen._make_device_draft_core = _unsupported
+    gen._make_device_d2_draft_core = _unsupported
+    gen.sample_token_ids_from_mlx_logits = _unsupported
+    _COMPACT_INSTALLED = True
+    print(
+        "[reduced-vocab] compact-mode sampler shims installed "
+        "(device draft cores disabled)",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/scripts/build_vocab_subset.py
+++ b/scripts/build_vocab_subset.py
@@ -1,0 +1,788 @@
+#!/usr/bin/env python3
+"""Build frequency-ranked token-id subsets for the FR-Spec reduced draft head.
+
+Counts Qwen3.8-27B tokenizer ids over a mixed corpus (English web/edu, English
+wikipedia, math/reasoning, multi-language code, Chinese wikipedia,
+chat-templated dialogue), unions them with a hard-coded always-keep set
+(specials, control ids >= 248000, digits, punctuation, whitespace/indent,
+single-byte tokens), and writes sorted int32 ``ids_16k/32k/48k/64k.npy`` plus a
+coverage report.  Coverage is measured on a per-domain held-out 10% split.
+
+Reference implementation of the method: the corpus and tokenizer paths below
+are local to the machine this was built on.  Needs ``tokenizers``, ``numpy``,
+``pyarrow`` and ``datasets``::
+
+    python scripts/build_vocab_subset.py --tokenizer <model dir> [--offline]
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import time
+import unicodedata
+import urllib.request
+import zlib
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+CORPUS_ROOT = Path(os.environ.get("VOCAB_CORPUS_ROOT", "corpus"))
+DEFAULT_TOKENIZER = CORPUS_ROOT / "models/Qwen3.8-27B"
+VOCAB_SIZE = 248320          # text_config.vocab_size of Qwen3.8-27B
+CONTROL_FLOOR = 248000       # everything above is chat/control specials
+
+SIZES = {"16k": 16384, "32k": 32768, "48k": 49152, "64k": 65536}
+
+CHUNK_CHARS = 4000
+BATCH_DOCS = 256
+
+
+def _read_text_file(path: Path, budget: int):
+    if not path.is_file():
+        return
+    got = 0
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        while got < budget:
+            block = handle.read(1 << 20)
+            if not block:
+                break
+            got += len(block)
+            yield block
+
+
+def _arrow_column(path: Path, column: str, budget: int):
+    try:
+        import pyarrow as pa
+    except ImportError:
+        return
+    if not path.is_file():
+        return
+    got = 0
+    with pa.memory_map(str(path), "rb") as source:
+        try:
+            reader = pa.ipc.open_stream(source)
+        except pa.ArrowInvalid:
+            source.seek(0)
+            reader = pa.ipc.open_file(source)
+        batches = (
+            reader
+            if hasattr(reader, "__iter__")
+            else (reader.get_batch(i) for i in range(reader.num_record_batches))
+        )
+        for batch in batches:
+            if column not in batch.schema.names:
+                return
+            for value in batch.column(column).to_pylist():
+                if not value:
+                    continue
+                got += len(value)
+                yield value
+                if got >= budget:
+                    return
+
+
+def _parquet_column(path: Path, column: str, budget: int):
+    import pyarrow.parquet as pq
+
+    if not path.is_file():
+        return
+    handle = pq.ParquetFile(str(path))
+    got = 0
+    for rg in range(handle.num_row_groups):
+        table = handle.read_row_group(rg, columns=[column])
+        for value in table.column(column).to_pylist():
+            if not value:
+                continue
+            got += len(value)
+            yield value
+            if got >= budget:
+                return
+
+
+class _HttpRangeFile(io.RawIOBase):
+    """Minimal random-access file over HTTP range requests (for parquet)."""
+
+    def __init__(self, url: str):
+        self.url = url
+        self.pos = 0
+        self.downloaded = 0
+        with urllib.request.urlopen(
+            urllib.request.Request(url, method="HEAD"), timeout=60
+        ) as response:
+            self.size = int(response.headers["Content-Length"])
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def seek(self, offset, whence=0):
+        if whence == 0:
+            self.pos = offset
+        elif whence == 1:
+            self.pos += offset
+        else:
+            self.pos = self.size + offset
+        return self.pos
+
+    def tell(self):
+        return self.pos
+
+    def read(self, size=-1):
+        if size is None or size < 0:
+            size = self.size - self.pos
+        if size == 0 or self.pos >= self.size:
+            return b""
+        end = min(self.pos + size, self.size) - 1
+        request = urllib.request.Request(
+            self.url, headers={"Range": f"bytes={self.pos}-{end}"}
+        )
+        with urllib.request.urlopen(request, timeout=120) as response:
+            data = response.read()
+        self.pos += len(data)
+        self.downloaded += len(data)
+        return data
+
+    def readinto(self, buffer):
+        data = self.read(len(buffer))
+        buffer[: len(data)] = data
+        return len(data)
+
+
+def _http_parquet_column(url: str, column: str, budget: int):
+    import pyarrow.parquet as pq
+
+    handle = _HttpRangeFile(url)
+    reader = pq.ParquetFile(handle)
+    got = 0
+    for rg in range(reader.num_row_groups):
+        table = reader.read_row_group(rg, columns=[column])
+        for value in table.column(column).to_pylist():
+            if not value:
+                continue
+            got += len(value)
+            yield value
+            if got >= budget:
+                return
+
+
+def _http_gz_jsonl(url: str, field: str, byte_budget: int, char_budget: int):
+    request = urllib.request.Request(url, headers={"Range": f"bytes=0-{byte_budget}"})
+    with urllib.request.urlopen(request, timeout=180) as response:
+        raw = response.read()
+    text = zlib.decompressobj(16 + zlib.MAX_WBITS).decompress(raw).decode(
+        "utf-8", "ignore"
+    )
+    got = 0
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        value = record.get(field) or ""
+        if not value:
+            continue
+        got += len(value)
+        yield value
+        if got >= char_budget:
+            return
+
+
+def _json_strings(path: Path, budget: int):
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except Exception:
+        return
+    got = 0
+    stack = [data]
+    while stack and got < budget:
+        node = stack.pop()
+        if isinstance(node, str):
+            if node:
+                got += len(node)
+                yield node
+        elif isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def _local_code(budget: int):
+    roots = [
+        (CORPUS_ROOT / "llama.cpp", ("*.c", "*.cpp", "*.h", "*.hpp", "*.cu", "*.metal",
+                              "*.cmake", "*.sh", "*.py")),
+        (CORPUS_ROOT / "mtplx/repo", ("*.py", "*.ts", "*.js", "*.metal", "*.toml",
+                               "*.yaml", "*.yml", "*.json", "*.sh")),
+        (CORPUS_ROOT / "train", ("*.py", "*.sh")),
+        (CORPUS_ROOT / "scripts", ("*.py", "*.sh")),
+    ]
+    got = 0
+    for root, patterns in roots:
+        if not root.is_dir():
+            continue
+        for pattern in patterns:
+            for path in sorted(root.rglob(pattern)):
+                if got >= budget:
+                    return
+                try:
+                    if path.stat().st_size > 400_000:
+                        continue
+                    body = path.read_text(encoding="utf-8", errors="ignore")
+                except Exception:
+                    continue
+                if not body.strip():
+                    continue
+                got += len(body)
+                yield body
+
+
+def _chat_docs(tokenizer_dir: Path, budget: int):
+    """Chat-template rendered dialogue so control/role tokens get counted."""
+    try:
+        import transformers
+
+        tok = transformers.AutoTokenizer.from_pretrained(
+            str(tokenizer_dir), trust_remote_code=False
+        )
+    except Exception as exc:
+        print(f"  [chat] transformers unavailable ({exc}); using raw template", file=sys.stderr)
+        tok = None
+    seeds: list[tuple[str, str]] = []
+    for path in [
+        CORPUS_ROOT / "mtplx/eval/data/gsm8k_200.json",
+        CORPUS_ROOT / "mtplx/eval/data/mmlu_redux_300.json",
+        CORPUS_ROOT / "mtplx/eval/data/aime25_30.json",
+        CORPUS_ROOT / "eval/data/arc_c_200.json",
+    ]:
+        if not path.is_file():
+            continue
+        try:
+            rows = json.loads(path.read_text())
+        except Exception:
+            continue
+        if isinstance(rows, dict):
+            rows = rows.get("data") or rows.get("rows") or []
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            question = str(row.get("question") or row.get("prompt") or row.get("problem") or "")
+            answer = str(row.get("answer") or row.get("solution") or row.get("target") or "")
+            if question:
+                seeds.append((question, answer))
+    got = 0
+    for question, answer in seeds:
+        messages = [{"role": "user", "content": question}]
+        if answer:
+            messages.append({"role": "assistant", "content": answer})
+        if tok is not None:
+            try:
+                rendered = tok.apply_chat_template(messages, tokenize=False)
+            except Exception:
+                rendered = f"<|im_start|>user\n{question}<|im_end|>\n<|im_start|>assistant\n{answer}<|im_end|>\n"
+        else:
+            rendered = f"<|im_start|>user\n{question}<|im_end|>\n<|im_start|>assistant\n{answer}<|im_end|>\n"
+        got += len(rendered)
+        yield rendered
+        if got >= budget:
+            return
+
+
+def build_sources(tokenizer_dir: Path, offline: bool, scale: float):
+    """Return {domain: iterable-of-text-generators}."""
+    mb = lambda x: int(x * 1024 * 1024 * scale)  # noqa: E731
+    wt103 = (
+        Path.home()
+        / ".cache/huggingface/datasets/Salesforce___wikitext/wikitext-103-raw-v1/0.0.0"
+        / "b08601e04326c79dfdd32d625aee71d232d685c3"
+    )
+    gsm8k = (
+        Path.home()
+        / ".cache/huggingface/datasets/openai___gsm8k/main/0.0.0"
+        / "740312add88f781978c0658806c59bc2815b9866"
+    )
+    math500 = (
+        Path.home()
+        / ".cache/huggingface/datasets/HuggingFaceH4___math-500/default/0.0.0"
+        / "6e4ed1a2a79af7d8630a6b768ec859cb5af4d3be"
+    )
+    mmlu = (
+        Path.home()
+        / ".cache/huggingface/datasets/cais___mmlu/all/0.0.0"
+        / "c30699e8356da336a370243923dbaf21066bb9fe"
+    )
+
+    sources: dict[str, list] = {
+        "web_en": [
+            ("fineweb-edu train.txt", _read_text_file(CORPUS_ROOT / "train/data/train.txt", mb(26))),
+            (
+                "fineweb-edu parquet",
+                _parquet_column(CORPUS_ROOT / "train/data/fwe_000.parquet", "text", mb(24)),
+            ),
+        ],
+        "wiki_en": [
+            (
+                "wikitext-103 raw (shard 0)",
+                _arrow_column(wt103 / "wikitext-train-00000-of-00002.arrow", "text", mb(30)),
+            ),
+            (
+                "wikitext-2 raw",
+                _read_text_file(
+                    CORPUS_ROOT / "eval/data/wikitext-2-raw/wiki.train.raw", mb(10)
+                ),
+            ),
+        ],
+        "math": [
+            ("gsm8k train", _arrow_column(gsm8k / "gsm8k-train.arrow", "answer", mb(3))),
+            ("gsm8k questions", _arrow_column(gsm8k / "gsm8k-train.arrow", "question", mb(3))),
+            ("math-500 solutions", _arrow_column(math500 / "math-500-test.arrow", "solution", mb(2))),
+            ("mmlu (all)", _arrow_column(mmlu / "mmlu-test.arrow", "question", mb(3))),
+            ("mmlu auxiliary_train", _arrow_column(mmlu / "mmlu-auxiliary_train.arrow", "question", mb(4))),
+            ("mtplx eval gsm8k", _json_strings(CORPUS_ROOT / "mtplx/eval/data/gsm8k_200.json", mb(1))),
+            ("mtplx eval aime25", _json_strings(CORPUS_ROOT / "mtplx/eval/data/aime25_30.json", mb(1))),
+            ("mtplx eval gpqa", _json_strings(CORPUS_ROOT / "mtplx/eval/data/gpqa_diamond_198.json", mb(1))),
+            ("local mmlu_500", _json_strings(CORPUS_ROOT / "eval/data/mmlu_500.json", mb(1))),
+        ],
+        "code": [("local repos (c/c++/cuda/metal/py/ts/sh)", _local_code(mb(36)))],
+        "zh": [],
+        "chat": [("chat-template rendered eval prompts", _chat_docs(tokenizer_dir, mb(6)))],
+    }
+
+    if not offline:
+        sources["code"].append(
+            (
+                "rosetta-code (multi-language)",
+                _http_parquet_column(
+                    "https://huggingface.co/datasets/christopher/rosetta-code/"
+                    "resolve/main/data/train-00000-of-00001-8b4da49264116bbf.parquet",
+                    "code",
+                    mb(12),
+                ),
+            )
+        )
+        sources["code"].append(
+            (
+                "codeparrot-clean-valid (python)",
+                _http_gz_jsonl(
+                    "https://huggingface.co/datasets/codeparrot/codeparrot-clean-valid/"
+                    "resolve/main/file-000000000054.json.gz",
+                    "content",
+                    12_000_000,
+                    mb(14),
+                ),
+            )
+        )
+        sources["zh"].append(
+            (
+                "wikipedia zh 20231101 (row groups)",
+                _http_parquet_column(
+                    "https://huggingface.co/datasets/wikimedia/wikipedia/"
+                    "resolve/main/20231101.zh/train-00002-of-00006.parquet",
+                    "text",
+                    mb(24),
+                ),
+            )
+        )
+    return sources
+
+
+def _bytes_to_unicode() -> dict[int, str]:
+    """GPT-2 / Qwen byte-level BPE byte <-> printable-unicode map."""
+    bs = (
+        list(range(ord("!"), ord("~") + 1))
+        + list(range(ord("\xa1"), ord("\xac") + 1))
+        + list(range(ord("\xae"), ord("\xff") + 1))
+    )
+    cs = bs[:]
+    n = 0
+    for b in range(256):
+        if b not in bs:
+            bs.append(b)
+            cs.append(256 + n)
+            n += 1
+    return dict(zip(bs, [chr(c) for c in cs]))
+
+
+def decode_vocab(tokenizer_json: Path) -> tuple[dict[int, str], set[int]]:
+    """Return {id: decoded-text} and the set of added/special ids."""
+    data = json.loads(tokenizer_json.read_text(encoding="utf-8"))
+    vocab = data["model"]["vocab"]
+    byte_decoder = {v: k for k, v in _bytes_to_unicode().items()}
+    decoded: dict[int, str] = {}
+    for token, idx in vocab.items():
+        try:
+            raw = bytes(byte_decoder[ch] for ch in token)
+        except KeyError:
+            decoded[int(idx)] = token
+            continue
+        decoded[int(idx)] = raw.decode("utf-8", errors="replace")
+    special: set[int] = set()
+    for entry in data.get("added_tokens") or []:
+        special.add(int(entry["id"]))
+        decoded.setdefault(int(entry["id"]), str(entry.get("content", "")))
+    return decoded, special
+
+
+_PUNCT_CATS = {"Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po", "Sm", "Sc", "Sk", "So"}
+
+
+def always_keep(decoded: dict[int, str], special: set[int]) -> dict[str, set[int]]:
+    groups: dict[str, set[int]] = {
+        "special_added": set(special),
+        "control_ge_248000": {i for i in range(CONTROL_FLOOR, VOCAB_SIZE)},
+        "single_byte": set(),
+        "digits": set(),
+        "whitespace_indent": set(),
+        "punct_symbol": set(),
+        "code_symbol_runs": set(),
+    }
+    for idx, text in decoded.items():
+        if idx >= VOCAB_SIZE:
+            continue
+        if not text:
+            continue
+        if len(text.encode("utf-8", "ignore")) == 1:
+            groups["single_byte"].add(idx)
+        core = text.strip(" ")
+        if core and all(ch.isdigit() for ch in core):
+            groups["digits"].add(idx)
+        if all(ch in " \t\n\r\x0b\x0c" for ch in text):
+            groups["whitespace_indent"].add(idx)
+        if core and all(unicodedata.category(ch) in _PUNCT_CATS for ch in core):
+            groups["punct_symbol"].add(idx)
+        if text and all(
+            (33 <= ord(ch) <= 47) or (58 <= ord(ch) <= 64)
+            or (91 <= ord(ch) <= 96) or (123 <= ord(ch) <= 126)
+            or ch in " \t\n\r"
+            for ch in text
+        ):
+            groups["code_symbol_runs"].add(idx)
+    return groups
+
+
+def chunks(text: str, size: int = CHUNK_CHARS):
+    for start in range(0, len(text), size):
+        yield text[start : start + size]
+
+
+def count_domain(tokenizer, docs, vocab_size: int, holdout_every: int = 10):
+    """Return (train_counts, holdout_counts, n_tokens_train, n_tokens_holdout)."""
+    train = np.zeros(vocab_size, dtype=np.int64)
+    holdout = np.zeros(vocab_size, dtype=np.int64)
+    batch: list[str] = []
+    flags: list[bool] = []
+    doc_index = 0
+    encode = getattr(tokenizer, "encode_batch_fast", None) or tokenizer.encode_batch
+
+    def flush():
+        if not batch:
+            return
+        encodings = encode(batch, add_special_tokens=False)
+        train_ids: list[np.ndarray] = []
+        hold_ids: list[np.ndarray] = []
+        for encoding, is_hold in zip(encodings, flags):
+            arr = np.asarray(encoding.ids, dtype=np.int64)
+            (hold_ids if is_hold else train_ids).append(arr)
+        if train_ids:
+            flat = np.concatenate(train_ids)
+            train[: vocab_size] += np.bincount(flat, minlength=vocab_size)[:vocab_size]
+        if hold_ids:
+            flat = np.concatenate(hold_ids)
+            holdout[: vocab_size] += np.bincount(flat, minlength=vocab_size)[:vocab_size]
+        batch.clear()
+        flags.clear()
+
+    for doc in docs:
+        is_hold = (doc_index % holdout_every) == (holdout_every - 1)
+        doc_index += 1
+        for piece in chunks(doc):
+            batch.append(piece)
+            flags.append(is_hold)
+            if len(batch) >= BATCH_DOCS:
+                flush()
+    flush()
+    return train, holdout, int(train.sum()), int(holdout.sum())
+
+
+def coverage(counts: np.ndarray, ids: np.ndarray) -> float:
+    total = float(counts.sum())
+    if total <= 0:
+        return float("nan")
+    return float(counts[ids].sum()) / total
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokenizer", default=str(DEFAULT_TOKENIZER))
+    parser.add_argument("--out-dir", default=str(HERE / "ids"))
+    parser.add_argument("--report", default=str(HERE / "vocab_coverage.md"))
+    parser.add_argument("--offline", action="store_true", help="skip network sources")
+    parser.add_argument("--scale", type=float, default=1.0, help="scale all budgets")
+    parser.add_argument(
+        "--weights",
+        default="web_en=0.22,wiki_en=0.12,code=0.34,math=0.16,chat=0.06,zh=0.10",
+        help=(
+            "per-domain share of the ranking mass (default: a coding/agent "
+            "workload mix). Use 'equal' for a flat 1/N split."
+        ),
+    )
+    parser.add_argument(
+        "--refresh", action="store_true", help="ignore the cached token counts"
+    )
+    args = parser.parse_args()
+
+    from tokenizers import Tokenizer
+
+    tokenizer_dir = Path(args.tokenizer)
+    tokenizer_json = tokenizer_dir / "tokenizer.json"
+    tokenizer = Tokenizer.from_file(str(tokenizer_json))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"tokenizer      : {tokenizer_json}")
+    print(f"vocab_size     : {VOCAB_SIZE}")
+
+    decoded, special = decode_vocab(tokenizer_json)
+    groups = always_keep(decoded, special)
+    keep = set()
+    for name, ids in groups.items():
+        keep |= ids
+        print(f"  always-keep {name:<20} {len(ids):>6}")
+    keep_ids = np.array(sorted(keep), dtype=np.int64)
+    print(f"  always-keep TOTAL              {keep_ids.size}")
+
+    cache_path = out_dir / "counts_cache.npz"
+    meta_cache = out_dir / "counts_cache.json"
+    domain_train: dict[str, np.ndarray] = {}
+    domain_hold: dict[str, np.ndarray] = {}
+    domain_meta: dict[str, dict] = {}
+
+    if cache_path.is_file() and meta_cache.is_file() and not args.refresh:
+        blob = np.load(cache_path)
+        domain_meta = json.loads(meta_cache.read_text())
+        for domain in domain_meta:
+            domain_train[domain] = blob[f"{domain}__train"]
+            domain_hold[domain] = blob[f"{domain}__hold"]
+        print(f"reusing cached counts from {cache_path} (--refresh to recount)")
+        sources = {}
+    else:
+        sources = build_sources(tokenizer_dir, args.offline, args.scale)
+
+    for domain, entries in sources.items():
+        started = time.perf_counter()
+        train = np.zeros(VOCAB_SIZE, dtype=np.int64)
+        hold = np.zeros(VOCAB_SIZE, dtype=np.int64)
+        used: list[str] = []
+        for label, generator in entries:
+            try:
+                t, h, nt, nh = count_domain(tokenizer, generator, VOCAB_SIZE)
+            except Exception as exc:
+                print(f"  [{domain}] SKIP {label}: {type(exc).__name__}: {exc}")
+                continue
+            if nt + nh == 0:
+                print(f"  [{domain}] empty {label}")
+                continue
+            train += t
+            hold += h
+            used.append(f"{label} ({nt + nh:,} tok)")
+            print(f"  [{domain}] {label}: {nt + nh:,} tokens")
+        domain_train[domain] = train
+        domain_hold[domain] = hold
+        domain_meta[domain] = {
+            "sources": used,
+            "train_tokens": int(train.sum()),
+            "holdout_tokens": int(hold.sum()),
+            "distinct": int((train > 0).sum()),
+            "seconds": round(time.perf_counter() - started, 1),
+        }
+        print(
+            f"  [{domain}] total {int(train.sum()) + int(hold.sum()):,} tokens, "
+            f"{int((train > 0).sum()):,} distinct, "
+            f"{domain_meta[domain]['seconds']}s"
+        )
+
+    if sources:
+        np.savez_compressed(
+            cache_path,
+            **{f"{d}__train": domain_train[d] for d in domain_train},
+            **{f"{d}__hold": domain_hold[d] for d in domain_hold},
+        )
+        meta_cache.write_text(json.dumps(domain_meta, indent=2))
+        print(f"cached counts -> {cache_path}")
+
+    # balance domains so a huge web corpus cannot bury code/zh tokens
+    if args.weights.strip().lower() == "equal":
+        weights = {d: 1.0 for d in domain_train}
+    else:
+        weights = {}
+        for item in args.weights.split(","):
+            if not item.strip():
+                continue
+            key, _, value = item.partition("=")
+            weights[key.strip()] = float(value)
+    live = {d: weights.get(d, 0.0) for d in domain_train if domain_train[d].sum() > 0}
+    scale_w = sum(live.values()) or 1.0
+    live = {d: w / scale_w for d, w in live.items()}
+    print("ranking weights: " + ", ".join(f"{d}={w:.3f}" for d, w in live.items()))
+
+    weighted = np.zeros(VOCAB_SIZE, dtype=np.float64)
+    for domain, counts in domain_train.items():
+        total = float(counts.sum())
+        if total <= 0 or live.get(domain, 0.0) <= 0:
+            continue
+        weighted += live[domain] * (counts.astype(np.float64) / total)
+
+    order = np.lexsort((np.arange(VOCAB_SIZE), -weighted))  # freq desc, id asc
+
+    subsets: dict[str, np.ndarray] = {}
+    for name, size in SIZES.items():
+        if size < keep_ids.size:
+            raise SystemExit(
+                f"always-keep set ({keep_ids.size}) exceeds requested size {size}"
+            )
+        chosen = list(keep_ids)
+        seen = set(keep_ids.tolist())
+        for idx in order:
+            if len(chosen) >= size:
+                break
+            token_id = int(idx)
+            if token_id in seen:
+                continue
+            if weighted[token_id] <= 0:
+                break
+            seen.add(token_id)
+            chosen.append(token_id)
+        if len(chosen) < size:
+            for token_id in range(VOCAB_SIZE):
+                if len(chosen) >= size:
+                    break
+                if token_id not in seen:
+                    seen.add(token_id)
+                    chosen.append(token_id)
+        ids = np.array(sorted(chosen), dtype=np.int32)
+        subsets[name] = ids
+        path = out_dir / f"ids_{name}.npy"
+        np.save(path, ids)
+        print(f"wrote {path}  ({ids.size} ids)")
+
+    lines: list[str] = []
+    lines.append("# Reduced-vocabulary draft head: corpus coverage\n")
+    lines.append(
+        f"Tokenizer `{tokenizer_json}` - vocab_size **{VOCAB_SIZE}**. "
+        f"Generated {time.strftime('%Y-%m-%d %H:%M')} by `ext/build_vocab_subset.py`.\n"
+    )
+    lines.append(
+        "Coverage = fraction of corpus tokens whose id is inside the subset S. "
+        "It is measured on a **held-out 10% document split** per domain "
+        "(documents whose index mod 10 == 9 were excluded from the counts that "
+        "produced the ranking).\n"
+    )
+    lines.append(
+        "Ranking weights (share of probability mass each domain contributes to "
+        "the frequency ranking): "
+        + ", ".join(f"`{d}`={w:.2f}" for d, w in live.items())
+        + ".\n"
+    )
+    lines.append("## Always-keep set\n")
+    lines.append("| group | ids |")
+    lines.append("|---|---:|")
+    for name, ids in sorted(groups.items()):
+        lines.append(f"| `{name}` | {len(ids):,} |")
+    lines.append(f"| **union** | **{keep_ids.size:,}** |")
+    lines.append("")
+    lines.append("## Corpus\n")
+    lines.append("| domain | train tokens | held-out tokens | distinct ids | sources |")
+    lines.append("|---|---:|---:|---:|---|")
+    for domain, meta in domain_meta.items():
+        lines.append(
+            f"| `{domain}` | {meta['train_tokens']:,} | {meta['holdout_tokens']:,} | "
+            f"{meta['distinct']:,} | " + "; ".join(meta["sources"]) + " |"
+        )
+    lines.append("")
+    lines.append("## Held-out coverage by subset size\n")
+    header = "| domain | " + " | ".join(f"|S|={n}" for n in SIZES) + " |"
+    lines.append(header)
+    lines.append("|---|" + "---:|" * len(SIZES))
+    for domain in domain_meta:
+        hold = domain_hold[domain]
+        if hold.sum() <= 0:
+            continue
+        cells = [f"{100 * coverage(hold, subsets[n].astype(np.int64)):.3f}%" for n in SIZES]
+        lines.append(f"| `{domain}` | " + " | ".join(cells) + " |")
+    all_hold = np.zeros(VOCAB_SIZE, dtype=np.int64)
+    for hold in domain_hold.values():
+        all_hold += hold
+    cells = [f"{100 * coverage(all_hold, subsets[n].astype(np.int64)):.3f}%" for n in SIZES]
+    lines.append("| **all (pooled)** | " + " | ".join(cells) + " |")
+    lines.append("")
+    lines.append("## In-sample coverage (ranking split)\n")
+    lines.append(header)
+    lines.append("|---|" + "---:|" * len(SIZES))
+    for domain in domain_meta:
+        train = domain_train[domain]
+        if train.sum() <= 0:
+            continue
+        cells = [f"{100 * coverage(train, subsets[n].astype(np.int64)):.3f}%" for n in SIZES]
+        lines.append(f"| `{domain}` | " + " | ".join(cells) + " |")
+    lines.append("")
+    lines.append("## Draft-head cost per size\n")
+    lines.append(
+        "4-bit / group-size-64 affine head, K=5120: "
+        "`weight = |S| x 640 uint32`, `scales = biases = |S| x 80` (fp16).\n"
+    )
+    lines.append("| |S| | head bytes | vs full 248,320 | read @340 GB/s |")
+    lines.append("|---:|---:|---:|---:|")
+    full_bytes = VOCAB_SIZE * (640 * 4 + 80 * 2 * 2)
+    for name, size in SIZES.items():
+        nbytes = size * (640 * 4 + 80 * 2 * 2)
+        lines.append(
+            f"| {size:,} ({name}) | {nbytes / 1e6:.0f} MB | "
+            f"{100 * nbytes / full_bytes:.1f}% | {1000 * nbytes / 340e9:.2f} ms |"
+        )
+    lines.append(
+        f"| {VOCAB_SIZE:,} (full) | {full_bytes / 1e6:.0f} MB | 100.0% | "
+        f"{1000 * full_bytes / 340e9:.2f} ms |"
+    )
+    lines.append("")
+    Path(args.report).write_text("\n".join(lines) + "\n")
+    print(f"wrote {args.report}")
+
+    meta_path = out_dir / "build_meta.json"
+    meta_path.write_text(
+        json.dumps(
+            {
+                "vocab_size": VOCAB_SIZE,
+                "tokenizer": str(tokenizer_json),
+                "always_keep": {k: len(v) for k, v in groups.items()},
+                "always_keep_total": int(keep_ids.size),
+                "ranking_weights": live,
+                "domains": domain_meta,
+                "sizes": {k: int(v.size) for k, v in subsets.items()},
+                "holdout_coverage": {
+                    k: {
+                        d: coverage(domain_hold[d], subsets[k].astype(np.int64))
+                        for d in domain_meta
+                        if domain_hold[d].sum() > 0
+                    }
+                    for k in SIZES
+                },
+            },
+            indent=2,
+        )
+    )
+    print(f"wrote {meta_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_reduced_vocab.py
+++ b/scripts/test_reduced_vocab.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""PASS/FAIL harness for the reduced-vocabulary draft head.
+
+    python scripts/test_reduced_vocab.py --ids <ids.npy>
+
+ 1. row slice   : reduced logits on S == full-head logits on S
+ 2. masking     : logits outside S are the sentinel and never win
+ 3. argmax      : reduced argmax == full argmax whenever it is in S
+ 4. samplers    : MTPLX draft samplers give finite q, support inside S, sum 1
+ 5. mx.compile  : the head traces and runs inside a compiled graph
+ 6. timing      : ms/call, full vs reduced
+ 7. optional    : wrap a real artifact draft head (--artifact <model dir>)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+FAILURES: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    print(f"{'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail else ""))
+    if not ok:
+        FAILURES.append(name)
+    return ok
+
+
+def skip(name: str, detail: str = "") -> None:
+    print(f"SKIP  {name}" + (f"  -- {detail}" if detail else ""))
+
+
+def load_module():
+    try:
+        import mtplx.reduced_vocab_draft as mod
+
+        print(f"module: {mod.__file__} (installed)")
+        return mod
+    except Exception:
+        pass
+    path = HERE / "reduced_vocab_draft.py"
+    spec = importlib.util.spec_from_file_location("reduced_vocab_draft", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["reduced_vocab_draft"] = mod
+    spec.loader.exec_module(mod)
+    print(f"module: {path} (local file)")
+    return mod
+
+
+def build_random_quantized_head(vocab: int, hidden: int, bits: int, group_size: int):
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    head = nn.QuantizedLinear(
+        hidden, 64, bias=False, group_size=group_size, bits=bits, mode="affine"
+    )
+    weights, scales, biases = [], [], []
+    step = 16384
+    for start in range(0, vocab, step):
+        rows = min(step, vocab - start)
+        dense = (mx.random.normal((rows, hidden)) * 0.05).astype(mx.float16)
+        wq, sc, bi = mx.quantize(dense, group_size=group_size, bits=bits, mode="affine")
+        mx.eval(wq, sc, bi)
+        weights.append(wq)
+        scales.append(sc)
+        biases.append(bi)
+        del dense
+    head.weight = mx.concatenate(weights, axis=0)
+    head.scales = mx.concatenate(scales, axis=0)
+    head.biases = mx.concatenate(biases, axis=0)
+    mx.eval(head.weight, head.scales, head.biases)
+    return head
+
+
+def timeit(fn, x, iters: int) -> float:
+    import mlx.core as mx
+
+    for _ in range(10):
+        mx.eval(fn(x))
+    started = time.perf_counter()
+    for _ in range(iters):
+        mx.eval(fn(x))
+    return 1000.0 * (time.perf_counter() - started) / iters
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ids", default=str(HERE / "ids/ids_32k.npy"))
+    parser.add_argument("--vocab", type=int, default=248320)
+    parser.add_argument("--hidden", type=int, default=5120)
+    parser.add_argument("--bits", type=int, default=4)
+    parser.add_argument("--group-size", type=int, default=64)
+    parser.add_argument("--iters", type=int, default=1000)
+    parser.add_argument("--mode", default="full", choices=["full", "compact"])
+    parser.add_argument("--neg", default="finite")
+    parser.add_argument("--artifact", default=None, help="model dir for the live smoke test")
+    args = parser.parse_args()
+
+    import mlx.core as mx
+
+    print(f"mlx {getattr(mx, '__version__', '?')}  python {sys.version.split()[0]}")
+    mod = load_module()
+
+    ids = mod.load_subset_ids(args.ids, vocab_size=args.vocab)
+    print(
+        f"subset: {args.ids}  |S|={ids.size} "
+        f"({100.0 * ids.size / args.vocab:.1f}% of {args.vocab})"
+    )
+
+    print("\n-- building the reference head --")
+    started = time.perf_counter()
+    base = build_random_quantized_head(args.vocab, args.hidden, args.bits, args.group_size)
+    print(
+        f"   base head {tuple(base.weight.shape)} uint32 + scales "
+        f"{tuple(base.scales.shape)}  built in {time.perf_counter() - started:.1f}s"
+    )
+
+    started = time.perf_counter()
+    head = mod.build_reduced_head(base, ids, mode=args.mode, neg=args.neg, keep_base=True)
+    print(f"   reduced head built in {time.perf_counter() - started:.1f}s")
+    check(
+        "1a. sliced weight/scales/biases row counts",
+        int(head.head.weight.shape[0]) == ids.size
+        and int(head.head.scales.shape[0]) == ids.size
+        and int(head.head.biases.shape[0]) == ids.size,
+        f"{tuple(head.head.weight.shape)} / {tuple(head.head.scales.shape)}",
+    )
+    check(
+        "1b. sliced packed row bit-identical to the full head",
+        bool(mx.all(head.head.weight == base.weight[mx.array(ids.astype(np.int32))]).item()),
+    )
+
+    x = (mx.random.normal((1, 1, args.hidden)) * 0.5).astype(mx.float16)
+    mx.eval(x)
+    full = base(x)
+    red = head(x)
+    mx.eval(full, red)
+
+    if args.mode == "full":
+        check("2a. output shape is full-vocab", tuple(red.shape) == (1, 1, args.vocab),
+              str(tuple(red.shape)))
+        idx = mx.array(ids.astype(np.int32))
+        on_s_full = mx.take(full.reshape(-1), idx)
+        on_s_red = mx.take(red.reshape(-1), idx)
+        mx.eval(on_s_full, on_s_red)
+        exact = bool(mx.all(on_s_full == on_s_red).item())
+        max_abs = float(mx.max(mx.abs(on_s_full.astype(mx.float32) - on_s_red.astype(mx.float32))).item())
+        check("2b. logits on S identical to the full head", exact,
+              f"max|diff| = {max_abs:g}" + ("" if exact else "  (NOT bit-exact)"))
+
+        mask = np.ones(args.vocab, dtype=bool)
+        mask[ids] = False
+        off = np.asarray(red.reshape(-1), dtype=np.float32)[mask]
+        on = np.asarray(on_s_red, dtype=np.float32)
+        check("2c. off-subset logits are the mask sentinel",
+              bool(np.all(off == off[0])), f"sentinel = {off[0]:g}")
+        check("2d. sentinel is far below every in-subset logit",
+              bool(off[0] < on.min() - 1e3),
+              f"min on-S logit = {on.min():.3f}")
+        check("2e. no NaN anywhere in the reduced row",
+              not bool(np.isnan(np.asarray(red.reshape(-1), dtype=np.float32)).any()))
+    else:
+        check("2a. output shape is compact", tuple(red.shape) == (1, 1, ids.size),
+              str(tuple(red.shape)))
+
+    print("\n-- argmax agreement over 64 random hidden states --")
+    id_set = set(int(i) for i in ids)
+    agree = total_in_s = 0
+    always_in_s = True
+    for _ in range(64):
+        xi = (mx.random.normal((1, 1, args.hidden)) * 0.5).astype(mx.float16)
+        fa = int(mx.argmax(base(xi), axis=-1).item())
+        ra_raw = int(mx.argmax(head(xi), axis=-1).item())
+        ra = ra_raw if args.mode == "full" else int(ids[ra_raw])
+        always_in_s &= ra in id_set
+        if fa in id_set:
+            total_in_s += 1
+            agree += int(fa == ra)
+    check("3a. reduced argmax always inside S", always_in_s)
+    check(
+        "3b. reduced argmax == full argmax whenever full argmax in S",
+        total_in_s == 0 or agree == total_in_s,
+        f"{agree}/{total_in_s} cases (full argmax landed in S {total_in_s}/64 times)",
+    )
+
+    print("\n-- MTPLX draft samplers on the reduced row --")
+    row = head(x)[:, -1, :][0]
+    mx.eval(row)
+    try:
+        from mtplx.fast_sampling import sparse_distribution_from_mlx_logits
+        from mtplx.sampling import SamplerConfig
+    except ImportError as exc:
+        skip("4A. host draft sampler", f"mtplx not importable ({exc})")
+        sparse_distribution_from_mlx_logits = None
+    if sparse_distribution_from_mlx_logits is not None:
+        try:
+            cfg = SamplerConfig(temperature=1.0, top_p=0.95, top_k=20)
+            dist = sparse_distribution_from_mlx_logits(row, cfg)
+            probs = np.asarray(dist.probs, dtype=np.float64)
+            support = np.asarray(dist.token_ids, dtype=np.int64)
+            if args.mode == "compact":
+                support = ids[support]
+            check("4a. sparse_distribution_from_mlx_logits returns finite mass",
+                  bool(np.all(np.isfinite(probs))) and abs(probs.sum() - 1.0) < 1e-9,
+                  f"support={support.size}, sum={probs.sum():.12f}")
+            check("4b. every support id is inside S",
+                  bool(np.all(np.isin(support, ids))))
+            check("4c. SparseDistribution.vocab_size is the full vocabulary",
+                  int(dist.vocab_size) == args.vocab or args.mode == "compact",
+                  f"vocab_size={dist.vocab_size}")
+            stable = True
+            for temperature in (0.6, 1.0, 2.0):
+                for top_p in (0.95, 1.0):
+                    d = sparse_distribution_from_mlx_logits(
+                        row, SamplerConfig(temperature=temperature, top_p=top_p, top_k=20)
+                    )
+                    pr = np.asarray(d.probs, dtype=np.float64)
+                    stable &= bool(np.all(np.isfinite(pr))) and abs(pr.sum() - 1.0) < 1e-9
+            check("4d. sampler stable across T in {0.6,1,2} x top_p in {0.95,1.0}", stable)
+        except Exception as exc:
+            check("4A. host draft sampler", False, f"{type(exc).__name__}: {exc}")
+
+    if args.mode == "full":
+        try:
+            from mtplx.generation import _device_draft_q_arrays
+        except ImportError as exc:
+            skip("4B. device draft core q arrays", f"mtplx.generation not importable ({exc})")
+            _device_draft_q_arrays = None
+        if _device_draft_q_arrays is not None:
+            try:
+                top_idx, q_norm = _device_draft_q_arrays(
+                    row, temperature=1.0, top_k=20, top_p=0.95
+                )
+                mx.eval(top_idx, q_norm)
+                q = np.asarray(q_norm, dtype=np.float64)
+                tid = np.asarray(top_idx, dtype=np.int64)
+                check("4e. device-core q arrays finite and normalized",
+                      bool(np.all(np.isfinite(q))) and abs(q.sum() - 1.0) < 1e-6,
+                      f"sum={q.sum():.9f}")
+                check("4f. device-core support inside S", bool(np.all(np.isin(tid, ids))))
+            except Exception as exc:
+                check("4B. device draft core q arrays", False, f"{type(exc).__name__}: {exc}")
+
+    print("\n-- mx.compile --")
+    try:
+        def chain(v):
+            logits = head(v)
+            return mx.argmax(logits[:, -1, :], axis=-1).reshape(1, 1)
+
+        compiled = mx.compile(chain)
+        out_c = compiled(x)
+        out_e = chain(x)
+        mx.eval(out_c, out_e)
+        check("5. compiled graph matches eager", int(out_c.item()) == int(out_e.item()),
+              f"token={int(out_c.item())}")
+    except Exception as exc:
+        check("5. mx.compile", False, f"{type(exc).__name__}: {exc}")
+
+    print(f"\n-- timing ({args.iters} iters, one mx.eval per call) --")
+    t_full = timeit(base, x, args.iters)
+    t_red = timeit(head, x, args.iters)
+    t_slice = timeit(head.head, x, args.iters)
+    head_bytes = args.vocab * (args.hidden * args.bits // 8) + args.vocab * (
+        args.hidden // args.group_size
+    ) * 4
+    print(f"   full head          : {t_full:8.3f} ms/call")
+    print(f"   reduced (sliced)   : {t_slice:8.3f} ms/call   (matmul only, |S| logits)")
+    print(f"   reduced + scatter  : {t_red:8.3f} ms/call   (full-vocab output)")
+    print(f"   scatter overhead   : {t_red - t_slice:8.3f} ms/call")
+    print(f"   speedup            : {t_full / max(t_red, 1e-9):8.2f}x  "
+          f"(saved {t_full - t_red:.3f} ms/draft step)")
+    print(f"   full-head weights  : {head_bytes / 1e6:.1f} MB "
+          f"-> implied BW {head_bytes / (t_full * 1e-3) / 1e9:.1f} GB/s")
+    check("6. reduced head is faster than the full head", t_red < t_full,
+          f"{t_full:.3f} -> {t_red:.3f} ms")
+
+    if args.artifact:
+        print("\n-- live artifact smoke (loads the model) --")
+        try:
+            from mtplx.draft_lm_head import _install_draft_lm_head
+            from mtplx.runtime import load
+
+            rt = load(Path(args.artifact), mtp=True)
+            report = _install_draft_lm_head(rt, bits=4, group_size=64, mode="affine")
+            text = getattr(rt.model, "language_model", rt.model)
+            installed = getattr(text, "_mtplx_draft_lm_head", None)
+            print(f"   report keys: {sorted(report)}")
+            wrapped = mod.build_reduced_head(installed, ids, mode="full", neg=args.neg)
+            hidden = (mx.random.normal((1, 1, args.hidden)) * 0.02).astype(
+                installed.weight.dtype if hasattr(installed, "weight") else mx.float16
+            )
+            out = wrapped(hidden.astype(mx.float16))
+            mx.eval(out)
+            check("7. wrapper works on the real artifact draft head",
+                  tuple(out.shape) == (1, 1, args.vocab), str(tuple(out.shape)))
+        except Exception as exc:
+            check("7. live artifact smoke", False, f"{type(exc).__name__}: {exc}")
+
+    print("\n" + "=" * 66)
+    if FAILURES:
+        print(f"RESULT: FAIL ({len(FAILURES)} failing checks)")
+        for name in FAILURES:
+            print(f"  - {name}")
+        return 1
+    print("RESULT: PASS (all checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Type:** opt-in perf feature, default off; output distribution provably unchanged (speculative sampling is exact for any proposal `q`).
**Problem:** every draft step streams the full 248,320 x 5,120 quantized draft head, ~0.70 GB of weights + scales + biases, about 2.1 ms of pure bandwidth per step at 340 GB/s. That is roughly a third of the measured 6.1 ms draft step.
**Evidence:** +5.2% tok/s (36.9 to 38.8), draft 4.3 to 2.2 ms/tok, ~0.7 GB freed, L4 byte-identical greedy capture.
**Fix:** FR-Spec (arXiv:2502.14856): an exact row subset of the draft-only LM head over a frequency-ranked 64k subset. `full` mode is a drop-in, `compact` mode is optional. Enabled only by `MTPLX_DRAFT_VOCAB_IDS`; unset means no change.

## Details

Exact row subset, no re-quantization: `mx.quantize` packs along the last axis, so `nn.QuantizedLinear` stores weight `(out_features, in_features * bits // 32)` uint32 with `scales`/`biases` of `(out_features, in_features // group_size)`. Output feature `i` lives entirely in row `i` of all three arrays, so `weight[S], scales[S], biases[S]` is an exact row subset and logits on `S` are bit-identical to the full head's. Rejection sampling with the residual correction `normalize(max(p - q, 0))` is exact for any proposal `q` provided the same `q` that produced the draft token is used in the acceptance test, and the draft head feeds only the draft logits, never the verify/target logits, so `p` and the output distribution are untouched.

`full` (default) returns a full-vocabulary-shaped row with a very negative sentinel outside `S`, so top-k/top-p sampling, argmax, `SparseDistribution` vocab_size and the compiled device draft core keep working untouched. `MTPLX_DRAFT_VOCAB_KEEP_BASE=1` keeps the full head resident for A/B work; the default frees it (~0.7 GB). Nothing in 2.9.0 does this: no reference to a reduced or compact draft vocabulary anywhere in the tree, and `draft_lm_head.py` is byte-identical between 2.7.1 and 2.9.0 (`draft_sampling.resolve_draft_temperature()` is adjacent but different: draft temperature, not vocabulary).

`compact` returns an `|S|`-shaped row plus sampler shims that map the subset index back to the vocabulary id, and hard-disables the paths that read raw indices. On its own it is worth +0.10 tok/s (+0.23%), draft/tok 2.247 to 2.201 ms, `accepted_by_depth` unchanged; `full` mode alone carries the entire +5.2%.

`scripts/build_vocab_subset.py` counts tokenizer ids over a mixed corpus (English web/edu, English Wikipedia, math/reasoning, multi-language code, Chinese Wikipedia, chat-templated dialogue), unions them with an always-keep set (all 33 specials, all 320 control ids >= 248000, digits, punctuation, whitespace/indent runs, all 128 single-byte tokens: 6,014 ids), and emits sorted int32 `.npy` at 16k/32k/48k/64k. It has hard-coded corpus and model paths: it is a reference implementation of the method, not shippable code. Coverage is measured on a per-domain held-out 10% document split, so the numbers are not self-fulfilling:

| domain | \|S\|=16k | \|S\|=32k | \|S\|=48k | \|S\|=64k |
|---|---:|---:|---:|---:|
| web_en | 85.13% | 93.37% | 96.87% | 98.57% |
| wiki_en | 85.76% | 94.39% | 97.54% | 98.96% |
| math | 92.61% | 97.44% | 98.96% | 99.61% |
| code | 88.29% | 94.57% | 97.10% | 98.30% |
| zh | 75.64% | 86.91% | 91.86% | 94.98% |
| chat | 94.98% | 98.52% | 99.50% | 99.88% |
| pooled | 84.16% | 92.41% | 95.81% | 97.62% |

We shipped 64k, 26% of the vocabulary.

## Reviewer concerns

* Artifact and tokenizer binding. The `.npy` must match the model's tokenizer; a stale or mismatched subset degrades acceptance silently, since verify still corrects every token and only speed drops. No checksum or tokenizer-id binding is implemented.
* Multilingual coverage. 94.98% held-out coverage on Chinese at 64k vs 98.57% on English web, so acceptance on non-Latin-script traffic drops more. A shipped default should be larger, per-locale, or opt-in.
* `compact` silent failure. A consumer that bypasses the installed sampler shims would emit raw subset indices, which verify silently corrects at the cost of acceptance collapsing. `full` mode has no such path.
* Silent hook failure. The hook in `draft_lm_head.py` sits in a bare `except Exception` that never fails the load. Right for an experiment, probably wrong upstream: a misconfigured `MTPLX_DRAFT_VOCAB_IDS` should be loud.

## Protocol

M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), 5 prompts x 400 tokens x 2 reps, n=10 per arm, ABBA-interleaved, same-window controls.
Arms are the full 248k head vs the 64k subset, greedy decoding; metric is single-stream tok/s, with draft time per token from the same runs.

## Validation

* L4 byte-identical greedy capture with the head on and off, plus `scripts/test_reduced_vocab.py`, which checks the row-subset identity, the sentinel behaviour and the compact shim mapping.
* `accepted_by_depth` before and after: expect within noise, not necessarily identical, since drafts may legitimately differ where the subset bites. A collapse there is the signal that the subset is dropping tokens the target wanted.
* Still worth running: a non-English arm, and a deliberate tokenizer-mismatch arm to see what the failure looks like.

