### PR TITLE
fix(server): name-preserving truncation in the compact tool contract

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -5688,10 +5688,29 @@ def _mtplx_tool_contract_text(
     tool_choice: Any = None,
 ) -> str:
     signatures = [signature for tool in tools if (signature := _tool_signature(tool))]
-    allowed = "; ".join(signatures) if signatures else "(none)"
+    names = [name for name in (_tool_spec_name(tool) for tool in tools) if name]
     example = _tool_call_example(tools)
+    allowed = "; ".join(signatures) if signatures else "(none)"
     if len(allowed) > 1200:
-        allowed = allowed[:1197].rstrip() + "..."
+        # Name-preserving fallback: the old raw byte cut dropped whole tool
+        # names at the tail, which the "never invent ... undeclared tool"
+        # clause then read as "tool missing". Keep every declared name
+        # visible; only sacrifice per-tool signature detail when the 1200
+        # budget runs out (a bare name still declares the tool).
+        parts: list[str] = []
+        size = 0
+        for index, signature in enumerate(signatures):
+            name = names[index] if index < len(names) else ""
+            for candidate in (signature, name):
+                extra = len(candidate) if not parts else 2 + len(candidate)
+                if size + extra <= 1200:
+                    parts.append(candidate)
+                    size += extra
+                    break
+            else:
+                parts.append(name)
+                size += 2 + len(name)
+        allowed = "; ".join(parts)
     forced_clause = _forced_tool_contract_clause(tool_choice)
     return (
         f"{_MTPLX_TOOL_CONTRACT_SENTINEL} {_current_date_line()} Your "

--- a/tests/test_server_openai.py
+++ b/tests/test_server_openai.py
@@ -7883,6 +7883,71 @@ def test_tool_contract_stabilizes_tool_schema_with_agent_tail_guardrail(legacy_r
     assert [message["role"] for message in with_contract] == ["system", "user"]
 
 
+def test_tool_contract_keeps_every_tool_name_when_over_budget():
+    # Build enough tools that the joined "Declared tools and schemas" line
+    # exceeds the 1200-char budget, so the fallback path is exercised. The
+    # sentinel `task` sits at the tail: the old raw byte cut dropped it
+    # entirely, which the "never invent ... undeclared tool" clause then read
+    # as "tool missing".
+    tools = []
+    for index in range(20):
+        tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": f"tool_{index}",
+                    "description": "x",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            f"prop_{k}": {"type": "string"} for k in range(8)
+                        },
+                        "required": ["prop_0"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        )
+    tools.append(
+        {
+            "type": "function",
+            "function": {
+                "name": "task",
+                "description": "Launch a subagent task.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "description": {"type": "string"},
+                        "prompt": {"type": "string"},
+                    },
+                    "required": ["description", "prompt"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    )
+
+    # Guard: the joined full signatures must exceed the 1200-char budget, so
+    # the over-budget fallback (the code under test) is actually exercised
+    # rather than the under-budget byte-identical path.
+    full = "; ".join(
+        sig for sig in (openai._tool_signature(t) for t in tools) if sig
+    )
+    assert len(full) > 1200
+
+    text = openai._mtplx_tool_contract_text(tools)
+    marker = "Declared tools and schemas: "
+    start = text.find(marker)
+    end = text.find(". Call only these", start)
+    segment = text[start + len(marker): end]
+
+    # Every declared tool name must survive the budget, including the sentinel
+    # at the tail (the tool the old byte cut dropped).
+    for tool in tools:
+        name = tool["function"]["name"]
+        assert re.search(r"\b" + re.escape(name) + r"\b", segment), name
+
+
 def test_native_tool_prompt_mode_keeps_template_tools_and_adds_agent_tail(legacy_rewrites):
     tokenizer = CaptureTokenizer()
     observability: dict[str, object] = {}


### PR DESCRIPTION
Fixes #376

## What
`_mtplx_tool_contract_text` joins every tool signature with `"; "` and, when the
result exceeds the 1200-char budget, hard-truncates to the first 1197 + `"..."`.
Any tool whose signature falls past that boundary is **absent** from the
"Declared tools and schemas" line. Combined with the same contract's
`"Never invent ... any undeclared tool"` clause, a tool that *is* served is read
by the model as missing — e.g. opencode's `task` (subagent spawning) disappears
whenever a few rich-schema MCP tools (Serena) push the joined list past 1200
chars. This is a prompt-*rendering* truncation, not the #298 serving/hide bug
(2.9.2 already serves every tool).

## Fix
Make the over-budget fallback **name-preserving**: keep every declared tool name
visible and only sacrifice per-tool signature detail when the budget runs out (a
bare name still declares the tool). Under-budget output is byte-identical to
before, so prefix stability is preserved.

## Test
Adds `test_tool_contract_keeps_every_tool_name_when_over_budget` (in
`tests/test_server_openai.py`, alongside the other `test_tool_contract_*`
tests): builds an over-budget tool set with a `task` sentinel at the tail,
guards that the set is actually over budget, and asserts every name survives
(word-boundary match on the extracted "Declared tools" segment). Fails on the
old byte cut, passes with the fix.

Verified locally: the exact test passes on the patch and fails on the
pre-patch code; an under-budget 6-tool set renders byte-identically (same MD5)
before/after.
