### PR TITLE
request_capture: persist exact completion token ids

### DIFF
--- a/mtplx/request_capture.py
+++ b/mtplx/request_capture.py
@@ -116,6 +116,20 @@ def capture_outcome(request_id: str | None, outcome: dict[str, Any]) -> None:
         pass
 
 
+def completion_token_ids(tokens: Any) -> dict[str, Any]:
+    """Exact sampled completion token ids, completing the bit-exact replay
+    envelope: ``prompt_token_ids`` (captured at dispatch) is the input the model
+    conditioned on; this is the output it produced. Unlike the completion text
+    (clipped, and lossy after tool-call/reasoning parsing) these are the raw
+    ids straight off the sampler — what a replay or a distillation/training
+    pipeline needs. Bounded by ``max_tokens``, so no clipping. Never raises."""
+    try:
+        ids = [int(t) for t in (tokens or [])]
+    except (TypeError, ValueError):
+        ids = []
+    return {"completion_token_ids": ids, "completion_token_count": len(ids)}
+
+
 def clip_text_head_tail(text: str, head: int = 2000, tail: int = 2000) -> dict[str, Any]:
     """Store enough text to diagnose early stops without unbounded files —
     the tail is where the failure signature lives."""

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -18988,6 +18988,7 @@ def _finalize_batched_ar_generation(
             (request_observability or {}).get("request_id"),
             {
                 "scheduler_lane": "ar_batch",
+                **request_capture.completion_token_ids(generated.get("tokens")),
                 "completion_tokens": completion_tokens,
                 "finish_reason": generated.get("finish_reason"),
                 "resolved_seed": stats.get("server_seed"),
@@ -19180,6 +19181,7 @@ def _finalize_mtp_batch_generation(
             (request_observability or {}).get("request_id"),
             {
                 "scheduler_lane": "mtp_batch",
+                **request_capture.completion_token_ids(generated.get("tokens")),
                 "completion_tokens": completion_tokens,
                 "finish_reason": generated.get("finish_reason"),
                 "resolved_seed": stats.get("server_seed"),
@@ -20946,6 +20948,7 @@ def _run_generation(
             (request_observability or {}).get("request_id"),
             {
                 "scheduler_lane": "serial",
+                **request_capture.completion_token_ids(last.get("tokens")),
                 "completion_tokens": last["completion_tokens"],
                 "finish_reason": last.get("finish_reason"),
                 "resolved_seed": last["stats"].get("server_seed"),


### PR DESCRIPTION
## Summary

`request_capture` (`MTPLX_REQUEST_CAPTURE_DIR`) already persists the exact
post-encoding `prompt_token_ids`, resolved sampler, and seed at dispatch — but
the completion outcome only keeps **clipped completion text**. That leaves the
output side of the replay envelope incomplete, and the text is lossy after
reasoning/tool-call parsing.

This PR adds the raw sampled **completion token ids** to the outcome across all
three scheduler lanes (`serial`, `ar_batch`, `mtp_batch`), via a small
`completion_token_ids()` helper next to `clip_text_head_tail()`. The ids are
already in memory (`GenerationOutput.tokens`), so this is a pure
persist-what-we-have change:

- Completes the bit-exact replay envelope (input **and** output token streams).
- Gives the exact input+output token sequence a distillation / eval-dataset
  pipeline needs — directly useful for Forge-style workflows.
- Bounded by `max_tokens`, so no clipping needed.
- Off unless `MTPLX_REQUEST_CAPTURE_DIR` is set; no decode-hot-path cost (written
  only in the existing `capture_outcome` merge).

Adds `completion_token_ids` and `completion_token_count` to the `outcome` block;
does not remove or rename any existing field.

## Verification

- `python -m pytest tests/test_no_mlx_imports.py tests/test_runtime_kpis.py` — pass (19/19).
  (`tests/test_public_cli.py` shows pre-existing failures on this machine,
  identical with the change stashed — unrelated to this diff.)
- On-device end-to-end (M5, `Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed`, sustained/MTP depth 3):
  with capture enabled, a completion's `completion_token_ids` decode
  token-for-token back to the served text, and `completion_token_count`
  matches `usage.completion_tokens`. Example (temp 0):
  API content `"the quick brown fox"` → captured ids `[1719, 3841, 13477, 37550, 248046]`
  → `tokenizer.decode(...)` = `"the quick brown fox"` (last id is `<|im_end|>`).

## Benchmark Evidence

N/A — no runtime/perf change. Capture is opt-in and the ids are already
materialized; this only writes them into the outcome file.

## Possible follow-up

`score_prompt_logprobs()` already computes per-position top-K teacher logprobs.
A natural next step would be an opt-in flag to also persist top-K logprobs in
the capture record (for logit-KD / KL distillation), but I've kept this PR
scoped to the zero-cost token-id change. Happy to follow up if of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)