### PR TITLE
gdn_capture: fused_add_rmsnorm(threadgroup_size=512) perturbs prefill above 64 rows

### DIFF
--- a/mtplx/gdn_capture.py
+++ b/mtplx/gdn_capture.py
@@ -3028,12 +3028,19 @@ def forward_with_gdn_capture(
                 h = hidden_states + r
                 mlp_input = layer.post_attention_layernorm(h)
             else:
+                # 512 diverges from the unfused reference above 64 rows; None is exact.
+                _fused_norm_tg_raw = os.environ.get(
+                    "MTPLX_FUSE_POST_NORM_RESIDUAL_TG", ""
+                ).strip()
+                _fused_norm_tg = (
+                    int(_fused_norm_tg_raw) if _fused_norm_tg_raw.isdigit() else None
+                )
                 h, mlp_input = fused_add_rmsnorm(
                     hidden_states,
                     r,
                     layer.post_attention_layernorm.weight,
                     layer.post_attention_layernorm.eps,
-                    threadgroup_size=512,
+                    threadgroup_size=_fused_norm_tg,
                 )
         else:
             h = hidden_states + r


### PR DESCRIPTION
**Type:** correctness fix for an off-by-default lane; restores bitwise exactness

**Problem:** `gdn_capture.py:3036` calls the fused post-norm-residual kernel with a hardcoded
`threadgroup_size=512`, which perturbs the normalization by one fp16 ULP at prefill widths
>= 128 rows. The lane's selfcheck probes only `rows=4` inside a 0.02 tolerance, so nothing
catches it.

**Evidence:** row sweep against the unfused reference. `threadgroup_size=512` is bitwise at
<= 64 rows and off by 1.953e-3 from 128 rows up; the exact-fit kernel (`None`) is bitwise at
every row count from 1 to 1024.

| rows | `=512` (hardcoded) | `=None` (exact-fit) | `=1024` |
|---:|---|---|---|
| 1, 2, 4, 8, 64 | bitwise 0.0 | bitwise 0.0 | bitwise 0.0 |
| 128 | 30 elements differ, max 1.953e-3 | bitwise 0.0 | bitwise 0.0 |
| 192 | 50 differ, 1.953e-3 | bitwise 0.0 | bitwise 0.0 |
| 256 | 25 differ, 1.953e-3 | bitwise 0.0 | bitwise 0.0 |
| 354 | 41 differ, 1.953e-3 | bitwise 0.0 | bitwise 0.0 |
| 1024 | 140 differ, 1.953e-3 | n/a | bitwise 0.0 |

With the bug, `tok/cycle` and `accepted_by_depth` moved. After the fix both match the
lane-off control exactly.

**Fix:** read the threadgroup size from `MTPLX_FUSE_POST_NORM_RESIDUAL_TG`; unset means
`None`, the exact-fit kernel, and setting 512 restores the old behaviour byte for byte.

---

## Details

`h = x + residual` stays bitwise at every row count. Only the normalization drifts.

Why nothing caught it:

* 1.953e-3 is far inside `kernel_selfcheck._NORM_TOLERANCE = 0.02`, so the selfcheck passes.
* The lane's selfcheck probes only `rows=4, axis=512`, a row count where the bug does not exist.
* Decode is M=1..4 rows, so the standard M=1..4 exactness checks miss it entirely.

The lane is off by default (`MTPLX_FUSE_POST_NORM_RESIDUAL`), so the bug is only observable
with it enabled. Three arms with it enabled:

| arm | tok/s | tok/cycle | accepted_by_depth | L4 |
|---|---:|---:|---|---|
| lane on, `=512` (as shipped) | 45.87 (-0.49%) | 3.205 | 0.883/0.745/0.587 | prose DIFF |
| lane on, after the fix (`=None`) | 45.98 (-0.23%) | 3.210 | 0.878/0.743/0.598 | byte-identical |
| lane off (control) | 46.09 | 3.210 | 0.878/0.743/0.598 | reference |

M2 Max (38-core, 64 GB, macOS 26.2, mlx 0.32.0, mtplx 2.7.1 patched), model
`Qwen3.8-27B-MTPLX-OSmid-FP16`, 5 prompts x 400 tokens x 2 reps, n=10 per arm,
ABBA-interleaved, same-window controls.

We rejected this lane on speed (-0.23% even after the fix): it saves one kernel launch per
layer and pays for it by not using `mx.fast.rms_norm`, a hand-tuned MLX primitive. We are not
proposing to enable it. The exactness fix is worth taking regardless, since an off-by-default
lane that silently perturbs prefill is a trap for whoever flips it next.

Still present in 2.9.0: `gdn_capture.py` is byte-identical between 2.7.1 and 2.9.0, and the
hardcoded `threadgroup_size=512` sits at line 3036 of the 2.9.0 file.

## Validation

* Row sweep at 1/4/64/128/192/256/354/1024 against the unfused reference. Expect bitwise 0.0
  at every row count with the fix, and the 1.953e-3 divergences reproduced without it.
* Widen the `kernel_selfcheck` probe for this lane beyond `rows=4`. That is the change that
  would have caught this, and is worth doing independently of the fix.
* Reconsider whether `_NORM_TOLERANCE = 0.02` is the right gate for a lane that claims bitwise
  equivalence. A bitwise-claiming lane wants a bitwise check.

Risk is low: behaviour changes only for users who explicitly enabled the lane, and it changes
toward the unfused reference. The old behaviour stays available via one env var.

