### PR TITLE
fix(release): keep Sparkle notes readable in dark mode

### DIFF
--- a/scripts/release_macos_v1.sh
+++ b/scripts/release_macos_v1.sh
@@ -261,29 +261,8 @@ DMG_URL="$GITHUB_ASSET_BASE/$(basename "$DMG")"
 
 # Sparkle's "what's new" dialog and the hosted notes page render the real
 # release notes authored in docs/releases/v$VERSION.md (gated above).
-"$PYTOOLS_VENV/bin/python" - "$RELEASE_NOTES_MD" "$NOTES_OUT/v$VERSION.html" "$VERSION" <<'PY'
-import pathlib
-import sys
-
-import markdown
-
-source, destination, version = sys.argv[1], sys.argv[2], sys.argv[3]
-body = markdown.markdown(
-    pathlib.Path(source).read_text(encoding="utf-8"),
-    extensions=["extra"],
-)
-html = (
-    "<!doctype html>\n"
-    '<meta charset="utf-8">\n'
-    f"<title>MTPLX {version}</title>\n"
-    '<style>body{font-family:-apple-system,system-ui,sans-serif;'
-    "max-width:42em;margin:2em auto;padding:0 1em;line-height:1.55}"
-    "h1,h2{line-height:1.2}code{background:#f2f2f4;padding:0 .25em;"
-    "border-radius:4px}</style>\n"
-    f"{body}\n"
-)
-pathlib.Path(destination).write_text(html, encoding="utf-8")
-PY
+"$PYTOOLS_VENV/bin/python" "$ROOT/scripts/render_release_notes.py" \
+  "$RELEASE_NOTES_MD" "$NOTES_OUT/v$VERSION.html" "$VERSION"
 
 python3 - "$RELEASES_OUT/latest.json" "$VERSION" "$APP_BUILD" "$DMG_URL" "$DMG_SHA256" "$DMG_SIZE" "$RELEASE_NOTES_URL" <<'PY'
 import datetime

--- a/scripts/render_release_notes.py
+++ b/scripts/render_release_notes.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Render MTPLX Markdown release notes for the hosted page and Sparkle."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+import sys
+
+
+RELEASE_NOTES_CSS = """
+:root {
+  color-scheme: light dark;
+  --mtplx-notes-text: #1d1d1f;
+  --mtplx-notes-code-bg: #f2f2f4;
+  --mtplx-notes-code-text: #1d1d1f;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mtplx-notes-text: #f5f5f7;
+    --mtplx-notes-code-bg: #343437;
+    --mtplx-notes-code-text: #f5f5f7;
+  }
+}
+body {
+  color: var(--mtplx-notes-text);
+  background: transparent;
+  font-family: -apple-system, system-ui, sans-serif;
+  max-width: 42em;
+  margin: 2em auto;
+  padding: 0 1em;
+  line-height: 1.55;
+}
+h1, h2 { line-height: 1.2; }
+code {
+  color: var(--mtplx-notes-code-text) !important;
+  background: var(--mtplx-notes-code-bg) !important;
+  padding: 0 .25em;
+  border-radius: 4px;
+}
+pre code {
+  display: block;
+  padding: .75em;
+  overflow-x: auto;
+}
+""".strip()
+
+
+def release_notes_document(body: str, version: str) -> str:
+    title = html.escape(f"MTPLX {version}")
+    return (
+        "<!doctype html>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="color-scheme" content="light dark">\n'
+        f"<title>{title}</title>\n"
+        f"<style>\n{RELEASE_NOTES_CSS}\n</style>\n"
+        f"{body}\n"
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        raise SystemExit("usage: render_release_notes.py SOURCE DESTINATION VERSION")
+
+    import markdown
+
+    source_arg, destination_arg, version = argv[1:]
+    source = Path(source_arg)
+    destination = Path(destination_arg)
+    body = markdown.markdown(
+        source.read_text(encoding="utf-8"),
+        extensions=["extra"],
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(release_notes_document(body, version), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/sparkle_rehearsal_kit.sh
+++ b/scripts/sparkle_rehearsal_kit.sh
@@ -175,24 +175,8 @@ render_notes() {
   # render_notes <version> <markdown-file>
   local version="$1"
   local source_md="$2"
-  "$PYTOOLS_VENV/bin/python" - "$source_md" "$NOTES_OUT/v$version.html" "$version" <<'PY'
-import pathlib
-import sys
-
-import markdown
-
-source, destination, version = sys.argv[1], sys.argv[2], sys.argv[3]
-body = markdown.markdown(
-    pathlib.Path(source).read_text(encoding="utf-8"), extensions=["extra"]
-)
-html = (
-    "<!doctype html>\n"
-    '<meta charset="utf-8">\n'
-    f"<title>MTPLX {version}</title>\n"
-    f"{body}\n"
-)
-pathlib.Path(destination).write_text(html, encoding="utf-8")
-PY
+  "$PYTOOLS_VENV/bin/python" "$ROOT/scripts/render_release_notes.py" \
+    "$source_md" "$NOTES_OUT/v$version.html" "$version"
   /usr/bin/ditto --norsrc "$NOTES_OUT/v$version.html" "$SPARKLE_ARCHIVES/MTPLX-$version.html"
 }
 

--- a/tests/test_release_notes_renderer.py
+++ b/tests/test_release_notes_renderer.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "render_release_notes.py"
+SPEC = importlib.util.spec_from_file_location("render_release_notes", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+render_release_notes = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(render_release_notes)
+
+
+def test_release_notes_inline_code_has_explicit_light_and_dark_contrast() -> None:
+    document = render_release_notes.release_notes_document(
+        "<p><code>quantize: false</code></p>",
+        "2.9.2",
+    )
+
+    assert '<meta name="color-scheme" content="light dark">' in document
+    assert "@media (prefers-color-scheme: dark)" in document
+    assert "--mtplx-notes-code-bg: #f2f2f4" in document
+    assert "--mtplx-notes-code-text: #1d1d1f" in document
+    assert "--mtplx-notes-code-bg: #343437" in document
+    assert "--mtplx-notes-code-text: #f5f5f7" in document
+    assert "color: var(--mtplx-notes-code-text) !important" in document
+    assert "background: var(--mtplx-notes-code-bg) !important" in document
+    assert "<code>quantize: false</code>" in document
+
+
+def test_release_notes_title_escapes_untrusted_version_text() -> None:
+    document = render_release_notes.release_notes_document("<p>Notes</p>", '2.9.3<script>')
+
+    assert "<title>MTPLX 2.9.3&lt;script&gt;</title>" in document
+    assert "<title>MTPLX 2.9.3<script></title>" not in document


### PR DESCRIPTION
Fixes #367.

The generated release-notes HTML now declares light and dark color schemes and gives inline code explicit foreground and background colors. The code colors use `!important` so Sparkle theme styling cannot recreate white text on a light code background.

The production release script and Sparkle rehearsal kit now share one tested renderer, so their note pages cannot drift again.

Validation:
- full Python suite: exit 0, 4,377 tests collected
- release-note renderer tests: 2 passed
- real v2.9.2 Markdown render through an ephemeral release-tools environment: passed
- Ruff, both shell syntax checks, and `git diff --check`: passed

@youssofal, please review.