### PR TITLE
graphbank: batch the paged-offset device reads in _resolve_bucket

### DIFF
--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -1946,6 +1946,24 @@ class CompiledVerifyBank:
 
     def _resolve_bucket(self, cache: Any, length: int) -> int | None:
         """Static paged-attention ceiling for this call, or None on overflow."""
+        # Batched: per-entry size() forces a serial sync after trim/rollback.
+        if str(
+            os.environ.get("MTPLX_BATCH_PAGED_OFFSETS", "1")
+        ).strip().lower() not in {"0", "off", "false", "no"}:
+            paged_offsets = []
+            for spec_idx, spec_kind, _n in self._spec or []:
+                if spec_kind != VERIFY_SPEC_KIND_FULL_ATTN:
+                    continue
+                spec_entry = cache[spec_idx]
+                if not hasattr(spec_entry, "capacity"):
+                    continue
+                entry_state = getattr(spec_entry, "cache", None)
+                if isinstance(entry_state, (list, tuple)) and len(entry_state) > 2:
+                    entry_offset = entry_state[2]
+                    if isinstance(entry_offset, mx.array):
+                        paged_offsets.append(entry_offset)
+            if paged_offsets:
+                mx.eval(*paged_offsets)
         max_needed = 0
         min_capacity: int | None = None
         for idx, kind, _n in self._spec or []:


### PR DESCRIPTION
**Type:** perf, bit-identical (pure scheduling); neutral on our benchmark, proposed on the mechanism.

**Problem:** `_resolve_bucket` calls `entry.size()` per full-attention cache entry, and on `TensorOffsetVllmMetalPagedKVCache` that forces `mx.eval(self.cache[2])` + `.item()` per entry. 16 full-attention entries means 16 serial lazy-scalar syncs whenever the offsets are not already materialized, which is the case after a trim or rollback: 2.48 ms measured for that walk.

**Evidence:** On a benchmark that never trims (`rollback_time_s = 0`) the offsets are always materialized, so the result is exactly neutral: 43.05 vs 43.05 tok/s, leave-one-out 0.00 tok/s, output byte-identical. A long-context instrumented run with the growth reserve exhausted moved decode 34.95 to 35.19 tok/s and accept 2.67 to 0.66 ms/call, but other variables changed in that run too.

**Fix:** One batched `mx.eval` over all full-attention offset arrays up front, so every later `.size()` hits the resolved path. Off-switch: `MTPLX_BATCH_PAGED_OFFSETS=0`.

Protocol: M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), 5 prompts x 400 tokens x 2 reps, n=10 per arm, ABBA-interleaved, same-window controls.

## Details

- Not present in 2.9.0: `_resolve_bucket` is byte-identical between 2.7.1 (line 1772) and 2.9.0 (line 1947).
- Possible pessimization: every full-attention offset is evaluated unconditionally, while the loop below can bail early on bucket overflow, so a bucket-overflow-heavy config pays a small extra sync.
- Alternative: caching the resolved value inside `TensorOffsetVllmMetalPagedKVCache.size()` fixes the N syncs at the source instead of at this one call site, and is probably the better change; we skipped it because it touches a shared cache class and we could not validate every caller.

## Validation

- A trimming/rollback workload (long context, exhausted growth reserve), where the mechanism should pay.
- Byte-identical capture with the switch on and off.

Holding this pending a repro on a trimming workload is a reasonable call. It is offered because the mechanism is correct, the change is exact, and the cost of being wrong is zero.

