### PR TITLE
Do not read the early tool-call cancel as a foreign cancel

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -29374,7 +29374,26 @@ def create_app(state: ServerState) -> FastAPI:
                             client_disconnected_now = (
                                 await raw_request.is_disconnected()
                             )
-                            if cancel_event.is_set() or client_disconnected_now:
+                            if (
+                                cancel_event.is_set()
+                                and not early_tool_cancel_used
+                            ) or client_disconnected_now:
+                                # `and not early_tool_cancel_used` because the
+                                # early tool-call cancel below sets the very
+                                # same event and then `continue`s straight back
+                                # into this branch. The worker only observes
+                                # the event once per committed token batch
+                                # (`on_tokens`), so whenever that batch gap
+                                # outlives the 0.25s poll above, the loop read
+                                # its own cancel as a foreign one and killed a
+                                # healthy tool-calling turn. Excluding it keeps
+                                # draining until the worker acknowledges, which
+                                # lands on the `kind == "cancelled"` handler
+                                # and its `early_tool_cancel_used and
+                                # streamed_assistant_tool_calls` terminal
+                                # frame. The completions loop already guards
+                                # its own `stop_hit` cancel this way.
+                                #
                                 # Truthful cancel accounting (#F36): only a
                                 # genuinely dead transport is a client
                                 # disconnect; an explicit server-side cancel


### PR DESCRIPTION
Fixes #343.

## The bug

The streaming chat-completions loop kills healthy tool-calling turns with

```
request cancelled via POST /v1/mtplx/cancel after 1510 streamed tokens
```

although no client ever calls that endpoint. It is a race the server runs
against itself:

1. 50 ms after a complete tool call, the loop cancels its own generation
   (`STREAM_TOOL_CALL_FINISH_GRACE_S`, L29415-L29424) — `cancel_event.set()` —
   and `continue`s.
2. Back at `await queue.get(0.25)`.
3. The generation thread only observes `cancel_event` inside `on_tokens`
   (L27772/L27783), i.e. once per committed token batch, so the acknowledgement
   latency *is* the inter-batch gap.
4. When that gap outlives the 250 ms poll, `except Empty` fires and its first
   check is `if cancel_event.is_set() or client_disconnected_now:` — the event
   the loop itself set one iteration earlier. Client still connected, so it
   emits the error frame and returns.

When the worker does acknowledge inside 250 ms, `kind == "cancelled"` (L30305)
handles it correctly via `early_tool_cancel_used and
streamed_assistant_tool_calls` (L30340) and the client gets its terminal
tool-call frame. Hence the apparent randomness.

On the box where I hit this (`qwen3_next`, depth 3, ~58k-token prompts, 23
tools) `/metrics` reported `producer_gap_ms_p95: 224`, `producer_gap_ms_max:
795`, and `producer_gaps_over_200ms: 177` in a single request — the 250 ms poll
loses that race constantly.

## The change

One condition, mirroring the guard the completions loop already applies to its
own `stop_hit` cancel (L31100):

```diff
-if cancel_event.is_set() or client_disconnected_now:
+if (
+    cancel_event.is_set()
+    and not early_tool_cancel_used
+) or client_disconnected_now:
```

The loop now keeps draining until the worker acknowledges, landing on the
existing `kind == "cancelled"` path that emits the proper terminal frame.

Deliberately **not** modelled on the `stop_monitor.stopped` guard a few lines
above, which `continue`s past the stall watchdog and the heartbeat: if a worker
never acknowledges an early cancel, this version still breaches
`MTPLX_STREAM_STALL_DEADLINE_S` and fails with a truthful message instead of
hanging.

Behaviour preserved:

- a genuine `POST /v1/mtplx/cancel/{id}` still ends the stream — the worker
  acknowledges and the `cancelled` handler runs;
- a real client disconnect is still caught by `client_disconnected_now`;
- the stall watchdog still bounds the wait.

## Verification

```
pytest tests/test_no_mlx_imports.py tests/test_public_cli.py \
       tests/test_runtime_kpis.py tests/test_stream_stall_watchdog.py \
       tests/test_server_obs_stream_termination.py tests/test_stream_guard_env.py
```

281 passed, before and after. `ruff check mtplx/server/openai.py` reports the
same 289 pre-existing findings on both sides of the diff — the change adds none.

I did not add a regression test: the branch lives inside a ~3k-line async
generator with no seam to drive it from. If you would like one, I am happy to
extract the predicate into a module-level helper (in the spirit of
`_OwnerStallProbe`) and unit-test it — say the word and I will push it here.

Two side notes from #343, not addressed in this PR because they are yours to
decide:

- the error text hardcodes `POST /v1/mtplx/cancel` for *any* cancel with a live
  transport, while `_stream_cancelled_queue_item` already carries a reason
  string that would have made this a one-minute diagnosis;
- 50 ms of grace against a decode loop whose p95 batch gap is 224 ms means the
  cancel essentially always lands mid-batch.
