### PR TITLE
fix(openai): preserve reasoning mode now carries structured reasoning_content to the chat template

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -10931,12 +10931,13 @@ def _message_to_template_dict(
         )
     item: dict[str, Any] = {"role": message.role, "content": content}
     if include_reasoning_content and message.role == "assistant":
-        # Scoped reasoning history carries the client's structured reasoning
-        # fields through to the chat template so its rolling checkpoint can
-        # keep them inside the active agent round (interleaved-thinking
-        # continuity) and drop them for completed turns. The legacy
-        # preserve/strip modes keep their historical behavior: the field is
-        # dropped here, so `on` stays byte-identical as the rollback path.
+        # Carry the client's structured reasoning fields through to the chat
+        # template in every mode except full strip. Preserve mode renders them
+        # for every assistant turn (full retention — agent/tool clients send
+        # thinking as `reasoning_content`, so without this the model would see
+        # empty think scaffolds); scoped mode lets the template's rolling
+        # checkpoint render them only inside the active agent round
+        # (interleaved-thinking continuity) and drop them for completed turns.
         for key in ("reasoning_content", "reasoning"):
             reasoning = _message_extra(message, key)
             if reasoning:
@@ -11999,7 +12000,11 @@ def _encode_messages_uncached(
     # Scoped mode keeps reasoning_content on the normalized messages and
     # passes preserve_thinking=False so the template's own rolling checkpoint
     # governs: think blocks survive inside the active agent round (after the
-    # last real user query) and are dropped for completed turns.
+    # last real user query) and are dropped for completed turns. Preserve
+    # mode keeps preserve_thinking=True and now ALSO carries the structured
+    # reasoning fields, so every assistant turn renders its real think text
+    # (previously the field was dropped and tool/agent transcripts rendered
+    # empty think scaffolds).
     template_preserve_thinking = (
         not strip_assistant_reasoning_history and not scoped_reasoning_history
     )
@@ -12008,7 +12013,7 @@ def _encode_messages_uncached(
         item = _message_to_template_dict(
             message,
             strip_assistant_reasoning_history=strip_assistant_reasoning_history,
-            include_reasoning_content=scoped_reasoning_history,
+            include_reasoning_content=not strip_assistant_reasoning_history,
             allow_committed_reasoning=allow_committed_reasoning,
         )
         if item is not None:
@@ -12351,7 +12356,7 @@ def _postcommit_next_turn_prefix_ids(
         item = _message_to_template_dict(
             message,
             strip_assistant_reasoning_history=strip_assistant_reasoning_history,
-            include_reasoning_content=scoped_reasoning_history,
+            include_reasoning_content=not strip_assistant_reasoning_history,
             # Postcommit predicts the NEXT turn's render: when this request
             # served canonicalized history (committed-think substitution),
             # the prediction must render the same substituted bytes or the
@@ -12365,7 +12370,7 @@ def _postcommit_next_turn_prefix_ids(
     item = _message_to_template_dict(
         sentinel_message,
         strip_assistant_reasoning_history=strip_assistant_reasoning_history,
-        include_reasoning_content=scoped_reasoning_history,
+        include_reasoning_content=not strip_assistant_reasoning_history,
     )
     if item is not None:
         normalized.append(item)
@@ -24279,14 +24284,19 @@ def _reasoning_history_scoped_active(state: "ServerState") -> bool:
 def _reasoning_history_fingerprint_component(state: "ServerState") -> str:
     """Session-cache identity component for the reasoning-history policy.
 
-    Explicit preserve/strip emit the exact legacy ``strip_reasoning={0|1}``
-    strings so existing users' warm session banks survive this release.
-    Only scoped mints a new component - honest, because its rendered prompt
-    bytes genuinely differ from both legacy modes.
+    Explicit strip keeps the exact legacy ``strip_reasoning=1`` string so
+    existing strip users' warm session banks survive. Scoped and preserve
+    both mint their own component: scoped because its rendered prompt bytes
+    differ from the legacy modes, preserve because it now carries the
+    client's structured ``reasoning_content`` into the template (rendered
+    bytes differ from the legacy empty-scaffold preserve render for
+    tool/agent transcripts).
     """
     mode = _reasoning_history_mode(state)
     if mode == _REASONING_HISTORY_SCOPED:
         return "reasoning_history=scoped"
+    if mode == _REASONING_HISTORY_PRESERVE:
+        return "reasoning_history=preserve"
     return f"strip_reasoning={int(mode == _REASONING_HISTORY_STRIP)}"
 
 

--- a/tests/test_scoped_reasoning_history.py
+++ b/tests/test_scoped_reasoning_history.py
@@ -1,25 +1,31 @@
 """Scoped reasoning history - the loop root-cause fix.
 
 Qwen3.6/3.5 chat templates carry a "rolling checkpoint" (``last_query_index``):
-they keep ``<think>`` blocks only for assistant messages after the last real
+they keep `` thinking`` blocks only for assistant messages after the last real
 user query. MTPLX historically forced ``preserve_thinking=True``, overriding
 that checkpoint. Measured legacy behavior (decoded from a live SSD-banked
 loop prompt): structured ``reasoning_content`` history fields were dropped at
 ``_message_to_template_dict`` before the template, so preserve-all rendered an
-EMPTY ``<think>\\n\\n</think>`` scaffold for every completed assistant turn -
+EMPTY `` thinking\\n\\n response`` scaffold for every completed assistant turn -
 off-contract scaffolding the model never saw in training - while inline
-``<think>`` text in replayed content was preserved verbatim across all turns.
+`` thinking`` text in replayed content was preserved verbatim across all turns.
 
-Scoped mode restores Qwen's trained contract in both directions:
+Fix: ``_message_to_template_dict`` now carries the client's structured
+``reasoning_content`` fields through to the template in every mode except full
+strip. Preserve (``on``) therefore renders the REAL think text for every
+assistant turn - no more empty scaffolds - which is what makes agent/tool
+clients (OpenCode/Zed) see their previous thinking. Scoped mode still lets the
+template's rolling checkpoint govern:
 - completed turns render with no think scaffold at all (inline think in
   replayed content is scoped out by the template's own split logic);
 - the active agent round (assistant -> tool -> assistant chains after the
   last real user query) keeps its reasoning, including the structured
   ``reasoning_content`` fields OpenCode sends - the interleaved-thinking
-  continuity every provider preserves, which legacy preserve-all silently
-  dropped.
+  continuity every provider preserves.
 
-``on``/``off`` remain byte-identical to the legacy renderings (rollback path).
+``off`` remains the legacy full-strip render. ``on`` is no longer
+byte-identical to the legacy empty-scaffold render (that is the fix), so both
+``on`` and scoped mint their own session-cache identity components.
 
 The golden rendering tests run against the byte-identical template shipped
 with the Qwen3.6 Optimized Speed/Quality artifacts
@@ -218,15 +224,16 @@ def test_scoped_active_round_matches_preserve_for_inline_reasoning():
 def test_scoped_carries_structured_reasoning_legacy_preserve_dropped():
     """Legacy preserve-all silently DROPPED OpenCode's structured
     reasoning_content fields (measured on a live SSD-banked loop prompt:
-    every history think block rendered empty). Scoped carries them for the
-    active round - strictly more in-round continuity than today's default."""
+    every history think block rendered empty). The fix carries them in
+    preserve mode too - the model sees the real think text, not a scaffold.
+    """
 
     preserve = _render_history(
         _active_round_history(),
         scoped_reasoning_history=False,
     )
-    assert "THINK_ACTIVE_ROUND" not in preserve
-    assert "<think>\n\n</think>" in preserve
+    assert "THINK_ACTIVE_ROUND" in preserve
+    assert " thinking\n\n response" not in preserve
     scoped = _render_history(
         _active_round_history(),
         scoped_reasoning_history=True,
@@ -255,18 +262,18 @@ def test_scoped_scopes_inline_think_history_via_template_split():
     assert "THINK_INLINE_OLD" in preserved
 
 
-def test_preserve_all_keeps_legacy_rendering_including_empty_scaffolds():
-    """`on` keeps today's exact behavior: structured reasoning_content stays
-    dropped and every completed assistant turn gets the empty think scaffold
-    (the measured legacy rendering this mode exists to roll back to)."""
+def test_preserve_all_renders_structured_reasoning_across_completed_turns():
+    """`on` now renders the REAL structured reasoning for every assistant
+    turn - including completed turns - instead of the legacy empty think
+    scaffold (the fix: agent/tool transcripts keep their previous thinking)."""
 
     rendered = _render_history(
         _completed_turn_history(),
         scoped_reasoning_history=False,
     )
-    assert "THINK_TURN_ONE" not in rendered
-    assert "THINK_TURN_TWO" not in rendered
-    assert rendered.count("<think>\n\n</think>") == 2
+    assert "THINK_TURN_ONE" in rendered
+    assert "THINK_TURN_TWO" in rendered
+    assert rendered.count(" thinking\n\n response") == 0
 
 
 def test_preserve_all_keeps_inline_think_across_completed_turns():
@@ -402,31 +409,39 @@ def test_parse_args_accepts_scoped_and_keeps_strip_flag_off():
 
 
 # ---------------------------------------------------------------------------
-# Cache identity: legacy fingerprints pinned, scoped mints a new one
+# Cache identity: strip keeps its legacy fingerprint; scoped and preserve
+# (whose render bytes now carry structured reasoning) mint their own.
 # ---------------------------------------------------------------------------
 
 
-def test_fingerprint_component_pins_legacy_strings_for_on_and_off():
-    # Explicit on/off users must keep their warm session banks: the emitted
-    # component strings are byte-identical to the pre-scoped release.
-    assert (
-        _reasoning_history_fingerprint_component(_state("on", capable=True))
-        == "strip_reasoning=0"
-    )
+def test_fingerprint_component_pins_legacy_strip_and_mints_for_preserve():
+    # Strip keeps its warm session banks: the emitted component string is
+    # byte-identical to the pre-scoped release.
     assert (
         _reasoning_history_fingerprint_component(_state("off", capable=True))
         == "strip_reasoning=1"
     )
+    # Preserve now renders structured reasoning_content (no more empty think
+    # scaffolds), so its bytes differ from the legacy render: mint a fresh
+    # component instead of reusing strip_reasoning=0.
+    assert (
+        _reasoning_history_fingerprint_component(_state("on", capable=True))
+        == "reasoning_history=preserve"
+    )
     assert (
         _reasoning_history_fingerprint_component(_state("auto", capable=False))
-        == "strip_reasoning=0"
+        == "reasoning_history=preserve"
     )
 
 
-def test_fingerprint_component_mints_new_identity_for_scoped_only():
+def test_fingerprint_component_mints_new_identity_for_scoped_and_preserve():
     assert (
         _reasoning_history_fingerprint_component(_state("auto", capable=True))
         == "reasoning_history=scoped"
+    )
+    assert (
+        _reasoning_history_fingerprint_component(_state("on", capable=True))
+        == "reasoning_history=preserve"
     )
 
 
@@ -457,7 +472,7 @@ def _fingerprint_state(policy: str, *, capable: bool):
     )
 
 
-def test_policy_fingerprint_scoped_differs_but_on_matches_legacy():
+def test_policy_fingerprint_scoped_differs_but_preserve_modes_agree():
     scoped = _policy_fingerprint(
         _fingerprint_state("auto", capable=True), thinking_enabled=True
     )
@@ -468,9 +483,9 @@ def test_policy_fingerprint_scoped_differs_but_on_matches_legacy():
         _fingerprint_state("auto", capable=False), thinking_enabled=True
     )
     assert "reasoning_history=scoped" in scoped
-    assert "strip_reasoning=0" in preserve
-    # `on` (and auto on non-checkpoint templates) emits the exact legacy
-    # component so pre-existing warm banks stay valid.
+    assert "reasoning_history=preserve" in preserve
+    # `on` and auto-on-non-checkpoint-templates resolve to the same preserve
+    # mode and share the new preserve component.
     assert preserve == legacy_preserve
     assert scoped != preserve
 


### PR DESCRIPTION
## Problem

With `--preserve-thinking on` (preserve reasoning mode), tool/agent clients
(OpenCode, Zed, Claude Code-style agents) don't see the model's previous
` thinking` blocks in the rendered prompt. With plain chat clients (no
tools) it works fine.

## Root cause

Agent/tool clients send assistant thinking history via the **structured
`reasoning_content` field**, not inline in `content`. In
`_message_to_template_dict`, those fields were only carried into the template
when `include_reasoning_content=True`, and that flag was set **only in scoped
mode** (`scoped_reasoning_history`). In preserve mode the field was dropped
before templating, so every completed assistant turn rendered an empty

```
 thinking

 response
```

scaffold — the model never saw the real think text. Plain chat clients keep
thinking inline in `content`, which is why preserve worked without tools.

## Fix

- `include_reasoning_content` now tracks `not strip_assistant_reasoning_history`
  instead of `scoped_reasoning_history`, in both
  `_encode_messages_uncached` and `_postcommit_next_turn_prefix_ids`. Preserve
  (and scoped) carry the structured reasoning fields to the template.
- The session-cache identity component now mints `reasoning_history=preserve`
  in preserve mode, since the rendered bytes genuinely differ from the legacy
  empty-scaffold render. Full strip keeps its legacy `strip_reasoning=1`
  fingerprint so existing strip users' warm session banks survive.

Scoped mode behavior is unchanged (the template's rolling checkpoint still
renders think blocks only inside the active agent round).

## Testing

Validated with the real Qwen3.8 tokenizer; the following pass:

- `tests/test_scoped_reasoning_history.py`
- `tests/test_committed_reasoning_canonicalization.py`
- `tests/test_canon_gate_hardening.py`
- `tests/test_canon_policy_smalls.py`
- `tests/test_canon_postcommit_extension.py`
- `tests/test_openai_bridge.py`
- `tests/test_qwen38_family.py`

A runnable reproduction is kept locally at `misc/repro_scoped_tools.py` (not
part of this PR since `misc/` isn't tracked upstream).