### PR TITLE
feat: support Qwen3.8-Flash-Next (qwen4_exp) with native MTP and compiled decode

### DIFF
--- a/MTP-ASSEMBLY-SPEC.md
+++ b/MTP-ASSEMBLY-SPEC.md
@@ -1,0 +1,422 @@
+# MTP-ASSEMBLY-SPEC.md
+## Qwen3.8-Flash-Next (arch `qwen4_exp`) MTP head — definitive assembly spec for the MLX port
+
+Status target: real-weight draft acceptance is currently ZERO with the speculative
+machinery proven exact, i.e. the head forward is mis-assembled. This document is the
+line-by-line reference to diff against.
+
+Sources reconciled: llama.cpp PR #27739 (JJJYmmm fork @ dfa0c0f, convert-time fused
+`eh_proj` variant), llama.cpp PR #27742 (no MTP yet; qwen35 `graph_mtp` template),
+vLLM PR #53896 (`vllm/models/qwen4_exp/nvidia/mtp.py`), TokenSpeed branch
+`zt/qwen3.8_next` (`qwen4_exp_nextn.py`), SGLang PR #36497 (`qwen4_exp_mtp.py`,
+`hyperconnection.py`), HF checkpoint tensor index, RadixArk NVFP4 config.json.
+All four MTP implementations agree on the math; the two representational
+disagreements are resolved in §1.7.
+
+---
+
+## 0. Notation, dims, tensor inventory
+
+```
+H  = 2560            hidden_size
+S  = 4               hc_count (hyper-connection streams)
+D  = S*H = 10240     flattened stream width
+R  = 320             hc_lowrank
+V  = 248320          vocab
+T                    tokens in the batch
+eps                  config rms_norm_eps (reuse the trunk's value)
+theta_mtp = 1e7      rope theta of the MTP block (config text_config.mtp.rope_theta)
+```
+
+**Flatten convention (load-bearing):** every width-D vector is the row-major flatten
+of `[S, H]` — element index `s*H + h`, stream index OUTER, hidden index INNER.
+`x.reshape(T, S, H)` must recover the streams. All `[·,10240]` and `[10240]`
+checkpoint tensors assume this layout (SGLang: `hidden.view(T, hc_count, hidden_size)`
+directly after the flat norm; `unflatten(-1, (hc, H))` in TokenSpeed).
+
+**Ground-truth checkpoint inventory (31 `mtp.*` tensors) and where each is consumed:**
+
+| tensor | shape | consumed at (spec step) |
+|---|---|---|
+| `mtp.pre_fc_norm_embedding.weight` | [2560] | §1.2 step F2 (norm of token embedding) |
+| `mtp.fc_embedding.weight` | [2560,2560] | §1.2 step F3 |
+| `mtp.pre_fc_norm_hidden.weight` | [10240] | §1.2 step F4 (ONE variance over all 10240) |
+| `mtp.fc_hidden.weight` | [2560,2560] | §1.2 step F5 (shared across the 4 streams) |
+| `mtp.layers.0.attn_hyper_connection.hc_norm.weight` | [10240] | §1.4 A1 (grouped, per-stream variance) |
+| `mtp.layers.0.attn_hyper_connection.input_mix_weight_down` | [320,10240] | §1.4 A1 |
+| `mtp.layers.0.attn_hyper_connection.input_mix_weight_up` | [10240,320] | §1.4 A1 |
+| `mtp.layers.0.attn_hyper_connection.block_inject_weight` | [4,10240] | §1.4 A1 (inject gate) / A3 (combine) |
+| `mtp.layers.0.self_attn.q_proj` (fused q+output-gate, 2× width) | — | §1.4 A2 |
+| `mtp.layers.0.self_attn.{k_proj,v_proj,o_proj,q_norm,k_norm}` | — | §1.4 A2 |
+| `mtp.layers.0.self_attn.indexer.*` (index_qk_proj, q/k layernorm) | — | **UNUSED in the dense baseline** (§1.7-D3) |
+| `mtp.layers.0.mlp_hyper_connection.{hc_norm,down,up,block_inject}` | as attn | §1.4 M1/M3 |
+| `mtp.layers.0.mlp.gate` (router), `experts.{gate_up_proj,down_proj}` (512) | — | §1.4 M2 |
+| `mtp.layers.0.mlp.shared_expert.*`, `shared_expert_gate` | — | §1.4 M2 |
+| `mtp.hyper_connection_mixer.hc_norm.weight` | [10240] | §1.5 step O2 (grouped, per-stream variance) |
+| `mtp.hyper_connection_mixer.input_mix_weight_down` | [320,10240] | §1.5 O2 |
+| `mtp.hyper_connection_mixer.input_mix_weight_up` | [10240,320] | §1.5 O2 |
+
+**Shared with the trunk (no mtp copies exist in the checkpoint):**
+`model.embed_tokens.weight` (token embedding lookup, §1.1), `lm_head.weight`
+(§1.5 O4). There is **no** `mtp.norm`, **no** `mtp.shared_head.*`, **no**
+`mtp.embed_tokens` (§1.7-D2). The trunk's final norm / final mixer are NOT used
+inside the head.
+
+Every listed tensor is consumed exactly once per head forward, except the QSA
+indexer tensors, which are deliberately unused (flagged, §1.7-D3). If your
+implementation consumes any tensor zero times or twice (e.g. reuses
+`pre_fc_norm_hidden` as a final norm), it is wrong by construction.
+
+---
+
+## 1. The forward pass (one head step)
+
+Signature (per token; batched over T):
+
+```
+head(token_id: int, h_prev: float[D], pos: int, kv_cache) -> (logits: float[V], m_out: float[D])
+```
+
+- `h_prev` is the FLATTENED 4-STREAM HYPER-CONNECTION STATE `[D]=[10240]` of the
+  *previous* position — the trunk's pre-final-mixer state on step 0, the head's own
+  `m_out` on steps ≥ 1. It is NEVER the collapsed/post-mixer `[2560]` hidden.
+- `m_out` is the head's own pre-final-mixer stream state at `pos`, fed to the next step.
+
+### 1.0 Primitives
+
+**GemmaRMSNorm(x, w, width)** — variance over the last `width` dims, zero-centered
+weight:
+
+```
+y = x * rsqrt(mean(x^2, axis=-1 over width) + eps) * (1 + w)
+```
+
+The `(1 + w)` is Gemma-style (SGLang/vLLM both instantiate `GemmaRMSNorm`;
+llama.cpp bakes the +1 in at convert time). All norms in this spec use it:
+`pre_fc_norm_embedding`, `pre_fc_norm_hidden`, every `hc_norm`, `q_norm`, `k_norm`.
+Sanity: checkpoint norm weights should cluster near 0, not near 1 (§4 T2c).
+
+**GroupedRMSNorm(X, w)** for stream states, `X: [T,S,H]`, `w: [D]` viewed `[S,H]`:
+variance computed PER (token, stream) over H only:
+
+```
+Xn[t,s,:] = X[t,s,:] * rsqrt(mean(X[t,s,:]^2) + eps) * (1 + w[s,:])
+```
+
+**GatedResidual.mix(X, hc_norm, Wdown, Wup [, Winject])** — the hyper-connection
+pre-mixer. `X: [T,S,H]`; returns `(mixed: [T,H], Xn_flat: [T,D] [, gamma: [T,S]])`:
+
+```
+1. Xn      = GroupedRMSNorm(X, hc_norm)                # per-stream variance
+2. xn_flat = Xn.reshape(T, D)                          # stream-major flatten
+3. z       = silu( (xn_flat @ Wdown.T) / S )           # [T,R]; divide by S BEFORE silu
+4. g       = sigmoid( z @ Wup.T ).reshape(T, S, H)     # [T,S,H]
+5. mixed   = mean over s of ( g[:,s,:] * Xn[:,s,:] )   # [T,H]; MEAN, not sum
+6. (if Winject given)
+   gamma   = 2 * sigmoid( (xn_flat @ Winject.T) / S )  # [T,S]; from the NORMED flat
+```
+
+At init `gamma == 1` (2·σ(0)) — the ×2 and the two ÷S scalings are trained-in;
+omitting any of them mis-scales every residual.
+
+**GatedResidual.combine(X, y, gamma)** — the post-mixer injection. `y: [T,H]` is the
+sub-block output; adds into the RAW (pre-norm) streams:
+
+```
+X'[t,s,:] = X[t,s,:] + gamma[t,s] * y[t,:]             # broadcast y to all S streams
+```
+
+(vLLM defers this combine into the next mix's norm — "delayed combine" — which is
+algebraically identical; implement it immediately as above.)
+
+### 1.1 Inputs
+
+```
+I1. e_tok = embed_tokens[token_id]          # [H], the TRUNK's model.embed_tokens
+I2. h     = h_prev                          # [D], see §2 for which row this must be
+```
+
+Do NOT run the trunk's "replicate the embedding into S streams" input path here —
+that is only for trunk layer 0. The head builds its stream state via the fusion
+below.
+
+### 1.2 Input fusion — `residual_linear_shared` (ADD, not concat)
+
+```
+F1. (nothing precedes; h is used raw, un-normed, as the fusion input)
+F2. e_n  = GemmaRMSNorm(e_tok, pre_fc_norm_embedding, width=H)      # [H]
+F3. e_p  = e_n @ fc_embedding.T                                     # [H]
+F4. h_n  = GemmaRMSNorm(h, pre_fc_norm_hidden, width=D)             # [D]
+         # ONE variance over the full 10240 vector (all 4 streams jointly),
+         # elementwise (1+w) with w=[10240]. NOT per-stream. (llama.cpp comment:
+         # "norms the whole hyper-connection row ... unlike deepseek4".)
+F5. Hs   = h_n.reshape(S, H) @ fc_hidden.T                          # [S,H]
+         # ONE [2560,2560] weight applied to EACH of the 4 normed streams.
+F6. X0   = Hs + e_p[None, :]                                        # [S,H]
+         # the projected embedding is broadcast-ADDED to EVERY stream.
+```
+
+`X0: [T,S,H]` is the head's stream state entering the decoder layer.
+Equivalence note: llama.cpp PR #27739 fuses F3+F5+F6 at CONVERT time into one
+`eh_proj = [fc_embedding | fc_hidden]` `[2H,H]` matmul of `concat(e_n, h_n_stream)`
+per stream — `A·e + B·h == [A|B]·concat(e,h)`. The checkpoint ships the two `[H,H]`
+weights, so at runtime you implement the ADD form above. There is NO DeepSeek-style
+`Linear(2H,H)` over `concat(norm(e), norm(h))` in this model.
+
+### 1.3 (reserved — no step between fusion and the layer; no norm, no collapse)
+
+### 1.4 Decoder layer — one full trunk-style block at stream width
+
+This is byte-for-byte a trunk layer (`mtp.layers.0` ≙ layer index 48), forced to:
+`layer_type = full_attention`, PLE OFF (`ple_layer_ids=[]`), `attn_output_gate=True`,
+`rope_theta = theta_mtp = 1e7`, its OWN KV cache. **Reuse your proven trunk-layer
+code**; only the config overrides above differ.
+
+Attention half:
+
+```
+A1. mixed, Xn_flat, gamma_a = mix(X0, attn_hc.hc_norm, attn_hc.down, attn_hc.up,
+                                  attn_hc.block_inject)             # mixed: [T,H]
+A2. y_a = SelfAttention(mixed, pos, kv_cache):
+      - q_proj is FUSED [q | output-gate]: out-width = 2 * n_head * head_dim,
+        interleaved PER HEAD (head h occupies rows [h*2*hd, (h+1)*2*hd): first hd
+        rows = Q, next hd = gate) — take strided views, do not de-interleave weights.
+      - q = per-head GemmaRMSNorm(q, q_norm); k = per-head GemmaRMSNorm(k, k_norm)
+      - RoPE(pos) with theta_mtp=1e7 (m-rope sections as in the trunk; for text-only
+        this reduces to standard rope) applied to q and k
+      - DENSE causal attention against this head's own KV cache (indexer skipped)
+      - out = attn_out * sigmoid(gate)     # elementwise, before o_proj
+      - y_a = out @ o_proj.T
+A3. X1 = combine(X0, y_a, gamma_a)                                  # [T,S,H]
+```
+
+MoE half:
+
+```
+M1. mixed, _, gamma_m = mix(X1, mlp_hc.hc_norm, mlp_hc.down, mlp_hc.up,
+                            mlp_hc.block_inject)                    # [T,H]
+M2. y_m = MoE(mixed)   # identical to the trunk MoE: router `gate` softmax top-k over
+        # 512 experts (same top-k / routed scaling / normalization as your trunk),
+        # PLUS shared expert: y_m = moe_out + shexp(mixed) * sigmoid(mixed @ shared_expert_gate.T)
+M3. X2 = combine(X1, y_m, gamma_m)                                  # [T,S,H]
+```
+
+### 1.5 Output: feedback tap, final mixer, logits
+
+```
+O1. m_out = X2.reshape(T, D)          # FEEDBACK for the next draft step — captured
+                                      # BEFORE the final mixer, for EVERY token
+                                      # (before any output-row masking/gather).
+O2. sample_hidden = mix(X2, mixer.hc_norm, mixer.down, mixer.up)    # [T,H]
+    # mtp.hyper_connection_mixer, mix-only (no block_inject — none exists).
+    # Its hc_norm is GROUPED per-stream (variance over H per stream) — the OPPOSITE
+    # convention of pre_fc_norm_hidden in F4. Do not swap them.
+O3. (no further norm — the mixer IS the final norm; there is no mtp.norm tensor)
+O4. logits = sample_hidden @ lm_head.T          # the TRUNK's lm_head, [V]
+```
+
+Return `(logits, m_out)`.
+
+### 1.6 Consumption audit (assert in code)
+
+Per forward: F2..F6 consume the 4 head-input tensors once; A1–A3 consume the 4
+attn_hc tensors + attention weights once; M1–M3 the 4 mlp_hc tensors + MoE weights
+once; O2 the 3 mixer tensors once. Indexer tensors: zero uses (intentional).
+`embed_tokens` once (I1), `lm_head` once (O4). Anything else touched ⇒ bug.
+
+### 1.7 Source disagreements & resolutions
+
+- **D1 Fusion form.** llama.cpp #27739: convert-time `eh_proj [2H,H]` concat-matmul.
+  vLLM/TokenSpeed/SGLang: runtime add (`residual_linear_shared`). Mathematically
+  identical per stream; checkpoint shapes (two `[2560,2560]`) mandate the ADD form
+  (§1.2). Resolved: ADD, 4/4 sources agree on the math.
+- **D2 embed/lm_head.** SGLang extraction mentions `mtp.embed_tokens` /
+  `mtp.shared_head.head` (modules it *builds*); ground-truth inventory + vLLM
+  confirm the checkpoint ships neither. Resolved: share the trunk's
+  `embed_tokens` and `lm_head`.
+- **D3 QSA in the head.** llama.cpp: dense, indexer loaded-but-unused ("tested,
+  no throughput gain"). SGLang/vLLM: run QSA with step-0 index capture + reuse.
+  Dense attention is a strict superset of QSA top-k selection (identical whenever
+  context ≤ index_topk) and is the correct baseline for an implementation chasing
+  correctness. Resolved: DENSE; QSA is a later optimization, never a correctness
+  requirement.
+- **D4 Positions.** llama.cpp + SGLang: the head decodes each input token at that
+  token's absolute trunk position (rule in §2.2). vLLM's EAGLE plumbing uses
+  target positions for the shifted ids (a uniform −1). A uniform shift is
+  RoPE-relative-benign; MIXED conventions inside one implementation are not.
+  Resolved: use the absolute-position rule of §2.2 everywhere.
+- **D5 Naming.** "Qwen3.8-Flash-Next" is the public name; every codebase calls the
+  arch `qwen4_exp` / Qwen4-Exp (LLM_TYPE_122B_A10B, 48 trunk layers).
+
+---
+
+## 2. The multi-step draft loop
+
+### 2.1 What the trunk must expose
+
+On EVERY target forward, capture per token the **pre-final-mixer** stream state:
+the `[T, D]` tensor immediately BEFORE the trunk's model-level
+`hyper_connection_mixer.mix(...)` collapses it to `[T, H]` (and before the trunk's
+output-row gather/masking — you need rows for all verified tokens, not just the
+sampled ones). Call row `i` of it `Hs_i`. This is what llama.cpp calls
+`t_h_nextn` / "mtp_h_input", SGLang `hc_hidden_states`, vLLM `multi_hidden`
+(`spec_hidden_size = hidden_size * hc_count = 10240`).
+
+### 2.2 Pairing and position rule (the invariant)
+
+Let positions `0..n-1` be target-decoded (each has an `Hs` row) and `t_next` be the
+token the target just sampled (to be placed at position `n`).
+
+> **Head input at position `p` is always `(token that sits at position p,
+> Hs of position p−1)`, decoded at RoPE/KV position `p`.**
+> The head's output at `p` is the candidate for position `p+1`.
+
+Equivalently: the token id is always paired with the stream state of the token
+*before* it ("shift the target embeddings right by one" — llama.cpp
+speculative.cpp; "cat(target_ids[1:], next_token)" — vLLM/SGLang).
+
+### 2.3 Head KV-cache policy (catch-up)
+
+Keep `n_exact` = highest position whose head-KV cell was built from TARGET `Hs`
+rows. After every verification round:
+
+```
+1. Truncate the head KV to positions ≤ n_exact.        # drop cells built from the
+                                                       # head's own m_out feedback
+2. Catch-up decode (one batched head forward, logits discarded):
+   for each newly committed token at position p in (n_exact, n-1]:
+       input (token_p, Hs_{p-1}) at position p
+   First-ever round only: position 0 pairs with zeros (no Hs_{-1}); one cell,
+   engines do the same, influence is negligible.
+3. n_exact = n-1.
+```
+
+This mirrors llama.cpp's per-round catch-up decode and TokenSpeed's "rewrite
+provisional tail KV with exact values". Never leave draft-feedback-built cells in
+the cache across a verification boundary.
+
+### 2.4 Draft steps
+
+```
+step 0:  (logits, M) = head(t_next,  Hs_{n-1}, pos = n)      ; d_1 = sample(logits)
+step k:  (logits, M) = head(d_k,     M_prev,   pos = n + k)  ; d_{k+1} = sample(logits)
+```
+
+- The drafted token is fed BY ID and embedded inside the head via the trunk's
+  `embed_tokens` (I1) — never feed a hidden state in place of the embedding.
+- `M_prev` is the head's own `m_out` `[D]` from the previous step (O1) — the
+  recurrence runs on the 4-stream state, not on `sample_hidden`.
+- Position advances by exactly +1 per step; the head KV grows one cell per step.
+- Sampling: greedy for acceptance debugging. Engine defaults: llama.cpp top-k 10
+  with a p_min high-confidence cutoff; SGLang (steps=3, topk=1, draft=4); blog
+  "MTP-213" = 2 steps / topk 1 / 3 draft tokens, accept length ≈ 3.3 incl. bonus.
+- Stop when top prob < p_min or n_max drafts collected.
+
+### 2.5 Verify and iterate
+
+Target decodes `[t_next, d_1..d_m]` at positions `n..n+m` (emitting `Hs` rows for
+all of them), accepts prefix length `a`, samples `t_next'` at position `n+a`.
+Set `n ← n+a+1`, go to §2.3. Carry `(Hs_{n-1}, t_next')` across the boundary
+(llama.cpp's `pending_h`).
+
+---
+
+## 3. Top 3 zero-acceptance bugs, in probability order
+
+Zero (not merely low) acceptance means the head's argmax is essentially never the
+target's token — the head is seeing garbage input or producing mis-scaled output.
+Given proven machinery, the head-assembly candidates are:
+
+### BUG 1 (most likely): wrong hidden feed — wrong capture point, tiled collapse, or transposed flatten
+Generic spec-decode plumbing exposes the *collapsed* `[2560]` final hidden.
+Failure variants, all shape-silent:
+  (a) capturing the trunk hidden AFTER the final mixer (or after a final norm) and
+      tiling it ×4 to fill 10240;
+  (b) capturing before the mixer but flattening as `[H,S]` instead of `[S,H]`
+      (element `s*H+h` vs `h*S+s`) anywhere across the trunk↔head boundary —
+      including inside the head when reshaping for F5/A1/M1/O2;
+  (c) capturing after output-row masking, so rows misalign with tokens.
+Every variant feeds severely out-of-distribution input ⇒ ~0% acceptance.
+
+### BUG 2: input fusion mis-assembled
+Failure variants, all shape-silent:
+  (a) `pre_fc_norm_hidden` applied per-stream (4 variances over 2560) instead of ONE
+      variance over the full 10240 (F4) — the single easiest trap because every
+      OTHER `[10240]` norm in the model (hc_norm, mixer norm) IS per-stream;
+  (b) the projected embedding added to only one stream, or concatenated, instead of
+      broadcast-added to all four (F6);
+  (c) `fc_hidden` applied to a collapsed mean of the streams instead of per-stream
+      (F5), or `h` normed with the trunk's replicate-embedding input path;
+  (d) plain `w` instead of Gemma `(1+w)` in `pre_fc_norm_*` (only plausible if the
+      head uses a different norm class than your proven trunk).
+
+### BUG 3: final mixer / feedback tap mis-assembled
+Failure variants:
+  (a) replacing O2 with a plain RMSNorm + mean over streams (dropping the low-rank
+      sigmoid gate), or borrowing the TRUNK's mixer weights instead of
+      `mtp.hyper_connection_mixer.*`;
+  (b) mixer `hc_norm` computed with ONE variance over 10240 (the F4 convention)
+      instead of grouped per-stream — the exact inverse of BUG 2a;
+  (c) SUM instead of MEAN over streams, or missing the ÷S before silu (mix step 3),
+      breaking the trained scale of `sample_hidden` and hence the logits;
+  (d) feeding the next draft step `sample_hidden` (2560, or tiled) instead of the
+      pre-mixer `m_out` — this one uniquely leaves step-1 acceptance nonzero while
+      zeroing steps ≥ 2, which is how you distinguish it.
+
+Honorable mentions if all three pass: token/hidden pairing off by one (§2.2 —
+pairing `(t_i, Hs_i)`); inject gate missing the ×2 or ÷S, or computed from raw
+instead of normed streams; trunk rope theta reused instead of 1e7.
+
+---
+
+## 4. Cheap numeric sanity tests (one per bug)
+
+Run all on real weights; each is < 1 minute and requires no training data beyond a
+short prompt.
+
+### T1 — mixer reconstruction identity (kills BUG 1, and validates mix() for BUG 3)
+For the last token of any prompt, capture `v = Hs [10240]` exactly as you feed it to
+the head. Apply **your own** `GatedResidual.mix` code with the **TARGET's**
+model-level `hyper_connection_mixer` weights:
+
+```
+u = mix(v.reshape(1,4,2560), tgt_mixer.hc_norm, tgt_mixer.down, tgt_mixer.up)
+assert max|u - h_final| <= 1e-3 * rms(h_final)
+```
+
+where `h_final [2560]` is the hidden your (working) trunk actually fed to `lm_head`
+for that token. This passes ONLY when (capture point, stream layout, grouped norm,
+÷S, silu/sigmoid order, gated MEAN) are all simultaneously right. Sub-probe for
+tiling: `rows = v.reshape(4,2560)`; if all pairwise cosines > 0.999 you fed a tiled
+collapsed hidden — real streams differ materially.
+
+### T2 — fusion probes (kills BUG 2)
+With real head weights, random `e [2560]`, random `X [4,2560]`:
+  (a) **global-variance probe:** compute F4 on `X` and on `X` with stream 2 scaled
+      ×10. ALL FOUR streams of the normed output must change (single 10240
+      variance). If only stream 2 changes, you built the per-stream norm.
+  (b) **broadcast/zero probes:** with `X = 0`: all four output streams of §1.2 must
+      be IDENTICAL and equal `fc_embedding(GemmaRMSNorm(e, w_e))`. With `e = 0`:
+      output stream `s` must equal `fc_hidden(F4(X)[s])` and streams must DIFFER.
+  (c) **Gemma probe:** `pre_fc_norm_embedding.weight.mean()` and
+      `pre_fc_norm_hidden.weight.mean()` — near 0 (|mean| ≲ 0.2) ⇒ `(1+w)`
+      semantics required; near 1 ⇒ plain `w`. (Expected: near 0.)
+
+### T3 — grouped-norm + feedback probes (kills BUG 3)
+  (a) **grouped-variance probe** on `mtp.hyper_connection_mixer.hc_norm`: scale
+      stream 2 of the input ×10; ONLY stream 2 of the normed tensor may change
+      (per-stream variance) — the exact OPPOSITE expectation of T2a. If your code
+      gives the same answer for T2a and T3a, one of the two norms is wrong.
+  (b) **feedback probe:** at draft step 1, assert the fed-back vector has
+      `dim == 10240` and `m.reshape(4,2560)` rows are NOT all pairwise-cosine
+      > 0.999 (i.e. it is `m_out` from O1, not a tiled `sample_hidden`).
+  (c) **step-profile probe:** measure per-step acceptance separately; nonzero at
+      step 1 but zero at step ≥ 2 ⇒ BUG 3d specifically.
+
+### T0 — end-to-end teacher forcing (run first; localizes everything)
+Over a ~200-token prompt with trunk rows `Hs_i`: for each i, compute
+`argmax(head(t_{i+1}, Hs_i, pos=i+1))` and score agreement with `t_{i+2}`
+(no KV chaining needed — batch it with the catch-up path). Healthy head: ≳40–70%
+top-1 agreement. ≲5% ⇒ forward broken (run T1→T2→T3 in order). If the SHIFTED
+pairing `(t_i, Hs_i)` scores dramatically higher than the spec pairing, your
+machinery's token/hidden pairing is off by one (§2.2), not the head.

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -18,6 +18,7 @@ from .constants import (
     EXPECTED_QWEN_MOE_MTP_KEYS,
     EXPECTED_QWEN_MOE_PREQUANTIZED_MTP_KEYS,
     EXPECTED_QWEN_MOE_SWITCH_MLP_MTP_KEYS,
+    EXPECTED_QWEN4_EXP_MTP_KEYS,
     MULTIMODAL_SIDECARS,
     expand_mtp_layer_keys,
 )
@@ -218,6 +219,23 @@ def _expected_prequantized_keys_for_present_aux(
     return expected
 
 
+def _is_qwen4_exp_config(config: dict[str, Any]) -> bool:
+    tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
+    model_type = str(tcfg.get("model_type") or config.get("model_type") or "").lower()
+    if model_type in {"qwen4_exp", "qwen4_exp_text"}:
+        return True
+    archs = (
+        (config.get("architectures") if isinstance(config, dict) else None)
+        or tcfg.get("architectures")
+        or []
+    )
+    for arch in archs:
+        compact = str(arch).lower().replace("_", "").replace("-", "")
+        if "qwen4exp" in compact:
+            return True
+    return False
+
+
 def _mtp_expected_key_set(
     config: dict[str, Any],
     *,
@@ -233,6 +251,14 @@ def _mtp_expected_key_set(
 
     def _expanded(base: tuple[str, ...]) -> set[str]:
         return expand_mtp_layer_keys(base, n_layers)
+
+    if _is_qwen4_exp_config(config):
+        expected = _expanded(EXPECTED_QWEN4_EXP_MTP_KEYS)
+        return (
+            expected,
+            len(expected),
+            "bf16-qwen4-exp",
+        )
 
     if _is_qwen_moe_mtp_layout(config, normalized):
         if any(".mlp.switch_mlp." in key for key in normalized):
@@ -905,7 +931,20 @@ def _hf_model_weight_keys(repo_id: str, files: set[str]) -> tuple[tuple[str, ...
     for filename in sorted(
         name
         for name in files
-        if Path(name).name.startswith("model") and name.endswith(".safetensors")
+        if (
+            Path(name).name.startswith("model")
+            or Path(name).name.lower() in {"weights.safetensors", "model.safetensors"}
+            or Path(name).name.startswith("consolidated")
+        )
+        and name.endswith(".safetensors")
+        and not Path(name).name.lower().startswith("adapter")
+        and not Path(name).name.lower().startswith("optimizer")
+        and not (
+            Path(name).name.lower() in {"mtp.safetensors", "model-mtp.safetensors", "model-mtp-head.safetensors"}
+            or Path(name).name.lower().endswith("-mtp.safetensors")
+            or Path(name).name.lower().endswith("-mtp-head.safetensors")
+            or (Path(name).name.lower() == "weights.safetensors" and Path(name).parent.name.lower() == "mtp")
+        )
     ):
         shard_keys, error = _remote_safetensors_keys(repo_id, filename)
         keys.update(shard_keys)
@@ -1062,7 +1101,7 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         sorted(
             name
             for name in files
-            if name.endswith(".safetensors")
+            if name.endswith(".safetensors") and not Path(name).name.lower().startswith("adapter")
         )
     )
     mtp_file = str(expected_mtp_file(Path("."), config, files=files))

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -348,11 +348,20 @@ def text_config(config: dict[str, Any]) -> dict[str, Any]:
 
 def expected_mtp_file(model_dir: Path | str, config: dict[str, Any] | None = None) -> Path:
     model_path = Path(model_dir)
-    config = config if config is not None else load_config(model_path)
-    extra = config.get("mlx_lm_extra_tensors", {})
+    if config is None:
+        try:
+            config = load_config(model_path)
+        except Exception:
+            config = {}
+    extra = config.get("mlx_lm_extra_tensors", {}) if isinstance(config, dict) else {}
     if isinstance(extra, dict) and extra.get("mtp_file"):
         return model_path / str(extra["mtp_file"])
-    for rel in ("mtp.safetensors", "mtp/weights.safetensors", "model-mtp.safetensors"):
+    for rel in (
+        "mtp.safetensors",
+        "mtp/weights.safetensors",
+        "model-mtp.safetensors",
+        "model-mtp-head.safetensors",
+    ):
         candidate = model_path / rel
         if candidate.exists():
             return candidate
@@ -377,7 +386,11 @@ def mtp_weights_present_on_disk(
     unchanged and a real detection bug on an MTP-bearing model still surfaces.
     """
     model_path = Path(model_dir)
-    config = config if config is not None else load_config(model_path)
+    if config is None:
+        try:
+            config = load_config(model_path)
+        except Exception:
+            config = {}
 
     # 1. Explicit MTP sidecar file (Qwen/GLM/hy3 external draft head).
     if expected_mtp_file(model_path, config).exists():

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -1057,7 +1057,7 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         sorted(
             name
             for name in files
-            if Path(name).name.startswith("model") and name.endswith(".safetensors")
+            if name.endswith(".safetensors")
         )
     )
     mtp_file = str(expected_mtp_file(Path("."), config, files=files))

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -219,6 +219,64 @@ def _expected_prequantized_keys_for_present_aux(
     return expected
 
 
+def _normalize_qwen4_mtp_key_set(keys: set[str]) -> set[str]:
+    out = set()
+    for k in keys:
+        norm = normalize_mtp_key(k)
+        if norm.endswith(".enorm.weight"):
+            norm = norm[:-len(".enorm.weight")] + ".pre_fc_norm_embedding.weight"
+        elif norm.endswith(".hnorm.weight"):
+            norm = norm[:-len(".hnorm.weight")] + ".pre_fc_norm_hidden.weight"
+
+        for suffix in ("input_mix_weight_down", "input_mix_weight_up", "block_inject_weight"):
+            if norm.endswith("." + suffix + ".weight"):
+                norm = norm[:-len(".weight")]
+
+        if ".self_attn.q_layernorm." in norm:
+            norm = norm.replace(".self_attn.q_layernorm.", ".self_attn.q_norm.")
+        if ".self_attn.k_layernorm." in norm:
+            norm = norm.replace(".self_attn.k_layernorm.", ".self_attn.k_norm.")
+
+        if norm in {"mtp.eh_proj.weight", "mtp.fc.weight"}:
+            out.add("mtp.fc_embedding.weight")
+            out.add("mtp.fc_hidden.weight")
+            continue
+        if ".eh_proj." in norm or ".fc." in norm:
+            for name in (".eh_proj.", ".fc."):
+                if name in norm:
+                    prefix, suffix = norm.split(name, 1)
+                    out.add(f"{prefix}.fc_embedding.{suffix}")
+                    out.add(f"{prefix}.fc_hidden.{suffix}")
+                    break
+            continue
+
+        if ".mlp.experts.gate_up_proj." in norm:
+            prefix, suffix = norm.split(".mlp.experts.gate_up_proj.", 1)
+            out.add(f"{prefix}.mlp.switch_mlp.gate_proj.{suffix}")
+            out.add(f"{prefix}.mlp.switch_mlp.up_proj.{suffix}")
+            continue
+        if ".mlp.switch_mlp.gate_up_proj." in norm:
+            prefix, suffix = norm.split(".mlp.switch_mlp.gate_up_proj.", 1)
+            out.add(f"{prefix}.mlp.switch_mlp.gate_proj.{suffix}")
+            out.add(f"{prefix}.mlp.switch_mlp.up_proj.{suffix}")
+            continue
+        if ".mlp.experts.down_proj." in norm:
+            prefix, suffix = norm.split(".mlp.experts.down_proj.", 1)
+            out.add(f"{prefix}.mlp.switch_mlp.down_proj.{suffix}")
+            continue
+        if ".mlp.experts.gate_proj." in norm:
+            prefix, suffix = norm.split(".mlp.experts.gate_proj.", 1)
+            out.add(f"{prefix}.mlp.switch_mlp.gate_proj.{suffix}")
+            continue
+        if ".mlp.experts.up_proj." in norm:
+            prefix, suffix = norm.split(".mlp.experts.up_proj.", 1)
+            out.add(f"{prefix}.mlp.switch_mlp.up_proj.{suffix}")
+            continue
+
+        out.add(norm)
+    return out
+
+
 def _is_qwen4_exp_config(config: dict[str, Any]) -> bool:
     tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
     model_type = str(tcfg.get("model_type") or config.get("model_type") or "").lower()
@@ -253,6 +311,7 @@ def _mtp_expected_key_set(
         return expand_mtp_layer_keys(base, n_layers)
 
     if _is_qwen4_exp_config(config):
+        normalized = _normalize_qwen4_mtp_key_set(normalized)
         has_prequantized_aux = any(
             key.endswith(".scales") or key.endswith(".biases")
             for key in normalized
@@ -459,7 +518,39 @@ def mtp_weights_present_on_disk(
 
     index_path = model_path / "model.safetensors.index.json"
     if not index_path.exists():
-        # No index to inspect: cannot prove absence, preserve legacy behavior.
+        direct_shards = [
+            model_path / f
+            for f in ("model.safetensors", "weights.safetensors")
+            if (model_path / f).is_file()
+        ]
+        if not direct_shards:
+            direct_shards = [
+                p for p in model_path.glob("*.safetensors")
+                if p.is_file() and not p.name.startswith("adapter") and not p.name.startswith("optimizer")
+            ]
+        if direct_shards:
+            has_mtp = False
+            for shard in direct_shards:
+                tensors, err = _safetensors_header_tensor_infos(shard)
+                if err:
+                    return True  # If unreadable, conservative True
+                keys = [str(t.key) for t in tensors]
+                if any(is_mtp_key(k) for k in keys):
+                    has_mtp = True
+                    break
+                start = int(
+                    text_config(config).get("num_hidden_layers")
+                    or config.get("num_hidden_layers")
+                    or 0
+                )
+                count = _num_mtp_layers(config)
+                if start and count:
+                    wanted = tuple(f"model.layers.{start + i}." for i in range(count))
+                    if any(k.startswith(wanted) for k in keys):
+                        has_mtp = True
+                        break
+            return has_mtp
+        # No index to inspect and no direct shards: cannot prove absence, preserve legacy behavior.
         return True
     try:
         weight_map = json.loads(index_path.read_text(encoding="utf-8")).get(
@@ -667,6 +758,8 @@ def inspect_mtp_tensors(model_dir: Path | str, config: dict[str, Any] | None = N
         )
 
     key_set = {normalize_mtp_key(t.key) for t in tensors}
+    if _is_qwen4_exp_config(config or {}):
+        key_set = _normalize_qwen4_mtp_key_set(key_set)
     expected_keys, expected_count, sidecar_format = _mtp_expected_key_set(
         config or {},
         keys=tuple(key_set),
@@ -978,12 +1071,14 @@ def _inspect_mtp_tensors_from_keys(
     exists: bool,
     keys: tuple[str, ...] = (),
 ) -> MTPInspection:
-    normalized_keys = tuple(sorted(normalize_mtp_key(key) for key in keys))
+    key_set = {normalize_mtp_key(key) for key in keys}
+    if _is_qwen4_exp_config(config or {}):
+        key_set = _normalize_qwen4_mtp_key_set(key_set)
+    normalized_keys = tuple(sorted(key_set))
     expected_keys, expected_count, sidecar_format = _mtp_expected_key_set(
         config,
         keys=normalized_keys,
     )
-    key_set = set(normalized_keys)
     return MTPInspection(
         mtp_file=mtp_file,
         exists=exists,

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -253,6 +253,20 @@ def _mtp_expected_key_set(
         return expand_mtp_layer_keys(base, n_layers)
 
     if _is_qwen4_exp_config(config):
+        has_prequantized_aux = any(
+            key.endswith(".scales") or key.endswith(".biases")
+            for key in normalized
+        )
+        if prequantized or has_prequantized_aux:
+            expected = _expected_prequantized_keys_for_present_aux(
+                _expanded(EXPECTED_QWEN4_EXP_MTP_KEYS),
+                normalized,
+            )
+            return (
+                expected,
+                len(expected),
+                "prequantized-mlx-affine-qwen4-exp",
+            )
         expected = _expanded(EXPECTED_QWEN4_EXP_MTP_KEYS)
         return (
             expected,

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -346,7 +346,11 @@ def text_config(config: dict[str, Any]) -> dict[str, Any]:
     return config.get("text_config", config)
 
 
-def expected_mtp_file(model_dir: Path | str, config: dict[str, Any] | None = None) -> Path:
+def expected_mtp_file(
+    model_dir: Path | str,
+    config: dict[str, Any] | None = None,
+    files: Any | None = None,
+) -> Path:
     model_path = Path(model_dir)
     if config is None:
         try:
@@ -356,12 +360,29 @@ def expected_mtp_file(model_dir: Path | str, config: dict[str, Any] | None = Non
     extra = config.get("mlx_lm_extra_tensors", {}) if isinstance(config, dict) else {}
     if isinstance(extra, dict) and extra.get("mtp_file"):
         return model_path / str(extra["mtp_file"])
-    for rel in (
+    candidates = (
         "mtp.safetensors",
         "mtp/weights.safetensors",
         "model-mtp.safetensors",
         "model-mtp-head.safetensors",
-    ):
+    )
+    if files is not None:
+        file_set = {str(f).lstrip("./") for f in files}
+        for rel in candidates:
+            if rel in file_set:
+                return model_path / rel
+        for f in sorted(file_set):
+            fname = Path(f).name.lower()
+            if (
+                fname == "mtp.safetensors"
+                or fname == "model-mtp.safetensors"
+                or fname == "model-mtp-head.safetensors"
+                or fname.endswith("-mtp.safetensors")
+                or fname.endswith("-mtp-head.safetensors")
+                or (fname == "weights.safetensors" and Path(f).parent.name.lower() == "mtp")
+            ):
+                return model_path / f
+    for rel in candidates:
         candidate = model_path / rel
         if candidate.exists():
             return candidate
@@ -1039,7 +1060,7 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
             if Path(name).name.startswith("model") and name.endswith(".safetensors")
         )
     )
-    mtp_file = str(expected_mtp_file(Path("."), config))
+    mtp_file = str(expected_mtp_file(Path("."), config, files=files))
     if mtp_file.startswith("./"):
         mtp_file = mtp_file[2:]
     mtp_file = mtp_file.lstrip("/")

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -129,10 +129,19 @@ def is_mtp_key(key: str) -> bool:
 
 def _num_mtp_layers(config: dict[str, Any]) -> int:
     tcfg = text_config(config)
+    mtp_raw = {}
+    if isinstance(tcfg, dict) and isinstance(tcfg.get("mtp"), dict):
+        mtp_raw = tcfg["mtp"]
+    elif isinstance(config, dict) and isinstance(config.get("mtp"), dict):
+        mtp_raw = config["mtp"]
     return int(
-        tcfg.get("mtp_num_hidden_layers")
+        mtp_raw.get("num_hidden_layers")
+        or tcfg.get("mtp_num_hidden_layers")
         or tcfg.get("num_nextn_predict_layers")
-        or config.get("num_nextn_predict_layers")
+        or tcfg.get("num_mtp_modules")
+        or (config.get("mtp_num_hidden_layers") if isinstance(config, dict) else 0)
+        or (config.get("num_nextn_predict_layers") if isinstance(config, dict) else 0)
+        or (config.get("num_mtp_modules") if isinstance(config, dict) else 0)
         or 0
     )
 
@@ -1024,11 +1033,7 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
     mtp_exists = mtp_file in files if files else False
     weight_keys: tuple[str, ...] = ()
     config_declares_mtp = bool(
-        tcfg.get("mtp_num_hidden_layers")
-        or tcfg.get("num_nextn_predict_layers")
-        or tcfg.get("num_mtp_modules")
-        or config.get("num_nextn_predict_layers")
-        or config.get("num_mtp_modules")
+        _num_mtp_layers(config) > 0
         or "mtp" in str(architecture or "").lower()
         or "nextn" in str(architecture or "").lower()
     )
@@ -1068,14 +1073,7 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         config_exists=True,
         architecture=architecture,
         model_type=tcfg.get("model_type") or config.get("model_type"),
-        mtp_num_hidden_layers=int(
-            tcfg.get("mtp_num_hidden_layers")
-            or tcfg.get("num_nextn_predict_layers")
-            or tcfg.get("num_mtp_modules")
-            or config.get("num_nextn_predict_layers")
-            or config.get("num_mtp_modules")
-            or 0
-        ),
+        mtp_num_hidden_layers=_num_mtp_layers(config),
         hidden_size=tcfg.get("hidden_size"),
         num_hidden_layers=tcfg.get("num_hidden_layers"),
         vocab_size=tcfg.get("vocab_size"),
@@ -1231,14 +1229,7 @@ def inspect_model(model_dir: Path | str) -> ModelInspection:
         config_exists=config_exists,
         architecture=architecture,
         model_type=tcfg.get("model_type") or config.get("model_type"),
-        mtp_num_hidden_layers=int(
-            tcfg.get("mtp_num_hidden_layers")
-            or tcfg.get("num_nextn_predict_layers")
-            or tcfg.get("num_mtp_modules")
-            or config.get("num_nextn_predict_layers")
-            or config.get("num_mtp_modules")
-            or 0
-        ),
+        mtp_num_hidden_layers=_num_mtp_layers(config),
         hidden_size=tcfg.get("hidden_size"),
         num_hidden_layers=tcfg.get("num_hidden_layers"),
         vocab_size=tcfg.get("vocab_size"),

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -524,6 +524,9 @@ class ModelInspection:
     mtp_pattern: str | None = None
     source: str = "local"
     quantization: dict[str, Any] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
+    auto_map: dict[str, Any] | None = None
+    requires_remote_code: bool = False
     sidecars: dict[str, bool] = field(default_factory=dict)
     model_files: tuple[str, ...] = ()
     weight_keys: tuple[str, ...] = field(default_factory=tuple, repr=False)
@@ -572,6 +575,8 @@ class ModelInspection:
             "laguna_s_2_1_mlx_4bit_match": self.laguna_s_2_1_mlx_4bit_match,
             "laguna_s_2_1_artifacts_complete": self.laguna_s_2_1_artifacts_complete,
             "quantization": self.quantization,
+            "auto_map": self.auto_map,
+            "requires_remote_code": self.requires_remote_code,
             "sidecars": self.sidecars,
             "model_files": list(self.model_files),
             "passes_primary_gate": self.passes_primary_gate,
@@ -1101,10 +1106,28 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
             expected_tensor_count=mtp.expected_tensor_count,
             metadata_only=True,
         )
+    tokenizer_config = None
+    if files is None or "tokenizer_config.json" in files:
+        tokenizer_config, _t_path, _t_error = _hf_download_json(
+            repo_id,
+            "tokenizer_config.json",
+            **revision_kwargs,
+        )
+    auto_map = None
+    if isinstance(config, dict) and isinstance(config.get("auto_map"), dict) and config.get("auto_map"):
+        auto_map = config.get("auto_map")
+    elif isinstance(tcfg, dict) and isinstance(tcfg.get("auto_map"), dict) and tcfg.get("auto_map"):
+        auto_map = tcfg.get("auto_map")
+    elif isinstance(tokenizer_config, dict) and isinstance(tokenizer_config.get("auto_map"), dict) and tokenizer_config.get("auto_map"):
+        auto_map = tokenizer_config.get("auto_map")
+
     inspection = ModelInspection(
         model_dir=repo_id,
         source="hf",
         config_exists=True,
+        config=config,
+        auto_map=auto_map,
+        requires_remote_code=bool(auto_map),
         architecture=architecture,
         model_type=tcfg.get("model_type") or config.get("model_type"),
         mtp_num_hidden_layers=_num_mtp_layers(config),
@@ -1149,6 +1172,9 @@ def _inspect_hf_model(repo_id: str) -> ModelInspection:
         laguna_s_2_1_artifacts_complete=inspection.laguna_s_2_1_artifacts_complete,
         mtp_pattern=inspection.mtp_pattern,
         quantization=inspection.quantization,
+        config=inspection.config,
+        auto_map=inspection.auto_map,
+        requires_remote_code=inspection.requires_remote_code,
         sidecars=inspection.sidecars,
         model_files=inspection.model_files,
         weight_keys=inspection.weight_keys,

--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -485,6 +485,20 @@ def expected_mtp_file(
         candidate = model_path / rel
         if candidate.exists():
             return candidate
+    if model_path.is_dir():
+        for p in sorted(model_path.glob("*.safetensors")):
+            fname = p.name.lower()
+            if (
+                fname == "mtp.safetensors"
+                or fname == "model-mtp.safetensors"
+                or fname == "model-mtp-head.safetensors"
+                or fname.endswith("-mtp.safetensors")
+                or fname.endswith("-mtp-head.safetensors")
+            ):
+                return p
+        mtp_sub = model_path / "mtp" / "weights.safetensors"
+        if mtp_sub.is_file():
+            return mtp_sub
     return model_path / "mtp.safetensors"
 
 

--- a/mtplx/attention_split.py
+++ b/mtplx/attention_split.py
@@ -136,6 +136,12 @@ def split_sdpa_output(
 
 
 def _attention_has_gated_q_proj(attn: Any) -> bool:
+    # QSA (qwen4_exp) uses a gated q_proj of the same 2*heads*dim shape as
+    # Qwen3Next, plus an indexer. The split hook reimplements dense gated
+    # SDPA with mlx-lm RoPE and would drop that indexer — never treat QSA as
+    # house gated-q, even if a caller installed the wrapper anyway.
+    if getattr(attn, "indexer", None) is not None:
+        return False
     q_proj = getattr(attn, "q_proj", None)
     q_norm = getattr(attn, "q_norm", None)
     if q_proj is None or q_norm is None:
@@ -460,8 +466,19 @@ def _full_attention_layers(model: Any):
         if getattr(layer, "is_linear", False):
             continue
         attn = getattr(layer, "self_attn", None)
-        if attn is not None:
-            yield attn
+        if attn is None:
+            continue
+        # QSA indexer is load-bearing for long prompts. split_call patches
+        # class __call__ to a 4-arg house signature and, when enabled,
+        # replaces the body with Qwen3Next dense gated SDPA (mlx-lm RoPE,
+        # no indexer). Installing that on qwen4_exp would TypeError on the
+        # old (x, rope, mask, cache, idx_cache) call or silently drop
+        # sparsity after the house-signature conform. Skip the install;
+        # QSA keeps its own path. Same refusal style as Laguna skipping
+        # the qwen3-next kernel stack, scoped to this incompatible hook.
+        if getattr(attn, "indexer", None) is not None:
+            continue
+        yield attn
 
 
 def configure_split_full_attention(

--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -1002,7 +1002,12 @@ _QWEN3_8_MARKER = re.compile(r"qwen3[._-]?8(?!\d*b)")
 
 
 def _explicit_qwen_family_marker(text: str) -> str | None:
-    if "qwen4_exp" in text or "qwen4-exp" in text or "flash-next" in text or "flash.next" in text:
+    if (
+        "qwen4" in text
+        or "flash-next" in text
+        or "flash.next" in text
+        or "qwen4exp" in text
+    ):
         return "qwen4_exp"
     if _QWEN3_8_MARKER.search(text):
         return "qwen3_8"
@@ -1085,6 +1090,8 @@ def model_family_from_inspection(
         if descriptor is not None
         else backend_id_from_inspection(inspection)
     )
+    if backend_id in {"qwen4_exp", "qwen4_exp_mtp"} or "qwen4" in backend_id:
+        return "qwen4_exp"
     if backend_id == GEMMA4_ASSISTANT_DESCRIPTOR.backend_id or "gemma4" in text or "gemma-4" in text:
         return "gemma4"
     if backend_id == STEP3P5_MTP_DESCRIPTOR.backend_id or "step3p5" in text or "step3p7" in text or "step-3.7" in text:

--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -112,7 +112,7 @@ class TunePolicy:
     supported: bool
     control_field: str = "depth"
     candidates: tuple[str, ...] = ("AR", "D1", "D2", "D3")
-    supported_families: tuple[str, ...] = ("qwen3_5", "qwen3_6", "qwen3_8", "gemma4")
+    supported_families: tuple[str, ...] = ("qwen3_5", "qwen3_6", "qwen3_8", "qwen4_exp", "gemma4")
     unsupported_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -445,6 +445,22 @@ QWEN3_8_DRAFT_SEMANTICS = DraftSemantics(
     maximum=3,
     unit="depth",
 )
+# Qwen3.8-Flash-Next (model_type qwen4_exp). Default to D1 (safe operating point;
+# D2/D3 are serial target decode until causal packed verification is implemented;
+# D4 is refused to prevent causality leakage).
+QWEN4_EXP_DRAFT_SEMANTICS = DraftSemantics(
+    request_field="depth",
+    display_label="Draft depth",
+    default=1,
+    minimum=1,
+    maximum=3,
+    unit="depth",
+)
+QWEN4_EXP_TUNE_POLICY = TunePolicy(
+    supported=True,
+    candidates=("AR", "D1", "D2", "D3"),
+    supported_families=("qwen3_5", "qwen3_6", "qwen3_8", "qwen4_exp", "gemma4"),
+)
 
 
 def sampler_defaults_for_model(
@@ -458,7 +474,7 @@ def sampler_defaults_for_model(
         model_ref=model_ref,
         descriptor=resolved,
     )
-    if family == "qwen3_8":
+    if family in {"qwen3_8", "qwen4_exp"}:
         return QWEN3_8_SAMPLER_DEFAULTS
     return resolved.sampler_defaults
 
@@ -474,6 +490,8 @@ def draft_semantics_for_model(
         model_ref=model_ref,
         descriptor=resolved,
     )
+    if family == "qwen4_exp":
+        return QWEN4_EXP_DRAFT_SEMANTICS
     if family == "qwen3_8":
         return QWEN3_8_DRAFT_SEMANTICS
     return resolved.draft_semantics
@@ -938,6 +956,8 @@ def descriptor_for_architecture_id(value: str | None) -> BackendDescriptor | Non
         return None
     if arch_id in {"glm-moe-dsa-mtp", "glm4-moe-lite-mtp"}:
         return GLM_MTP_DESCRIPTOR
+    if arch_id == "qwen4-exp-mtp":
+        return QWEN3_NEXT_DESCRIPTOR
     for descriptor in backend_descriptors():
         if descriptor.architecture_id == arch_id:
             return descriptor
@@ -978,6 +998,8 @@ _QWEN3_8_MARKER = re.compile(r"qwen3[._-]?8(?!\d*b)")
 
 
 def _explicit_qwen_family_marker(text: str) -> str | None:
+    if "qwen4_exp" in text or "qwen4-exp" in text or "flash-next" in text or "flash.next" in text:
+        return "qwen4_exp"
     if _QWEN3_8_MARKER.search(text):
         return "qwen3_8"
     if "qwen3.6" in text or "qwen3_6" in text or "qwen36" in text or "qwen3-6" in text:
@@ -1093,6 +1115,8 @@ def tune_policy_for_model(
     )
     if family in {"qwen3_5", "qwen3_6"}:
         return TunePolicy(supported=True)
+    if family == "qwen4_exp":
+        return QWEN4_EXP_TUNE_POLICY
     if family == "qwen3_8":
         # Multi-step-trained MTP head wants deeper candidates, but the live
         # depth-4 lane killed the daemon on drop day (see
@@ -1123,7 +1147,7 @@ def kv_quant_policy_for_model(
         model_ref=model_ref,
         descriptor=descriptor,
     )
-    if family in {"qwen3_5", "qwen3_6", "qwen3_8"}:
+    if family in {"qwen3_5", "qwen3_6", "qwen3_8", "qwen4_exp"}:
         return QWEN3_NEXT_DESCRIPTOR.kv_quant_policy
     if family == "gemma4":
         return GEMMA4_ASSISTANT_DESCRIPTOR.kv_quant_policy
@@ -1167,7 +1191,7 @@ def context_window_policy_for_model(
         model_ref=model_ref,
         descriptor=descriptor,
     )
-    if family in {"qwen3_5", "qwen3_6", "qwen3_8"}:
+    if family in {"qwen3_5", "qwen3_6", "qwen3_8", "qwen4_exp"}:
         base = QWEN3_NEXT_DESCRIPTOR.context_window_policy
     elif family == "gemma4":
         base = GEMMA4_ASSISTANT_DESCRIPTOR.context_window_policy
@@ -1193,7 +1217,7 @@ def reasoning_policy_for_model(
         model_ref=model_ref,
         descriptor=descriptor,
     )
-    if family == "qwen3_8":
+    if family in {"qwen3_8", "qwen4_exp"}:
         return QWEN3_8_REASONING_CODEC
     if family in {"qwen3_5", "qwen3_6"}:
         return QWEN3_NEXT_DESCRIPTOR.reasoning_codec
@@ -1288,7 +1312,7 @@ def descriptor_for_model(
         model_ref=model_ref,
         descriptor=descriptor,
     )
-    if family != "qwen3_8":
+    if family not in {"qwen3_8", "qwen4_exp"}:
         return descriptor
     return replace(
         descriptor,

--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -934,6 +934,8 @@ DESCRIPTORS_BY_BACKEND_ID: dict[str, BackendDescriptor] = {
     HY_V3_MTP_DESCRIPTOR.backend_id: HY_V3_MTP_DESCRIPTOR,
     "mimo_mtp": NATIVE_CONTRACT_DESCRIPTOR,
     "nemotron_h_mtp": NATIVE_CONTRACT_DESCRIPTOR,
+    "deepseek_v4": MLX_LM_AR_DESCRIPTOR,
+    "qwen4_exp": MLX_LM_AR_DESCRIPTOR,
 }
 
 
@@ -958,6 +960,8 @@ def descriptor_for_architecture_id(value: str | None) -> BackendDescriptor | Non
         return GLM_MTP_DESCRIPTOR
     if arch_id == "qwen4-exp-mtp":
         return QWEN3_NEXT_DESCRIPTOR
+    if arch_id == "qwen4-exp":
+        return MLX_LM_AR_DESCRIPTOR
     for descriptor in backend_descriptors():
         if descriptor.architecture_id == arch_id:
             return descriptor

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -14,6 +14,7 @@ RUNTIME_CONTRACT_FILE = "mtplx_runtime.json"
 SUPPORTED_ARCH_IDS = {
     "laguna-s-2.1-ar",
     "deepseek-v4",
+    "qwen4-exp",
     "qwen3-next-mtp",
     "deepseek-v3-mtp",
     "glm-moe-dsa-mtp",
@@ -24,6 +25,7 @@ SUPPORTED_ARCH_IDS = {
     "gemma4-assistant-mtp",
     "step3p5-mtp",
     "hy-v3-mtp",
+    "qwen4-exp-mtp",
 }
 
 TIER_VERIFIED = "verified"
@@ -220,6 +222,27 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         ),
         notes="Product-verified default backend; this remains the only promoted shipping runtime.",
     ),
+    "qwen4-exp-mtp": ArchitectureSupport(
+        arch_id="qwen4-exp-mtp",
+        display_name="Qwen3.8-Flash-Next / qwen4_exp MTP",
+        family="qwen4_exp",
+        backend="qwen3_next",
+        support_level="experimental-native-contract-gated",
+        runtime_compatibility="native-contract-gated",
+        can_run_verified=True,
+        aliases=("qwen4_exp", "Qwen4ExpForConditionalGeneration", "qwen4_exp_text"),
+        config_markers=("mtp_num_hidden_layers", "num_nextn_predict_layers"),
+        family_gate="qwen4-exp-mtp-head-plus-gdn-rollback",
+        references=(
+            "REFERENCES:mlx_lm/models/qwen4_exp.py",
+            "REFERENCES:transformers/models/qwen4_exp/modeling_qwen4_exp.py",
+        ),
+        notes=(
+            "Native MTP for hybrid Gated DeltaNet + sparse QSA. Draft depth "
+            "tunes AR/D1/D2/D3; engine drafts up to N=4. Rejection restores "
+            "recurrent GDN state (KV trim is not sufficient)."
+        ),
+    ),
     "deepseek-v3-mtp": ArchitectureSupport(
         arch_id="deepseek-v3-mtp",
         display_name="DeepSeek V3 / V3.2 MTP",
@@ -293,6 +316,35 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
             "stays 'native-ar-only' because it is what routes a checkpoint with "
             "no draft head to the AR-only verdict; an MTP-bearing artifact is "
             "resolved dynamically by the family gate instead."
+        ),
+    ),
+    "qwen4-exp": ArchitectureSupport(
+        arch_id="qwen4-exp",
+        display_name="Qwen3.8-Flash-Next (qwen4_exp)",
+        family="qwen",
+        backend="qwen4_exp",
+        support_level="experimental-native-ar-only",
+        runtime_compatibility="native-ar-only",
+        can_run_verified=True,
+        aliases=(
+            "qwen4_exp",
+            "qwen4_exp_text",
+            "qwen4exp",
+            "qwen4-exp",
+            "Qwen4ExpForConditionalGeneration",
+            "Qwen4ExpForCausalLM",
+        ),
+        config_markers=(),
+        family_gate="qwen4-exp-mlx",
+        references=(
+            "https://huggingface.co/Qwen/Qwen3.8-Flash-Next",
+            "/tmp/mlx-lm-pr1788/mlx_lm/models/qwen4_exp.py",
+        ),
+        notes=(
+            "Native MLX loader (mtplx.models.qwen4_exp) for Qwen3.8-Flash-Next "
+            "(architecture qwen4_exp). Day-0 support for hybrid linear-attention "
+            "(GatedDeltaNet), QSA sparse attention, gated residuals "
+            "(Hyper-Connections), sharded n-gram PLE embedding, and fine-grained MoE."
         ),
     ),
     "deepseek-v4-mtp": ArchitectureSupport(
@@ -1107,6 +1159,17 @@ def _passes_deepseek_v4_gate(inspection: Any) -> bool:
     return model_type == "deepseek_v4" or "deepseekv4forcausallm" in architecture
 
 
+def _passes_qwen4_exp_gate(inspection: Any) -> bool:
+    """Qwen3.8-Flash-Next / Qwen4-Exp MLX artifact: model_type qwen4_exp / qwen4_exp_text
+    or Qwen4ExpForConditionalGeneration architecture."""
+    model_type = _text(getattr(inspection, "model_type", None))
+    architecture = _compact(_text(getattr(inspection, "architecture", None)))
+    return (
+        model_type in {"qwen4_exp", "qwen4_exp_text"}
+        or "qwen4exp" in architecture
+    )
+
+
 def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
     """Trunk weights exist and the declared quantization is constructible."""
     model_dir = getattr(inspection, "model_dir", None)
@@ -1178,6 +1241,8 @@ def _passes_family_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool
         return _passes_mlx_lm_ar_gate(inspection)
     if arch_id == "deepseek-v4":
         return _passes_deepseek_v4_gate(inspection)
+    if arch_id == "qwen4-exp":
+        return _passes_qwen4_exp_gate(inspection)
     if arch_id == "laguna-s-2.1-ar":
         return bool(
             getattr(inspection, "laguna_s_2_1_mlx_4bit_match", False)

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1214,6 +1214,8 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
             return False
     if not has_trunk:
         return False
+    if _requires_remote_code(model_dir, inspection=inspection):
+        return False
     return _unsupported_quant_bits(model_dir, inspection=inspection) is None
 
 
@@ -1255,6 +1257,8 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
         except OSError:
             return False
     if not has_trunk:
+        return False
+    if _requires_remote_code(model_dir, inspection=inspection):
         return False
     return _unsupported_quant_bits(model_dir, inspection=inspection) is None
 
@@ -1322,7 +1326,7 @@ def _unsupported_quant_bits(
     return None
 
 
-def _requires_remote_code(model_dir: Any) -> bool:
+def _requires_remote_code(model_dir: Any, inspection: Any = None) -> bool:
     """True when loading needs transformers to execute repository code.
 
     MTPLX never passes trust_remote_code: a checkpoint whose config or
@@ -1330,6 +1334,18 @@ def _requires_remote_code(model_dir: Any) -> bool:
     in the repo) cannot be loaded under this policy, whatever the weights
     look like.
     """
+    if inspection is not None:
+        if getattr(inspection, "requires_remote_code", False):
+            return True
+        if getattr(inspection, "auto_map", None):
+            return True
+        cfg = getattr(inspection, "config", None)
+        if isinstance(cfg, dict):
+            if isinstance(cfg.get("auto_map"), dict) and cfg.get("auto_map"):
+                return True
+            tcfg = cfg.get("text_config")
+            if isinstance(tcfg, dict) and isinstance(tcfg.get("auto_map"), dict) and tcfg.get("auto_map"):
+                return True
     for name in ("config.json", "tokenizer_config.json"):
         try:
             data = json.loads(
@@ -1410,7 +1426,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
     contract_path = getattr(inspection, "runtime_contract_path", None)
     if not contract_path:
         contract_path = str(_contract_path(model_dir)) if _contract_path(model_dir).exists() else None
-    if _requires_remote_code(model_dir):
+    if _requires_remote_code(model_dir, inspection=inspection):
         support = architecture_support_for(detected_arch_id)
         return CompatibilityVerdict(
             tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -231,7 +231,7 @@ ARCHITECTURE_CATALOG: dict[str, ArchitectureSupport] = {
         runtime_compatibility="native-contract-gated",
         can_run_verified=True,
         aliases=("qwen4_exp", "Qwen4ExpForConditionalGeneration", "qwen4_exp_text"),
-        config_markers=("mtp_num_hidden_layers", "num_nextn_predict_layers"),
+        config_markers=("mtp_num_hidden_layers", "num_nextn_predict_layers", "mtp"),
         family_gate="qwen4-exp-mtp-head-plus-gdn-rollback",
         references=(
             "REFERENCES:mlx_lm/models/qwen4_exp.py",

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1558,24 +1558,26 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             recommended_backend=(support.backend if support else None),
             runtime_contract_path=contract_path,
             runtime_contract_error=contract_error,
-            unsafe_force_required=detected_arch_id == "qwen3-next-mtp",
+            unsafe_force_required=detected_arch_id in {"qwen3-next-mtp", "qwen4-exp-mtp"},
             unverified_model=True,
             mtp_supported="partial" if has_mtp else "no",
             runtime_compatibility=(
                 "needs-grafting"
-                if detected_arch_id == "qwen3-next-mtp"
+                if detected_arch_id in {"qwen3-next-mtp", "qwen4-exp-mtp"}
                 else (support.runtime_compatibility if support else "unsupported")
             ),
             support_level=(support.support_level if support else "unsupported"),
             support_notes=(support.notes if support else None),
         )
 
-    if detected_arch_id == "qwen3-next-mtp":
+    if detected_arch_id in {"qwen3-next-mtp", "qwen4-exp-mtp"}:
         support = architecture_support_for(detected_arch_id)
+        is_qwen4 = detected_arch_id == "qwen4-exp-mtp"
+        family_label = "Qwen4" if is_qwen4 else "Qwen"
         marker_text = (
-            "Qwen3-Next MTP markers detected"
-            if has_mtp
-            else "Qwen3-Next architecture detected"
+            f"{support.display_name} markers detected"
+            if (support and has_mtp)
+            else (f"{support.display_name} architecture detected" if support else "Qwen architecture detected")
         )
         if support is not None and _passes_family_runtime_gate(detected_arch_id, inspection, tensor_gate):
             return CompatibilityVerdict(
@@ -1587,7 +1589,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                 exit_code=EXIT_VERIFIED,
                 message=(
                     f"{marker_text}; native MTP tensors match the supported "
-                    "Qwen family layout. No mtplx_runtime.json exactness "
+                    f"{family_label} family layout. No mtplx_runtime.json exactness "
                     "baseline is present, so runs are marked unverified until "
                     "a first-load smoke baseline is recorded."
                 ),
@@ -1639,15 +1641,16 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                     support_level="native-backend-missing-model-weights",
                     support_notes=(support.notes if support else None),
                 )
+            ar_arch_id = "qwen4-exp" if is_qwen4 else detected_arch_id
             return CompatibilityVerdict(
                 tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,
-                arch_id=detected_arch_id,
+                arch_id=ar_arch_id,
                 supported=False,
                 recognized=True,
                 can_run=True,
                 exit_code=EXIT_UNVERIFIED,
                 message=(
-                    f"{marker_text}, but this folder contains no Qwen MTP "
+                    f"{marker_text}, but this folder contains no {family_label} MTP "
                     "tensors (mtp.safetensors or embedded mtp.* / "
                     "language_model.mtp.* weights). mtp_heads not found -> "
                     "mtp_off: MTPLX will serve this model autoregressive, "
@@ -1672,7 +1675,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             exit_code=EXIT_UNVERIFIED,
             message=(
                 f"{marker_text}, and an MTP artifact is present, but its tensor "
-                "layout does not match the Qwen native MTP runtime gate. "
+                f"layout does not match the {family_label} native MTP runtime gate. "
                 "mtplx_runtime.json is optional metadata; repair or regenerate "
                 "the MTP sidecar/embedded weights so the tensor gate passes."
             ),

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1214,7 +1214,7 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
             return False
     if not has_trunk:
         return False
-    return _unsupported_quant_bits(model_dir) is None
+    return _unsupported_quant_bits(model_dir, inspection=inspection) is None
 
 
 def _passes_qwen4_exp_mtp_gate(inspection: Any, tensor_gate: bool) -> bool:
@@ -1256,7 +1256,7 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
             return False
     if not has_trunk:
         return False
-    return _unsupported_quant_bits(model_dir) is None
+    return _unsupported_quant_bits(model_dir, inspection=inspection) is None
 
 
 # mlx.core.quantize supports exactly these widths; a config declaring any
@@ -1265,21 +1265,56 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
 _MLX_SUPPORTED_QUANT_BITS = frozenset({2, 3, 4, 5, 6, 8})
 
 
-def _unsupported_quant_bits(model_dir: Any) -> int | None:
+def _unsupported_quant_bits(
+    model_dir: Any, inspection: Any = None
+) -> int | None:
     """Return the declared quant bit width when this MLX build cannot load it."""
-    try:
-        config = json.loads(
-            (Path(str(model_dir)) / "config.json").read_text(encoding="utf-8")
-        )
-    except (OSError, ValueError):
-        return None
-    quantization = config.get("quantization")
-    if not isinstance(quantization, dict):
-        return None
-    candidates = [quantization.get("bits")]
-    for value in quantization.values():
-        if isinstance(value, dict):
-            candidates.append(value.get("bits"))
+    config = None
+    if isinstance(model_dir, dict):
+        config = model_dir
+    elif inspection is not None and getattr(inspection, "config", None):
+        config = inspection.config
+    elif inspection is not None and isinstance(getattr(inspection, "quantization", None), dict):
+        config = {"quantization": getattr(inspection, "quantization")}
+
+    if config is None:
+        try:
+            config = json.loads(
+                (Path(str(model_dir)) / "config.json").read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError):
+            config = {}
+
+    quant_dicts = []
+    if isinstance(config, dict):
+        if isinstance(config.get("quantization"), dict):
+            quant_dicts.append(config["quantization"])
+        if isinstance(config.get("quantization_config"), dict):
+            quant_dicts.append(config["quantization_config"])
+        tcfg = config.get("text_config")
+        if isinstance(tcfg, dict):
+            if isinstance(tcfg.get("quantization"), dict):
+                quant_dicts.append(tcfg["quantization"])
+            if isinstance(tcfg.get("quantization_config"), dict):
+                quant_dicts.append(tcfg["quantization_config"])
+
+    if inspection is not None:
+        iq = getattr(inspection, "quantization", None)
+        if isinstance(iq, dict):
+            quant_dicts.append(iq)
+        iqc = getattr(inspection, "quantization_config", None)
+        if isinstance(iqc, dict):
+            quant_dicts.append(iqc)
+
+    candidates = []
+    for q in quant_dicts:
+        candidates.append(q.get("bits"))
+        candidates.append(q.get("weight_bits"))
+        for value in q.values():
+            if isinstance(value, dict):
+                candidates.append(value.get("bits"))
+                candidates.append(value.get("weight_bits"))
+
     for bits in candidates:
         if isinstance(bits, int) and not isinstance(bits, bool):
             if bits not in _MLX_SUPPORTED_QUANT_BITS:
@@ -1399,7 +1434,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             support_level="trust-remote-code-refused",
             support_notes=(support.notes if support else None),
         )
-    bad_bits = _unsupported_quant_bits(model_dir)
+    bad_bits = _unsupported_quant_bits(model_dir, inspection=inspection)
     if bad_bits is not None:
         support = architecture_support_for(detected_arch_id)
         return CompatibilityVerdict(
@@ -1639,13 +1674,26 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             # A dir with no TRUNK weights at all is a different failure — no
             # model, not a missing head — and keeps a clean human refusal
             # instead of a FileNotFoundError deep in the loader.
-            try:
+            source = getattr(inspection, "source", None)
+            if source == "hf":
+                model_files = getattr(inspection, "model_files", ()) or ()
                 trunk_weights_exist = any(
-                    not _is_mtp_sidecar_file(path)
-                    for path in Path(model_dir).glob("*.safetensors")
+                    not _is_mtp_sidecar_file(Path(fname))
+                    for fname in model_files
                 )
-            except OSError:
-                trunk_weights_exist = False
+                if not trunk_weights_exist and getattr(inspection, "weight_keys", None):
+                    trunk_weights_exist = any(
+                        not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                        for k in inspection.weight_keys
+                    )
+            else:
+                try:
+                    trunk_weights_exist = any(
+                        not _is_mtp_sidecar_file(path)
+                        for path in Path(model_dir).glob("*.safetensors")
+                    )
+                except OSError:
+                    trunk_weights_exist = False
             if not trunk_weights_exist:
                 return CompatibilityVerdict(
                     tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1150,6 +1150,25 @@ def _passes_nemotron_h_gate(inspection: Any) -> bool:
     return _has_marker_under_prefixes(keys, last_prefixes, ("final_layernorm.weight",))
 
 
+_RECOGNIZED_MTP_SIDECAR_NAMES = frozenset(
+    {
+        "mtp.safetensors",
+        "model-mtp.safetensors",
+        "model-mtp-head.safetensors",
+        "weights.safetensors",
+    }
+)
+
+
+def _is_mtp_sidecar_file(path: Path) -> bool:
+    name = path.name.lower()
+    if name in _RECOGNIZED_MTP_SIDECAR_NAMES:
+        return True
+    if name.endswith("-mtp.safetensors") or name.endswith("-mtp-head.safetensors"):
+        return True
+    return False
+
+
 def _passes_deepseek_v4_gate(inspection: Any) -> bool:
     """DeepSeek-V4-Flash MLX artifact: model_type deepseek_v4 (or the
     DeepseekV4ForCausalLM architecture).  The mlx-community conversion drops the
@@ -1174,7 +1193,7 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
         return False
     try:
         has_trunk = any(
-            path.name != "mtp.safetensors"
+            not _is_mtp_sidecar_file(path)
             for path in Path(str(model_dir)).glob("*.safetensors")
         )
     except OSError:
@@ -1203,7 +1222,7 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
         return False
     try:
         has_trunk = any(
-            path.name != "mtp.safetensors"
+            not _is_mtp_sidecar_file(path)
             for path in Path(str(model_dir)).glob("*.safetensors")
         )
     except OSError:
@@ -1593,7 +1612,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             # instead of a FileNotFoundError deep in the loader.
             try:
                 trunk_weights_exist = any(
-                    path.name != "mtp.safetensors"
+                    not _is_mtp_sidecar_file(path)
                     for path in Path(model_dir).glob("*.safetensors")
                 )
             except OSError:

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1170,6 +1170,18 @@ def _is_mtp_sidecar_file(path: Path) -> bool:
     return False
 
 
+def _is_trunk_safetensors(path: Path | str) -> bool:
+    p = Path(path)
+    name = p.name.lower()
+    if not name.endswith(".safetensors"):
+        return False
+    if _is_mtp_sidecar_file(p):
+        return False
+    if name.startswith("adapter") or name.startswith("optimizer") or name.startswith("training_"):
+        return False
+    return True
+
+
 def _passes_deepseek_v4_gate(inspection: Any) -> bool:
     """DeepSeek-V4-Flash MLX artifact: model_type deepseek_v4 (or the
     DeepseekV4ForCausalLM architecture).  The mlx-community conversion drops the
@@ -1196,18 +1208,18 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
     if source == "hf":
         model_files = getattr(inspection, "model_files", ()) or ()
         has_trunk = any(
-            not _is_mtp_sidecar_file(Path(fname))
+            _is_trunk_safetensors(Path(fname))
             for fname in model_files
         )
         if not has_trunk and getattr(inspection, "weight_keys", None):
             has_trunk = any(
-                not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                not (k.startswith("mtp.") or k.startswith("language_model.mtp.") or k.startswith("adapter_"))
                 for k in inspection.weight_keys
             )
     else:
         try:
             has_trunk = any(
-                not _is_mtp_sidecar_file(path)
+                _is_trunk_safetensors(path)
                 for path in Path(str(model_dir)).glob("*.safetensors")
             )
         except OSError:
@@ -1223,12 +1235,7 @@ def _passes_qwen4_exp_mtp_gate(inspection: Any, tensor_gate: bool) -> bool:
     """Qwen4-Exp MTP artifact: valid Qwen4-Exp model plus declared MTP tensors."""
     if not _passes_qwen4_exp_gate(inspection):
         return False
-    keys = _weight_keys(inspection)
-    has_mtp_tensors = bool(
-        tensor_gate
-        or any(_is_sidecar_mtp_key(k) or "mtp." in k for k in (keys or ()))
-    )
-    return bool(has_mtp_tensors)
+    return bool(tensor_gate)
 
 
 def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
@@ -1240,18 +1247,18 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
     if source == "hf":
         model_files = getattr(inspection, "model_files", ()) or ()
         has_trunk = any(
-            not _is_mtp_sidecar_file(Path(fname))
+            _is_trunk_safetensors(Path(fname))
             for fname in model_files
         )
         if not has_trunk and getattr(inspection, "weight_keys", None):
             has_trunk = any(
-                not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                not (k.startswith("mtp.") or k.startswith("language_model.mtp.") or k.startswith("adapter_"))
                 for k in inspection.weight_keys
             )
     else:
         try:
             has_trunk = any(
-                not _is_mtp_sidecar_file(path)
+                _is_trunk_safetensors(path)
                 for path in Path(str(model_dir)).glob("*.safetensors")
             )
         except OSError:
@@ -1694,18 +1701,18 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             if source == "hf":
                 model_files = getattr(inspection, "model_files", ()) or ()
                 trunk_weights_exist = any(
-                    not _is_mtp_sidecar_file(Path(fname))
+                    _is_trunk_safetensors(Path(fname))
                     for fname in model_files
                 )
                 if not trunk_weights_exist and getattr(inspection, "weight_keys", None):
                     trunk_weights_exist = any(
-                        not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                        not (k.startswith("mtp.") or k.startswith("language_model.mtp.") or k.startswith("adapter_"))
                         for k in inspection.weight_keys
                     )
             else:
                 try:
                     trunk_weights_exist = any(
-                        not _is_mtp_sidecar_file(path)
+                        _is_trunk_safetensors(path)
                         for path in Path(model_dir).glob("*.safetensors")
                     )
                 except OSError:

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1155,7 +1155,6 @@ _RECOGNIZED_MTP_SIDECAR_NAMES = frozenset(
         "mtp.safetensors",
         "model-mtp.safetensors",
         "model-mtp-head.safetensors",
-        "weights.safetensors",
     }
 )
 
@@ -1163,6 +1162,8 @@ _RECOGNIZED_MTP_SIDECAR_NAMES = frozenset(
 def _is_mtp_sidecar_file(path: Path) -> bool:
     name = path.name.lower()
     if name in _RECOGNIZED_MTP_SIDECAR_NAMES:
+        return True
+    if name == "weights.safetensors" and path.parent.name.lower() == "mtp":
         return True
     if name.endswith("-mtp.safetensors") or name.endswith("-mtp-head.safetensors"):
         return True

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1185,7 +1185,7 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
 
 
 def _passes_qwen4_exp_mtp_gate(inspection: Any, tensor_gate: bool) -> bool:
-    """Qwen4-Exp MTP artifact: valid Qwen4-Exp model plus declared MTP markers or tensors."""
+    """Qwen4-Exp MTP artifact: valid Qwen4-Exp model plus declared MTP tensors."""
     if not _passes_qwen4_exp_gate(inspection):
         return False
     keys = _weight_keys(inspection)
@@ -1193,11 +1193,7 @@ def _passes_qwen4_exp_mtp_gate(inspection: Any, tensor_gate: bool) -> bool:
         tensor_gate
         or any(_is_sidecar_mtp_key(k) or "mtp." in k for k in (keys or ()))
     )
-    mtp_layers = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
-    mtp_dict = getattr(inspection, "mtp", None)
-    if mtp_dict is not None and isinstance(mtp_dict, dict):
-        mtp_layers = max(mtp_layers, int(mtp_dict.get("num_hidden_layers", 0) or 0))
-    return bool(has_mtp_tensors or mtp_layers > 0)
+    return bool(has_mtp_tensors)
 
 
 def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1192,13 +1192,26 @@ def _passes_qwen4_exp_gate(inspection: Any) -> bool:
     model_dir = getattr(inspection, "model_dir", None)
     if not model_dir:
         return False
-    try:
+    source = getattr(inspection, "source", None)
+    if source == "hf":
+        model_files = getattr(inspection, "model_files", ()) or ()
         has_trunk = any(
-            not _is_mtp_sidecar_file(path)
-            for path in Path(str(model_dir)).glob("*.safetensors")
+            not _is_mtp_sidecar_file(Path(fname))
+            for fname in model_files
         )
-    except OSError:
-        return False
+        if not has_trunk and getattr(inspection, "weight_keys", None):
+            has_trunk = any(
+                not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                for k in inspection.weight_keys
+            )
+    else:
+        try:
+            has_trunk = any(
+                not _is_mtp_sidecar_file(path)
+                for path in Path(str(model_dir)).glob("*.safetensors")
+            )
+        except OSError:
+            return False
     if not has_trunk:
         return False
     return _unsupported_quant_bits(model_dir) is None
@@ -1221,13 +1234,26 @@ def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
     model_dir = getattr(inspection, "model_dir", None)
     if not model_dir:
         return False
-    try:
+    source = getattr(inspection, "source", None)
+    if source == "hf":
+        model_files = getattr(inspection, "model_files", ()) or ()
         has_trunk = any(
-            not _is_mtp_sidecar_file(path)
-            for path in Path(str(model_dir)).glob("*.safetensors")
+            not _is_mtp_sidecar_file(Path(fname))
+            for fname in model_files
         )
-    except OSError:
-        return False
+        if not has_trunk and getattr(inspection, "weight_keys", None):
+            has_trunk = any(
+                not (k.startswith("mtp.") or k.startswith("language_model.mtp."))
+                for k in inspection.weight_keys
+            )
+    else:
+        try:
+            has_trunk = any(
+                not _is_mtp_sidecar_file(path)
+                for path in Path(str(model_dir)).glob("*.safetensors")
+            )
+        except OSError:
+            return False
     if not has_trunk:
         return False
     return _unsupported_quant_bits(model_dir) is None

--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1161,13 +1161,43 @@ def _passes_deepseek_v4_gate(inspection: Any) -> bool:
 
 def _passes_qwen4_exp_gate(inspection: Any) -> bool:
     """Qwen3.8-Flash-Next / Qwen4-Exp MLX artifact: model_type qwen4_exp / qwen4_exp_text
-    or Qwen4ExpForConditionalGeneration architecture."""
+    or Qwen4ExpForConditionalGeneration architecture, requiring model shards."""
     model_type = _text(getattr(inspection, "model_type", None))
     architecture = _compact(_text(getattr(inspection, "architecture", None)))
-    return (
+    if not (
         model_type in {"qwen4_exp", "qwen4_exp_text"}
         or "qwen4exp" in architecture
+    ):
+        return False
+    model_dir = getattr(inspection, "model_dir", None)
+    if not model_dir:
+        return False
+    try:
+        has_trunk = any(
+            path.name != "mtp.safetensors"
+            for path in Path(str(model_dir)).glob("*.safetensors")
+        )
+    except OSError:
+        return False
+    if not has_trunk:
+        return False
+    return _unsupported_quant_bits(model_dir) is None
+
+
+def _passes_qwen4_exp_mtp_gate(inspection: Any, tensor_gate: bool) -> bool:
+    """Qwen4-Exp MTP artifact: valid Qwen4-Exp model plus declared MTP markers or tensors."""
+    if not _passes_qwen4_exp_gate(inspection):
+        return False
+    keys = _weight_keys(inspection)
+    has_mtp_tensors = bool(
+        tensor_gate
+        or any(_is_sidecar_mtp_key(k) or "mtp." in k for k in (keys or ()))
     )
+    mtp_layers = int(getattr(inspection, "mtp_num_hidden_layers", 0) or 0)
+    mtp_dict = getattr(inspection, "mtp", None)
+    if mtp_dict is not None and isinstance(mtp_dict, dict):
+        mtp_layers = max(mtp_layers, int(mtp_dict.get("num_hidden_layers", 0) or 0))
+    return bool(has_mtp_tensors or mtp_layers > 0)
 
 
 def _passes_mlx_lm_ar_gate(inspection: Any) -> bool:
@@ -1243,6 +1273,8 @@ def _passes_family_runtime_gate(arch_id: str, inspection: Any, tensor_gate: bool
         return _passes_deepseek_v4_gate(inspection)
     if arch_id == "qwen4-exp":
         return _passes_qwen4_exp_gate(inspection)
+    if arch_id == "qwen4-exp-mtp":
+        return _passes_qwen4_exp_mtp_gate(inspection, tensor_gate)
     if arch_id == "laguna-s-2.1-ar":
         return bool(
             getattr(inspection, "laguna_s_2_1_mlx_4bit_match", False)

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -130,19 +130,43 @@ class TailOwnedKVCache:
 
     @property
     def state(self):
+        indexer = getattr(self, "indexer", None)
+        indexer_keys = getattr(indexer, "keys", None) if indexer is not None else None
         if self.keys is None or self.values is None:
-            return self.keys, self.values
-        if self.offset == self.keys.shape[2]:
-            return self.keys, self.values
-        return (
-            self.keys[..., : self.offset, :],
-            self.values[..., : self.offset, :],
-        )
+            base = (self.keys, self.values)
+        elif self.offset == self.keys.shape[2]:
+            base = (self.keys, self.values)
+        else:
+            base = (
+                self.keys[..., : self.offset, :],
+                self.values[..., : self.offset, :],
+            )
+        if indexer is not None:
+            return (*base, indexer_keys)
+        return base
 
     @state.setter
     def state(self, value) -> None:
-        self.keys, self.values = value
-        self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+        if value is None:
+            self.keys = self.values = None
+            self.offset = 0
+            indexer = getattr(self, "indexer", None)
+            if indexer is not None:
+                indexer.keys = None
+                if hasattr(indexer, "_len"):
+                    indexer._len = 0
+            return
+        if len(value) == 3:
+            self.keys, self.values, indexer_keys = value
+            self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+            indexer = getattr(self, "indexer", None)
+            if indexer is not None:
+                indexer.keys = indexer_keys
+                if hasattr(indexer, "_len"):
+                    indexer._len = 0 if indexer_keys is None else int(indexer_keys.shape[1])
+        else:
+            self.keys, self.values = value
+            self.offset = 0 if self.keys is None else int(self.keys.shape[2])
 
     @property
     def meta_state(self) -> tuple[str, ...]:
@@ -408,16 +432,31 @@ class BlockOwnedKVCache(TailOwnedKVCache):
 
     @property
     def state(self):
-        return self._active_arrays()
+        base = self._active_arrays()
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            return (*base, getattr(indexer, "keys", None))
+        return base
 
     @state.setter
     def state(self, value) -> None:
-        keys, values = value
+        if value is None:
+            keys = values = indexer_keys = None
+        elif len(value) == 3:
+            keys, values, indexer_keys = value
+        else:
+            keys, values = value
+            indexer_keys = None
         self.key_blocks = []
         self.value_blocks = []
         self.offset = 0
         if keys is not None and values is not None:
             self._load_contiguous_state(keys, values, int(keys.shape[2]))
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            indexer.keys = indexer_keys
+            if hasattr(indexer, "_len"):
+                indexer._len = 0 if indexer_keys is None else int(indexer_keys.shape[1])
 
     @property
     def meta_state(self) -> tuple[str, ...]:
@@ -1918,11 +1957,21 @@ class VllmMetalPagedKVCache:
 
     @property
     def state(self):
-        return self._active_arrays()
+        base = self._active_arrays()
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            return (*base, getattr(indexer, "keys", None))
+        return base
 
     @state.setter
     def state(self, value) -> None:
-        keys, values = value
+        if value is None:
+            keys = values = indexer_keys = None
+        elif len(value) == 3:
+            keys, values, indexer_keys = value
+        else:
+            keys, values = value
+            indexer_keys = None
         self.key_cache = None
         self.value_cache = None
         self.key_scale_cache = None
@@ -1933,6 +1982,11 @@ class VllmMetalPagedKVCache:
         self._dtypes = None
         if keys is not None and values is not None:
             self._load_contiguous_state(keys, values, int(keys.shape[2]))
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            indexer.keys = indexer_keys
+            if hasattr(indexer, "_len"):
+                indexer._len = 0 if indexer_keys is None else int(indexer_keys.shape[1])
 
     @property
     def meta_state(self) -> tuple[str, ...]:
@@ -2852,15 +2906,29 @@ class TensorOffsetVllmMetalPagedKVCache:
         flat_v = self._flat_value_cache()
         keys = flat_k.transpose(1, 0, 2)[None, ...]
         values = flat_v.transpose(1, 0, 2)[None, ...]
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            return keys, values, getattr(indexer, "keys", None)
         return keys, values
 
     @state.setter
     def state(self, value) -> None:
-        keys, values = value
+        if value is None:
+            keys = values = indexer_keys = None
+        elif len(value) == 3:
+            keys, values, indexer_keys = value
+        else:
+            keys, values = value
+            indexer_keys = None
         self.key_cache = None
         self.value_cache = None
         self.offset = 0
         if keys is None or values is None:
+            indexer = getattr(self, "indexer", None)
+            if indexer is not None:
+                indexer.keys = None
+                if hasattr(indexer, "_len"):
+                    indexer._len = 0
             return
         paged = VllmMetalPagedKVCache(
             block_size=int(self.block_size),
@@ -2872,6 +2940,11 @@ class TensorOffsetVllmMetalPagedKVCache:
             paged.value_cache,
             self.offset,
         ]
+        indexer = getattr(self, "indexer", None)
+        if indexer is not None:
+            indexer.keys = indexer_keys
+            if hasattr(indexer, "_len"):
+                indexer._len = 0 if indexer_keys is None else int(indexer_keys.shape[1])
 
     def size(self) -> int:
         import mlx.core as mx

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -2845,7 +2845,9 @@ class TensorOffsetVllmMetalPagedKVCache:
 
     def update_and_fetch(self, keys: Any, values: Any) -> tuple[Any, Any]:
         self.update_without_fetch(keys, values)
-        return self.state
+        flat_k = self._flat_key_cache()
+        flat_v = self._flat_value_cache()
+        return flat_k.transpose(1, 0, 2)[None, ...], flat_v.transpose(1, 0, 2)[None, ...]
 
     def make_mask(self, N: int, window_size=None, return_array: bool = False):
         import mlx.core as mx

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -85,6 +85,8 @@ class TailOwnedKVCache:
         )
         if hasattr(entry, "indexer"):
             cache.indexer = getattr(entry, "indexer")
+        if getattr(entry, "left_padding", None) is not None:
+            cache.left_padding = getattr(entry, "left_padding")
         return cache
 
     def _own_tail(self, keys: Any, values: Any) -> tuple[Any, Any]:
@@ -196,6 +198,18 @@ class TailOwnedKVCache:
         return n
 
     def make_mask(self, *args, **kwargs):
+        if getattr(self, "left_padding", None) is not None:
+            from mlx_lm.models.cache import create_causal_mask
+
+            N = args[0] if args else kwargs.pop("N", 1)
+            offset = kwargs.pop("offset", self.offset)
+            kwargs.pop("return_array", None)
+            return create_causal_mask(
+                N,
+                offset=offset,
+                left_padding=self.left_padding,
+                **kwargs,
+            )
         from mlx_lm.models.cache import create_attention_mask
 
         return create_attention_mask(*args, offset=self.offset, **kwargs)
@@ -259,6 +273,8 @@ class BlockOwnedKVCache(TailOwnedKVCache):
         )
         if hasattr(entry, "indexer"):
             cache.indexer = getattr(entry, "indexer")
+        if getattr(entry, "left_padding", None) is not None:
+            cache.left_padding = getattr(entry, "left_padding")
         return cache
 
     def _record_shape(self, keys: Any, values: Any) -> None:
@@ -950,6 +966,8 @@ class VllmMetalPagedKVCache:
         )
         if hasattr(entry, "indexer"):
             paged.indexer = getattr(entry, "indexer")
+        if getattr(entry, "left_padding", None) is not None:
+            paged.left_padding = getattr(entry, "left_padding")
         return paged
 
     @property
@@ -2039,6 +2057,18 @@ class VllmMetalPagedKVCache:
         return n
 
     def make_mask(self, *args, **kwargs):
+        if getattr(self, "left_padding", None) is not None:
+            from mlx_lm.models.cache import create_causal_mask
+
+            N = args[0] if args else kwargs.pop("N", 1)
+            offset = kwargs.pop("offset", self.offset)
+            kwargs.pop("return_array", None)
+            return create_causal_mask(
+                N,
+                offset=offset,
+                left_padding=self.left_padding,
+                **kwargs,
+            )
         from mlx_lm.models.cache import create_attention_mask
 
         return create_attention_mask(*args, offset=self.offset, **kwargs)
@@ -2771,6 +2801,8 @@ class TensorOffsetVllmMetalPagedKVCache:
         )
         if hasattr(entry, "indexer"):
             promoted.indexer = getattr(entry, "indexer")
+        if getattr(entry, "left_padding", None) is not None:
+            promoted.left_padding = getattr(entry, "left_padding")
         return promoted
 
     @property
@@ -2852,6 +2884,17 @@ class TensorOffsetVllmMetalPagedKVCache:
     def make_mask(self, N: int, window_size=None, return_array: bool = False):
         import mlx.core as mx
 
+        if getattr(self, "left_padding", None) is not None:
+            from mlx_lm.models.cache import create_causal_mask
+
+            offset_val = self.cache[2]
+            offset = int(offset_val.item()) if hasattr(offset_val, "item") else int(offset_val)
+            return create_causal_mask(
+                N,
+                offset=offset,
+                left_padding=self.left_padding,
+                window_size=window_size,
+            )
         del return_array
         rinds = mx.arange(self.capacity)
         linds = self.cache[2] + mx.arange(N)
@@ -3024,6 +3067,8 @@ class TensorOffsetVllmMetalPagedKVCache:
         )
         if hasattr(self, "indexer"):
             paged.indexer = getattr(self, "indexer")
+        if getattr(self, "left_padding", None) is not None:
+            paged.left_padding = getattr(self, "left_padding")
         if self.cache[0] is None or self.cache[1] is None:
             return paged
         paged.key_cache = self.cache[0]

--- a/mtplx/cache_state.py
+++ b/mtplx/cache_state.py
@@ -76,13 +76,16 @@ class TailOwnedKVCache:
 
     @classmethod
     def from_cache(cls, entry: Any, *, mode: str, step: int | None = None) -> "TailOwnedKVCache":
-        return cls(
+        cache = cls(
             mode=mode,
             step=int(step or getattr(entry, "step", 256)),
             keys=getattr(entry, "keys", None),
             values=getattr(entry, "values", None),
             offset=int(getattr(entry, "offset", 0)),
         )
+        if hasattr(entry, "indexer"):
+            cache.indexer = getattr(entry, "indexer")
+        return cache
 
     def _own_tail(self, keys: Any, values: Any) -> tuple[Any, Any]:
         started = time.perf_counter()
@@ -160,6 +163,12 @@ class TailOwnedKVCache:
     def trim(self, n: int) -> int:
         n = min(int(self.offset), int(n))
         self.offset -= n
+        if hasattr(self, "indexer") and getattr(self, "indexer", None) is not None:
+            indexer = getattr(self, "indexer")
+            keys = getattr(indexer, "keys", None)
+            if keys is not None:
+                keep = int(keys.shape[1]) - int(n)
+                indexer.keys = keys[:, :keep, :] if keep > 0 else None
         return n
 
     def make_mask(self, *args, **kwargs):
@@ -217,13 +226,16 @@ class BlockOwnedKVCache(TailOwnedKVCache):
         mode: str,
         block_size: int | None = None,
     ) -> "BlockOwnedKVCache":
-        return cls(
+        cache = cls(
             mode=mode,
             block_size=int(block_size or getattr(entry, "step", 1024) or 1024),
             keys=getattr(entry, "keys", None),
             values=getattr(entry, "values", None),
             offset=int(getattr(entry, "offset", 0)),
         )
+        if hasattr(entry, "indexer"):
+            cache.indexer = getattr(entry, "indexer")
+        return cache
 
     def _record_shape(self, keys: Any, values: Any) -> None:
         self._tail_shape = (
@@ -888,7 +900,7 @@ class VllmMetalPagedKVCache:
         turboquant_config: Any | None = None,
         kv_quant_config: Any | None = None,
     ) -> "VllmMetalPagedKVCache":
-        return cls(
+        paged = cls(
             block_size=block_size,
             num_blocks=num_blocks,
             keys=getattr(entry, "keys", None),
@@ -897,6 +909,9 @@ class VllmMetalPagedKVCache:
             turboquant_config=turboquant_config,
             kv_quant_config=kv_quant_config,
         )
+        if hasattr(entry, "indexer"):
+            paged.indexer = getattr(entry, "indexer")
+        return paged
 
     @property
     def allocated_blocks(self) -> int | None:
@@ -1956,6 +1971,12 @@ class VllmMetalPagedKVCache:
             self._dequant_memo["tokens"] = min(
                 int(self._dequant_memo["tokens"]), int(self.offset)
             )
+        if hasattr(self, "indexer") and getattr(self, "indexer", None) is not None:
+            indexer = getattr(self, "indexer")
+            keys = getattr(indexer, "keys", None)
+            if keys is not None:
+                keep = int(keys.shape[1]) - int(n)
+                indexer.keys = keys[:, :keep, :] if keep > 0 else None
         # The kv_quant numerics route deliberately survives trim():
         # speculative-verify rejections retract rows mid-request, and
         # re-latching here would switch math when a rejection lands the
@@ -2687,13 +2708,16 @@ class TensorOffsetVllmMetalPagedKVCache:
     def from_paged_cache(cls, entry: VllmMetalPagedKVCache) -> "TensorOffsetVllmMetalPagedKVCache":
         if entry.key_cache is None or entry.value_cache is None:
             raise ValueError("cannot promote empty paged KV cache")
-        return cls(
+        promoted = cls(
             key_cache=entry.key_cache,
             value_cache=entry.value_cache,
             offset=int(entry.offset),
             block_size=int(entry.block_size),
             num_blocks=int(entry.num_blocks),
         )
+        if hasattr(entry, "indexer"):
+            promoted.indexer = getattr(entry, "indexer")
+        return promoted
 
     @property
     def key_cache(self):
@@ -2923,6 +2947,8 @@ class TensorOffsetVllmMetalPagedKVCache:
             block_size=int(self.block_size),
             num_blocks=int(self.num_blocks),
         )
+        if hasattr(self, "indexer"):
+            paged.indexer = getattr(self, "indexer")
         if self.cache[0] is None or self.cache[1] is None:
             return paged
         paged.key_cache = self.cache[0]

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -10142,20 +10142,23 @@ def _generate_one_shot_public(
                     seed=args.seed,
                 )
             else:
-                out = generate_mtpk(
-                    rt,
-                    prompt_ids,
-                    max_tokens=max_tokens_value,
-                    sampler=sampler,
-                    draft_sampler=_draft_sampler_from_spec(draft_sampler),
-                    speculative_depth=args.depth,
-                    seed=args.seed,
-                    mtp_hidden_variant="post_norm",
-                    mtp_cache_policy="persistent",
-                    mtp_history_policy="committed",
-                    verify_strategy="capture_commit",
-                    verify_core="linear-gdn-from-conv-tape",
-                )
+                from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_env
+
+                with qwen4_exp_product_verify_env(getattr(rt, "model", None)) as verify_strategy:
+                    out = generate_mtpk(
+                        rt,
+                        prompt_ids,
+                        max_tokens=max_tokens_value,
+                        sampler=sampler,
+                        draft_sampler=_draft_sampler_from_spec(draft_sampler),
+                        speculative_depth=args.depth,
+                        seed=args.seed,
+                        mtp_hidden_variant="post_norm",
+                        mtp_cache_policy="persistent",
+                        mtp_history_policy="committed",
+                        verify_strategy=verify_strategy,
+                        verify_core="linear-gdn-from-conv-tape",
+                    )
         finally:
             if smart_fans is not None and smart_request_id is not None:
                 smart_fans.end_request(smart_request_id, wait_for_restore=True)
@@ -10273,10 +10276,21 @@ def cmd_run_public(args: Any) -> int:
             tok_s_text = f"{tok_s:.2f}" if isinstance(tok_s, (int, float)) else "n/a"
             mode = str(stats.get("generation_mode") or "mtp").upper()
             mtp_depth = int(stats.get("mtp_depth") or 0)
+            extra = ""
+            accepted = stats.get("accepted_by_depth")
+            drafted = stats.get("drafted_by_depth")
+            if isinstance(accepted, list) and accepted:
+                extra += f" accept={accepted}"
+            if isinstance(drafted, list) and drafted:
+                extra += f" drafted={drafted}"
+            verify_calls = stats.get("verify_calls")
+            if isinstance(verify_calls, int) and verify_calls:
+                extra += f" verify_calls={verify_calls}"
             print(
                 f"\n[mtplx] profile={payload['profile']['name']} "
                 f"mode={mode} mtp_depth={mtp_depth} "
                 f"tokens={stats.get('generated_tokens')} tok_s={tok_s_text}"
+                f"{extra}"
             )
     return code
 
@@ -10930,21 +10944,24 @@ def _quickstart_generate(
                 token_callback=record_tokens,
             )
         else:
-            out = generate_mtpk(
-                rt,
-                prompt_ids,
-                max_tokens=max_tokens_value,
-                sampler=sampler,
-                draft_sampler=_draft_sampler_from_spec(draft_sampler),
-                speculative_depth=int(getattr(args, "depth", 3)),
-                seed=seed,
-                mtp_hidden_variant="post_norm",
-                mtp_cache_policy="persistent",
-                mtp_history_policy="committed",
-                verify_strategy="capture_commit",
-                verify_core="linear-gdn-from-conv-tape",
-                token_callback=record_tokens,
-            )
+            from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_env
+
+            with qwen4_exp_product_verify_env(getattr(rt, "model", None)) as verify_strategy:
+                out = generate_mtpk(
+                    rt,
+                    prompt_ids,
+                    max_tokens=max_tokens_value,
+                    sampler=sampler,
+                    draft_sampler=_draft_sampler_from_spec(draft_sampler),
+                    speculative_depth=int(getattr(args, "depth", 3)),
+                    seed=seed,
+                    mtp_hidden_variant="post_norm",
+                    mtp_cache_policy="persistent",
+                    mtp_history_policy="committed",
+                    verify_strategy=verify_strategy,
+                    verify_core="linear-gdn-from-conv-tape",
+                    token_callback=record_tokens,
+                )
     finally:
         if smart_fans is not None and smart_request_id is not None:
             smart_fans.end_request(smart_request_id, wait_for_restore=False)

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2175,46 +2175,62 @@ def _depth_sweep_native60(
     # Serve-path memory discipline (#261, F7): the depth-sweep harness loads
     # the model in-process; pin the serve-path Metal allocator caps first.
     from mtplx.server.openai import apply_memory_caps_preflight
+    from mtplx.artifacts import inspect_model
+    from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_env
+
+    try:
+        inspection = inspect_model(model)
+        is_qwen4 = (
+            getattr(inspection, "model_type", None) == "qwen4_exp"
+            or getattr(inspection, "architecture", None)
+            == "Qwen4ExpForConditionalGeneration"
+        )
+    except Exception:
+        is_qwen4 = "qwen4" in str(model).lower() or "qwen3.8" in str(model).lower()
+
+    verify_strategy = "batched" if is_qwen4 else "capture_commit"
+    verify_core = "stock" if is_qwen4 else "linear-gdn-from-conv-tape"
 
     memory_preflight = apply_memory_caps_preflight(
         entry="bench.depth_sweep",
         model=str(model),
     )
     try:
-        result = run_mtp_depth_sweep(
-            model,
-            prompt_suite,
-            depths=depths,
-            temperature=float(temperature),
-            top_p=float(top_p),
-            top_k=int(top_k),
-            max_tokens=max_tokens,
-            seed=seed,
-            limit=limit,
-            enable_thinking=False,
-            compare_ar=compare_ar,
-            ar_only=ar_only,
-            gemma4_draft_block_size=gemma4_draft_block_size,
-            base_hidden_variant=base_hidden_variant,
-            mtp_hidden_variant=mtp_hidden_variant,
-            concat_order=concat_order,
-            mtp_cache_policy=mtp_cache_policy,
-            mtp_history_policy=mtp_history_policy,
-            min_speculative_depth=1,
-            verify_strategy="capture_commit",
-            draft_core=str(draft_core or "stock"),
-            verify_core="linear-gdn-from-conv-tape",
-            draft_lm_head_bits=int(draft_lm_head["bits"]),
-            draft_lm_head_group_size=int(draft_lm_head["group_size"]),
-            draft_lm_head_mode=str(draft_lm_head["mode"]),
-            draft_temperature=(
-                None if draft_sampler is None else float(draft_sampler["temperature"])
-            ),
-            draft_top_p=None
-            if draft_sampler is None
-            else float(draft_sampler["top_p"]),
-            draft_top_k=None if draft_sampler is None else int(draft_sampler["top_k"]),
-        )
+        with qwen4_exp_product_verify_env(None) if is_qwen4 else contextlib.nullcontext():
+            result = run_mtp_depth_sweep(
+                model,
+                prompt_suite,
+                depths=depths,
+                temperature=float(temperature),
+                top_p=float(top_p),
+                top_k=int(top_k),
+                max_tokens=max_tokens,
+                seed=seed,
+                limit=limit,
+                enable_thinking=False,
+                compare_ar=compare_ar,
+                ar_only=ar_only,
+                gemma4_draft_block_size=gemma4_draft_block_size,
+                base_hidden_variant=base_hidden_variant,
+                mtp_hidden_variant=mtp_hidden_variant,
+                concat_order=concat_order,
+                mtp_cache_policy=mtp_cache_policy,
+                mtp_history_policy=mtp_history_policy,
+                min_speculative_depth=1,
+                verify_strategy=verify_strategy,
+                draft_core=str(draft_core or "stock"),
+                verify_core=verify_core,
+                draft_lm_head_bits=int(draft_lm_head["bits"]),
+                draft_lm_head_group_size=int(draft_lm_head["group_size"]),
+                draft_lm_head_mode=str(draft_lm_head["mode"]),
+                draft_temperature=(
+                    None if draft_sampler is None else float(draft_sampler["temperature"])
+                ),
+                draft_top_p=None
+                if draft_sampler is None
+                else float(draft_sampler["top_p"]),
+                draft_top_k=None if draft_sampler is None else int(draft_sampler["top_k"]),
+            )
         if isinstance(result, dict):
             result.setdefault("memory_preflight", memory_preflight)
         return result

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2180,10 +2180,18 @@ def _depth_sweep_native60(
 
     try:
         inspection = inspect_model(model)
+        m_type = str(getattr(inspection, "model_type", "") or "").lower()
+        arch = str(getattr(inspection, "architecture", "") or "").lower()
         is_qwen4 = (
-            getattr(inspection, "model_type", None) == "qwen4_exp"
+            m_type in {"qwen4_exp", "qwen4_exp_text", "qwen4exp", "qwen4", "qwen4-exp"}
+            or "qwen4exp" in arch
+            or "qwen4" in arch
             or getattr(inspection, "architecture", None)
-            == "Qwen4ExpForConditionalGeneration"
+            in {
+                "Qwen4ExpForConditionalGeneration",
+                "Qwen4ExpForCausalLM",
+                "Qwen4ForCausalLM",
+            }
         )
     except Exception:
         is_qwen4 = "qwen4" in str(model).lower() or "qwen3.8" in str(model).lower()

--- a/mtplx/constants.py
+++ b/mtplx/constants.py
@@ -85,6 +85,39 @@ EXPECTED_QWEN_MOE_SWITCH_MLP_MTP_TENSOR_COUNT = len(
     EXPECTED_QWEN_MOE_SWITCH_MLP_MTP_KEYS
 )
 
+EXPECTED_QWEN4_EXP_MTP_KEYS = (
+    "mtp.fc_embedding.weight",
+    "mtp.fc_hidden.weight",
+    "mtp.hyper_connection_mixer.hc_norm.weight",
+    "mtp.hyper_connection_mixer.input_mix_weight_down",
+    "mtp.hyper_connection_mixer.input_mix_weight_up",
+    "mtp.layers.0.attn_hyper_connection.block_inject_weight",
+    "mtp.layers.0.attn_hyper_connection.hc_norm.weight",
+    "mtp.layers.0.attn_hyper_connection.input_mix_weight_down",
+    "mtp.layers.0.attn_hyper_connection.input_mix_weight_up",
+    "mtp.layers.0.mlp.gate.weight",
+    "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+    "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+    "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+    "mtp.layers.0.mlp.shared_expert_gate.weight",
+    "mtp.layers.0.mlp.switch_mlp.down_proj.weight",
+    "mtp.layers.0.mlp.switch_mlp.gate_proj.weight",
+    "mtp.layers.0.mlp.switch_mlp.up_proj.weight",
+    "mtp.layers.0.mlp_hyper_connection.block_inject_weight",
+    "mtp.layers.0.mlp_hyper_connection.hc_norm.weight",
+    "mtp.layers.0.mlp_hyper_connection.input_mix_weight_down",
+    "mtp.layers.0.mlp_hyper_connection.input_mix_weight_up",
+    "mtp.layers.0.self_attn.k_norm.weight",
+    "mtp.layers.0.self_attn.k_proj.weight",
+    "mtp.layers.0.self_attn.o_proj.weight",
+    "mtp.layers.0.self_attn.q_norm.weight",
+    "mtp.layers.0.self_attn.q_proj.weight",
+    "mtp.layers.0.self_attn.v_proj.weight",
+    "mtp.pre_fc_norm_embedding.weight",
+    "mtp.pre_fc_norm_hidden.weight",
+)
+EXPECTED_QWEN4_EXP_MTP_TENSOR_COUNT = len(EXPECTED_QWEN4_EXP_MTP_KEYS)
+
 MTP_QUANTIZED_LINEAR_WEIGHT_KEYS = (
     "mtp.layers.0.mlp.down_proj.weight",
     "mtp.layers.0.mlp.gate_proj.weight",

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -4354,7 +4354,7 @@ def _sample_from_logits(
                 config.frequency_penalty,
                 penalty_overlay=penalty_overlay,
             )
-        _eval(logits)
+            _eval(logits)
         return int(mx.argmax(logits, axis=-1).item()), None
     probs = _distribution_from_mlx_logits(
         logits, config, token_counts=token_counts, penalty_overlay=penalty_overlay
@@ -5785,6 +5785,16 @@ def generate_ar(
                         token_callback(released)
         emit_trace()
 
+    # Double-buffered decode (mlx-lm pattern): dispatch step t+1's forward
+    # without blocking and let the next sample's materialization be the only
+    # block point, so host bookkeeping overlaps GPU execution. MTPLX_SYNC_AR=1
+    # restores the historical blocking eval.
+    _ar_sync_eval = str(os.environ.get("MTPLX_SYNC_AR", "")).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ) or bool(os.environ.get("MTPLX_EVAL_AUDIT"))
     for step in range(max_tokens):
         if _loop_guard is not None:
             _guard_transition = _loop_guard.observe(tokens)
@@ -5877,10 +5887,22 @@ def generate_ar(
             hidden_next = None
         forward_graph_elapsed = time.perf_counter() - started
         eval_started = time.perf_counter()
-        if hidden_next is None:
-            _eval(logits_next)
+        if _ar_sync_eval:
+            if hidden_next is None:
+                _eval(logits_next)
+            else:
+                _eval(logits_next, hidden_next)
         else:
-            _eval(logits_next, hidden_next)
+            # Include cache roots so conv-state slices (not logits ancestors)
+            # materialize with this dispatch instead of chaining lazily into
+            # the next step's graph.
+            _async_roots = [logits_next] if hidden_next is None else [
+                logits_next,
+                hidden_next,
+            ]
+            _async_roots.extend(_tree_mx_arrays(cache))
+            mx.async_eval(*_async_roots)
+            _owner_progress_tick()
         eval_elapsed = time.perf_counter() - eval_started
         elapsed_decode = time.perf_counter() - started
         target_decode_time += elapsed_decode
@@ -6881,6 +6903,9 @@ def generate_mtpk(
             "'graphbank', 'graphbank_capture_commit', 'target_prefix', "
             "or 'trim_commit'"
         )
+    from .qwen4_exp_mtp_patch import maybe_refuse_qwen4_exp_verify_lane
+
+    maybe_refuse_qwen4_exp_verify_lane(rt.model, verify_strategy)
     target_prefix_verify = verify_strategy == "target_prefix"
     # Constrained requests never engage the exact A3B route: the route
     # pre-commits its rejection correction (no None-guard on the append),

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -5385,6 +5385,9 @@ def _rollback_mtp_cache(mtp_cache, offset: int) -> None:
         trim = max(0, current - offset)
         if trim and hasattr(cache, "trim"):
             cache.trim(trim)
+        reuse = getattr(cache, "_sparse_index_reuse", None)
+        if reuse is not None and hasattr(reuse, "reset"):
+            reuse.reset()
 
 
 def _add_timing(event: dict, key: str, elapsed_s: float) -> None:

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -4354,7 +4354,7 @@ def _sample_from_logits(
                 config.frequency_penalty,
                 penalty_overlay=penalty_overlay,
             )
-            _eval(logits)
+        _eval(logits)
         return int(mx.argmax(logits, axis=-1).item()), None
     probs = _distribution_from_mlx_logits(
         logits, config, token_counts=token_counts, penalty_overlay=penalty_overlay
@@ -5785,16 +5785,6 @@ def generate_ar(
                         token_callback(released)
         emit_trace()
 
-    # Double-buffered decode (mlx-lm pattern): dispatch step t+1's forward
-    # without blocking and let the next sample's materialization be the only
-    # block point, so host bookkeeping overlaps GPU execution. MTPLX_SYNC_AR=1
-    # restores the historical blocking eval.
-    _ar_sync_eval = str(os.environ.get("MTPLX_SYNC_AR", "")).strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    ) or bool(os.environ.get("MTPLX_EVAL_AUDIT"))
     for step in range(max_tokens):
         if _loop_guard is not None:
             _guard_transition = _loop_guard.observe(tokens)
@@ -5887,22 +5877,10 @@ def generate_ar(
             hidden_next = None
         forward_graph_elapsed = time.perf_counter() - started
         eval_started = time.perf_counter()
-        if _ar_sync_eval:
-            if hidden_next is None:
-                _eval(logits_next)
-            else:
-                _eval(logits_next, hidden_next)
+        if hidden_next is None:
+            _eval(logits_next)
         else:
-            # Include cache roots so conv-state slices (not logits ancestors)
-            # materialize with this dispatch instead of chaining lazily into
-            # the next step's graph.
-            _async_roots = [logits_next] if hidden_next is None else [
-                logits_next,
-                hidden_next,
-            ]
-            _async_roots.extend(_tree_mx_arrays(cache))
-            mx.async_eval(*_async_roots)
-            _owner_progress_tick()
+            _eval(logits_next, hidden_next)
         eval_elapsed = time.perf_counter() - eval_started
         elapsed_decode = time.perf_counter() - started
         target_decode_time += elapsed_decode

--- a/mtplx/kernels/gdn_blocked_prefill.py
+++ b/mtplx/kernels/gdn_blocked_prefill.py
@@ -185,6 +185,35 @@ def _get_kernel(block_t=None, input_dtype=None):
     return kernel
 
 
+def blocked_prefill_ineligibility_reason(
+    q: mx.array,
+    v: mx.array,
+    g: mx.array,
+    mask,
+    state,
+) -> Optional[str]:
+    """Return the first structural reason the blocked kernel cannot run, or None."""
+    if mask is not None:
+        return "mask is not None (scalar-gating kernel is unmasked only)"
+    if getattr(g, "ndim", 0) != 3:
+        return f"g.ndim={getattr(g, 'ndim', None)} (need 3; vectorized gating stays stock)"
+    if q.ndim != 4 or v.ndim != 4:
+        return f"q.ndim={q.ndim} v.ndim={v.ndim} (need 4)"
+    _B, _T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[2:]
+    if Dk != 128:
+        return f"Dk={Dk} (kernel is hardcoded for Dk==128)"
+    if Dv % 32 != 0:
+        return f"Dv={Dv} (need Dv % 32 == 0)"
+    if Hk <= 0 or Hv % Hk != 0:
+        return f"Hv={Hv} Hk={Hk} (need Hv % Hk == 0)"
+    if q.dtype not in (mx.bfloat16, mx.float16, mx.float32):
+        return f"q.dtype={q.dtype} (need bf16/fp16/fp32)"
+    if state is not None and state.dtype != mx.float32:
+        return f"state.dtype={state.dtype} (need fp32)"
+    return None
+
+
 def blocked_prefill_eligible(
     q: mx.array,
     v: mx.array,
@@ -193,19 +222,7 @@ def blocked_prefill_eligible(
     state,
 ) -> bool:
     """Structural gate: route only shapes the kernel is written for."""
-    if mask is not None or g.ndim != 3:
-        return False
-    if q.ndim != 4 or v.ndim != 4:
-        return False
-    B, T, Hk, Dk = q.shape
-    Hv, Dv = v.shape[2:]
-    if Dk != 128 or Dv % 32 != 0 or Hk <= 0 or Hv % Hk != 0:
-        return False
-    if q.dtype not in (mx.bfloat16, mx.float16, mx.float32):
-        return False
-    if state is not None and state.dtype != mx.float32:
-        return False
-    return True
+    return blocked_prefill_ineligibility_reason(q, v, g, mask, state) is None
 
 
 def gated_delta_blocked_prefill(
@@ -418,13 +435,19 @@ def install_gdn_blocked_prefill_patch() -> dict:
     # first so they exist to be swept even before the model loads.
     import sys as _sys
 
-    for _name in ("mlx_lm.models.qwen3_5", "mlx_lm.models.qwen3_next"):
+    for _name in (
+        "mlx_lm.models.qwen3_5",
+        "mlx_lm.models.qwen3_next",
+        "mtplx.models.qwen4_exp",
+    ):
         try:
             __import__(_name)
         except Exception:
             pass
     for _name, _mod in list(_sys.modules.items()):
-        if _mod is None or not _name.startswith("mlx_lm"):
+        if _mod is None or not (
+            _name.startswith("mlx_lm") or _name.startswith("mtplx")
+        ):
             continue
         if getattr(_mod, "gated_delta_update", None) is original:
             try:
@@ -456,7 +479,9 @@ def uninstall_gdn_blocked_prefill_patch() -> None:
     import sys as _sys
 
     for _name, _mod in list(_sys.modules.items()):
-        if _mod is None or not _name.startswith("mlx_lm"):
+        if _mod is None or not (
+            _name.startswith("mlx_lm") or _name.startswith("mtplx")
+        ):
             continue
         current = getattr(_mod, "gated_delta_update", None)
         if current is not None and current is not original:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -72,6 +72,8 @@ class TextArgs(BaseModelArgs):
     num_experts_per_tok: int = 10
     moe_intermediate_size: int = 640
     shared_expert_intermediate_size: int = 640
+    norm_topk_prob: bool = True
+    routed_scaling_factor: float = 1.0
     # Gated DeltaNet
     linear_num_key_heads: int = 16
     linear_num_value_heads: int = 48
@@ -130,6 +132,16 @@ class TextArgs(BaseModelArgs):
             if "type" in rp and "rope_type" not in rp:
                 rp["rope_type"] = rp["type"]
             params["rope_parameters"] = rp
+        if "norm_topk_prob" in params:
+            params["norm_topk_prob"] = bool(params["norm_topk_prob"])
+        for k in (
+            "routed_scaling_factor",
+            "moe_routed_scaling_factor",
+            "router_scaling_factor",
+        ):
+            if k in params:
+                params["routed_scaling_factor"] = float(params[k])
+                break
         return super().from_dict(params)
 
 
@@ -579,6 +591,10 @@ class QSAIndexer(nn.Module):
             return None
 
         r = self.compress_ratio
+        left_padding = getattr(cache, "left_padding", None)
+        if left_padding is None and hasattr(cache, "indexer"):
+            left_padding = getattr(cache.indexer, "left_padding", None)
+
         if cache is not None:
             cached_pooled = getattr(cache, "pooled", None)
             n_cached = int(cached_pooled.shape[1]) if cached_pooled is not None else 0
@@ -589,10 +605,26 @@ class QSAIndexer(nn.Module):
             if n_cached < n_blocks:
                 new_raw_k = raw_k[:, n_cached * r : n_blocks * r, :]
                 n_new = n_blocks - n_cached
-                new_pooled = new_raw_k.reshape(B, n_new, r, self.head_dim)
-                new_pooled = self.k_layernorm(
-                    new_pooled.astype(mx.float32).mean(axis=2).astype(raw_k.dtype)
-                )
+                if left_padding is not None:
+                    tok_pos = mx.arange(n_cached * r, n_blocks * r)
+                    is_valid = tok_pos[None, :] >= left_padding[:, None]
+                    new_raw_k = mx.where(is_valid[..., None], new_raw_k, 0.0)
+                    valid_counts = mx.maximum(
+                        is_valid.reshape(B, n_new, r).sum(axis=-1, keepdims=True), 1
+                    )
+                    new_pooled = (
+                        new_raw_k.reshape(B, n_new, r, self.head_dim)
+                        .astype(mx.float32)
+                        .sum(axis=2)
+                        / valid_counts
+                    )
+                else:
+                    new_pooled = (
+                        new_raw_k.reshape(B, n_new, r, self.head_dim)
+                        .astype(mx.float32)
+                        .mean(axis=2)
+                    )
+                new_pooled = self.k_layernorm(new_pooled.astype(raw_k.dtype))
                 new_starts = mx.arange(n_cached, n_blocks) * r
                 cos_k, sin_k = rope(new_starts[None, :])
                 new_pooled = _rope_partial(new_pooled, cos_k, sin_k)
@@ -605,12 +637,27 @@ class QSAIndexer(nn.Module):
             else:
                 pooled = cached_pooled
         else:
-            pooled = raw_k[:, : n_blocks * r].reshape(
-                B, n_blocks, r, self.head_dim
-            )
-            pooled = self.k_layernorm(
-                pooled.astype(mx.float32).mean(axis=2).astype(raw_k.dtype)
-            )
+            pooled_raw = raw_k[:, : n_blocks * r]
+            if left_padding is not None:
+                tok_pos = mx.arange(n_blocks * r)
+                is_valid = tok_pos[None, :] >= left_padding[:, None]
+                pooled_raw = mx.where(is_valid[..., None], pooled_raw, 0.0)
+                valid_counts = mx.maximum(
+                    is_valid.reshape(B, n_blocks, r).sum(axis=-1, keepdims=True), 1
+                )
+                pooled = (
+                    pooled_raw.reshape(B, n_blocks, r, self.head_dim)
+                    .astype(mx.float32)
+                    .sum(axis=2)
+                    / valid_counts
+                )
+            else:
+                pooled = (
+                    pooled_raw.reshape(B, n_blocks, r, self.head_dim)
+                    .astype(mx.float32)
+                    .mean(axis=2)
+                )
+            pooled = self.k_layernorm(pooled.astype(raw_k.dtype))
             block_starts = mx.arange(n_blocks) * r
             cos_k, sin_k = rope(block_starts[None, :])
             pooled = _rope_partial(pooled, cos_k, sin_k)
@@ -619,9 +666,6 @@ class QSAIndexer(nn.Module):
         cos_q, sin_q = rope(q_pos[None, :])
         q = self.q_layernorm(q)
         q = _rope_partial(q, cos_q[:, :, None, :], sin_q[:, :, None, :])
-        left_padding = getattr(cache, "left_padding", None)
-        if left_padding is None and hasattr(cache, "indexer"):
-            left_padding = getattr(cache.indexer, "left_padding", None)
         return QSAPrep(
             q=q,
             pooled=pooled,
@@ -646,8 +690,8 @@ class QSAIndexer(nn.Module):
         is_complete = mx.arange(n_blocks)[None, :] < n_complete[:, None]  # (S, n_blocks)
 
         if left_padding is not None:
-            block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
-            is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
+            block_starts = mx.arange(n_blocks) * r  # (n_blocks,)
+            is_not_pad = block_starts[None, None, :] >= left_padding[:, None, None]  # (B, 1, n_blocks)
             valid_block = is_complete[None, :, :] & is_not_pad  # (B, S, n_blocks)
         else:
             valid_block = mx.broadcast_to(is_complete[None, :, :], (B, S, n_blocks))
@@ -945,9 +989,17 @@ class GatedDeltaNet(nn.Module):
             mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
         conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
         if cache is not None:
-            _set_cache_slot(
-                cache, 0, mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+            new_slot0 = mx.contiguous(
+                conv_input[:, -(self.conv_kernel_size - 1) :, :]
             )
+            if mask is not None:
+                row_active = (
+                    mask.any(axis=-1, keepdims=True)
+                    if mask.ndim > 1
+                    else mask[:, None]
+                )
+                new_slot0 = mx.where(row_active[..., None], new_slot0, conv_state)
+            _set_cache_slot(cache, 0, new_slot0)
         conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = mx.split(conv_out, [self.key_dim, 2 * self.key_dim], axis=-1)
@@ -1099,11 +1151,19 @@ class SparseMoeBlock(nn.Module):
         )
         self.shared_expert = MLP(args.hidden_size, args.shared_expert_intermediate_size)
         self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+        self.norm_topk_prob = getattr(args, "norm_topk_prob", True)
+        self.routed_scaling_factor = float(getattr(args, "routed_scaling_factor", 1.0) or 1.0)
 
     def __call__(self, x: mx.array) -> mx.array:
         logits = self.gate(x.astype(mx.float32))
         idx = mx.argpartition(-logits, self.top_k - 1, axis=-1)[..., : self.top_k]
-        w = mx.softmax(mx.take_along_axis(logits, idx, axis=-1), axis=-1, precise=True)
+        if self.norm_topk_prob:
+            w = mx.softmax(mx.take_along_axis(logits, idx, axis=-1), axis=-1, precise=True)
+        else:
+            scores = mx.softmax(logits, axis=-1, precise=True)
+            w = mx.take_along_axis(scores, idx, axis=-1)
+        if self.routed_scaling_factor != 1.0:
+            w = w * self.routed_scaling_factor
         out = (self.switch_mlp(x, idx) * w[..., None]).sum(axis=-2).astype(x.dtype)
         return out + mx.sigmoid(self.shared_expert_gate(x)) * self.shared_expert(x)
 
@@ -1317,7 +1377,15 @@ class PLELayer(nn.Module):
             x = mx.where(mask[..., None], x, 0)
         full = mx.concatenate([state, x], axis=1)
         if cache is not None:
-            _set_cache_slot(cache, 2, mx.contiguous(full[:, -n:, :]))
+            new_slot2 = mx.contiguous(full[:, -n:, :])
+            if mask is not None:
+                row_active = (
+                    mask.any(axis=-1, keepdims=True)
+                    if mask.ndim > 1
+                    else mask[:, None]
+                )
+                new_slot2 = mx.where(row_active[..., None], new_slot2, state)
+            _set_cache_slot(cache, 2, new_slot2)
         out = nn.silu(self.conv1d(full[:, -(n + S) :, :]))
         if mask is not None:
             out = mx.where(mask[..., None], out, 0)

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -2011,11 +2011,12 @@ class _AttnCache(KVCache):
             from mlx_lm.models.cache import create_causal_mask
 
             offset = getattr(self, "_idx", getattr(self, "offset", 0))
+            window_size = kwargs.pop("window_size", None)
             return create_causal_mask(
                 N,
                 offset=offset,
                 left_padding=self.left_padding,
-                return_array=return_array,
+                window_size=window_size,
                 **kwargs,
             )
         return super().make_mask(N, return_array=return_array, **kwargs)

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -987,22 +987,58 @@ class GatedDeltaNet(nn.Module):
             if slot0 is not None
             else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=x.dtype)
         )
-        if mask is not None:
-            mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
-        conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
-        if cache is not None:
-            new_slot0 = mx.contiguous(
-                conv_input[:, -(self.conv_kernel_size - 1) :, :]
-            )
-            if mask is not None:
-                row_active = (
-                    mask.any(axis=-1, keepdims=True)
-                    if mask.ndim > 1
-                    else mask[:, None]
+        K_minus_1 = self.conv_kernel_size - 1
+        if mask is None:
+            conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
+            if cache is not None:
+                _set_cache_slot(
+                    cache,
+                    0,
+                    mx.contiguous(conv_input[:, -K_minus_1:, :]),
                 )
+            conv_out = nn.silu(self.conv1d(conv_input))
+        elif S == 1:
+            row_active = (
+                mask.any(axis=-1, keepdims=True)
+                if mask.ndim > 1
+                else mask[:, None]
+            )
+            mixed_qkv_active = mx.where(mask[..., None], mixed_qkv, 0)
+            conv_input = mx.concatenate([conv_state, mixed_qkv_active], axis=1)
+            if cache is not None:
+                new_slot0 = mx.contiguous(conv_input[:, -K_minus_1:, :])
                 new_slot0 = mx.where(row_active[..., None], new_slot0, conv_state)
-            _set_cache_slot(cache, 0, new_slot0)
-        conv_out = nn.silu(self.conv1d(conv_input))
+                _set_cache_slot(cache, 0, new_slot0)
+            conv_out = nn.silu(self.conv1d(conv_input))
+            conv_out = mx.where(mask[..., None], conv_out, 0)
+        else:
+            conv_out_rows = []
+            new_slot0_rows = []
+            for i in range(B):
+                m_i = mask[i] if mask.ndim > 1 else mask
+                row_qkv = mixed_qkv[i]
+                c_state_i = conv_state[i : i + 1]
+                m_list = m_i.tolist() if hasattr(m_i, "tolist") else list(m_i)
+                valid_idx = [idx for idx, v in enumerate(m_list) if v]
+                n_valid = len(valid_idx)
+                if n_valid == 0:
+                    conv_out_rows.append(mx.zeros((1, S, self.conv_dim), dtype=x.dtype))
+                    new_slot0_rows.append(c_state_i)
+                elif n_valid == S:
+                    c_inp = mx.concatenate([c_state_i, row_qkv[None, ...]], axis=1)
+                    new_slot0_rows.append(mx.contiguous(c_inp[:, -K_minus_1:, :]))
+                    conv_out_rows.append(nn.silu(self.conv1d(c_inp)))
+                else:
+                    valid_qkv = row_qkv[valid_idx][None, ...]
+                    c_inp = mx.concatenate([c_state_i, valid_qkv], axis=1)
+                    new_slot0_rows.append(mx.contiguous(c_inp[:, -K_minus_1:, :]))
+                    v_out = nn.silu(self.conv1d(c_inp))
+                    full_out = mx.zeros((1, S, self.conv_dim), dtype=x.dtype)
+                    full_out[:, valid_idx] = v_out
+                    conv_out_rows.append(full_out)
+            if cache is not None:
+                _set_cache_slot(cache, 0, mx.concatenate(new_slot0_rows, axis=0))
+            conv_out = mx.concatenate(conv_out_rows, axis=0)
 
         q, k, v = mx.split(conv_out, [self.key_dim, 2 * self.key_dim], axis=-1)
         q = q.reshape(B, S, self.n_k, self.dk)
@@ -1367,31 +1403,64 @@ class PLELayer(nn.Module):
         )
 
     def _short_conv(self, x: mx.array, cache: Any, mask: Any = None) -> mx.array:
-        S = x.shape[1]
+        B, S, _ = x.shape
         n = self.short_conv_state_len
         slot = _cache_slot(cache, 2)
         state = (
             slot
             if slot is not None
-            else mx.zeros((x.shape[0], n, x.shape[-1]), dtype=x.dtype)
+            else mx.zeros((B, n, x.shape[-1]), dtype=x.dtype)
         )
-        if mask is not None:
-            x = mx.where(mask[..., None], x, 0)
-        full = mx.concatenate([state, x], axis=1)
-        if cache is not None:
-            new_slot2 = mx.contiguous(full[:, -n:, :])
-            if mask is not None:
-                row_active = (
-                    mask.any(axis=-1, keepdims=True)
-                    if mask.ndim > 1
-                    else mask[:, None]
-                )
+        if mask is None:
+            full = mx.concatenate([state, x], axis=1)
+            if cache is not None:
+                _set_cache_slot(cache, 2, mx.contiguous(full[:, -n:, :]))
+            out = nn.silu(self.conv1d(full[:, -(n + S) :, :]))
+            return out
+        elif S == 1:
+            row_active = (
+                mask.any(axis=-1, keepdims=True)
+                if mask.ndim > 1
+                else mask[:, None]
+            )
+            x_active = mx.where(mask[..., None], x, 0)
+            full = mx.concatenate([state, x_active], axis=1)
+            if cache is not None:
+                new_slot2 = mx.contiguous(full[:, -n:, :])
                 new_slot2 = mx.where(row_active[..., None], new_slot2, state)
-            _set_cache_slot(cache, 2, new_slot2)
-        out = nn.silu(self.conv1d(full[:, -(n + S) :, :]))
-        if mask is not None:
+                _set_cache_slot(cache, 2, new_slot2)
+            out = nn.silu(self.conv1d(full[:, -(n + S) :, :]))
             out = mx.where(mask[..., None], out, 0)
-        return out
+            return out
+        else:
+            out_rows = []
+            new_slot2_rows = []
+            for i in range(B):
+                m_i = mask[i] if mask.ndim > 1 else mask
+                row_x = x[i]
+                s_i = state[i : i + 1]
+                m_list = m_i.tolist() if hasattr(m_i, "tolist") else list(m_i)
+                valid_idx = [idx for idx, v in enumerate(m_list) if v]
+                n_valid = len(valid_idx)
+                if n_valid == 0:
+                    out_rows.append(mx.zeros((1, S, x.shape[-1]), dtype=x.dtype))
+                    new_slot2_rows.append(s_i)
+                elif n_valid == S:
+                    full_i = mx.concatenate([s_i, row_x[None, ...]], axis=1)
+                    new_slot2_rows.append(mx.contiguous(full_i[:, -n:, :]))
+                    out_rows.append(nn.silu(self.conv1d(full_i[:, -(n + S) :, :])))
+                else:
+                    valid_x = row_x[valid_idx][None, ...]
+                    full_i = mx.concatenate([s_i, valid_x], axis=1)
+                    new_slot2_rows.append(mx.contiguous(full_i[:, -n:, :]))
+                    v_out = nn.silu(self.conv1d(full_i[:, -(n + n_valid) :, :]))
+                    full_out = mx.zeros((1, S, x.shape[-1]), dtype=x.dtype)
+                    full_out[:, valid_idx] = v_out
+                    out_rows.append(full_out)
+
+            if cache is not None:
+                _set_cache_slot(cache, 2, mx.concatenate(new_slot2_rows, axis=0))
+            return mx.concatenate(out_rows, axis=0)
 
     def __call__(
         self,
@@ -1867,6 +1936,8 @@ class _AttnCache(KVCache):
     def extend(self, other: Any) -> None:
         if other is None:
             return
+        a_batch = self.keys.shape[0] if self.keys is not None else 1
+        b_batch = other.keys.shape[0] if getattr(other, "keys", None) is not None else 1
         if self.keys is None and getattr(other, "keys", None) is None:
             pass
         elif self.keys is None:
@@ -1878,8 +1949,6 @@ class _AttnCache(KVCache):
             self.values = mx.concatenate([self.values, other.values], axis=0)
         other_lp = getattr(other, "left_padding", None)
         if getattr(self, "left_padding", None) is not None or other_lp is not None:
-            a_batch = self.keys.shape[0] if self.keys is not None else 1
-            b_batch = other.keys.shape[0] if getattr(other, "keys", None) is not None else 1
             a_lp = (
                 self.left_padding
                 if getattr(self, "left_padding", None) is not None
@@ -1897,7 +1966,7 @@ class _AttnCache(KVCache):
                 self.lengths
                 if getattr(self, "lengths", None) is not None
                 else mx.zeros(
-                    (self.keys.shape[0] if self.keys is not None else 1,),
+                    (a_batch,),
                     dtype=mx.int32,
                 )
             )
@@ -1905,7 +1974,7 @@ class _AttnCache(KVCache):
                 other_len
                 if other_len is not None
                 else mx.zeros(
-                    (other.keys.shape[0] if getattr(other, "keys", None) is not None else 1,),
+                    (b_batch,),
                     dtype=mx.int32,
                 )
             )

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1796,6 +1796,13 @@ class _IndexerCache(_BaseCache):
             self._buf = self._buf[batch_indices]
         if self.left_padding is not None:
             self.left_padding = self.left_padding[batch_indices]
+            if getattr(self.left_padding, "size", 0) > 0:
+                min_left_pad = int(self.left_padding.min().item())
+                if min_left_pad > 0:
+                    if self._buf is not None:
+                        self._buf = self._buf[:, min_left_pad:, :]
+                    self._len = max(0, self._len - min_left_pad)
+                    self.left_padding -= min_left_pad
         self.pooled = None
 
     def extend(self, other: Any) -> None:
@@ -1954,6 +1961,22 @@ class _AttnCache(KVCache):
             self.lengths = self.lengths[batch_indices]
         if getattr(self, "_lengths", None) is not None:
             self._lengths = self._lengths[batch_indices]
+
+        if getattr(self, "left_padding", None) is not None and getattr(self.left_padding, "size", 0) > 0:
+            min_left_pad = int(self.left_padding.min().item())
+            if min_left_pad > 0:
+                if self.keys is not None:
+                    self.keys = self.keys[..., min_left_pad:, :]
+                    self.values = self.values[..., min_left_pad:, :]
+                if getattr(self, "offset", None) is not None:
+                    if isinstance(self.offset, mx.array):
+                        self.offset -= min_left_pad
+                    elif isinstance(self.offset, (int, float)):
+                        self.offset = max(0, int(self.offset) - min_left_pad)
+                if hasattr(self, "_idx"):
+                    self._idx = max(0, self._idx - min_left_pad)
+                self.left_padding -= min_left_pad
+
         if (
             hasattr(self, "indexer")
             and self.indexer is not None

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -412,6 +412,7 @@ def _qsa_gather_attention(
     v: mx.array,
     sel: QSASelection,
     scale: float,
+    mask: Optional[Any] = None,
 ) -> mx.array:
     """SDPA over gathered K=budget tokens per query. q/k/v are [B, H, S, D].
 
@@ -426,6 +427,21 @@ def _qsa_gather_attention(
     safe = mx.clip(mx.where(sel.valid, sel.token_idx, 0), 0, max(T - 1, 0))
     k_sel = _gather_kv_tokens(k, safe)  # (B, H_kv, S, K, D)
     v_sel = _gather_kv_tokens(v, safe)
+
+    mask_gathered = None
+    if isinstance(mask, mx.array):
+        m = mask
+        while m.ndim < 4:
+            m = m[None]
+        if m.shape[0] != B and m.shape[0] == 1:
+            m = mx.broadcast_to(m, (B, m.shape[1], m.shape[2], m.shape[3]))
+        if m.shape[2] != S and m.shape[2] == 1:
+            m = mx.broadcast_to(m, (m.shape[0], m.shape[1], S, m.shape[3]))
+        idx = safe[:, None, :, :]
+        if m.shape[1] > 1:
+            idx = mx.broadcast_to(idx, (B, m.shape[1], S, safe.shape[-1]))
+        mask_gathered = mx.take_along_axis(m, idx, axis=-1)
+
     if H != H_kv:
         rep = H // H_kv
         # Reshape q to (B, H_kv, rep, S, 1, D) and broadcast against (B, H_kv, 1, S, D, K)
@@ -434,6 +450,11 @@ def _qsa_gather_attention(
         k_view = k_sel.swapaxes(-1, -2).reshape(B, H_kv, 1, S, D, -1)
         scores = (mx.matmul(q_view, k_view) * scale).squeeze(-2)  # (B, H_kv, rep, S, K)
         scores = scores.reshape(B, H, S, -1)  # (B, H, S, K)
+        if mask_gathered is not None:
+            if mask_gathered.dtype == mx.bool_:
+                scores = mx.where(mask_gathered, scores, _qsa_neg_inf(q.dtype))
+            else:
+                scores = scores + mask_gathered
         scores = mx.where(sel.valid[:, None, :, :], scores, _qsa_neg_inf(q.dtype))
         probs = mx.softmax(scores.astype(mx.float32), axis=-1).astype(q.dtype)
         probs_view = probs.reshape(B, H_kv, rep, S, 1, -1)  # (B, H_kv, rep, S, 1, K)
@@ -442,6 +463,11 @@ def _qsa_gather_attention(
         return out.reshape(B, H, S, D)
     # (B, H, S, 1, D) @ (B, H, S, D, K) -> (B, H, S, 1, K)
     scores = mx.matmul(q[..., None, :], k_sel.swapaxes(-1, -2)).squeeze(-2) * scale
+    if mask_gathered is not None:
+        if mask_gathered.dtype == mx.bool_:
+            scores = mx.where(mask_gathered, scores, _qsa_neg_inf(q.dtype))
+        else:
+            scores = scores + mask_gathered
     scores = mx.where(sel.valid[:, None, :, :], scores, _qsa_neg_inf(q.dtype))
     probs = mx.softmax(scores.astype(mx.float32), axis=-1).astype(q.dtype)
     # (B, H, S, 1, K) @ (B, H, S, K, D) -> (B, H, S, D)
@@ -663,7 +689,7 @@ class Attention(nn.Module):
             return scaled_dot_product_attention(
                 q, k, v, cache=cache, scale=self.scale, mask=mask
             )
-        return _qsa_gather_attention(q, k, v, sel, self.scale)
+        return _qsa_gather_attention(q, k, v, sel, self.scale, mask=mask)
 
     def __call__(
         self,

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -262,6 +262,26 @@ class RotaryEmbedding:
         return mx.cos(emb) * self.mscale, mx.sin(emb) * self.mscale
 
 
+def _cache_slot(cache: Any, idx: int) -> Any:
+    if cache is None:
+        return None
+    try:
+        if hasattr(cache, "__len__") and len(cache) <= idx:
+            return None
+        return cache[idx]
+    except (IndexError, TypeError, KeyError):
+        return None
+
+
+def _set_cache_slot(cache: Any, idx: int, value: Any) -> None:
+    if cache is None:
+        return
+    try:
+        cache[idx] = value
+    except (IndexError, TypeError, KeyError):
+        pass
+
+
 def _l2norm(x: mx.array, eps: float = 1e-6) -> mx.array:
     inv_norm = mx.rsqrt(mx.sum(x * x, axis=-1, keepdims=True) + eps)
     return x * inv_norm
@@ -438,9 +458,10 @@ def _qsa_gather_attention(
             m = mx.broadcast_to(m, (B, m.shape[1], m.shape[2], m.shape[3]))
         if m.shape[2] != S and m.shape[2] == 1:
             m = mx.broadcast_to(m, (m.shape[0], m.shape[1], S, m.shape[3]))
-        idx = safe[:, None, :, :]
+        safe_mask = mx.clip(safe, 0, max(int(m.shape[-1]) - 1, 0))
+        idx = safe_mask[:, None, :, :]
         if m.shape[1] > 1:
-            idx = mx.broadcast_to(idx, (B, m.shape[1], S, safe.shape[-1]))
+            idx = mx.broadcast_to(idx, (B, m.shape[1], S, safe_mask.shape[-1]))
         mask_gathered = mx.take_along_axis(m, idx, axis=-1)
 
     if H != H_kv:
@@ -860,16 +881,19 @@ class GatedDeltaNet(nn.Module):
         z = z.reshape(B, S, self.n_v, self.dv)
         b, a = mx.split(self.in_proj_ba(x), [self.n_v], axis=-1)
 
+        slot0 = _cache_slot(cache, 0) if cache is not None else None
         conv_state = (
-            cache[0]
-            if (cache is not None and cache[0] is not None)
+            slot0
+            if slot0 is not None
             else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=x.dtype)
         )
         if mask is not None:
             mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
         conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
         if cache is not None:
-            cache[0] = mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+            _set_cache_slot(
+                cache, 0, mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+            )
         conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = mx.split(conv_out, [self.key_dim, 2 * self.key_dim], axis=-1)
@@ -880,11 +904,12 @@ class GatedDeltaNet(nn.Module):
         q = mx.fast.rms_norm(q, None, self._l2_eps) * self._inv_scale_sq
         k = mx.fast.rms_norm(k, None, self._l2_eps) * self._inv_scale
 
-        state = cache[1] if cache is not None else None
+        state = _cache_slot(cache, 1) if cache is not None else None
         out, state = self._gated_delta_update(q, k, v, a, b, state, mask)
         if cache is not None:
-            cache[1] = state
-            cache.advance(S)
+            _set_cache_slot(cache, 1, state)
+            if hasattr(cache, "advance"):
+                cache.advance(S)
         return self.out_proj(self.norm(out, z).reshape(B, S, -1))
 
     def _gated_delta_update(
@@ -1228,18 +1253,15 @@ class PLELayer(nn.Module):
     def _short_conv(self, x: mx.array, cache: Any) -> mx.array:
         S = x.shape[1]
         n = self.short_conv_state_len
-        has_cache_slots = cache is not None and (
-            isinstance(cache, (list, tuple, ArraysCache))
-            or (hasattr(cache, "__getitem__") and hasattr(cache, "__setitem__"))
-        )
+        slot = _cache_slot(cache, 2)
         state = (
-            cache[2]
-            if (has_cache_slots and cache[2] is not None)
+            slot
+            if slot is not None
             else mx.zeros((x.shape[0], n, x.shape[-1]), dtype=x.dtype)
         )
         full = mx.concatenate([state, x], axis=1)
-        if has_cache_slots:
-            cache[2] = mx.contiguous(full[:, -n:, :])
+        if cache is not None:
+            _set_cache_slot(cache, 2, mx.contiguous(full[:, -n:, :]))
         return nn.silu(self.conv1d(full[:, -(n + S) :, :]))
 
     def __call__(
@@ -1388,19 +1410,15 @@ class Qwen4ExpModel(nn.Module):
             eos = self.args.eos_token_id
             eos = eos[0] if isinstance(eos, list) else eos
             pc = cache[self.ple_layers[0]] if len(cache) > self.ple_layers[0] else None
-            has_slots = pc is not None and (
-                isinstance(pc, (list, tuple, ArraysCache))
-                or (hasattr(pc, "__getitem__") and hasattr(pc, "__setitem__"))
-            )
-            prev = pc[3] if has_slots else None
+            prev = _cache_slot(pc, 3)
             prev_ctx = (
                 prev
                 if prev is not None
                 else mx.full((ids.shape[0], ctx_len), eos, ids.dtype)
             )
-            if has_slots:
+            if pc is not None:
                 tail = mx.concatenate([prev_ctx, ids], axis=1)[:, -ctx_len:]
-                pc[3] = tail
+                _set_cache_slot(pc, 3, tail)
 
         h = mx.tile(h, (1, 1, self.hc))
         if _compile_enabled() and (

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -116,6 +116,16 @@ class ModelArgs(BaseModelArgs):
     quantization: Any = None
     language_model_only: bool = False
 
+    @classmethod
+    def from_dict(cls, params: dict):
+        tcfg = params.get("text_config")
+        if not tcfg or not isinstance(tcfg, dict):
+            fields = {"model_type", "vision_config", "quantization", "language_model_only"}
+            args = {k: v for k, v in params.items() if k in fields}
+            args["text_config"] = dict(params)
+            return cls(**args)
+        return super().from_dict(params)
+
     def __post_init__(self):
         cfg = dict(self.text_config) if self.text_config else {}
         if not cfg:
@@ -1191,7 +1201,10 @@ class PLELayer(nn.Module):
     def _short_conv(self, x: mx.array, cache: Any) -> mx.array:
         S = x.shape[1]
         n = self.short_conv_state_len
-        has_cache_slots = cache is not None and isinstance(cache, (list, tuple, ArraysCache))
+        has_cache_slots = cache is not None and (
+            isinstance(cache, (list, tuple, ArraysCache))
+            or (hasattr(cache, "__getitem__") and hasattr(cache, "__setitem__"))
+        )
         state = (
             cache[2]
             if (has_cache_slots and cache[2] is not None)
@@ -1330,7 +1343,10 @@ class Qwen4ExpModel(nn.Module):
             eos = self.args.eos_token_id
             eos = eos[0] if isinstance(eos, list) else eos
             pc = cache[self.ple_layers[0]] if len(cache) > self.ple_layers[0] else None
-            has_slots = pc is not None and isinstance(pc, (list, tuple, ArraysCache))
+            has_slots = pc is not None and (
+                isinstance(pc, (list, tuple, ArraysCache))
+                or (hasattr(pc, "__getitem__") and hasattr(pc, "__setitem__"))
+            )
             prev = pc[3] if has_slots else None
             prev_ctx = (
                 prev

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1580,7 +1580,7 @@ def _build_ple_tail_context(
     ctx_len: int,
     eos: int,
     left_padding: Optional[Any] = None,
-    offset: int = 0,
+    offset: Any = 0,
     mask: Optional[Any] = None,
 ) -> mx.array:
     if left_padding is None and mask is None:
@@ -1611,7 +1611,8 @@ def _build_ple_tail_context(
     )
     for i in range(B):
         lp = int(lp_list[i]) if i < len(lp_list) else 0
-        start_idx = max(0, min(S, lp - int(offset)))
+        off_i = int(offset[i].item()) if isinstance(offset, mx.array) else int(offset)
+        start_idx = max(0, min(S, lp - off_i))
         valid_ids = ids[i : i + 1, start_idx:S]
         v_len = int(valid_ids.shape[1])
         if v_len >= ctx_len:
@@ -1724,9 +1725,9 @@ class Qwen4ExpModel(nn.Module):
             if pc is not None:
                 offset = 0
                 if attn_cache is not None and hasattr(attn_cache, "offset"):
-                    offset = int(getattr(attn_cache, "offset", 0))
+                    offset = getattr(attn_cache, "offset", 0)
                 elif linear_cache is not None and hasattr(linear_cache, "offset"):
-                    offset = int(getattr(linear_cache, "offset", 0))
+                    offset = getattr(linear_cache, "offset", 0)
                 tail = _build_ple_tail_context(
                     prev_ctx,
                     ids,
@@ -1897,11 +1898,12 @@ class _IndexerCache(_BaseCache):
 
     def extract(self, idx: int) -> "_IndexerCache":
         cache = _IndexerCache()
-        if self._buf is not None and self._len > 0:
-            k = self._buf[idx : idx + 1, : self._len, :]
+        lp = int(self.left_padding[idx].item()) if self.left_padding is not None else 0
+        end = self._len if self._len > 0 else (self._buf.shape[1] if self._buf is not None else 0)
+        if self._buf is not None and end > lp:
+            k = self._buf[idx : idx + 1, lp:end, :]
             cache.keys = mx.contiguous(k)
-        if self.left_padding is not None:
-            cache.left_padding = self.left_padding[idx : idx + 1]
+        cache.left_padding = None
         return cache
 
     @classmethod
@@ -2192,18 +2194,24 @@ class _AttnCache(KVCache):
 
     def extract(self, idx: int) -> "_AttnCache":
         cache = _AttnCache()
+        lp = int(self.left_padding[idx].item()) if getattr(self, "left_padding", None) is not None else 0
         if self.keys is not None:
-            off = (
-                int(self.offset[idx].item())
-                if isinstance(getattr(self, "offset", None), mx.array)
-                else int(getattr(self, "offset", self.keys.shape[2]))
+            end = (
+                self._idx
+                if (hasattr(self, "_idx") and self._idx is not None and self._idx > 0)
+                else int(self.keys.shape[2])
             )
-            off = min(off, self.keys.shape[2])
-            cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, :off, :])
-            cache.values = mx.contiguous(self.values[idx : idx + 1, :, :off, :])
-            cache.offset = off
-        if getattr(self, "left_padding", None) is not None:
-            cache.left_padding = self.left_padding[idx : idx + 1]
+            end = min(end, self.keys.shape[2])
+            if end > lp:
+                cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, lp:end, :])
+                cache.values = mx.contiguous(self.values[idx : idx + 1, :, lp:end, :])
+                cache.offset = int(cache.keys.shape[2])
+            else:
+                cache.keys = None
+                cache.values = None
+                cache.offset = 0
+            cache._idx = cache.offset
+        cache.left_padding = None
         if getattr(self, "lengths", None) is not None:
             cache.lengths = self.lengths[idx : idx + 1]
         if getattr(self, "_lengths", None) is not None:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -626,7 +626,11 @@ class QSAIndexer(nn.Module):
                     )
                 new_pooled = self.k_layernorm(new_pooled.astype(raw_k.dtype))
                 new_starts = mx.arange(n_cached, n_blocks) * r
-                cos_k, sin_k = rope(new_starts[None, :])
+                if left_padding is not None:
+                    logical_starts = mx.maximum(0, new_starts[None, :] - left_padding[:, None])
+                    cos_k, sin_k = rope(logical_starts)
+                else:
+                    cos_k, sin_k = rope(new_starts[None, :])
                 new_pooled = _rope_partial(new_pooled, cos_k, sin_k)
                 pooled = (
                     new_pooled
@@ -659,7 +663,11 @@ class QSAIndexer(nn.Module):
                 )
             pooled = self.k_layernorm(pooled.astype(raw_k.dtype))
             block_starts = mx.arange(n_blocks) * r
-            cos_k, sin_k = rope(block_starts[None, :])
+            if left_padding is not None:
+                logical_starts = mx.maximum(0, block_starts[None, :] - left_padding[:, None])
+                cos_k, sin_k = rope(logical_starts)
+            else:
+                cos_k, sin_k = rope(block_starts[None, :])
             pooled = _rope_partial(pooled, cos_k, sin_k)
 
         if isinstance(offset, mx.array):

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1403,6 +1403,38 @@ class DecoderLayer(nn.Module):
         return hyper + (x[..., None, :] * inject[..., None]).reshape(*x.shape[:-1], -1)
 
 
+def _build_ple_tail_context(
+    prev_ctx: mx.array,
+    ids: mx.array,
+    ctx_len: int,
+    eos: int,
+    left_padding: Optional[Any] = None,
+) -> mx.array:
+    if left_padding is None:
+        return mx.concatenate([prev_ctx, ids], axis=1)[:, -ctx_len:]
+
+    B, S = ids.shape
+    lp_list = (
+        left_padding.tolist()
+        if hasattr(left_padding, "tolist")
+        else list(left_padding)
+    )
+    rows = []
+    for i in range(B):
+        lp = int(lp_list[i]) if i < len(lp_list) else 0
+        v_len = max(0, S - lp)
+        if v_len >= ctx_len:
+            rows.append(ids[i : i + 1, S - ctx_len : S])
+        elif v_len > 0:
+            needed = ctx_len - v_len
+            prefix = prev_ctx[i : i + 1, -needed:]
+            suffix = ids[i : i + 1, lp:S]
+            rows.append(mx.concatenate([prefix, suffix], axis=1))
+        else:
+            rows.append(prev_ctx[i : i + 1])
+    return mx.concatenate(rows, axis=0)
+
+
 class Qwen4ExpModel(nn.Module):
     def __init__(self, args: TextArgs):
         super().__init__()
@@ -1473,6 +1505,20 @@ class Qwen4ExpModel(nn.Module):
             )
         conv_mask = create_ssm_mask(h, linear_cache)
 
+        left_padding = getattr(linear_cache, "left_padding", None)
+        if left_padding is None:
+            for c in cache:
+                if c is not None:
+                    if getattr(c, "left_padding", None) is not None:
+                        left_padding = c.left_padding
+                        break
+                    if (
+                        hasattr(c, "indexer")
+                        and getattr(c.indexer, "left_padding", None) is not None
+                    ):
+                        left_padding = c.indexer.left_padding
+                        break
+
         prev_ctx = None
         if self.ple_layers and ids is not None:
             ctx_len = self.args.ngram_size - 1
@@ -1486,7 +1532,9 @@ class Qwen4ExpModel(nn.Module):
                 else mx.full((ids.shape[0], ctx_len), eos, ids.dtype)
             )
             if pc is not None:
-                tail = mx.concatenate([prev_ctx, ids], axis=1)[:, -ctx_len:]
+                tail = _build_ple_tail_context(
+                    prev_ctx, ids, ctx_len, eos, left_padding
+                )
                 _set_cache_slot(pc, 3, tail)
 
         h = mx.tile(h, (1, 1, self.hc))
@@ -1706,6 +1754,12 @@ class _AttnCache(KVCache):
         super().__init__()
         self.indexer = _IndexerCache()
         self._mtplx_indexer_trim = True
+
+    def update_and_fetch(self, keys: Any, values: Any) -> tuple[Any, Any]:
+        res = super().update_and_fetch(keys, values)
+        if isinstance(res, tuple) and len(res) >= 2:
+            return res[0], res[1]
+        return res
 
     def trim(self, n: int) -> int:
         trimmed = super().trim(n)
@@ -2133,7 +2187,11 @@ class Model(nn.Module):
             self.lm_head = nn.Linear(
                 args.text.hidden_size, args.text.vocab_size, bias=False
             )
-        self.mtp_weights: Dict[str, Any] = {}
+        self._mtp_weights: Dict[str, Any] = {}
+
+    @property
+    def mtp_weights(self) -> Dict[str, Any]:
+        return getattr(self, "_mtp_weights", {})
 
     def __call__(
         self,
@@ -2186,9 +2244,9 @@ class Model(nn.Module):
 
     def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
         sanitized = sanitize(weights)
-        # Retain MTP tensors accessible via side-channel for MTP lane,
-        # but exclude them from strict trunk loading.
-        self.mtp_weights = {
+        # Retain MTP tensors accessible via private side-channel for MTP lane,
+        # but exclude them from strict trunk loading and module parameter tree.
+        self._mtp_weights = {
             k: v for k, v in sanitized.items() if k.startswith("mtp.")
         }
         return {k: v for k, v in sanitized.items() if not k.startswith("mtp.")}

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1524,6 +1524,107 @@ class _IndexerCache(_BaseCache):
         return self.keys
 
     @property
+    def batch_size(self) -> int:
+        if self._buf is not None:
+            return int(self._buf.shape[0])
+        return 1
+
+    def empty(self) -> bool:
+        return self._buf is None or self._len == 0
+
+    def filter(self, batch_indices: Any) -> None:
+        if self._buf is not None:
+            self._buf = self._buf[batch_indices]
+        self.pooled = None
+
+    def extend(self, other: Any) -> None:
+        if other is None:
+            return
+        self_k = self.keys
+        other_k = getattr(other, "keys", None)
+        if self_k is None and other_k is None:
+            self._buf = None
+            self._len = 0
+            self.pooled = None
+            return
+
+        a_batch = self.batch_size
+        b_batch = getattr(other, "batch_size", 1)
+        L1 = int(self_k.shape[1]) if self_k is not None else 0
+        L2 = int(other_k.shape[1]) if other_k is not None else 0
+        max_L = max(L1, L2)
+        D = (
+            self_k.shape[-1]
+            if self_k is not None
+            else (other_k.shape[-1] if other_k is not None else 128)
+        )
+        dt = (
+            self_k.dtype
+            if self_k is not None
+            else (other_k.dtype if other_k is not None else mx.float32)
+        )
+
+        def pad_right_aligned(k, batch, cur_len):
+            if k is None:
+                return mx.zeros((batch, max_L, D), dtype=dt)
+            if cur_len < max_L:
+                pad = max_L - cur_len
+                return mx.concatenate([mx.zeros((batch, pad, D), dtype=dt), k], axis=1)
+            return k
+
+        a_pad = pad_right_aligned(self_k, a_batch, L1)
+        b_pad = pad_right_aligned(other_k, b_batch, L2)
+        self._buf = mx.concatenate([a_pad, b_pad], axis=0)
+        self._len = max_L
+        self.pooled = None
+
+    def extract(self, idx: int) -> "_IndexerCache":
+        cache = _IndexerCache()
+        if self._buf is not None and self._len > 0:
+            k = self._buf[idx : idx + 1, : self._len, :]
+            cache.keys = mx.contiguous(k)
+        return cache
+
+    @classmethod
+    def merge(cls, caches: list[Any]) -> "_IndexerCache":
+        cache = cls()
+        if not caches or all(
+            c is None
+            or (hasattr(c, "empty") and c.empty())
+            or getattr(c, "_buf", None) is None
+            for c in caches
+        ):
+            return cache
+        keys_list = [getattr(c, "keys", None) for c in caches]
+        lengths = [int(k.shape[1]) if k is not None else 0 for k in keys_list]
+        max_len = max(lengths) if lengths else 0
+        if max_len == 0:
+            return cache
+        B = len(caches)
+        sample = next(k for k in keys_list if k is not None)
+        D = sample.shape[-1]
+        dt = sample.dtype
+        buf = mx.zeros((B, max_len, D), dtype=dt)
+        for i, (l, k) in enumerate(zip(lengths, keys_list)):
+            if k is not None and l > 0:
+                pad = max_len - l
+                buf[i : i + 1, pad:max_len, :] = k
+        cache._buf = buf
+        cache._len = max_len
+        cache.pooled = None
+        return cache
+
+    def trim(self, n: int) -> None:
+        if self._buf is not None and self._len > 0:
+            keep = self._len - int(n)
+            if keep <= 0:
+                self._buf = None
+                self._len = 0
+            else:
+                self._len = keep
+        self.pooled = None
+
+    @property
     def state(self):
         return self.keys
 
@@ -1536,6 +1637,60 @@ class _AttnCache(KVCache):
     def __init__(self):
         super().__init__()
         self.indexer = _IndexerCache()
+
+    def filter(self, batch_indices: Any) -> None:
+        if self.keys is not None:
+            self.keys = self.keys[batch_indices]
+            self.values = self.values[batch_indices]
+        if (
+            hasattr(self, "indexer")
+            and self.indexer is not None
+            and hasattr(self.indexer, "filter")
+        ):
+            self.indexer.filter(batch_indices)
+
+    def extend(self, other: Any) -> None:
+        if other is None:
+            return
+        if self.keys is None and getattr(other, "keys", None) is None:
+            pass
+        elif self.keys is None:
+            self.keys = other.keys
+            self.values = other.values
+            self.offset = getattr(other, "offset", 0)
+        elif getattr(other, "keys", None) is not None:
+            self.keys = mx.concatenate([self.keys, other.keys], axis=0)
+            self.values = mx.concatenate([self.values, other.values], axis=0)
+        if (
+            hasattr(self, "indexer")
+            and self.indexer is not None
+            and hasattr(self.indexer, "extend")
+        ):
+            self.indexer.extend(getattr(other, "indexer", None))
+
+    def extract(self, idx: int) -> "_AttnCache":
+        cache = _AttnCache()
+        if self.keys is not None:
+            cache.keys = mx.contiguous(self.keys[idx : idx + 1])
+            cache.values = mx.contiguous(self.values[idx : idx + 1])
+            cache.offset = cache.keys.shape[2]
+        if (
+            hasattr(self, "indexer")
+            and self.indexer is not None
+            and hasattr(self.indexer, "extract")
+        ):
+            cache.indexer = self.indexer.extract(idx)
+        return cache
+
+    @classmethod
+    def merge(cls, caches: list[Any]):
+        merged = super().merge(caches)
+        indexers = [getattr(c, "indexer", None) for c in caches]
+        merged.indexer = _IndexerCache.merge(indexers)
+        from mtplx.qwen4_exp_mtp_patch import _install_indexer_aware_trim
+
+        _install_indexer_aware_trim(merged)
+        return merged
 
     @property
     def state(self):
@@ -1718,27 +1873,32 @@ def _fuse_proj_pair(
 
 
 def _rewrite_packed_experts(weights: Dict[str, Any]) -> None:
-    """Keep HF packed experts.gate_up_proj as switch_mlp.gate_up_proj (no split)."""
+    """Keep HF packed experts.gate_up_proj and experts.down_proj as switch_mlp.* (no split).
+
+    Remaps all quantization leaves (weight, scales, biases, bias) so prequantized
+    sidecars load fully onto FusedSwitchGLU.
+    """
     for key in list(weights):
-        packed = False
-        if key.endswith(".mlp.experts.gate_up_proj"):
-            dest = (
-                key[: -len("experts.gate_up_proj")] + "switch_mlp.gate_up_proj.weight"
-            )
-            packed = True
-        elif key.endswith(".mlp.experts.gate_up_proj.weight"):
-            dest = key.replace(".mlp.experts.gate_up_proj.weight", ".mlp.switch_mlp.gate_up_proj.weight")
-            packed = True
-        elif key.endswith(".mlp.experts.down_proj"):
-            dest = key[: -len("experts.down_proj")] + "switch_mlp.down_proj.weight"
-            packed = True
-        elif key.endswith(".mlp.experts.down_proj.weight"):
-            dest = key.replace(
-                ".mlp.experts.down_proj.weight", ".mlp.switch_mlp.down_proj.weight"
-            )
-            packed = True
-        if packed:
-            weights[dest] = weights.pop(key)
+        for proj in ("gate_up_proj", "down_proj"):
+            if key.endswith(f".experts.{proj}") or key == f"experts.{proj}":
+                dest = key[: -len(f"experts.{proj}")] + f"switch_mlp.{proj}.weight"
+                weights[dest] = weights.pop(key)
+                break
+            matched = False
+            for leaf in _PROJ_LEAVES:
+                target_suffix = f".experts.{proj}.{leaf}"
+                if key.endswith(target_suffix):
+                    dest = key[: -len(target_suffix)] + f".switch_mlp.{proj}.{leaf}"
+                    weights[dest] = weights.pop(key)
+                    matched = True
+                    break
+                elif key == f"experts.{proj}.{leaf}":
+                    dest = f"switch_mlp.{proj}.{leaf}"
+                    weights[dest] = weights.pop(key)
+                    matched = True
+                    break
+            if matched:
+                break
 
 
 def remap_fused_projections(weights: Dict[str, Any]) -> Dict[str, Any]:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1865,6 +1865,10 @@ class _IndexerCache(_BaseCache):
                 if other_lp is not None
                 else mx.zeros((b_batch,), dtype=mx.int32)
             )
+            if L1 < max_L:
+                a_lp = a_lp + (max_L - L1)
+            if L2 < max_L:
+                b_lp = b_lp + (max_L - L2)
             self.left_padding = mx.concatenate([a_lp, b_lp], axis=0)
         self.pooled = None
 
@@ -1998,17 +2002,91 @@ class _AttnCache(KVCache):
     def extend(self, other: Any) -> None:
         if other is None:
             return
-        a_batch = self.keys.shape[0] if self.keys is not None else 1
-        b_batch = other.keys.shape[0] if getattr(other, "keys", None) is not None else 1
-        if self.keys is None and getattr(other, "keys", None) is None:
-            pass
-        elif self.keys is None:
-            self.keys = other.keys
-            self.values = other.values
-            self.offset = getattr(other, "offset", 0)
-        elif getattr(other, "keys", None) is not None:
-            self.keys = mx.concatenate([self.keys, other.keys], axis=0)
-            self.values = mx.concatenate([self.values, other.values], axis=0)
+        self_k = self.keys
+        self_v = self.values
+        other_k = getattr(other, "keys", None)
+        other_v = getattr(other, "values", None)
+        if self_k is None and other_k is None:
+            return
+
+        a_batch = self_k.shape[0] if self_k is not None else 1
+        b_batch = other_k.shape[0] if other_k is not None else 1
+
+        off1 = (
+            int(self.offset.max().item())
+            if isinstance(getattr(self, "offset", None), mx.array)
+            else int(getattr(self, "offset", 0))
+        )
+        if self_k is not None:
+            L1 = off1 if off1 > 0 else self_k.shape[2]
+            L1 = min(L1, self_k.shape[2])
+            self_k = self_k[..., :L1, :]
+            self_v = self_v[..., :L1, :]
+        else:
+            L1 = 0
+
+        off2 = (
+            int(other.offset.max().item())
+            if isinstance(getattr(other, "offset", None), mx.array)
+            else int(getattr(other, "offset", 0))
+        )
+        if other_k is not None:
+            L2 = off2 if off2 > 0 else other_k.shape[2]
+            L2 = min(L2, other_k.shape[2])
+            other_k = other_k[..., :L2, :]
+            other_v = other_v[..., :L2, :]
+        else:
+            L2 = 0
+
+        max_L = max(L1, L2)
+        if max_L == 0:
+            return
+
+        H = (
+            self_k.shape[1]
+            if self_k is not None
+            else (other_k.shape[1] if other_k is not None else 1)
+        )
+        Dk = (
+            self_k.shape[3]
+            if self_k is not None
+            else (other_k.shape[3] if other_k is not None else 128)
+        )
+        Dv = (
+            self_v.shape[3]
+            if self_v is not None
+            else (other_v.shape[3] if other_v is not None else 128)
+        )
+        dt_k = (
+            self_k.dtype
+            if self_k is not None
+            else (other_k.dtype if other_k is not None else mx.float32)
+        )
+        dt_v = (
+            self_v.dtype
+            if self_v is not None
+            else (other_v.dtype if other_v is not None else mx.float32)
+        )
+
+        def pad_kv(k, v, batch, cur_len):
+            if k is None:
+                return (
+                    mx.zeros((batch, H, max_L, Dk), dtype=dt_k),
+                    mx.zeros((batch, H, max_L, Dv), dtype=dt_v),
+                )
+            if cur_len < max_L:
+                pad = max_L - cur_len
+                k_pad = mx.concatenate([mx.zeros((batch, H, pad, Dk), dtype=dt_k), k], axis=2)
+                v_pad = mx.concatenate([mx.zeros((batch, H, pad, Dv), dtype=dt_v), v], axis=2)
+                return k_pad, v_pad
+            return k, v
+
+        k1_pad, v1_pad = pad_kv(self_k, self_v, a_batch, L1)
+        k2_pad, v2_pad = pad_kv(other_k, other_v, b_batch, L2)
+        self.keys = mx.concatenate([k1_pad, k2_pad], axis=0)
+        self.values = mx.concatenate([v1_pad, v2_pad], axis=0)
+        self.offset = max_L
+
         other_lp = getattr(other, "left_padding", None)
         if getattr(self, "left_padding", None) is not None or other_lp is not None:
             a_lp = (
@@ -2021,24 +2099,23 @@ class _AttnCache(KVCache):
                 if other_lp is not None
                 else mx.zeros((b_batch,), dtype=mx.int32)
             )
+            if L1 < max_L:
+                a_lp = a_lp + (max_L - L1)
+            if L2 < max_L:
+                b_lp = b_lp + (max_L - L2)
             self.left_padding = mx.concatenate([a_lp, b_lp], axis=0)
+
         other_len = getattr(other, "lengths", None)
         if getattr(self, "lengths", None) is not None or other_len is not None:
             a_len = (
                 self.lengths
                 if getattr(self, "lengths", None) is not None
-                else mx.zeros(
-                    (a_batch,),
-                    dtype=mx.int32,
-                )
+                else mx.full((a_batch,), L1, dtype=mx.int32)
             )
             b_len = (
                 other_len
                 if other_len is not None
-                else mx.zeros(
-                    (b_batch,),
-                    dtype=mx.int32,
-                )
+                else mx.full((b_batch,), L2, dtype=mx.int32)
             )
             self.lengths = mx.concatenate([a_len, b_len], axis=0)
         if (
@@ -2047,13 +2124,21 @@ class _AttnCache(KVCache):
             and hasattr(self.indexer, "extend")
         ):
             self.indexer.extend(getattr(other, "indexer", None))
+            if getattr(self, "left_padding", None) is not None:
+                self.indexer.left_padding = self.left_padding
 
     def extract(self, idx: int) -> "_AttnCache":
         cache = _AttnCache()
         if self.keys is not None:
-            cache.keys = mx.contiguous(self.keys[idx : idx + 1])
-            cache.values = mx.contiguous(self.values[idx : idx + 1])
-            cache.offset = cache.keys.shape[2]
+            off = (
+                int(self.offset[idx].item())
+                if isinstance(getattr(self, "offset", None), mx.array)
+                else int(getattr(self, "offset", self.keys.shape[2]))
+            )
+            off = min(off, self.keys.shape[2])
+            cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, :off, :])
+            cache.values = mx.contiguous(self.values[idx : idx + 1, :, :off, :])
+            cache.offset = off
         if getattr(self, "left_padding", None) is not None:
             cache.left_padding = self.left_padding[idx : idx + 1]
         if getattr(self, "lengths", None) is not None:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1823,6 +1823,7 @@ class _AttnCache(KVCache):
     def __init__(self):
         super().__init__()
         self.indexer = _IndexerCache()
+        self.left_padding = None
         self._mtplx_indexer_trim = True
 
     def update_and_fetch(self, keys: Any, values: Any) -> tuple[Any, Any]:
@@ -1846,12 +1847,22 @@ class _AttnCache(KVCache):
         if self.keys is not None:
             self.keys = self.keys[batch_indices]
             self.values = self.values[batch_indices]
+        if getattr(self, "left_padding", None) is not None:
+            self.left_padding = self.left_padding[batch_indices]
+        if getattr(self, "offset", None) is not None and isinstance(self.offset, mx.array):
+            self.offset = self.offset[batch_indices]
+        if getattr(self, "lengths", None) is not None:
+            self.lengths = self.lengths[batch_indices]
+        if getattr(self, "_lengths", None) is not None:
+            self._lengths = self._lengths[batch_indices]
         if (
             hasattr(self, "indexer")
             and self.indexer is not None
             and hasattr(self.indexer, "filter")
         ):
             self.indexer.filter(batch_indices)
+            if getattr(self, "left_padding", None) is not None:
+                self.indexer.left_padding = self.left_padding
 
     def extend(self, other: Any) -> None:
         if other is None:
@@ -1865,6 +1876,40 @@ class _AttnCache(KVCache):
         elif getattr(other, "keys", None) is not None:
             self.keys = mx.concatenate([self.keys, other.keys], axis=0)
             self.values = mx.concatenate([self.values, other.values], axis=0)
+        other_lp = getattr(other, "left_padding", None)
+        if getattr(self, "left_padding", None) is not None or other_lp is not None:
+            a_batch = self.keys.shape[0] if self.keys is not None else 1
+            b_batch = other.keys.shape[0] if getattr(other, "keys", None) is not None else 1
+            a_lp = (
+                self.left_padding
+                if getattr(self, "left_padding", None) is not None
+                else mx.zeros((a_batch,), dtype=mx.int32)
+            )
+            b_lp = (
+                other_lp
+                if other_lp is not None
+                else mx.zeros((b_batch,), dtype=mx.int32)
+            )
+            self.left_padding = mx.concatenate([a_lp, b_lp], axis=0)
+        other_len = getattr(other, "lengths", None)
+        if getattr(self, "lengths", None) is not None or other_len is not None:
+            a_len = (
+                self.lengths
+                if getattr(self, "lengths", None) is not None
+                else mx.zeros(
+                    (self.keys.shape[0] if self.keys is not None else 1,),
+                    dtype=mx.int32,
+                )
+            )
+            b_len = (
+                other_len
+                if other_len is not None
+                else mx.zeros(
+                    (other.keys.shape[0] if getattr(other, "keys", None) is not None else 1,),
+                    dtype=mx.int32,
+                )
+            )
+            self.lengths = mx.concatenate([a_len, b_len], axis=0)
         if (
             hasattr(self, "indexer")
             and self.indexer is not None
@@ -1878,6 +1923,12 @@ class _AttnCache(KVCache):
             cache.keys = mx.contiguous(self.keys[idx : idx + 1])
             cache.values = mx.contiguous(self.values[idx : idx + 1])
             cache.offset = cache.keys.shape[2]
+        if getattr(self, "left_padding", None) is not None:
+            cache.left_padding = self.left_padding[idx : idx + 1]
+        if getattr(self, "lengths", None) is not None:
+            cache.lengths = self.lengths[idx : idx + 1]
+        if getattr(self, "_lengths", None) is not None:
+            cache._lengths = self._lengths[idx : idx + 1]
         if (
             hasattr(self, "indexer")
             and self.indexer is not None
@@ -1886,11 +1937,46 @@ class _AttnCache(KVCache):
             cache.indexer = self.indexer.extract(idx)
         return cache
 
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        if getattr(self, "left_padding", None) is not None:
+            from mlx_lm.models.cache import create_causal_mask
+
+            offset = getattr(self, "_idx", getattr(self, "offset", 0))
+            return create_causal_mask(
+                N,
+                offset=offset,
+                left_padding=self.left_padding,
+                return_array=return_array,
+                **kwargs,
+            )
+        return super().make_mask(N, return_array=return_array, **kwargs)
+
     @classmethod
     def merge(cls, caches: list[Any]):
         merged = super().merge(caches)
         indexers = [getattr(c, "indexer", None) for c in caches]
         merged.indexer = _IndexerCache.merge(indexers)
+        lps = [getattr(c, "left_padding", None) for c in caches]
+        if any(lp is not None for lp in lps):
+            lengths = [
+                getattr(c, "size", lambda: getattr(c, "offset", 0))()
+                for c in caches
+            ]
+            max_length = max(lengths) if lengths else 0
+            lp_list = []
+            for c, l in zip(caches, lengths):
+                pad_offset = max_length - l
+                c_lp = getattr(c, "left_padding", None)
+                if c_lp is not None:
+                    lp_list.append(c_lp + pad_offset)
+                else:
+                    b = (
+                        c.keys.shape[0]
+                        if getattr(c, "keys", None) is not None
+                        else 1
+                    )
+                    lp_list.append(mx.full((b,), pad_offset, dtype=mx.int32))
+            merged.left_padding = mx.concatenate(lp_list, axis=0)
         if getattr(merged, "left_padding", None) is not None:
             merged.indexer.left_padding = merged.left_padding
         from mtplx.qwen4_exp_mtp_patch import _install_indexer_aware_trim

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -690,19 +690,21 @@ class QSAIndexer(nn.Module):
         B, S, _, _ = q.shape
         n_blocks = int(pooled.shape[1])
         r = self.compress_ratio
-        if q_pos.ndim == 2:
-            n_complete = (q_pos + 1) // r
-            is_complete = mx.arange(n_blocks)[None, None, :] < n_complete[:, :, None]
+
+        if left_padding is not None:
+            phys_q_pos = (q_pos[None, :] if q_pos.ndim == 1 else q_pos) + left_padding[:, None]
         else:
-            n_complete = (q_pos + 1) // r
-            is_complete = (mx.arange(n_blocks)[None, :] < n_complete[:, None])[None, :, :]
+            phys_q_pos = mx.broadcast_to(q_pos[None, :] if q_pos.ndim == 1 else q_pos, (B, S))
+
+        n_complete = (phys_q_pos + 1) // r
+        is_complete = mx.arange(n_blocks)[None, None, :] < n_complete[:, :, None]
 
         if left_padding is not None:
             block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
             is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
             valid_block = is_complete & is_not_pad  # (B, S, n_blocks)
         else:
-            valid_block = mx.broadcast_to(is_complete, (B, S, n_blocks))
+            valid_block = is_complete
 
         # Sum_h ReLU(<q_h, k_b>) without materializing the 4-head score tensor.
         acc = None
@@ -726,16 +728,9 @@ class QSAIndexer(nn.Module):
         if left_padding is not None:
             valid_blk = valid_blk & (tok >= left_padding[:, None, None])
 
-        if q_pos.ndim == 2:
-            tail_start = n_complete * r
-            tail = tail_start[:, :, None] + mx.arange(r)
-            tail_valid = (tail <= q_pos[:, :, None]) & (tail < kv_len)
-        else:
-            tail_start = n_complete * r
-            tail = tail_start[:, None] + mx.arange(r)  # (S, r)
-            tail_valid = (tail <= q_pos[:, None]) & (tail < kv_len)
-            tail = mx.broadcast_to(tail[None], (B, S, r))
-            tail_valid = mx.broadcast_to(tail_valid[None], (B, S, r))
+        tail_start = n_complete * r
+        tail = tail_start[:, :, None] + mx.arange(r)
+        tail_valid = (tail <= phys_q_pos[:, :, None]) & (tail < kv_len)
         if left_padding is not None:
             tail_valid = tail_valid & (tail >= left_padding[:, None, None])
 
@@ -2275,11 +2270,29 @@ class _AttnCache(KVCache):
         indexer_keys = getattr(self.indexer, "keys", None)
         if self.keys is None or self.values is None:
             return self.keys, self.values, indexer_keys
-        if self.offset == self.keys.shape[2]:
+        if isinstance(getattr(self, "offset", None), mx.array):
+            active_len = (
+                self._idx
+                if (hasattr(self, "_idx") and self._idx is not None)
+                else int(self.keys.shape[2])
+            )
+            k = (
+                self.keys
+                if active_len >= self.keys.shape[2]
+                else self.keys[..., :active_len, :]
+            )
+            v = (
+                self.values
+                if active_len >= self.values.shape[2]
+                else self.values[..., :active_len, :]
+            )
+            return k, v, self.offset, self.left_padding, indexer_keys
+        off = int(self.offset)
+        if off == self.keys.shape[2]:
             return self.keys, self.values, indexer_keys
         return (
-            self.keys[..., : self.offset, :],
-            self.values[..., : self.offset, :],
+            self.keys[..., :off, :],
+            self.values[..., :off, :],
             indexer_keys,
         )
 
@@ -2288,15 +2301,41 @@ class _AttnCache(KVCache):
         if v is None:
             self.keys = self.values = None
             self.offset = 0
+            self.left_padding = None
+            self._idx = 0
             if hasattr(self, "indexer") and self.indexer is not None:
                 self.indexer.keys = None
                 self.indexer._len = 0
+                self.indexer.left_padding = None
             return
-        if len(v) == 3:
+        if len(v) == 5:
+            keys, values, offset, left_padding, indexer_keys = v
+            self.keys = keys
+            self.values = values
+            self.offset = offset
+            self.left_padding = left_padding
+            self._idx = 0 if self.keys is None else int(self.keys.shape[2])
+            if hasattr(self, "indexer") and self.indexer is not None:
+                self.indexer.keys = indexer_keys
+                self.indexer._len = (
+                    0 if indexer_keys is None else int(indexer_keys.shape[1])
+                )
+                self.indexer.left_padding = left_padding
+        elif len(v) == 4:
+            keys, values, offset, left_padding = v
+            self.keys = keys
+            self.values = values
+            self.offset = offset
+            self.left_padding = left_padding
+            self._idx = 0 if self.keys is None else int(self.keys.shape[2])
+            if hasattr(self, "indexer") and self.indexer is not None:
+                self.indexer.left_padding = left_padding
+        elif len(v) == 3:
             keys, values, indexer_keys = v
             self.keys = keys
             self.values = values
             self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+            self._idx = self.offset
             if hasattr(self, "indexer") and self.indexer is not None:
                 self.indexer.keys = indexer_keys
                 self.indexer._len = (
@@ -2307,6 +2346,7 @@ class _AttnCache(KVCache):
             self.keys = keys
             self.values = values
             self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+            self._idx = self.offset
 
 
 # ---------------------------------------------------------------------------

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -870,8 +870,10 @@ class Attention(nn.Module):
             k, v = cache.update_and_fetch(k, v)
 
         indexer = self.indexer
+        if indexer is None:
+            out = self._core_attend(q, k, v, mask, cache, None)
         # Decode / MTP reuse wrapper: keep the S==1 __call__ contract.
-        if S == 1 or not hasattr(indexer, "prepare"):
+        elif S == 1 or not hasattr(indexer, "prepare"):
             sel = indexer(x, rope, idx_cache, offset)
             if sel is not None and not isinstance(sel, QSASelection) and hasattr(sel, "ndim"):
                 # Dense keep mask from an older wrapper; convert to additive.

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1971,11 +1971,14 @@ class _AttnCache(KVCache):
         super().__init__()
         self.indexer = _IndexerCache()
         self.left_padding = None
+        self._idx = 0
         self._mtplx_indexer_trim = True
 
     def update_and_fetch(self, keys: Any, values: Any) -> tuple[Any, Any]:
         if isinstance(getattr(self, "offset", None), mx.array):
-            prev = int(self.keys.shape[2]) if self.keys is not None else 0
+            if not hasattr(self, "_idx") or self._idx is None or self.keys is None:
+                self._idx = int(self.keys.shape[2]) if self.keys is not None else 0
+            prev = self._idx
             if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
                 B, n_kv_heads, _, k_head_dim = keys.shape
                 v_head_dim = values.shape[3]
@@ -1995,6 +1998,7 @@ class _AttnCache(KVCache):
             new_idx = prev + keys.shape[2]
             self.keys[..., prev:new_idx, :] = keys
             self.values[..., prev:new_idx, :] = values
+            self._idx = new_idx
             self.offset = self.offset + keys.shape[2]
             return self.keys[..., :new_idx, :], self.values[..., :new_idx, :]
         res = super().update_and_fetch(keys, values)
@@ -2005,6 +2009,8 @@ class _AttnCache(KVCache):
     def trim(self, n: int) -> int:
         trimmed = super().trim(n)
         dropped = int(n if trimmed is None else trimmed)
+        if hasattr(self, "_idx") and self._idx is not None:
+            self._idx = max(0, self._idx - dropped)
         if hasattr(self, "indexer") and self.indexer is not None:
             if dropped:
                 self.indexer.trim(dropped)
@@ -2136,6 +2142,7 @@ class _AttnCache(KVCache):
         k2_pad, v2_pad = pad_kv(other_k, other_v, b_batch, L2)
         self.keys = mx.concatenate([k1_pad, k2_pad], axis=0)
         self.values = mx.concatenate([v1_pad, v2_pad], axis=0)
+        self._idx = max_L
         a_off = (
             self.offset.astype(mx.int32).reshape(-1)
             if isinstance(getattr(self, "offset", None), mx.array)
@@ -2234,13 +2241,14 @@ class _AttnCache(KVCache):
         merged = super().merge(caches)
         indexers = [getattr(c, "indexer", None) for c in caches]
         merged.indexer = _IndexerCache.merge(indexers)
+        lengths = [
+            getattr(c, "size", lambda: getattr(c, "offset", 0))()
+            for c in caches
+        ]
+        max_length = max(lengths) if lengths else 0
+        merged._idx = max_length
         lps = [getattr(c, "left_padding", None) for c in caches]
         if any(lp is not None for lp in lps):
-            lengths = [
-                getattr(c, "size", lambda: getattr(c, "offset", 0))()
-                for c in caches
-            ]
-            max_length = max(lengths) if lengths else 0
             lp_list = []
             for c, l in zip(caches, lengths):
                 pad_offset = max_length - l

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -586,89 +586,48 @@ class QSAIndexer(nn.Module):
         if kv_len <= self.token_budget:
             return None
 
-        n_blocks = kv_len // self.compress_ratio
-        if n_blocks <= 0:
-            return None
-
         r = self.compress_ratio
         left_padding = getattr(cache, "left_padding", None)
         if left_padding is None and hasattr(cache, "indexer"):
             left_padding = getattr(cache.indexer, "left_padding", None)
 
-        if cache is not None:
-            cached_pooled = getattr(cache, "pooled", None)
-            n_cached = int(cached_pooled.shape[1]) if cached_pooled is not None else 0
-            if n_cached > n_blocks:
-                cached_pooled = cached_pooled[:, :n_blocks, :] if n_blocks > 0 else None
-                n_cached = n_blocks if n_blocks > 0 else 0
-
-            if n_cached < n_blocks:
-                new_raw_k = raw_k[:, n_cached * r : n_blocks * r, :]
-                n_new = n_blocks - n_cached
-                if left_padding is not None:
-                    tok_pos = mx.arange(n_cached * r, n_blocks * r)
-                    is_valid = tok_pos[None, :] >= left_padding[:, None]
-                    new_raw_k = mx.where(is_valid[..., None], new_raw_k, 0.0)
-                    valid_counts = mx.maximum(
-                        is_valid.reshape(B, n_new, r).sum(axis=-1, keepdims=True), 1
-                    )
-                    new_pooled = (
-                        new_raw_k.reshape(B, n_new, r, self.head_dim)
-                        .astype(mx.float32)
-                        .sum(axis=2)
-                        / valid_counts
-                    )
-                else:
-                    new_pooled = (
-                        new_raw_k.reshape(B, n_new, r, self.head_dim)
-                        .astype(mx.float32)
-                        .mean(axis=2)
-                    )
-                new_pooled = self.k_layernorm(new_pooled.astype(raw_k.dtype))
-                new_starts = mx.arange(n_cached, n_blocks) * r
-                if left_padding is not None:
-                    logical_starts = mx.maximum(0, new_starts[None, :] - left_padding[:, None])
-                    cos_k, sin_k = rope(logical_starts)
-                else:
-                    cos_k, sin_k = rope(new_starts[None, :])
-                new_pooled = _rope_partial(new_pooled, cos_k, sin_k)
-                pooled = (
-                    new_pooled
-                    if cached_pooled is None or n_cached == 0
-                    else mx.concatenate([cached_pooled, new_pooled], axis=1)
-                )
-                cache.pooled = pooled
-            else:
-                pooled = cached_pooled
-        else:
-            pooled_raw = raw_k[:, : n_blocks * r]
-            if left_padding is not None:
-                tok_pos = mx.arange(n_blocks * r)
-                is_valid = tok_pos[None, :] >= left_padding[:, None]
-                pooled_raw = mx.where(is_valid[..., None], pooled_raw, 0.0)
-                valid_counts = mx.maximum(
-                    is_valid.reshape(B, n_blocks, r).sum(axis=-1, keepdims=True), 1
-                )
-                pooled = (
-                    pooled_raw.reshape(B, n_blocks, r, self.head_dim)
-                    .astype(mx.float32)
-                    .sum(axis=2)
-                    / valid_counts
-                )
-            else:
-                pooled = (
-                    pooled_raw.reshape(B, n_blocks, r, self.head_dim)
-                    .astype(mx.float32)
-                    .mean(axis=2)
-                )
-            pooled = self.k_layernorm(pooled.astype(raw_k.dtype))
-            block_starts = mx.arange(n_blocks) * r
-            if left_padding is not None:
-                logical_starts = mx.maximum(0, block_starts[None, :] - left_padding[:, None])
-                cos_k, sin_k = rope(logical_starts)
-            else:
-                cos_k, sin_k = rope(block_starts[None, :])
+        if left_padding is None or (hasattr(left_padding, "tolist") and all(lp == 0 for lp in left_padding.tolist())):
+            max_n_blocks = kv_len // r
+            if max_n_blocks <= 0:
+                return None
+            pooled_raw = raw_k[:, : max_n_blocks * r].reshape(B, max_n_blocks, r, self.head_dim).mean(axis=2)
+            pooled = self.k_layernorm(pooled_raw.astype(raw_k.dtype))
+            cos_k, sin_k = rope(mx.arange(max_n_blocks)[None, :] * r)
             pooled = _rope_partial(pooled, cos_k, sin_k)
+        else:
+            lp_list = left_padding.tolist() if hasattr(left_padding, "tolist") else list(left_padding)
+            n_blocks_list = [max(0, (kv_len - int(lp)) // r) for lp in lp_list]
+            max_n_blocks = max(n_blocks_list) if n_blocks_list else 0
+            if max_n_blocks <= 0:
+                return None
+            rows_p = []
+            for i, (lp, nb) in enumerate(zip(lp_list, n_blocks_list)):
+                lp_i = int(lp)
+                if nb > 0:
+                    row_k = raw_k[i : i + 1, lp_i : lp_i + nb * r, :]
+                    row_raw = row_k.reshape(1, nb, r, self.head_dim).mean(axis=2)
+                    row_p = self.k_layernorm(row_raw.astype(raw_k.dtype))
+                    starts = mx.arange(nb)[None, :] * r
+                    cos_k, sin_k = rope(starts)
+                    row_p = _rope_partial(row_p, cos_k, sin_k)
+                    if nb < max_n_blocks:
+                        pad = max_n_blocks - nb
+                        row_p = mx.concatenate(
+                            [row_p, mx.zeros((1, pad, self.head_dim), dtype=row_p.dtype)],
+                            axis=1,
+                        )
+                else:
+                    row_p = mx.zeros((1, max_n_blocks, self.head_dim), dtype=raw_k.dtype)
+                rows_p.append(row_p)
+            pooled = mx.concatenate(rows_p, axis=0) if len(rows_p) > 1 else rows_p[0]
+
+        if cache is not None:
+            cache.pooled = pooled
 
         if isinstance(offset, mx.array):
             off_arr = offset.reshape(-1)
@@ -696,47 +655,65 @@ class QSAIndexer(nn.Module):
     ) -> QSASelection:
         """Score this query slice against every compressed block; return token idx."""
         B, S, _, _ = q.shape
-        n_blocks = int(pooled.shape[1])
+        max_n_blocks = int(pooled.shape[1])
         r = self.compress_ratio
 
-        if left_padding is not None:
-            phys_q_pos = (q_pos[None, :] if q_pos.ndim == 1 else q_pos) + left_padding[:, None]
-        else:
-            phys_q_pos = mx.broadcast_to(q_pos[None, :] if q_pos.ndim == 1 else q_pos, (B, S))
+        q_pos_2d = q_pos if q_pos.ndim == 2 else q_pos[None, :]
+        if q_pos_2d.shape[0] != B:
+            q_pos_2d = mx.broadcast_to(q_pos_2d, (B, S))
 
-        n_complete = (phys_q_pos + 1) // r
-        is_complete = mx.arange(n_blocks)[None, None, :] < n_complete[:, :, None]
+        n_complete = (q_pos_2d + 1) // r
 
         if left_padding is not None:
-            block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
-            is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
-            valid_block = is_complete & is_not_pad  # (B, S, n_blocks)
+            lp_list = (
+                left_padding.tolist()
+                if hasattr(left_padding, "tolist")
+                else list(left_padding)
+            )
+            n_blocks_per_row = mx.array(
+                [max(0, (kv_len - int(lp)) // r) for lp in lp_list], dtype=mx.int32
+            )
+            valid_block = (
+                (mx.arange(max_n_blocks)[None, None, :] < n_complete[:, :, None])
+                & (mx.arange(max_n_blocks)[None, None, :] < n_blocks_per_row[:, None, None])
+            )
         else:
-            valid_block = is_complete
+            valid_block = mx.arange(max_n_blocks)[None, None, :] < n_complete[:, :, None]
 
         # Sum_h ReLU(<q_h, k_b>) without materializing the 4-head score tensor.
         acc = None
-        pooled_t = pooled.astype(mx.float32).swapaxes(-1, -2)  # (B, D, n_blocks)
+        pooled_t = pooled.astype(mx.float32).swapaxes(-1, -2)  # (B, D, max_n_blocks)
         for h in range(self.n_heads):
-            s_h = q[:, :, h].astype(mx.float32) @ pooled_t  # (B, S, n_blocks)
+            s_h = q[:, :, h].astype(mx.float32) @ pooled_t  # (B, S, max_n_blocks)
             s_h = mx.maximum(s_h, 0)
             acc = s_h if acc is None else acc + s_h
         scores = acc / math.sqrt(self.head_dim)
         masked = mx.where(valid_block, scores, -mx.inf)
 
-        k_blk = min(self.block_topk, n_blocks)
+        k_blk = min(self.block_topk, max_n_blocks)
         top = mx.argpartition(-masked, k_blk - 1, axis=-1)[..., :k_blk]
         is_top_complete = mx.take_along_axis(valid_block, top, axis=-1)
         top = mx.where(is_top_complete, top, 0)
 
-        tok = (top[..., None] * r + mx.arange(r)).reshape(B, S, k_blk * r)
+        if left_padding is not None:
+            lp_arr = left_padding.reshape(B, 1, 1, 1)
+            tok = (lp_arr + top[..., None] * r + mx.arange(r)).reshape(B, S, k_blk * r)
+        else:
+            tok = (top[..., None] * r + mx.arange(r)).reshape(B, S, k_blk * r)
+
         valid_blk = mx.broadcast_to(
             is_top_complete[..., None], (*is_top_complete.shape, r)
         ).reshape(B, S, k_blk * r) & (tok < kv_len)
         if left_padding is not None:
             valid_blk = valid_blk & (tok >= left_padding[:, None, None])
 
-        tail_start = n_complete * r
+        if left_padding is not None:
+            tail_start = left_padding[:, None] + n_complete * r
+            phys_q_pos = left_padding[:, None] + q_pos_2d
+        else:
+            tail_start = n_complete * r
+            phys_q_pos = q_pos_2d
+
         tail = tail_start[:, :, None] + mx.arange(r)
         tail_valid = (tail <= phys_q_pos[:, :, None]) & (tail < kv_len)
         if left_padding is not None:
@@ -2043,11 +2020,6 @@ class _AttnCache(KVCache):
                 if self.keys is not None:
                     self.keys = self.keys[..., min_left_pad:, :]
                     self.values = self.values[..., min_left_pad:, :]
-                if getattr(self, "offset", None) is not None:
-                    if isinstance(self.offset, mx.array):
-                        self.offset -= min_left_pad
-                    elif isinstance(self.offset, (int, float)):
-                        self.offset = max(0, int(self.offset) - min_left_pad)
                 if hasattr(self, "_idx"):
                     self._idx = max(0, self._idx - min_left_pad)
                 self.left_padding -= min_left_pad

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -662,8 +662,12 @@ class QSAIndexer(nn.Module):
             cos_k, sin_k = rope(block_starts[None, :])
             pooled = _rope_partial(pooled, cos_k, sin_k)
 
-        q_pos = mx.arange(offset, offset + S)
-        cos_q, sin_q = rope(q_pos[None, :])
+        if isinstance(offset, mx.array):
+            off_arr = offset.reshape(-1)
+            q_pos = off_arr[:, None] + mx.arange(S)[None, :]
+        else:
+            q_pos = mx.arange(offset, offset + S)
+        cos_q, sin_q = rope(q_pos if q_pos.ndim == 2 else q_pos[None, :])
         q = self.q_layernorm(q)
         q = _rope_partial(q, cos_q[:, :, None, :], sin_q[:, :, None, :])
         return QSAPrep(
@@ -686,15 +690,19 @@ class QSAIndexer(nn.Module):
         B, S, _, _ = q.shape
         n_blocks = int(pooled.shape[1])
         r = self.compress_ratio
-        n_complete = (q_pos + 1) // r
-        is_complete = mx.arange(n_blocks)[None, :] < n_complete[:, None]  # (S, n_blocks)
+        if q_pos.ndim == 2:
+            n_complete = (q_pos + 1) // r
+            is_complete = mx.arange(n_blocks)[None, None, :] < n_complete[:, :, None]
+        else:
+            n_complete = (q_pos + 1) // r
+            is_complete = (mx.arange(n_blocks)[None, :] < n_complete[:, None])[None, :, :]
 
         if left_padding is not None:
             block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
             is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
-            valid_block = is_complete[None, :, :] & is_not_pad  # (B, S, n_blocks)
+            valid_block = is_complete & is_not_pad  # (B, S, n_blocks)
         else:
-            valid_block = mx.broadcast_to(is_complete[None, :, :], (B, S, n_blocks))
+            valid_block = mx.broadcast_to(is_complete, (B, S, n_blocks))
 
         # Sum_h ReLU(<q_h, k_b>) without materializing the 4-head score tensor.
         acc = None
@@ -718,11 +726,16 @@ class QSAIndexer(nn.Module):
         if left_padding is not None:
             valid_blk = valid_blk & (tok >= left_padding[:, None, None])
 
-        tail_start = n_complete * r
-        tail = tail_start[:, None] + mx.arange(r)  # (S, r)
-        tail_valid = (tail <= q_pos[:, None]) & (tail < kv_len)
-        tail = mx.broadcast_to(tail[None], (B, S, r))
-        tail_valid = mx.broadcast_to(tail_valid[None], (B, S, r))
+        if q_pos.ndim == 2:
+            tail_start = n_complete * r
+            tail = tail_start[:, :, None] + mx.arange(r)
+            tail_valid = (tail <= q_pos[:, :, None]) & (tail < kv_len)
+        else:
+            tail_start = n_complete * r
+            tail = tail_start[:, None] + mx.arange(r)  # (S, r)
+            tail_valid = (tail <= q_pos[:, None]) & (tail < kv_len)
+            tail = mx.broadcast_to(tail[None], (B, S, r))
+            tail_valid = mx.broadcast_to(tail_valid[None], (B, S, r))
         if left_padding is not None:
             tail_valid = tail_valid & (tail >= left_padding[:, None, None])
 
@@ -838,7 +851,8 @@ class Attention(nn.Module):
         # mx.fast.rope has no amplitude scale; yarn (mscale != 1) takes the
         # cos/sin path where mscale is folded into the rotation.
         if (
-            freqs is not None
+            isinstance(offset, int)
+            and freqs is not None
             and dims is not None
             and float(getattr(rope, "mscale", 1.0) or 1.0) == 1.0
         ):
@@ -862,8 +876,14 @@ class Attention(nn.Module):
                 freqs=freqs,
             )
         else:
-            cos, sin = rope(mx.arange(offset, offset + S)[None])
-            cos, sin = cos[:, None], sin[:, None]
+            shift = int(getattr(rope, "position_shift", 0) or 0)
+            if isinstance(offset, mx.array):
+                off_arr = offset.reshape(-1) + shift
+                pos = off_arr[:, None] + mx.arange(S)[None, :]
+            else:
+                pos = mx.arange(offset + shift, offset + shift + S)[None, :]
+            cos, sin = rope(pos)
+            cos, sin = cos[:, None, :, :], sin[:, None, :, :]
             q, k = _rope_partial(q, cos, sin), _rope_partial(k, cos, sin)
 
         if cache is not None:
@@ -1946,6 +1966,29 @@ class _AttnCache(KVCache):
         self._mtplx_indexer_trim = True
 
     def update_and_fetch(self, keys: Any, values: Any) -> tuple[Any, Any]:
+        if isinstance(getattr(self, "offset", None), mx.array):
+            prev = int(self.keys.shape[2]) if self.keys is not None else 0
+            if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
+                B, n_kv_heads, _, k_head_dim = keys.shape
+                v_head_dim = values.shape[3]
+                n_steps = (self.step + keys.shape[2] - 1) // self.step
+                k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
+                v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+                new_k = mx.zeros(k_shape, keys.dtype)
+                new_v = mx.zeros(v_shape, values.dtype)
+                if self.keys is not None:
+                    if prev % self.step != 0:
+                        self.keys = self.keys[..., :prev, :]
+                        self.values = self.values[..., :prev, :]
+                    self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                    self.values = mx.concatenate([self.values, new_v], axis=2)
+                else:
+                    self.keys, self.values = new_k, new_v
+            new_idx = prev + keys.shape[2]
+            self.keys[..., prev:new_idx, :] = keys
+            self.values[..., prev:new_idx, :] = values
+            self.offset = self.offset + keys.shape[2]
+            return self.keys[..., :new_idx, :], self.values[..., :new_idx, :]
         res = super().update_and_fetch(keys, values)
         if isinstance(res, tuple) and len(res) >= 2:
             return res[0], res[1]
@@ -2085,7 +2128,17 @@ class _AttnCache(KVCache):
         k2_pad, v2_pad = pad_kv(other_k, other_v, b_batch, L2)
         self.keys = mx.concatenate([k1_pad, k2_pad], axis=0)
         self.values = mx.concatenate([v1_pad, v2_pad], axis=0)
-        self.offset = max_L
+        a_off = (
+            self.offset.astype(mx.int32).reshape(-1)
+            if isinstance(getattr(self, "offset", None), mx.array)
+            else mx.full((a_batch,), int(getattr(self, "offset", L1)), dtype=mx.int32)
+        )
+        b_off = (
+            other.offset.astype(mx.int32).reshape(-1)
+            if isinstance(getattr(other, "offset", None), mx.array)
+            else mx.full((b_batch,), int(getattr(other, "offset", L2)), dtype=mx.int32)
+        )
+        self.offset = mx.concatenate([a_off, b_off], axis=0)
 
         other_lp = getattr(other, "left_padding", None)
         if getattr(self, "left_padding", None) is not None or other_lp is not None:
@@ -2614,6 +2667,9 @@ class Model(nn.Module):
     @property
     def mtp_weights(self) -> Dict[str, Any]:
         return getattr(self, "_mtp_weights", {})
+
+    def clear_mtp_weights(self) -> None:
+        self._mtp_weights = {}
 
     def __call__(
         self,

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1,0 +1,1775 @@
+# Copyright © 2024 Apple Inc. / MTPLX authors
+# Native MLX port of Qwen3.8-Flash-Next (architecture: qwen4_exp / qwen4_exp_text).
+# Day-0 support for:
+#   - GatedDeltaNet (hybrid linear-attention with split QKV/Z/A/B projections & 1D conv)
+#   - QSA (Query-Selected Attention / Sparse Attention with QSAIndexer)
+#   - GatedResidual (Hyper-Connections with low-rank MLP mixing & injection weights)
+#   - PLELayer (Per-Layer Embedding: sharded n-gram hash table with short conv)
+#   - Fine-grained MoE (SwitchGLU routed experts + gated shared expert)
+
+from __future__ import annotations
+
+import gc
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import ArraysCache, KVCache, _BaseCache
+from mlx_lm.models.gated_delta import compute_g, gated_delta_update
+from mlx_lm.models.switch_layers import (
+    SwitchGLU,
+    SwitchLinear,
+    SwiGLU,
+    _gather_sort,
+    _scatter_unsort,
+)
+
+from ..kernels.gdn_blocked_prefill import (
+    blocked_prefill_eligible,
+    blocked_prefill_ineligibility_reason,
+    gated_delta_blocked_prefill,
+)
+
+
+def _compile_enabled() -> bool:
+    return (
+        str(os.environ.get("MTPLX_QWEN4EXP_COMPILE", "")).strip().lower()
+        in {"1", "true", "yes", "on"}
+        or str(os.environ.get("MTPLX_COMPILE_AR_FORWARD", "")).strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextArgs(BaseModelArgs):
+    model_type: str = "qwen4_exp_text"
+    hidden_size: int = 2560
+    num_hidden_layers: int = 48
+    num_attention_heads: int = 24
+    num_key_value_heads: int = 2
+    head_dim: int = 256
+    vocab_size: int = 248320
+    rms_norm_eps: float = 1e-6
+    layer_types: list = field(default_factory=list)
+    full_attention_interval: int = 4
+    # MoE
+    num_experts: int = 512
+    num_experts_per_tok: int = 10
+    moe_intermediate_size: int = 640
+    shared_expert_intermediate_size: int = 640
+    # Gated DeltaNet
+    linear_num_key_heads: int = 16
+    linear_num_value_heads: int = 48
+    linear_key_head_dim: int = 128
+    linear_value_head_dim: int = 128
+    linear_conv_kernel_dim: int = 4
+    output_gate_type: str = "sigmoid"
+    # Hyper-Connections (residual)
+    hc_count: int = 4
+    hc_lowrank: int = 320
+    # QSA
+    indexer_n_heads: int = 4
+    indexer_kv_heads: int = 1
+    indexer_head_dim: int = 128
+    indexer_budget: int = 2048
+    indexer_compress_ratio: int = 4
+    # N-gram / PLE
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    split_ngram_parts: int = 128
+    ple_embed_dim: int = 2560
+    ple_layer_ids: list = field(default_factory=lambda: [2])
+    ple_conv_kernel_size: int = 4
+    seed: int = 0
+    eos_token_id: Any = 248044
+    partial_rotary_factor: float = 0.25
+    rope_parameters: dict = field(default_factory=dict)
+    rope_theta: float = 10_000_000.0
+    tie_word_embeddings: bool = False
+    max_position_embeddings: int = 262144
+    # Multi-Token Prediction (MTP) metadata
+    mtp_num_hidden_layers: int = 0
+    mtp: dict = field(default_factory=dict)
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "qwen4_exp"
+    text_config: dict = field(default_factory=dict)
+    vision_config: dict = field(default_factory=dict)
+    quantization: Any = None
+    language_model_only: bool = False
+
+    def __post_init__(self):
+        cfg = dict(self.text_config) if self.text_config else {}
+        if not cfg:
+            # Fallback if flat dictionary was passed
+            cfg = {
+                k: getattr(self, k)
+                for k in dir(self)
+                if not k.startswith("_")
+                and k not in ("text_config", "vision_config", "text", "from_dict")
+            }
+        self.text = TextArgs.from_dict(cfg)
+        rp = self.text.rope_parameters or {}
+        self.text.rope_theta = float(rp.get("rope_theta", self.text.rope_theta))
+        self.text.partial_rotary_factor = float(
+            rp.get("partial_rotary_factor", self.text.partial_rotary_factor)
+        )
+        if not self.text.layer_types:
+            n, k = self.text.num_hidden_layers, self.text.full_attention_interval
+            self.text.layer_types = [
+                "full_attention" if (i + 1) % k == 0 else "linear_attention"
+                for i in range(n)
+            ]
+
+
+# ---------------------------------------------------------------------------
+# Normalization layers
+# ---------------------------------------------------------------------------
+
+
+class RMSNorm(nn.Module):
+    """RMSNorm, normalized per group when group_size is given.
+
+    Hyper-connections normalize each of the hc_count streams separately, hence the
+    reshape: one weight of size hc_count*hidden, but one statistic per stream.
+    """
+
+    def __init__(self, dim: int, group_size: Optional[int] = None, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.ones(dim)
+        self.eps = eps
+        self.group_size = group_size
+        if group_size is not None and dim % group_size:
+            raise ValueError(f"dim {dim} not divisible by group_size {group_size}")
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.group_size is None:
+            return mx.fast.rms_norm(x, self.weight, self.eps)
+        shape = x.shape
+        x = x.reshape(*shape[:-1], -1, self.group_size)
+        x = mx.fast.rms_norm(x, None, self.eps).reshape(shape)
+        return x * self.weight
+
+
+class RMSNormGated(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6, activation: str = "sigmoid"):
+        super().__init__()
+        self.weight = mx.ones(dim)
+        self.eps = eps
+        self.activation = activation
+
+    def __call__(self, x: mx.array, gate: Optional[mx.array] = None) -> mx.array:
+        out = mx.fast.rms_norm(x, self.weight, self.eps)
+        if gate is None:
+            return out.astype(x.dtype)
+        act = mx.sigmoid if self.activation == "sigmoid" else nn.silu
+        g = act(gate.astype(mx.float32))
+        return (g * out.astype(mx.float32)).astype(x.dtype)
+
+
+# ---------------------------------------------------------------------------
+# RoPE / Rotary embeddings
+# ---------------------------------------------------------------------------
+
+
+def _rope_partial(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    """Apply rope to the first `rotary_dim` dimensions only."""
+    d = cos.shape[-1]
+    cos, sin = cos.astype(x.dtype), sin.astype(x.dtype)
+    xr, xp = x[..., :d], x[..., d:]
+    half = d // 2
+    x1, x2 = xr[..., :half], xr[..., half:]
+    rot = mx.concatenate([-x2, x1], axis=-1)
+    xr = xr * cos + rot * sin
+    return mx.concatenate([xr, xp], axis=-1) if xp.shape[-1] else xr
+
+
+class RotaryEmbedding:
+    def __init__(self, dim: int, base: float, rope_parameters: Optional[dict] = None):
+        self.dim = dim
+        self.mscale = 1.0
+        inv_freq = base ** (-mx.arange(0, dim, 2, dtype=mx.float32) / dim)
+        rp = rope_parameters or {}
+        if str(rp.get("rope_type", "default")).lower() == "yarn":
+            # Canonical yarn (mirrors mlx-lm rope_utils.YarnRoPE): blend
+            # interpolated and extrapolated periods across a correction range,
+            # and scale rotation amplitude by mscale.
+            factor = float(rp.get("factor", 1.0))
+            orig = float(rp.get("original_max_position_embeddings", 262144))
+            beta_fast = float(rp.get("beta_fast", 32))
+            beta_slow = float(rp.get("beta_slow", 1))
+
+            def _corr_dim(num_rotations: float) -> float:
+                return (
+                    dim * math.log(orig / (num_rotations * 2 * math.pi))
+                ) / (2 * math.log(base))
+
+            low = max(math.floor(_corr_dim(beta_fast)), 0)
+            high = min(math.ceil(_corr_dim(beta_slow)), dim - 1)
+            if low == high:
+                high += 0.001
+            ramp = mx.clip(
+                (mx.arange(dim // 2, dtype=mx.float32) - low) / (high - low), 0, 1
+            )
+            freq_mask = 1.0 - ramp
+            freq_extra = base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim)
+            freq_inter = factor * freq_extra
+            periods = (freq_inter * freq_extra) / (
+                freq_inter * freq_mask + freq_extra * (1.0 - freq_mask)
+            )
+            inv_freq = 1.0 / periods
+            if factor > 1:
+                self.mscale = 0.1 * math.log(factor) + 1.0
+        self.inv_freq = inv_freq
+        # mx.fast.rope(freqs=) uses theta = pos / freqs, so this is 1/inv_freq.
+        # Yarn (or any other) variants that rewrite inv_freq stay correct.
+        self.freqs = 1.0 / self.inv_freq
+
+    def __call__(self, positions: mx.array):
+        # positions: (B, T) -> cos/sin (B, T, dim); mscale folds the yarn
+        # amplitude into the rotation (passthrough dims stay unscaled).
+        freqs = positions.astype(mx.float32)[..., None] * self.inv_freq
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        return mx.cos(emb) * self.mscale, mx.sin(emb) * self.mscale
+
+
+def _l2norm(x: mx.array, eps: float = 1e-6) -> mx.array:
+    inv_norm = mx.rsqrt(mx.sum(x * x, axis=-1, keepdims=True) + eps)
+    return x * inv_norm
+
+
+def _blocked_prefill_force_stock() -> bool:
+    return str(os.environ.get("MTPLX_GDN_BLOCKED_PREFILL_FORCE_STOCK", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+_BLOCKED_PREFILL_LOGGED = False
+_BLOCKED_PREFILL_FALLBACK_LOGGED = False
+
+
+def _log_blocked_prefill_once(q: mx.array) -> None:
+    global _BLOCKED_PREFILL_LOGGED
+    if _BLOCKED_PREFILL_LOGGED:
+        return
+    _BLOCKED_PREFILL_LOGGED = True
+    try:
+        print(
+            "[qwen4_exp] gdn-blocked-prefill routed "
+            f"T={q.shape[1]} q={tuple(q.shape)} dtype={q.dtype}",
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+def _log_blocked_prefill_fallback_once(reason: str) -> None:
+    global _BLOCKED_PREFILL_FALLBACK_LOGGED
+    if _BLOCKED_PREFILL_FALLBACK_LOGGED:
+        return
+    _BLOCKED_PREFILL_FALLBACK_LOGGED = True
+    try:
+        print(
+            "[qwen4_exp] gdn-blocked-prefill fallback to step path: "
+            f"{reason}",
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# QSA (Query-Selected Attention)
+# ---------------------------------------------------------------------------
+#
+# Spec (tech report pp. 6-9): token budget K=2048, compression r=4, top-512
+# complete micro-blocks per query, plus the per-query incomplete tail. Core
+# attention must run on that gathered set — never on a dense [S, kv_len]
+# score/mask. The mlx-lm PR #1788 port (and this file, previously) converted
+# the selection into a boolean keep of shape (B, 1, S, kv_len) and fed it to
+# dense SDPA: at S=kv_len=131072 that is a 68 GiB fp16 [T,T] tensor, and even
+# under 2048-token generation chunking each chunk still attended the FULL
+# growing KV (O(T^2 / chunk) total). Gather + query-chunked indexer scoring
+# is the product path; MTPLX_QSA_DENSE_MASK=1 restores the old mask path for
+# A/B micro-benches.
+
+
+def _qsa_dense_mask_enabled() -> bool:
+    return str(os.environ.get("MTPLX_QSA_DENSE_MASK", "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _qsa_query_chunk() -> int:
+    raw = os.environ.get("MTPLX_QSA_QUERY_CHUNK", "2048").strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 2048
+
+
+def _qsa_neg_inf(dtype) -> mx.array:
+    if hasattr(mx, "finfo"):
+        try:
+            return mx.array(mx.finfo(dtype).min, dtype=dtype)
+        except Exception:
+            pass
+    return mx.array(-1e4 if dtype in (mx.float16, mx.bfloat16) else -1e9, dtype=dtype)
+
+
+def _indexer_score_chunk(n_blocks: int, default: int) -> int:
+    """Keep the (S, n_blocks) score tile under ~128 MiB float32."""
+    cap = max(1, (128 * 1024 * 1024) // max(int(n_blocks) * 4, 1))
+    return max(1, min(int(default), cap))
+
+
+@dataclass
+class QSASelection:
+    """Per-query token indices for sparse core attention. Never a [S, T] mask."""
+
+    token_idx: mx.array  # (B, S, K) int32
+    valid: mx.array  # (B, S, K) bool
+
+
+@dataclass
+class QSAPrep:
+    """Indexer state after key pooling; queries are scored in chunks."""
+
+    q: mx.array  # (B, S, H_idx, D_idx)
+    pooled: mx.array  # (B, n_blocks, D_idx)
+    q_pos: mx.array  # (S,)
+    kv_len: int
+
+
+_QSA_PATH_LOGGED = False
+
+
+def _log_qsa_path_once(msg: str) -> None:
+    global _QSA_PATH_LOGGED
+    if _QSA_PATH_LOGGED:
+        return
+    _QSA_PATH_LOGGED = True
+    try:
+        print(f"[qwen4_exp] {msg}", flush=True)
+    except Exception:
+        pass
+
+
+def _gather_kv_tokens(kv: mx.array, token_idx: mx.array) -> mx.array:
+    """Gather kv [B, H, T, D] at token_idx [B, S, K] -> [B, H, S, K, D].
+
+    B == 1 (every serving path here) gathers along axis 2 directly: no
+    transpose/reshape of the cache, so history is never copied per step.
+    """
+    B, H, T, D = kv.shape
+    _, S, K = token_idx.shape
+    if B == 1:
+        gathered = mx.take(kv, token_idx.reshape(-1), axis=2)  # (1, H, S*K, D)
+        return gathered.reshape(1, H, S, K, D)
+    kv_flat = kv.transpose(0, 2, 1, 3).reshape(B * T, H, D)
+    batch_off = (mx.arange(B, dtype=token_idx.dtype) * T).reshape(B, 1, 1)
+    gathered = mx.take(kv_flat, (token_idx + batch_off).reshape(-1), axis=0)
+    return gathered.reshape(B, S, K, H, D).transpose(0, 3, 1, 2, 4)
+
+
+def _qsa_gather_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    sel: QSASelection,
+    scale: float,
+) -> mx.array:
+    """SDPA over gathered K=budget tokens per query. q/k/v are [B, H, S, D].
+
+    Keys differ per query, so fused SDPA over a shared KV sequence cannot
+    be used. Keep S in-graph and GEMM the last dim (K), never flatten to
+    ``B*S`` independent q_len=1 calls. Broadcasts over GQA head groups to
+    avoid allocating 12x repeated K/V working sets in memory.
+    """
+    B, H, S, D = q.shape
+    T = int(k.shape[2])
+    H_kv = int(k.shape[1])
+    safe = mx.clip(mx.where(sel.valid, sel.token_idx, 0), 0, max(T - 1, 0))
+    k_sel = _gather_kv_tokens(k, safe)  # (B, H_kv, S, K, D)
+    v_sel = _gather_kv_tokens(v, safe)
+    if H != H_kv:
+        rep = H // H_kv
+        # Reshape q to (B, H_kv, rep, S, 1, D) and broadcast against (B, H_kv, 1, S, D, K)
+        # to avoid materializing 12x repeated k_sel/v_sel working sets in memory.
+        q_view = q.reshape(B, H_kv, rep, S, 1, D)
+        k_view = k_sel.swapaxes(-1, -2).reshape(B, H_kv, 1, S, D, -1)
+        scores = (mx.matmul(q_view, k_view) * scale).squeeze(-2)  # (B, H_kv, rep, S, K)
+        scores = scores.reshape(B, H, S, -1)  # (B, H, S, K)
+        scores = mx.where(sel.valid[:, None, :, :], scores, _qsa_neg_inf(q.dtype))
+        probs = mx.softmax(scores.astype(mx.float32), axis=-1).astype(q.dtype)
+        probs_view = probs.reshape(B, H_kv, rep, S, 1, -1)  # (B, H_kv, rep, S, 1, K)
+        v_view = v_sel.reshape(B, H_kv, 1, S, -1, D)        # (B, H_kv, 1, S, K, D)
+        out = mx.matmul(probs_view, v_view).squeeze(-2)     # (B, H_kv, rep, S, D)
+        return out.reshape(B, H, S, D)
+    # (B, H, S, 1, D) @ (B, H, S, D, K) -> (B, H, S, 1, K)
+    scores = mx.matmul(q[..., None, :], k_sel.swapaxes(-1, -2)).squeeze(-2) * scale
+    scores = mx.where(sel.valid[:, None, :, :], scores, _qsa_neg_inf(q.dtype))
+    probs = mx.softmax(scores.astype(mx.float32), axis=-1).astype(q.dtype)
+    # (B, H, S, 1, K) @ (B, H, S, K, D) -> (B, H, S, D)
+    return mx.matmul(probs[..., None, :], v_sel).squeeze(-2)
+
+
+def selection_to_dense_add_mask(sel: QSASelection, kv_len: int, dtype) -> mx.array:
+    """Legacy [B, 1, S, kv_len] additive mask — the O(S·T) materialization."""
+    B, S, _ = sel.token_idx.shape
+    idx = mx.where(sel.valid, sel.token_idx, kv_len)
+    keep = mx.zeros((B, S, kv_len + 1), dtype=mx.bool_)
+    keep = mx.put_along_axis(keep, idx, mx.array(True), axis=-1)[..., :kv_len]
+    return mx.where(
+        keep[:, None],
+        mx.array(0, dtype=dtype),
+        _qsa_neg_inf(dtype),
+    )
+
+
+class QSAIndexer(nn.Module):
+    """Select, per query, a budget of compressed key blocks.
+
+    Scoring is O(S · n_blocks) as in the spec (n_blocks = T/r), but the
+    (S, n_blocks) tile is produced in query chunks and immediately reduced
+    to (S, K) token indices. Nothing of shape [S, T] is allocated.
+    """
+
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.n_heads = args.indexer_n_heads
+        self.kv_heads = args.indexer_kv_heads
+        self.head_dim = args.indexer_head_dim
+        self.token_budget = args.indexer_budget
+        self.compress_ratio = args.indexer_compress_ratio
+        self.block_topk = self.token_budget // self.compress_ratio
+        self.index_qk_proj = nn.Linear(
+            args.hidden_size, (self.n_heads + self.kv_heads) * self.head_dim, bias=False
+        )
+        self.q_layernorm = RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_layernorm = RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+    def prepare(self, x: mx.array, rope: Any, cache: Any, offset: int) -> Optional[QSAPrep]:
+        B, S, _ = x.shape
+        qk = self.index_qk_proj(x)
+        split = self.n_heads * self.head_dim
+        q = qk[..., :split].reshape(B, S, self.n_heads, self.head_dim)
+        raw_k = qk[..., split:].reshape(B, S, self.head_dim)
+
+        if cache is not None:
+            raw_k = cache.update(raw_k)
+        kv_len = int(raw_k.shape[1])
+
+        if kv_len <= self.token_budget:
+            return None
+
+        n_blocks = kv_len // self.compress_ratio
+        if n_blocks <= 0:
+            return None
+
+        r = self.compress_ratio
+        if cache is not None:
+            cached_pooled = getattr(cache, "pooled", None)
+            n_cached = int(cached_pooled.shape[1]) if cached_pooled is not None else 0
+            if n_cached > n_blocks:
+                cached_pooled = cached_pooled[:, :n_blocks, :] if n_blocks > 0 else None
+                n_cached = n_blocks if n_blocks > 0 else 0
+
+            if n_cached < n_blocks:
+                new_raw_k = raw_k[:, n_cached * r : n_blocks * r, :]
+                n_new = n_blocks - n_cached
+                new_pooled = new_raw_k.reshape(B, n_new, r, self.head_dim)
+                new_pooled = self.k_layernorm(
+                    new_pooled.astype(mx.float32).mean(axis=2).astype(raw_k.dtype)
+                )
+                new_starts = mx.arange(n_cached, n_blocks) * r
+                cos_k, sin_k = rope(new_starts[None, :])
+                new_pooled = _rope_partial(new_pooled, cos_k, sin_k)
+                pooled = (
+                    new_pooled
+                    if cached_pooled is None or n_cached == 0
+                    else mx.concatenate([cached_pooled, new_pooled], axis=1)
+                )
+                cache.pooled = pooled
+            else:
+                pooled = cached_pooled
+        else:
+            pooled = raw_k[:, : n_blocks * r].reshape(
+                B, n_blocks, r, self.head_dim
+            )
+            pooled = self.k_layernorm(
+                pooled.astype(mx.float32).mean(axis=2).astype(raw_k.dtype)
+            )
+            block_starts = mx.arange(n_blocks) * r
+            cos_k, sin_k = rope(block_starts[None, :])
+            pooled = _rope_partial(pooled, cos_k, sin_k)
+
+        q_pos = mx.arange(offset, offset + S)
+        cos_q, sin_q = rope(q_pos[None, :])
+        q = self.q_layernorm(q)
+        q = _rope_partial(q, cos_q[:, :, None, :], sin_q[:, :, None, :])
+        return QSAPrep(q=q, pooled=pooled, q_pos=q_pos, kv_len=kv_len)
+
+    def select(
+        self,
+        q: mx.array,
+        q_pos: mx.array,
+        pooled: mx.array,
+        kv_len: int,
+    ) -> QSASelection:
+        """Score this query slice against every compressed block; return token idx."""
+        B, S, _, _ = q.shape
+        n_blocks = int(pooled.shape[1])
+        r = self.compress_ratio
+        n_complete = (q_pos + 1) // r
+        is_complete = mx.arange(n_blocks)[None, :] < n_complete[:, None]  # (S, n_blocks)
+
+        # Sum_h ReLU(<q_h, k_b>) without materializing the 4-head score tensor.
+        acc = None
+        pooled_t = pooled.astype(mx.float32).swapaxes(-1, -2)  # (B, D, n_blocks)
+        for h in range(self.n_heads):
+            s_h = q[:, :, h].astype(mx.float32) @ pooled_t  # (B, S, n_blocks)
+            s_h = mx.maximum(s_h, 0)
+            acc = s_h if acc is None else acc + s_h
+        scores = acc / math.sqrt(self.head_dim)
+        masked = mx.where(is_complete[None, :, :], scores, -mx.inf)
+
+        k_blk = min(self.block_topk, n_blocks)
+        top = mx.argpartition(-masked, k_blk - 1, axis=-1)[..., :k_blk]
+        is_top_complete = mx.take_along_axis(is_complete[None, :, :], top, axis=-1)
+        top = mx.where(is_top_complete, top, 0)
+
+        tok = (top[..., None] * r + mx.arange(r)).reshape(B, S, k_blk * r)
+        valid_blk = mx.broadcast_to(
+            is_top_complete[..., None], (*is_top_complete.shape, r)
+        ).reshape(B, S, k_blk * r) & (tok < kv_len)
+
+        tail_start = n_complete * r
+        tail = tail_start[:, None] + mx.arange(r)  # (S, r)
+        tail_valid = (tail <= q_pos[:, None]) & (tail < kv_len)
+        tail = mx.broadcast_to(tail[None], (B, S, r))
+        tail_valid = mx.broadcast_to(tail_valid[None], (B, S, r))
+
+        return QSASelection(
+            token_idx=mx.concatenate([tok, tail], axis=-1).astype(mx.int32),
+            valid=mx.concatenate([valid_blk, tail_valid], axis=-1),
+        )
+
+    def __call__(
+        self, x: mx.array, rope: Any, cache: Any, offset: int
+    ) -> Optional[QSASelection]:
+        prep = self.prepare(x, rope, cache, offset)
+        if prep is None:
+            return None
+        S = int(prep.q.shape[1])
+        n_blocks = int(prep.pooled.shape[1])
+        chunk = _indexer_score_chunk(n_blocks, _qsa_query_chunk())
+        if S <= chunk:
+            return self.select(prep.q, prep.q_pos, prep.pooled, prep.kv_len)
+        parts: List[QSASelection] = []
+        for s0 in range(0, S, chunk):
+            s1 = min(s0 + chunk, S)
+            parts.append(
+                self.select(
+                    prep.q[:, s0:s1],
+                    prep.q_pos[s0:s1],
+                    prep.pooled,
+                    prep.kv_len,
+                )
+            )
+        return QSASelection(
+            token_idx=mx.concatenate([p.token_idx for p in parts], axis=1),
+            valid=mx.concatenate([p.valid for p in parts], axis=1),
+        )
+
+
+class Attention(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        d = args.hidden_size
+        # q_proj also carries the output gate: n_heads * head_dim * 2
+        self.q_proj = nn.Linear(d, self.n_heads * self.head_dim * 2, bias=False)
+        self.k_proj = nn.Linear(d, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(d, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, d, bias=False)
+        self.q_norm = RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.indexer = QSAIndexer(args)
+        # House attention is (x, mask, cache). RoPE is a module attr (shared
+        # with the trunk RotaryEmbedding); the QSA indexer cache lives on
+        # cache.indexer. Runtime split-attention hooks assume this shape.
+        rotary_dim = int(args.head_dim * args.partial_rotary_factor)
+        self.rope = RotaryEmbedding(rotary_dim, args.rope_theta, args.rope_parameters)
+
+    def _core_attend(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        mask: Any,
+        cache: Any,
+        sel: Optional[QSASelection],
+    ) -> mx.array:
+        if sel is None:
+            return scaled_dot_product_attention(
+                q, k, v, cache=cache, scale=self.scale, mask=mask
+            )
+        if _qsa_dense_mask_enabled():
+            kv_len = int(k.shape[2])
+            add = selection_to_dense_add_mask(sel, kv_len, q.dtype)
+            mask = (
+                add
+                if mask is None
+                else (mask + add if not isinstance(mask, str) else add)
+            )
+            return scaled_dot_product_attention(
+                q, k, v, cache=cache, scale=self.scale, mask=mask
+            )
+        return _qsa_gather_attention(q, k, v, sel, self.scale)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Any = None,
+        cache: Any = None,
+    ) -> mx.array:
+        B, S, _ = x.shape
+        offset = cache.offset if cache is not None else 0
+        idx_cache = getattr(cache, "indexer", None) if cache is not None else None
+        rope = self.rope
+
+        q, gate = mx.split(self.q_proj(x).reshape(B, S, self.n_heads, -1), 2, axis=-1)
+        gate = gate.reshape(B, S, -1)
+        q = self.q_norm(q).transpose(0, 2, 1, 3)
+        k = self.k_norm(self.k_proj(x).reshape(B, S, self.n_kv_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        v = self.v_proj(x).reshape(B, S, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        # Contiguous positions: fused kernel. QSAIndexer keeps _rope_partial
+        # (block_starts are strided — that path is owned by the other lane).
+        # MTP _ShiftedRope exposes .dim/.freqs/.position_shift so the same
+        # kernel applies with the draft position offset.
+        freqs = getattr(rope, "freqs", None)
+        dims = getattr(rope, "dim", None)
+        # mx.fast.rope has no amplitude scale; yarn (mscale != 1) takes the
+        # cos/sin path where mscale is folded into the rotation.
+        if (
+            freqs is not None
+            and dims is not None
+            and float(getattr(rope, "mscale", 1.0) or 1.0) == 1.0
+        ):
+            rope_offset = offset + int(getattr(rope, "position_shift", 0) or 0)
+            q = mx.fast.rope(
+                q,
+                dims,
+                traditional=False,
+                base=None,
+                scale=1.0,
+                offset=rope_offset,
+                freqs=freqs,
+            )
+            k = mx.fast.rope(
+                k,
+                dims,
+                traditional=False,
+                base=None,
+                scale=1.0,
+                offset=rope_offset,
+                freqs=freqs,
+            )
+        else:
+            cos, sin = rope(mx.arange(offset, offset + S)[None])
+            cos, sin = cos[:, None], sin[:, None]
+            q, k = _rope_partial(q, cos, sin), _rope_partial(k, cos, sin)
+
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+
+        indexer = self.indexer
+        # Decode / MTP reuse wrapper: keep the S==1 __call__ contract.
+        if S == 1 or not hasattr(indexer, "prepare"):
+            sel = indexer(x, rope, idx_cache, offset)
+            if sel is not None and not isinstance(sel, QSASelection) and hasattr(sel, "ndim"):
+                # Dense keep mask from an older wrapper; convert to additive.
+                add = mx.where(sel, mx.array(0, q.dtype), _qsa_neg_inf(q.dtype))
+                mask = (
+                    add
+                    if mask is None
+                    else (mask + add if not isinstance(mask, str) else add)
+                )
+                sel = None
+            if sel is not None:
+                _log_qsa_path_once(
+                    "qsa-gather "
+                    f"S={S} kv={k.shape[2]} K={sel.token_idx.shape[-1]} "
+                    f"dense_mask={_qsa_dense_mask_enabled()}"
+                )
+            out = self._core_attend(q, k, v, mask, cache, sel)
+        else:
+            prep = indexer.prepare(x, rope, idx_cache, offset)
+            if prep is None:
+                out = self._core_attend(q, k, v, mask, cache, None)
+            else:
+                kv_len = prep.kv_len
+                n_blocks = int(prep.pooled.shape[1])
+                score_chunk = _indexer_score_chunk(n_blocks, _qsa_query_chunk())
+                gather_chunk = _qsa_query_chunk()
+                chunk = min(score_chunk, gather_chunk)
+                _log_qsa_path_once(
+                    "qsa-gather "
+                    f"S={S} kv={kv_len} n_blocks={n_blocks} chunk={chunk} "
+                    f"K~{self.indexer.token_budget} dense_mask={_qsa_dense_mask_enabled()}"
+                )
+                n_chunks = (S + chunk - 1) // chunk
+                pieces: List[mx.array] = []
+                for s0 in range(0, S, chunk):
+                    s1 = min(s0 + chunk, S)
+                    sel = indexer.select(
+                        prep.q[:, s0:s1],
+                        prep.q_pos[s0:s1],
+                        prep.pooled,
+                        prep.kv_len,
+                    )
+                    mask_c = mask
+                    if mask_c is not None and not isinstance(mask_c, str):
+                        mask_c = mask_c[..., s0:s1, : kv_len]
+                    piece = self._core_attend(
+                        q[:, :, s0:s1], k, v, mask_c, cache, sel
+                    )
+                    if n_chunks > 1:
+                        mx.eval(piece)
+                    pieces.append(piece)
+                out = mx.concatenate(pieces, axis=2)
+
+        out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
+        return self.o_proj(out * mx.sigmoid(gate))
+
+
+# ---------------------------------------------------------------------------
+# Gated DeltaNet (linear attention)
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaNet(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.n_v = args.linear_num_value_heads
+        self.n_k = args.linear_num_key_heads
+        self.dk = args.linear_key_head_dim
+        self.dv = args.linear_value_head_dim
+        self.key_dim = self.dk * self.n_k
+        self.value_dim = self.dv * self.n_v
+        self.conv_kernel_size = args.linear_conv_kernel_dim
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        d = args.hidden_size
+
+        self.conv1d = nn.Conv1d(
+            self.conv_dim,
+            self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            padding=0,
+        )
+        # Load-time fused projections (old split keys are remapped in sanitize).
+        self.in_proj_qkvz = nn.Linear(d, self.conv_dim + self.value_dim, bias=False)
+        self.in_proj_ba = nn.Linear(d, 2 * self.n_v, bias=False)
+        self.dt_bias = mx.ones(self.n_v)
+        self.A_log = mx.zeros(self.n_v)
+        self.norm = RMSNormGated(
+            self.dv, eps=args.rms_norm_eps, activation=args.output_gate_type
+        )
+        self.out_proj = nn.Linear(self.value_dim, d, bias=False)
+        # L2(x, eps) == rms_norm(x, weight=None, eps=eps/D) * (D**-0.5).
+        # Avoid allocating/passing weight array every step.
+        object.__setattr__(self, "_l2_eps", 1e-6 / float(self.dk))
+        inv_scale = self.dk**-0.5
+        object.__setattr__(self, "_inv_scale", inv_scale)
+        object.__setattr__(self, "_inv_scale_sq", inv_scale**2)
+
+    def __call__(self, x: mx.array, mask: Any, cache: Any) -> mx.array:
+        B, S, _ = x.shape
+        qkvz = self.in_proj_qkvz(x)
+        mixed_qkv, z = mx.split(qkvz, [self.conv_dim], axis=-1)
+        z = z.reshape(B, S, self.n_v, self.dv)
+        b, a = mx.split(self.in_proj_ba(x), [self.n_v], axis=-1)
+
+        conv_state = (
+            cache[0]
+            if (cache is not None and cache[0] is not None)
+            else mx.zeros((B, self.conv_kernel_size - 1, self.conv_dim), dtype=x.dtype)
+        )
+        if mask is not None:
+            mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
+        conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
+        if cache is not None:
+            cache[0] = mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+        conv_out = nn.silu(self.conv1d(conv_input))
+
+        q, k, v = mx.split(conv_out, [self.key_dim, 2 * self.key_dim], axis=-1)
+        q = q.reshape(B, S, self.n_k, self.dk)
+        k = k.reshape(B, S, self.n_k, self.dk)
+        v = v.reshape(B, S, self.n_v, self.dv)
+
+        q = mx.fast.rms_norm(q, None, self._l2_eps) * self._inv_scale_sq
+        k = mx.fast.rms_norm(k, None, self._l2_eps) * self._inv_scale
+
+        state = cache[1] if cache is not None else None
+        out, state = self._gated_delta_update(q, k, v, a, b, state, mask)
+        if cache is not None:
+            cache[1] = state
+            cache.advance(S)
+        return self.out_proj(self.norm(out, z).reshape(B, S, -1))
+
+    def _gated_delta_update(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        a: mx.array,
+        b: mx.array,
+        state: Any,
+        mask: Any,
+    ) -> Tuple[mx.array, mx.array]:
+        """Prefill (T>1) uses the blocked-sequential kernel when eligible.
+
+        Maps in_proj_qkv/z/b/a + conv + L2-normed q/k onto the kernel's
+        (q, k, v, g, beta, state) contract. Decode (T==1), training, CPU,
+        FORCE_STOCK, and any failed structural check stay on
+        ``gated_delta_update``.
+        """
+        if q.shape[1] == 1:
+            return gated_delta_update(
+                q,
+                k,
+                v,
+                a,
+                b,
+                self.A_log,
+                self.dt_bias,
+                state,
+                mask,
+                use_kernel=not self.training,
+            )
+        if (
+            q.shape[1] > 1
+            and not self.training
+            and mx.default_device() == mx.gpu
+            and not _blocked_prefill_force_stock()
+        ):
+            beta = mx.sigmoid(b)
+            g = compute_g(self.A_log, a, self.dt_bias)
+            if blocked_prefill_eligible(q, v, g, mask, state):
+                if state is None:
+                    state = mx.zeros(
+                        (q.shape[0], self.n_v, self.dv, self.dk), dtype=mx.float32
+                    )
+                _log_blocked_prefill_once(q)
+                return gated_delta_blocked_prefill(q, k, v, g, beta, state)
+            reason = blocked_prefill_ineligibility_reason(q, v, g, mask, state)
+            if reason is not None:
+                _log_blocked_prefill_fallback_once(reason)
+        return gated_delta_update(
+            q,
+            k,
+            v,
+            a,
+            b,
+            self.A_log,
+            self.dt_bias,
+            state,
+            mask,
+            use_kernel=not self.training,
+        )
+
+
+# ---------------------------------------------------------------------------
+# MoE & Feed-Forward blocks
+# ---------------------------------------------------------------------------
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.hidden = hidden
+        self.gate_up_proj = nn.Linear(dim, 2 * hidden, bias=False)
+        self.down_proj = nn.Linear(hidden, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate, up = mx.split(self.gate_up_proj(x), [self.hidden], axis=-1)
+        return self.down_proj(nn.silu(gate) * up)
+
+
+class FusedSwitchGLU(SwitchGLU):
+    """SwitchGLU with gate/up packed into one gathered projection.
+
+    mlx-lm's SwitchGLU owns two SwitchLinear modules. Subclassing keeps the
+    gather/sort contract; load-time remap concatenates the old split weights.
+    """
+
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=None,
+        bias: bool = False,
+    ):
+        nn.Module.__init__(self)
+        self.hidden_dims = hidden_dims
+        self.gate_up_proj = SwitchLinear(
+            input_dims, 2 * hidden_dims, num_experts, bias=bias
+        )
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = SwiGLU() if activation is None else activation
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        packed = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+        x_gate, x_up = mx.split(packed, [self.hidden_dims], axis=-1)
+        x = self.down_proj(
+            self.activation(x_up, x_gate),
+            idx,
+            sorted_indices=do_sort,
+        )
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)
+
+
+class SparseMoeBlock(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.switch_mlp = FusedSwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts
+        )
+        self.shared_expert = MLP(args.hidden_size, args.shared_expert_intermediate_size)
+        self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        logits = self.gate(x.astype(mx.float32))
+        idx = mx.argpartition(-logits, self.top_k - 1, axis=-1)[..., : self.top_k]
+        w = mx.softmax(mx.take_along_axis(logits, idx, axis=-1), axis=-1, precise=True)
+        out = (self.switch_mlp(x, idx) * w[..., None]).sum(axis=-2).astype(x.dtype)
+        return out + mx.sigmoid(self.shared_expert_gate(x)) * self.shared_expert(x)
+
+
+# ---------------------------------------------------------------------------
+# Hyper-Connections (gated residual)
+# ---------------------------------------------------------------------------
+
+
+class GatedResidual(nn.Module):
+    def __init__(self, args: TextArgs, use_combine: bool = True):
+        super().__init__()
+        self.hc = args.hc_count
+        self.d = args.hidden_size
+        hc_dim = self.hc * self.d
+        self.hc_norm = RMSNorm(hc_dim, group_size=self.d, eps=args.rms_norm_eps)
+        self.input_mix_weight_down = nn.Linear(hc_dim, args.hc_lowrank, bias=False)
+        self.input_mix_weight_up = nn.Linear(args.hc_lowrank, hc_dim, bias=False)
+        self.block_inject_weight = (
+            nn.Linear(hc_dim, self.hc, bias=False) if use_combine else None
+        )
+
+    def __call__(self, hyper: mx.array):
+        normed = self.hc_norm(hyper)
+        w = nn.silu(self.input_mix_weight_down(normed) / self.hc)
+        w = mx.sigmoid(self.input_mix_weight_up(w))
+        w = w.reshape(*w.shape[:-1], self.hc, self.d)
+        mixed = (w * normed.reshape(*normed.shape[:-1], self.hc, self.d)).mean(axis=-2)
+        if self.block_inject_weight is None:
+            return mixed
+        inject = 2 * mx.sigmoid(self.block_inject_weight(normed) / self.hc)
+        return mixed, hyper, inject
+
+
+# ---------------------------------------------------------------------------
+# N-gram & PLE (Per-Layer Embedding)
+# ---------------------------------------------------------------------------
+
+
+_MASK64 = (1 << 64) - 1
+_GAMMA = 0x9E3779B97F4A7C15
+_M1, _M2 = 0xBF58476D1CE4E5B9, 0x94D049BB133111EB
+_PRIME_1 = 10007
+
+
+def _splitmix64(v: int) -> int:
+    v = (v + _GAMMA) & _MASK64
+    v = ((v ^ (v >> 30)) * _M1) & _MASK64
+    v = ((v ^ (v >> 27)) * _M2) & _MASK64
+    return (v ^ (v >> 31)) & _MASK64
+
+
+def _is_prime(v: int) -> bool:
+    if v < 2:
+        return False
+    if v % 2 == 0:
+        return v == 2
+    return all(v % d for d in range(3, math.isqrt(v) + 1, 2))
+
+
+def _nth_prime_after(start: int, count: int) -> int:
+    p = start
+    for _ in range(count):
+        p += 1
+        while not _is_prime(p):
+            p += 1
+    return p
+
+
+class _ShardedEmbedding(nn.Module):
+    """One contiguous embedding table, addressed by global index.
+
+    Checkpoints stay sharded on disk (`shard_i.weight` / scales / biases).
+    :func:`sanitize` concatenates those shards along axis 0 into ``shard_0``
+    so ``__call__`` is a single gather. The child is named ``shard_0`` so
+    quantized configs keyed at ``...ngram_embedding.shard_0`` (group_size=32)
+    still match. ``gid`` is already ``shard * rows + row``.
+    """
+
+    def __init__(self, n_shards: int, rows: int, dim: int):
+        super().__init__()
+        self.n_shards = n_shards
+        self.rows = rows
+        self.dim = dim
+        self.shard_0 = nn.Embedding(n_shards * rows, dim)
+
+    def __call__(self, gid: mx.array) -> mx.array:
+        return self.shard_0(gid)
+
+
+class NGramEmbedding(nn.Module):
+    """N-gram hash table sharded into `split_ngram_parts` sub-embeddings."""
+
+    def __init__(self, args: TextArgs, embed_dim: int, ple_layer_index: int = 0):
+        super().__init__()
+        self.ngram_size = args.ngram_size
+        self.context_len = self.ngram_size - 1
+        self.heads_per_ngram = args.heads_per_ngram
+        self.ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        self.eos_token_id = (
+            args.eos_token_id[0]
+            if isinstance(args.eos_token_id, list)
+            else args.eos_token_id
+        )
+        head_dim = embed_dim // self.ngram_heads
+
+        sizes, offsets, total = [], [], 0
+        for h in range(self.ngram_heads):
+            g = ple_layer_index * self.ngram_heads + h
+            s = _nth_prime_after(args.ngram_vocab_size_base - 1, g + 1)
+            sizes.append(s)
+            offsets.append(total)
+            total += s
+        self.head_vocab_sizes = sizes
+
+        div = args.make_ngram_vocab_size_divisible_by
+        padded = math.ceil(total / div) * div
+        self.n_shards = args.split_ngram_parts
+        self.rows_per_shard = math.ceil(padded / self.n_shards)
+        self.ngram_embedding = _ShardedEmbedding(
+            self.n_shards, self.rows_per_shard, head_dim
+        )
+
+        mults = []
+        max_long = (1 << 63) - 1
+        half = max(1, (max_long // max(args.vocab_size, 1)) // 2)
+        base_seed = args.seed + _PRIME_1 * ple_layer_index
+        for i in range(self.ngram_size):
+            mults.append(
+                2 * (_splitmix64((base_seed + _GAMMA * (i + 1)) & _MASK64) % half) + 1
+            )
+        self.layer_multipliers = mx.array(mults, dtype=mx.int64)
+        self.ngram_heads_vocab_sizes = mx.array(sizes, dtype=mx.int64)
+        self.ngram_heads_offsets = mx.array(offsets, dtype=mx.int64)
+        self._mults = mx.array(mults, dtype=mx.int64)
+        self._sizes = mx.array(sizes, dtype=mx.int64)
+        self._offsets = mx.array(offsets, dtype=mx.int64)
+
+    def _shift_right(self, ids: mx.array, shift: int) -> mx.array:
+        """Shift right by `shift`, without crossing an EOS boundary."""
+        if shift == 0:
+            return ids
+        B, T = ids.shape
+        pos = mx.arange(T)
+        eos_pos = mx.where(ids == self.eos_token_id, pos, -1)
+        prev_incl = mx.cummax(eos_pos, axis=1)
+        prev = mx.concatenate(
+            [mx.full((B, 1), -1, dtype=prev_incl.dtype), prev_incl[:, :-1]], axis=1
+        )
+        in_segment = pos[None] - (prev + 1)
+        src = pos - shift
+        gathered = mx.take_along_axis(
+            ids, mx.broadcast_to(mx.maximum(src, 0)[None], (B, T)), axis=1
+        )
+        ok = (in_segment >= shift) & (src[None] >= 0)
+        return mx.where(ok, gathered, self.eos_token_id)
+
+    def __call__(self, ids: mx.array, prev_context: mx.array) -> mx.array:
+        n_new = ids.shape[1]
+        history = mx.concatenate([prev_context, ids], axis=1).astype(mx.int64)
+        shifted = [self._shift_right(history, s) for s in range(self.ngram_size)]
+
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            lo = (ngram - 2) * self.heads_per_ngram
+            hi = lo + self.heads_per_ngram
+            mixed = shifted[0] * self._mults[0]
+            for p in range(1, ngram):
+                mixed = mx.bitwise_xor(mixed, shifted[p] * self._mults[p])
+            gid = mixed[..., None] % self._sizes[lo:hi].reshape(1, 1, -1)
+            blocks.append(gid + self._offsets[lo:hi].reshape(1, 1, -1))
+
+        gid = mx.concatenate(blocks, axis=-1)[:, -n_new:]
+        return self.ngram_embedding(gid).reshape(*gid.shape[:2], -1)
+
+
+class PLELayer(nn.Module):
+    def __init__(self, args: TextArgs, ple_layer_index: int):
+        super().__init__()
+        self.d = args.hidden_size
+        self.hc = args.hc_count
+        hc_dim = self.d * self.hc
+        self.ple_embedding = NGramEmbedding(args, args.ple_embed_dim, ple_layer_index)
+        k = args.ple_conv_kernel_size
+        self.dilation = args.ngram_size
+        self.short_conv_state_len = (k - 1) * self.dilation
+        self.key_proj = nn.Linear(args.ple_embed_dim, hc_dim, bias=False)
+        self.value_proj = nn.Linear(args.ple_embed_dim, self.d, bias=False)
+        self.norm_key = RMSNorm(hc_dim, group_size=self.d, eps=args.rms_norm_eps)
+        self.norm_query = RMSNorm(hc_dim, group_size=self.d, eps=args.rms_norm_eps)
+        self.norm_conv = RMSNorm(hc_dim, group_size=self.d, eps=args.rms_norm_eps)
+        self.conv1d = nn.Conv1d(
+            hc_dim,
+            hc_dim,
+            kernel_size=k,
+            groups=hc_dim,
+            dilation=self.dilation,
+            bias=False,
+        )
+
+    def _short_conv(self, x: mx.array, cache: Any) -> mx.array:
+        S = x.shape[1]
+        n = self.short_conv_state_len
+        has_cache_slots = cache is not None and isinstance(cache, (list, tuple, ArraysCache))
+        state = (
+            cache[2]
+            if (has_cache_slots and cache[2] is not None)
+            else mx.zeros((x.shape[0], n, x.shape[-1]), dtype=x.dtype)
+        )
+        full = mx.concatenate([state, x], axis=1)
+        if has_cache_slots:
+            cache[2] = mx.contiguous(full[:, -n:, :])
+        return nn.silu(self.conv1d(full[:, -(n + S) :, :]))
+
+    def __call__(
+        self, hidden: mx.array, ids: mx.array, prev_ctx: mx.array, cache: Any
+    ) -> mx.array:
+        emb = self.ple_embedding(ids, prev_ctx).astype(hidden.dtype)
+        key = self.norm_key(self.key_proj(emb))
+        key = key.reshape(*key.shape[:-1], self.hc, self.d)
+        value = self.value_proj(emb)
+        query = self.norm_query(hidden)
+        query = query.reshape(*query.shape[:-1], self.hc, self.d)
+
+        gate = (key * query).sum(axis=-1, keepdims=True) / math.sqrt(self.d)
+        gate = mx.sqrt(mx.maximum(mx.abs(gate), 1e-6)) * mx.sign(gate)
+        gated = mx.sigmoid(gate) * value[..., None, :]
+        gated = gated.reshape(*gated.shape[:-2], -1)
+        return gated + self._short_conv(self.norm_conv(gated), cache)
+
+
+# ---------------------------------------------------------------------------
+# Decoder layer & Model trunk
+# ---------------------------------------------------------------------------
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: TextArgs, layer_idx: int):
+        super().__init__()
+        self.layer_type = args.layer_types[layer_idx]
+        if self.layer_type == "linear_attention":
+            self.linear_attn = GatedDeltaNet(args)
+        else:
+            self.self_attn = Attention(args)
+        self.mlp = SparseMoeBlock(args)
+        ple_idx = (
+            args.ple_layer_ids.index(layer_idx + 1)
+            if (layer_idx + 1) in args.ple_layer_ids
+            else None
+        )
+        self.ple = PLELayer(args, ple_idx) if ple_idx is not None else None
+        self.attn_hyper_connection = GatedResidual(args)
+        self.mlp_hyper_connection = GatedResidual(args)
+
+    def __call__(
+        self,
+        h: mx.array,
+        rope: Any,
+        mask: Any,
+        conv_mask: Any,
+        cache: Any,
+        idx_cache: Any,
+        ids: mx.array,
+        prev_ctx: Any,
+    ) -> mx.array:
+        del idx_cache  # QSA indexer cache is cache.indexer; house attn is (x, mask, cache)
+        if self.ple is not None:
+            h = h + self.ple(h, ids, prev_ctx, cache)
+
+        x, hyper, inject = self.attn_hyper_connection(h)
+        if self.layer_type == "linear_attention":
+            x = self.linear_attn(x, conv_mask, cache)
+        else:
+            # House call: (x, mask, cache). rope/idx_cache are attrs — see Attention.
+            if getattr(self.self_attn, "rope", None) is None:
+                self.self_attn.rope = rope
+            x = self.self_attn(x, mask, cache)
+        h = hyper + (x[..., None, :] * inject[..., None]).reshape(*x.shape[:-1], -1)
+
+        x, hyper, inject = self.mlp_hyper_connection(h)
+        x = self.mlp(x)
+        return hyper + (x[..., None, :] * inject[..., None]).reshape(*x.shape[:-1], -1)
+
+
+class Qwen4ExpModel(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.args = args
+        self.hc = args.hc_count
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        rotary_dim = int(args.head_dim * args.partial_rotary_factor)
+        self.rope = RotaryEmbedding(rotary_dim, args.rope_theta, args.rope_parameters)
+        self.layers = [DecoderLayer(args, i) for i in range(args.num_hidden_layers)]
+        for layer in self.layers:
+            attn = getattr(layer, "self_attn", None)
+            if attn is not None:
+                attn.rope = self.rope
+        self.hyper_connection_mixer = GatedResidual(args, use_combine=False)
+        self.first_full_attn_idx = next(
+            (i for i, l in enumerate(self.layers) if l.layer_type == "full_attention"),
+            None,
+        )
+        self.ple_layers = [
+            i for i in range(args.num_hidden_layers) if (i + 1) in args.ple_layer_ids
+        ]
+
+    def __call__(
+        self,
+        ids: mx.array | None = None,
+        cache: Optional[List[Any]] = None,
+        input_embeddings: Optional[mx.array] = None,
+        return_hyper: bool = False,
+    ) -> mx.array | Tuple[mx.array, mx.array]:
+        if ids is not None and ids.ndim == 1:
+            ids = ids[None]
+        if input_embeddings is not None and input_embeddings.ndim == 2:
+            input_embeddings = input_embeddings[None]
+
+        h = self.embed_tokens(ids) if input_embeddings is None else input_embeddings
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        attn_cache = (
+            cache[self.first_full_attn_idx]
+            if (
+                self.first_full_attn_idx is not None
+                and len(cache) > self.first_full_attn_idx
+                and cache[self.first_full_attn_idx] is not None
+            )
+            else None
+        )
+        mask = create_attention_mask(
+            h, [attn_cache] if attn_cache is not None else None
+        )
+        conv_mask = None
+
+        prev_ctx = None
+        if self.ple_layers and ids is not None:
+            ctx_len = self.args.ngram_size - 1
+            eos = self.args.eos_token_id
+            eos = eos[0] if isinstance(eos, list) else eos
+            pc = cache[self.ple_layers[0]] if len(cache) > self.ple_layers[0] else None
+            has_slots = pc is not None and isinstance(pc, (list, tuple, ArraysCache))
+            prev = pc[3] if has_slots else None
+            prev_ctx = (
+                prev
+                if prev is not None
+                else mx.full((ids.shape[0], ctx_len), eos, ids.dtype)
+            )
+            if has_slots:
+                tail = mx.concatenate([prev_ctx, ids], axis=1)[:, -ctx_len:]
+                pc[3] = tail
+
+        h = mx.tile(h, (1, 1, self.hc))
+        if _compile_enabled() and (
+            (ids is not None and ids.shape[1] == 1)
+            or (input_embeddings is not None and input_embeddings.shape[1] == 1)
+        ):
+            from .qwen4_exp_compiled import run_compiled_layers
+
+            h = run_compiled_layers(
+                self, h, self.rope, mask, conv_mask, cache, ids, prev_ctx
+            )
+        else:
+            for layer, c in zip(self.layers, cache):
+                idx_c = c.indexer if (c is not None and hasattr(c, "indexer")) else None
+                h = layer(h, self.rope, mask, conv_mask, c, idx_c, ids, prev_ctx)
+        mixed = self.hyper_connection_mixer(h)
+        if return_hyper:
+            return mixed, h
+        return mixed
+
+
+# ---------------------------------------------------------------------------
+# Caches
+# ---------------------------------------------------------------------------
+
+
+class _IndexerCache(_BaseCache):
+    """Holds the indexer raw keys and cached pooled block representations."""
+
+    _GROW = 256
+
+    def __init__(self):
+        self._buf = None
+        self._len = 0
+        self.pooled = None
+
+    @property
+    def keys(self):
+        if self._buf is None:
+            return None
+        return self._buf[:, : self._len, :]
+
+    @keys.setter
+    def keys(self, v):
+        # Restore/trim path (MTP rollback): adopt the array as-is; growth
+        # resumes by chunked reallocation on the next update().
+        self._buf = v
+        self._len = 0 if v is None else int(v.shape[1])
+        self.pooled = None
+
+    def update(self, k: mx.array) -> mx.array:
+        # Chunked growth (mlx-lm KVCache style): amortized O(1) appends
+        # instead of a full copy of history per decode step.
+        n = int(k.shape[1])
+        if self._buf is None:
+            pad = (-n) % self._GROW
+            if pad:
+                B, _, D = k.shape
+                self._buf = mx.concatenate(
+                    [k, mx.zeros((B, pad, D), dtype=k.dtype)], axis=1
+                )
+            else:
+                self._buf = k
+            self._len = n
+            return self.keys
+        cap = int(self._buf.shape[1])
+        if self._len + n > cap:
+            grow = ((self._len + n - cap + self._GROW - 1) // self._GROW) * self._GROW
+            B, _, D = self._buf.shape
+            self._buf = mx.concatenate(
+                [self._buf, mx.zeros((B, grow, D), dtype=self._buf.dtype)], axis=1
+            )
+        self._buf[:, self._len : self._len + n, :] = k
+        self._len += n
+        return self.keys
+
+    @property
+    def state(self):
+        return self.keys
+
+    @state.setter
+    def state(self, v):
+        self.keys = v
+
+
+class _AttnCache(KVCache):
+    def __init__(self):
+        super().__init__()
+        self.indexer = _IndexerCache()
+
+
+# ---------------------------------------------------------------------------
+# Top-level Model & Weight sanitization
+# ---------------------------------------------------------------------------
+
+_NGRAM_SHARD_MARKER = ".ngram_embedding.shard_"
+_NGRAM_SHARD_LEAVES = ("weight", "scales", "biases")
+
+
+def _concat_sharded_embedding_tables(weights: Dict[str, Any]) -> None:
+    """Fuse on-disk ngram shards into ``shard_0`` along axis 0, in-place.
+
+    Quantized shards concat ``weight`` / ``scales`` / ``biases`` independently
+    (rows are the concat axis, so quant groups stay valid). Unquantized shards
+    concat ``weight`` only. Destination is allocated first and each source
+    shard is ``mx.eval``'d then deleted so peak extra memory is one table plus
+    the remaining unfused shards, not a second full copy of the model.
+    """
+    n_shards_for: Dict[str, int] = {}
+    for key in weights:
+        idx = key.find(_NGRAM_SHARD_MARKER)
+        if idx < 0:
+            continue
+        rest = key[idx + len(_NGRAM_SHARD_MARKER) :]
+        shard_str, _, leaf = rest.partition(".")
+        if not shard_str.isdigit() or leaf not in _NGRAM_SHARD_LEAVES:
+            continue
+        prefix = key[: idx + len(".ngram_embedding")]
+        n = int(shard_str) + 1
+        if n > n_shards_for.get(prefix, 0):
+            n_shards_for[prefix] = n
+
+    for prefix, n_shards in n_shards_for.items():
+        if n_shards <= 1:
+            continue
+        for leaf in _NGRAM_SHARD_LEAVES:
+            k0 = f"{prefix}.shard_0.{leaf}"
+            if k0 not in weights:
+                continue
+            row_counts = [
+                int(weights[f"{prefix}.shard_{i}.{leaf}"].shape[0])
+                for i in range(n_shards)
+            ]
+            sample = weights[k0]
+            dest = mx.zeros((sum(row_counts), *sample.shape[1:]), dtype=sample.dtype)
+            mx.eval(dest)
+            del sample
+            offset = 0
+            for i, n_rows in enumerate(row_counts):
+                src = weights.pop(f"{prefix}.shard_{i}.{leaf}")
+                dest = mx.slice_update(
+                    dest, src, mx.array(offset, dtype=mx.int32), (0,)
+                )
+                mx.eval(dest)
+                offset += n_rows
+                del src
+            weights[k0] = dest
+            gc.collect()
+
+
+_PROJ_LEAVES = ("weight", "scales", "biases", "bias")
+
+
+def _as_mx(value: Any) -> mx.array:
+    return value if isinstance(value, mx.array) else mx.array(value)
+
+
+def _proj_leaves(weights: Dict[str, Any], stem: str) -> Dict[str, Any]:
+    leaves: Dict[str, Any] = {}
+    for leaf in _PROJ_LEAVES:
+        key = f"{stem}.{leaf}"
+        if key in weights:
+            leaves[leaf] = weights[key]
+    return leaves
+
+
+def _quant_status(leaves: Dict[str, Any]) -> str:
+    if not leaves:
+        return "missing"
+    return "quantized" if "scales" in leaves else "dense"
+
+
+def _output_axis(weight: Any) -> int:
+    # Linear: (out, in). SwitchLinear: (experts, out, in). Packed along last dim.
+    return 1 if getattr(weight, "ndim", 0) >= 3 else 0
+
+
+def _concat_proj_leaves(
+    left: Dict[str, Any], right: Dict[str, Any], axis: int
+) -> Dict[str, Any]:
+    fused: Dict[str, Any] = {}
+    for leaf in _PROJ_LEAVES:
+        if leaf in left or leaf in right:
+            if leaf not in left or leaf not in right:
+                raise ValueError(
+                    f"cannot concat projection leaf {leaf!r}: present on only one side"
+                )
+            fused[leaf] = mx.concatenate(
+                [_as_mx(left[leaf]), _as_mx(right[leaf])], axis=axis
+            )
+    return fused
+
+
+def _pop_proj(weights: Dict[str, Any], stem: str) -> None:
+    for leaf in _PROJ_LEAVES:
+        weights.pop(f"{stem}.{leaf}", None)
+
+
+def _write_proj(weights: Dict[str, Any], stem: str, leaves: Dict[str, Any]) -> None:
+    for leaf, value in leaves.items():
+        weights[f"{stem}.{leaf}"] = value
+
+
+def _fuse_proj_pair(
+    weights: Dict[str, Any], left_stem: str, right_stem: str, dest_stem: str
+) -> bool:
+    """Concat two same-status projections along the output axis. Exact, no requant.
+
+    Returns True when a fusion was written. Mixed quantization status is left
+    untouched (never change a weight's quant status).
+    """
+    if any(f"{dest_stem}.{leaf}" in weights for leaf in _PROJ_LEAVES):
+        if any(f"{left_stem}.{leaf}" in weights for leaf in _PROJ_LEAVES):
+            # Dest already present (HF packed gate_up / already remapped).
+            _pop_proj(weights, left_stem)
+            _pop_proj(weights, right_stem)
+        return False
+    left = _proj_leaves(weights, left_stem)
+    right = _proj_leaves(weights, right_stem)
+    if not left or not right:
+        return False
+    left_status = _quant_status(left)
+    right_status = _quant_status(right)
+    if left_status != right_status or left_status == "missing":
+        return False
+    axis = _output_axis(left["weight"])
+    _write_proj(weights, dest_stem, _concat_proj_leaves(left, right, axis))
+    _pop_proj(weights, left_stem)
+    _pop_proj(weights, right_stem)
+    return True
+
+
+def _rewrite_packed_experts(weights: Dict[str, Any]) -> None:
+    """Keep HF packed experts.gate_up_proj as switch_mlp.gate_up_proj (no split)."""
+    for key in list(weights):
+        packed = False
+        if key.endswith(".mlp.experts.gate_up_proj"):
+            dest = (
+                key[: -len("experts.gate_up_proj")] + "switch_mlp.gate_up_proj.weight"
+            )
+            packed = True
+        elif key.endswith(".mlp.experts.gate_up_proj.weight"):
+            dest = key.replace(".mlp.experts.gate_up_proj.weight", ".mlp.switch_mlp.gate_up_proj.weight")
+            packed = True
+        elif key.endswith(".mlp.experts.down_proj"):
+            dest = key[: -len("experts.down_proj")] + "switch_mlp.down_proj.weight"
+            packed = True
+        elif key.endswith(".mlp.experts.down_proj.weight"):
+            dest = key.replace(
+                ".mlp.experts.down_proj.weight", ".mlp.switch_mlp.down_proj.weight"
+            )
+            packed = True
+        if packed:
+            weights[dest] = weights.pop(key)
+
+
+def remap_fused_projections(weights: Dict[str, Any]) -> Dict[str, Any]:
+    """Map old split GDN/MoE projection keys onto the fused module names.
+
+    On-disk layout is unchanged; this is load-time surgery only. Quantized
+    tensors are concatenated along the output axis so each row keeps its
+    original groups (exact). Mixed-status pairs are not fused.
+    """
+    out = dict(weights)
+    _rewrite_packed_experts(out)
+
+    qkv_stems = [
+        key[: -len(".weight")]
+        for key in list(out)
+        if key.endswith(".linear_attn.in_proj_qkv.weight")
+    ]
+    for qkv in qkv_stems:
+        prefix = qkv[: -len("in_proj_qkv")]
+        _fuse_proj_pair(out, qkv, prefix + "in_proj_z", prefix + "in_proj_qkvz")
+
+    b_stems = [
+        key[: -len(".weight")]
+        for key in list(out)
+        if key.endswith(".linear_attn.in_proj_b.weight")
+    ]
+    for b in b_stems:
+        prefix = b[: -len("in_proj_b")]
+        _fuse_proj_pair(out, b, prefix + "in_proj_a", prefix + "in_proj_ba")
+
+    gate_stems = [
+        key[: -len(".weight")]
+        for key in list(out)
+        if key.endswith(".switch_mlp.gate_proj.weight")
+        or key.endswith(".shared_expert.gate_proj.weight")
+    ]
+    for gate in gate_stems:
+        dest = gate[: -len("gate_proj")] + "gate_up_proj"
+        _fuse_proj_pair(out, gate, gate[: -len("gate_proj")] + "up_proj", dest)
+
+    return out
+
+
+def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize checkpoint weights to match the MTPLX module hierarchy.
+
+    Key mappings performed:
+      - Strips `language_model.` prefix from Hugging Face checkpoints.
+      - Discards vision tower weights (`vision_tower.` / `model.visual.`).
+      - Transposes 1D conv weights `(C, 1, K)` -> `(C, K, 1)` for MLX.
+      - Stacks numbered MoE expert tensors into `switch_mlp` if unstacked.
+      - Concatenates sharded n-gram embedding tables into ``shard_0`` (post-load;
+        on-disk layout is unchanged).
+      - Fuses GDN in_proj_qkv+z / in_proj_b+a and MoE gate+up at load time.
+      - Retains all `mtp.*` tensors for downstream speculative/MTP lanes.
+    """
+    out: Dict[str, Any] = {}
+    for k, v in weights.items():
+        if k.startswith("language_model."):
+            k = k[len("language_model.") :]
+        if k.startswith("vision_tower.") or k.startswith("model.visual."):
+            continue
+        if "conv1d.weight" in k and v.ndim == 3 and v.shape[-1] != 1:
+            if v.shape[1] == 1:
+                v = v.transpose(0, 2, 1)
+        out[k] = v
+
+    # Check for unstacked numbered experts: model.layers.{l}.mlp.experts.{e}.{m}.{k}
+    expert_keys = [k for k in out if ".mlp.experts." in k and not k.startswith("mtp.")]
+    if expert_keys:
+        layer_indices = set()
+        for k in expert_keys:
+            parts = k.split(".")
+            if "layers" in parts:
+                idx = parts[parts.index("layers") + 1]
+                if idx.isdigit():
+                    layer_indices.add(int(idx))
+        for l in sorted(layer_indices):
+            prefix = f"model.layers.{l}.mlp"
+            for m in ("gate_proj", "down_proj", "up_proj", "gate_up_proj"):
+                for leaf in ("weight", "scales", "biases"):
+                    sample_key = f"{prefix}.experts.0.{m}.{leaf}"
+                    if sample_key in out:
+                        e = 0
+                        stacked = []
+                        while f"{prefix}.experts.{e}.{m}.{leaf}" in out:
+                            stacked.append(out.pop(f"{prefix}.experts.{e}.{m}.{leaf}"))
+                            e += 1
+                        if stacked:
+                            dest_m = "gate_up_proj" if m == "gate_up_proj" else m
+                            out[f"{prefix}.switch_mlp.{dest_m}.{leaf}"] = mx.stack(
+                                stacked
+                            )
+                    elif f"{prefix}.experts.{m}.{leaf}" in out:
+                        dest_m = "gate_up_proj" if m == "gate_up_proj" else m
+                        out[f"{prefix}.switch_mlp.{dest_m}.{leaf}"] = out.pop(
+                            f"{prefix}.experts.{m}.{leaf}"
+                        )
+
+    _concat_sharded_embedding_tables(out)
+    return remap_fused_projections(out)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = Qwen4ExpModel(args.text)
+        if not args.text.tie_word_embeddings:
+            self.lm_head = nn.Linear(
+                args.text.hidden_size, args.text.vocab_size, bias=False
+            )
+        self.mtp_weights: Dict[str, Any] = {}
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+        input_embeddings: Optional[mx.array] = None,
+        emit_logits: bool = True,
+        logits_keep: Optional[int] = None,
+        return_hidden: bool = False,
+        **kwargs: Any,
+    ) -> Union[mx.array, Tuple[Optional[mx.array], mx.array], None]:
+        result = self.model(
+            inputs,
+            cache,
+            input_embeddings,
+            return_hyper=bool(return_hidden),
+        )
+        if return_hidden:
+            mixed, hyper = result
+        else:
+            mixed = result
+            hyper = mixed
+        if not emit_logits:
+            return (None, hyper) if return_hidden else None
+
+        out = mixed
+        if logits_keep is not None:
+            out = out[:, -max(1, int(logits_keep)) :, :]
+
+        if self.args.text.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(out)
+        else:
+            logits = self.lm_head(out)
+
+        return (logits, hyper) if return_hidden else logits
+
+    @property
+    def layers(self) -> List[DecoderLayer]:
+        return self.model.layers
+
+    def make_cache(self) -> List[Any]:
+        caches = []
+        for i, t in enumerate(self.args.text.layer_types):
+            if t == "full_attention":
+                caches.append(_AttnCache())
+            else:
+                # 0: deltanet conv, 1: ssm state, 2: PLE conv, 3: n-gram context
+                caches.append(ArraysCache(4))
+        return caches
+
+    def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
+        sanitized = sanitize(weights)
+        # Retain MTP tensors accessible via side-channel for MTP lane
+        self.mtp_weights = {
+            k: v for k, v in sanitized.items() if k.startswith("mtp.")
+        }
+        return sanitized
+
+    @property
+    def quant_predicate(self) -> Callable[[str, Any, Any], bool]:
+        def fn(path: str, module: Any, _: Any) -> bool:
+            # Keep MoE router in full precision; norms and convs are skipped anyway
+            return not path.endswith("mlp.gate")
+
+        return fn

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -2293,6 +2293,13 @@ def _rewrite_packed_experts(weights: Dict[str, Any]) -> None:
                 break
 
 
+def _remap_hyper_connection_weights(weights: Dict[str, Any]) -> None:
+    for k in list(weights.keys()):
+        for suffix in ("input_mix_weight_down", "input_mix_weight_up", "block_inject_weight"):
+            if k == suffix or k.endswith("." + suffix):
+                weights[f"{k}.weight"] = weights.pop(k)
+
+
 def remap_fused_projections(weights: Dict[str, Any]) -> Dict[str, Any]:
     """Map old split GDN/MoE projection keys onto the fused module names.
 
@@ -2301,6 +2308,7 @@ def remap_fused_projections(weights: Dict[str, Any]) -> Dict[str, Any]:
     original groups (exact). Mixed-status pairs are not fused.
     """
     out = dict(weights)
+    _remap_hyper_connection_weights(out)
     _rewrite_packed_experts(out)
 
     qkv_stems = [

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1760,15 +1760,16 @@ class Model(nn.Module):
 
     def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
         sanitized = sanitize(weights)
-        # Retain MTP tensors accessible via side-channel for MTP lane
+        # Retain MTP tensors accessible via side-channel for MTP lane,
+        # but exclude them from strict trunk loading.
         self.mtp_weights = {
             k: v for k, v in sanitized.items() if k.startswith("mtp.")
         }
-        return sanitized
+        return {k: v for k, v in sanitized.items() if not k.startswith("mtp.")}
 
     @property
-    def quant_predicate(self) -> Callable[[str, Any, Any], bool]:
-        def fn(path: str, module: Any, _: Any) -> bool:
+    def quant_predicate(self) -> Callable[[str, Any], bool]:
+        def fn(path: str, module: Any) -> bool:
             # Keep MoE router in full precision; norms and convs are skipped anyway
             return not path.endswith("mlp.gate")
 

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -2345,8 +2345,8 @@ def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
     """Sanitize checkpoint weights to match the MTPLX module hierarchy.
 
     Key mappings performed:
-      - Strips `language_model.` prefix from Hugging Face checkpoints.
-      - Discards vision tower weights (`vision_tower.` / `model.visual.`).
+      - Strips `model.language_model.` and `language_model.` prefixes from Hugging Face checkpoints.
+      - Discards vision tower weights (`vision_tower.` / `model.visual.` / `visual.`).
       - Transposes 1D conv weights `(C, 1, K)` -> `(C, K, 1)` for MLX.
       - Stacks numbered MoE expert tensors into `switch_mlp` if unstacked.
       - Concatenates sharded n-gram embedding tables into ``shard_0`` (post-load;
@@ -2357,9 +2357,31 @@ def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
     """
     out: Dict[str, Any] = {}
     for k, v in weights.items():
-        if k.startswith("language_model."):
-            k = k[len("language_model.") :]
-        if k.startswith("vision_tower.") or k.startswith("model.visual."):
+        if k.startswith("model.language_model."):
+            suffix = k[len("model.language_model.") :]
+            if (
+                suffix.startswith("model.")
+                or suffix.startswith("lm_head.")
+                or suffix.startswith("mtp.")
+            ):
+                k = suffix
+            else:
+                k = "model." + suffix
+        elif k.startswith("language_model."):
+            suffix = k[len("language_model.") :]
+            if (
+                suffix.startswith("model.")
+                or suffix.startswith("lm_head.")
+                or suffix.startswith("mtp.")
+            ):
+                k = suffix
+            else:
+                k = "model." + suffix
+        if (
+            k.startswith("vision_tower.")
+            or k.startswith("model.visual.")
+            or k.startswith("visual.")
+        ):
             continue
         if "conv1d.weight" in k and v.ndim == 3 and v.shape[-1] != 1:
             if v.shape[1] == 1:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -760,10 +760,13 @@ class QSAIndexer(nn.Module):
         parts: List[QSASelection] = []
         for s0 in range(0, S, chunk):
             s1 = min(s0 + chunk, S)
+            q_pos_slice = (
+                prep.q_pos[:, s0:s1] if prep.q_pos.ndim == 2 else prep.q_pos[s0:s1]
+            )
             parts.append(
                 self.select(
                     prep.q[:, s0:s1],
-                    prep.q_pos[s0:s1],
+                    q_pos_slice,
                     prep.pooled,
                     prep.kv_len,
                     prep.left_padding,
@@ -930,9 +933,14 @@ class Attention(nn.Module):
                 pieces: List[mx.array] = []
                 for s0 in range(0, S, chunk):
                     s1 = min(s0 + chunk, S)
+                    q_pos_slice = (
+                        prep.q_pos[:, s0:s1]
+                        if prep.q_pos.ndim == 2
+                        else prep.q_pos[s0:s1]
+                    )
                     sel = indexer.select(
                         prep.q[:, s0:s1],
-                        prep.q_pos[s0:s1],
+                        q_pos_slice,
                         prep.pooled,
                         prep.kv_len,
                         prep.left_padding,

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -422,6 +422,7 @@ class QSAPrep:
     pooled: mx.array  # (B, n_blocks, D_idx)
     q_pos: mx.array  # (S,)
     kv_len: int
+    left_padding: Optional[mx.array] = None
 
 
 _QSA_PATH_LOGGED = False
@@ -618,7 +619,16 @@ class QSAIndexer(nn.Module):
         cos_q, sin_q = rope(q_pos[None, :])
         q = self.q_layernorm(q)
         q = _rope_partial(q, cos_q[:, :, None, :], sin_q[:, :, None, :])
-        return QSAPrep(q=q, pooled=pooled, q_pos=q_pos, kv_len=kv_len)
+        left_padding = getattr(cache, "left_padding", None)
+        if left_padding is None and hasattr(cache, "indexer"):
+            left_padding = getattr(cache.indexer, "left_padding", None)
+        return QSAPrep(
+            q=q,
+            pooled=pooled,
+            q_pos=q_pos,
+            kv_len=kv_len,
+            left_padding=left_padding,
+        )
 
     def select(
         self,
@@ -626,6 +636,7 @@ class QSAIndexer(nn.Module):
         q_pos: mx.array,
         pooled: mx.array,
         kv_len: int,
+        left_padding: Optional[mx.array] = None,
     ) -> QSASelection:
         """Score this query slice against every compressed block; return token idx."""
         B, S, _, _ = q.shape
@@ -633,6 +644,13 @@ class QSAIndexer(nn.Module):
         r = self.compress_ratio
         n_complete = (q_pos + 1) // r
         is_complete = mx.arange(n_blocks)[None, :] < n_complete[:, None]  # (S, n_blocks)
+
+        if left_padding is not None:
+            block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
+            is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
+            valid_block = is_complete[None, :, :] & is_not_pad  # (B, S, n_blocks)
+        else:
+            valid_block = mx.broadcast_to(is_complete[None, :, :], (B, S, n_blocks))
 
         # Sum_h ReLU(<q_h, k_b>) without materializing the 4-head score tensor.
         acc = None
@@ -642,23 +660,27 @@ class QSAIndexer(nn.Module):
             s_h = mx.maximum(s_h, 0)
             acc = s_h if acc is None else acc + s_h
         scores = acc / math.sqrt(self.head_dim)
-        masked = mx.where(is_complete[None, :, :], scores, -mx.inf)
+        masked = mx.where(valid_block, scores, -mx.inf)
 
         k_blk = min(self.block_topk, n_blocks)
         top = mx.argpartition(-masked, k_blk - 1, axis=-1)[..., :k_blk]
-        is_top_complete = mx.take_along_axis(is_complete[None, :, :], top, axis=-1)
+        is_top_complete = mx.take_along_axis(valid_block, top, axis=-1)
         top = mx.where(is_top_complete, top, 0)
 
         tok = (top[..., None] * r + mx.arange(r)).reshape(B, S, k_blk * r)
         valid_blk = mx.broadcast_to(
             is_top_complete[..., None], (*is_top_complete.shape, r)
         ).reshape(B, S, k_blk * r) & (tok < kv_len)
+        if left_padding is not None:
+            valid_blk = valid_blk & (tok >= left_padding[:, None, None])
 
         tail_start = n_complete * r
         tail = tail_start[:, None] + mx.arange(r)  # (S, r)
         tail_valid = (tail <= q_pos[:, None]) & (tail < kv_len)
         tail = mx.broadcast_to(tail[None], (B, S, r))
         tail_valid = mx.broadcast_to(tail_valid[None], (B, S, r))
+        if left_padding is not None:
+            tail_valid = tail_valid & (tail >= left_padding[:, None, None])
 
         return QSASelection(
             token_idx=mx.concatenate([tok, tail], axis=-1).astype(mx.int32),
@@ -675,7 +697,9 @@ class QSAIndexer(nn.Module):
         n_blocks = int(prep.pooled.shape[1])
         chunk = _indexer_score_chunk(n_blocks, _qsa_query_chunk())
         if S <= chunk:
-            return self.select(prep.q, prep.q_pos, prep.pooled, prep.kv_len)
+            return self.select(
+                prep.q, prep.q_pos, prep.pooled, prep.kv_len, prep.left_padding
+            )
         parts: List[QSASelection] = []
         for s0 in range(0, S, chunk):
             s1 = min(s0 + chunk, S)
@@ -685,6 +709,7 @@ class QSAIndexer(nn.Module):
                     prep.q_pos[s0:s1],
                     prep.pooled,
                     prep.kv_len,
+                    prep.left_padding,
                 )
             )
         return QSASelection(
@@ -844,6 +869,7 @@ class Attention(nn.Module):
                         prep.q_pos[s0:s1],
                         prep.pooled,
                         prep.kv_len,
+                        prep.left_padding,
                     )
                     mask_c = mask
                     if mask_c is not None and not isinstance(mask_c, str):
@@ -1278,7 +1304,7 @@ class PLELayer(nn.Module):
             bias=False,
         )
 
-    def _short_conv(self, x: mx.array, cache: Any) -> mx.array:
+    def _short_conv(self, x: mx.array, cache: Any, mask: Any = None) -> mx.array:
         S = x.shape[1]
         n = self.short_conv_state_len
         slot = _cache_slot(cache, 2)
@@ -1287,13 +1313,23 @@ class PLELayer(nn.Module):
             if slot is not None
             else mx.zeros((x.shape[0], n, x.shape[-1]), dtype=x.dtype)
         )
+        if mask is not None:
+            x = mx.where(mask[..., None], x, 0)
         full = mx.concatenate([state, x], axis=1)
         if cache is not None:
             _set_cache_slot(cache, 2, mx.contiguous(full[:, -n:, :]))
-        return nn.silu(self.conv1d(full[:, -(n + S) :, :]))
+        out = nn.silu(self.conv1d(full[:, -(n + S) :, :]))
+        if mask is not None:
+            out = mx.where(mask[..., None], out, 0)
+        return out
 
     def __call__(
-        self, hidden: mx.array, ids: mx.array, prev_ctx: mx.array, cache: Any
+        self,
+        hidden: mx.array,
+        ids: mx.array,
+        prev_ctx: mx.array,
+        cache: Any,
+        mask: Any = None,
     ) -> mx.array:
         emb = self.ple_embedding(ids, prev_ctx).astype(hidden.dtype)
         key = self.norm_key(self.key_proj(emb))
@@ -1306,7 +1342,12 @@ class PLELayer(nn.Module):
         gate = mx.sqrt(mx.maximum(mx.abs(gate), 1e-6)) * mx.sign(gate)
         gated = mx.sigmoid(gate) * value[..., None, :]
         gated = gated.reshape(*gated.shape[:-2], -1)
-        return gated + self._short_conv(self.norm_conv(gated), cache)
+        if mask is not None:
+            gated = mx.where(mask[..., None], gated, 0)
+        out = gated + self._short_conv(self.norm_conv(gated), cache, mask=mask)
+        if mask is not None:
+            out = mx.where(mask[..., None], out, 0)
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -1345,7 +1386,7 @@ class DecoderLayer(nn.Module):
     ) -> mx.array:
         del idx_cache  # QSA indexer cache is cache.indexer; house attn is (x, mask, cache)
         if self.ple is not None:
-            h = h + self.ple(h, ids, prev_ctx, cache)
+            h = h + self.ple(h, ids, prev_ctx, cache, conv_mask)
 
         x, hyper, inject = self.attn_hyper_connection(h)
         if self.layer_type == "linear_attention":
@@ -1482,6 +1523,7 @@ class _IndexerCache(_BaseCache):
         self._buf = None
         self._len = 0
         self.pooled = None
+        self.left_padding = None
 
     @property
     def keys(self):
@@ -1535,6 +1577,8 @@ class _IndexerCache(_BaseCache):
     def filter(self, batch_indices: Any) -> None:
         if self._buf is not None:
             self._buf = self._buf[batch_indices]
+        if self.left_padding is not None:
+            self.left_padding = self.left_padding[batch_indices]
         self.pooled = None
 
     def extend(self, other: Any) -> None:
@@ -1576,6 +1620,19 @@ class _IndexerCache(_BaseCache):
         b_pad = pad_right_aligned(other_k, b_batch, L2)
         self._buf = mx.concatenate([a_pad, b_pad], axis=0)
         self._len = max_L
+        other_lp = getattr(other, "left_padding", None)
+        if self.left_padding is not None or other_lp is not None:
+            a_lp = (
+                self.left_padding
+                if self.left_padding is not None
+                else mx.zeros((a_batch,), dtype=mx.int32)
+            )
+            b_lp = (
+                other_lp
+                if other_lp is not None
+                else mx.zeros((b_batch,), dtype=mx.int32)
+            )
+            self.left_padding = mx.concatenate([a_lp, b_lp], axis=0)
         self.pooled = None
 
     def extract(self, idx: int) -> "_IndexerCache":
@@ -1583,6 +1640,8 @@ class _IndexerCache(_BaseCache):
         if self._buf is not None and self._len > 0:
             k = self._buf[idx : idx + 1, : self._len, :]
             cache.keys = mx.contiguous(k)
+        if self.left_padding is not None:
+            cache.left_padding = self.left_padding[idx : idx + 1]
         return cache
 
     @classmethod
@@ -1611,6 +1670,15 @@ class _IndexerCache(_BaseCache):
                 buf[i : i + 1, pad:max_len, :] = k
         cache._buf = buf
         cache._len = max_len
+        lps = [getattr(c, "left_padding", None) for c in caches]
+        if any(lp is not None for lp in lps):
+            lp_list = [
+                lp
+                if lp is not None
+                else mx.zeros((getattr(c, "batch_size", 1),), dtype=mx.int32)
+                for lp, c in zip(lps, caches)
+            ]
+            cache.left_padding = mx.concatenate(lp_list, axis=0)
         cache.pooled = None
         return cache
 
@@ -1637,6 +1705,18 @@ class _AttnCache(KVCache):
     def __init__(self):
         super().__init__()
         self.indexer = _IndexerCache()
+        self._mtplx_indexer_trim = True
+
+    def trim(self, n: int) -> int:
+        trimmed = super().trim(n)
+        dropped = int(n if trimmed is None else trimmed)
+        if hasattr(self, "indexer") and self.indexer is not None:
+            if dropped:
+                self.indexer.trim(dropped)
+        reuse = getattr(self, "_sparse_index_reuse", None)
+        if reuse is not None and hasattr(reuse, "reset"):
+            reuse.reset()
+        return trimmed
 
     def filter(self, batch_indices: Any) -> None:
         if self.keys is not None:
@@ -1687,6 +1767,8 @@ class _AttnCache(KVCache):
         merged = super().merge(caches)
         indexers = [getattr(c, "indexer", None) for c in caches]
         merged.indexer = _IndexerCache.merge(indexers)
+        if getattr(merged, "left_padding", None) is not None:
+            merged.indexer.left_padding = merged.left_padding
         from mtplx.qwen4_exp_mtp_patch import _install_indexer_aware_trim
 
         _install_indexer_aware_trim(merged)

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -21,6 +21,7 @@ import mlx.nn as nn
 from mlx_lm.models.base import (
     BaseModelArgs,
     create_attention_mask,
+    create_ssm_mask,
     scaled_dot_product_attention,
 )
 from mlx_lm.models.cache import ArraysCache, KVCache, _BaseCache
@@ -1329,6 +1330,10 @@ class Qwen4ExpModel(nn.Module):
             (i for i, l in enumerate(self.layers) if l.layer_type == "full_attention"),
             None,
         )
+        self.first_linear_attn_idx = next(
+            (i for i, l in enumerate(self.layers) if l.layer_type == "linear_attention"),
+            None,
+        )
         self.ple_layers = [
             i for i in range(args.num_hidden_layers) if (i + 1) in args.ple_layer_ids
         ]
@@ -1361,7 +1366,21 @@ class Qwen4ExpModel(nn.Module):
         mask = create_attention_mask(
             h, [attn_cache] if attn_cache is not None else None
         )
-        conv_mask = None
+        linear_cache = (
+            cache[self.first_linear_attn_idx]
+            if (
+                self.first_linear_attn_idx is not None
+                and len(cache) > self.first_linear_attn_idx
+                and cache[self.first_linear_attn_idx] is not None
+            )
+            else None
+        )
+        if linear_cache is None:
+            linear_cache = next(
+                (c for c in cache if c is not None and hasattr(c, "make_mask")),
+                None,
+            )
+        conv_mask = create_ssm_mask(h, linear_cache)
 
         prev_ctx = None
         if self.ple_layers and ids is not None:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -690,8 +690,8 @@ class QSAIndexer(nn.Module):
         is_complete = mx.arange(n_blocks)[None, :] < n_complete[:, None]  # (S, n_blocks)
 
         if left_padding is not None:
-            block_starts = mx.arange(n_blocks) * r  # (n_blocks,)
-            is_not_pad = block_starts[None, None, :] >= left_padding[:, None, None]  # (B, 1, n_blocks)
+            block_ends = (mx.arange(n_blocks) + 1) * r  # (n_blocks,)
+            is_not_pad = block_ends[None, None, :] > left_padding[:, None, None]  # (B, 1, n_blocks)
             valid_block = is_complete[None, :, :] & is_not_pad  # (B, S, n_blocks)
         else:
             valid_block = mx.broadcast_to(is_complete[None, :, :], (B, S, n_blocks))
@@ -1548,27 +1548,46 @@ def _build_ple_tail_context(
     ctx_len: int,
     eos: int,
     left_padding: Optional[Any] = None,
+    offset: int = 0,
+    mask: Optional[Any] = None,
 ) -> mx.array:
-    if left_padding is None:
+    if left_padding is None and mask is None:
         return mx.concatenate([prev_ctx, ids], axis=1)[:, -ctx_len:]
 
     B, S = ids.shape
+    rows = []
+    if mask is not None:
+        for i in range(B):
+            m_i = mask[i] if mask.ndim > 1 else mask
+            m_list = m_i.tolist() if hasattr(m_i, "tolist") else list(m_i)
+            valid_idx = [idx for idx, v in enumerate(m_list) if v]
+            if len(valid_idx) >= ctx_len:
+                rows.append(ids[i : i + 1, valid_idx[-ctx_len:]])
+            elif len(valid_idx) > 0:
+                needed = ctx_len - len(valid_idx)
+                prefix = prev_ctx[i : i + 1, -needed:]
+                suffix = ids[i : i + 1, valid_idx]
+                rows.append(mx.concatenate([prefix, suffix], axis=1))
+            else:
+                rows.append(prev_ctx[i : i + 1])
+        return mx.concatenate(rows, axis=0)
+
     lp_list = (
         left_padding.tolist()
         if hasattr(left_padding, "tolist")
         else list(left_padding)
     )
-    rows = []
     for i in range(B):
         lp = int(lp_list[i]) if i < len(lp_list) else 0
-        v_len = max(0, S - lp)
+        start_idx = max(0, min(S, lp - int(offset)))
+        valid_ids = ids[i : i + 1, start_idx:S]
+        v_len = int(valid_ids.shape[1])
         if v_len >= ctx_len:
-            rows.append(ids[i : i + 1, S - ctx_len : S])
+            rows.append(valid_ids[:, -ctx_len:])
         elif v_len > 0:
             needed = ctx_len - v_len
             prefix = prev_ctx[i : i + 1, -needed:]
-            suffix = ids[i : i + 1, lp:S]
-            rows.append(mx.concatenate([prefix, suffix], axis=1))
+            rows.append(mx.concatenate([prefix, valid_ids], axis=1))
         else:
             rows.append(prev_ctx[i : i + 1])
     return mx.concatenate(rows, axis=0)
@@ -1671,8 +1690,19 @@ class Qwen4ExpModel(nn.Module):
                 else mx.full((ids.shape[0], ctx_len), eos, ids.dtype)
             )
             if pc is not None:
+                offset = 0
+                if attn_cache is not None and hasattr(attn_cache, "offset"):
+                    offset = int(getattr(attn_cache, "offset", 0))
+                elif linear_cache is not None and hasattr(linear_cache, "offset"):
+                    offset = int(getattr(linear_cache, "offset", 0))
                 tail = _build_ple_tail_context(
-                    prev_ctx, ids, ctx_len, eos, left_padding
+                    prev_ctx,
+                    ids,
+                    ctx_len,
+                    eos,
+                    left_padding=left_padding,
+                    offset=offset,
+                    mask=conv_mask,
                 )
                 _set_cache_slot(pc, 3, tail)
 

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -101,12 +101,36 @@ class TextArgs(BaseModelArgs):
     eos_token_id: Any = 248044
     partial_rotary_factor: float = 0.25
     rope_parameters: dict = field(default_factory=dict)
+    rope_scaling: dict = field(default_factory=dict)
     rope_theta: float = 10_000_000.0
     tie_word_embeddings: bool = False
     max_position_embeddings: int = 262144
     # Multi-Token Prediction (MTP) metadata
     mtp_num_hidden_layers: int = 0
     mtp: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, params: dict):
+        params = dict(params)
+        rope_scaling = params.get("rope_scaling")
+        rope_params = params.get("rope_parameters")
+        if isinstance(rope_scaling, dict) and not rope_params:
+            rp = dict(rope_scaling)
+            if "type" in rp and "rope_type" not in rp:
+                rp["rope_type"] = rp["type"]
+            params["rope_parameters"] = rp
+        elif isinstance(rope_params, dict) and isinstance(rope_scaling, dict):
+            merged = dict(rope_scaling)
+            merged.update(rope_params)
+            if "type" in merged and "rope_type" not in merged:
+                merged["rope_type"] = merged["type"]
+            params["rope_parameters"] = merged
+        elif isinstance(rope_params, dict):
+            rp = dict(rope_params)
+            if "type" in rp and "rope_type" not in rp:
+                rp["rope_type"] = rp["type"]
+            params["rope_parameters"] = rp
+        return super().from_dict(params)
 
 
 @dataclass
@@ -219,12 +243,16 @@ class RotaryEmbedding:
         self.mscale = 1.0
         inv_freq = base ** (-mx.arange(0, dim, 2, dtype=mx.float32) / dim)
         rp = rope_parameters or {}
-        if str(rp.get("rope_type", "default")).lower() == "yarn":
+        rope_type = str(rp.get("rope_type") or rp.get("type", "default")).lower()
+        if rope_type == "yarn":
             # Canonical yarn (mirrors mlx-lm rope_utils.YarnRoPE): blend
             # interpolated and extrapolated periods across a correction range,
             # and scale rotation amplitude by mscale.
             factor = float(rp.get("factor", 1.0))
-            orig = float(rp.get("original_max_position_embeddings", 262144))
+            orig = float(
+                rp.get("original_max_position_embeddings")
+                or rp.get("original_max_position", 262144)
+            )
             beta_fast = float(rp.get("beta_fast", 32))
             beta_slow = float(rp.get("beta_slow", 1))
 
@@ -1509,6 +1537,44 @@ class _AttnCache(KVCache):
         super().__init__()
         self.indexer = _IndexerCache()
 
+    @property
+    def state(self):
+        indexer_keys = getattr(self.indexer, "keys", None)
+        if self.keys is None or self.values is None:
+            return self.keys, self.values, indexer_keys
+        if self.offset == self.keys.shape[2]:
+            return self.keys, self.values, indexer_keys
+        return (
+            self.keys[..., : self.offset, :],
+            self.values[..., : self.offset, :],
+            indexer_keys,
+        )
+
+    @state.setter
+    def state(self, v):
+        if v is None:
+            self.keys = self.values = None
+            self.offset = 0
+            if hasattr(self, "indexer") and self.indexer is not None:
+                self.indexer.keys = None
+                self.indexer._len = 0
+            return
+        if len(v) == 3:
+            keys, values, indexer_keys = v
+            self.keys = keys
+            self.values = values
+            self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+            if hasattr(self, "indexer") and self.indexer is not None:
+                self.indexer.keys = indexer_keys
+                self.indexer._len = (
+                    0 if indexer_keys is None else int(indexer_keys.shape[1])
+                )
+        else:
+            keys, values = v
+            self.keys = keys
+            self.values = values
+            self.offset = 0 if self.keys is None else int(self.keys.shape[2])
+
 
 # ---------------------------------------------------------------------------
 # Top-level Model & Weight sanitization
@@ -1716,6 +1782,43 @@ def remap_fused_projections(weights: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
+_QWEN4_TRUNK_NORM_SUFFIXES = (
+    "hc_norm.weight",
+    "q_norm.weight",
+    "k_norm.weight",
+    "q_layernorm.weight",
+    "k_layernorm.weight",
+    "norm.weight",
+    "norm_key.weight",
+    "norm_query.weight",
+    "norm_conv.weight",
+)
+
+
+def _shift_trunk_gemma_norms(weights: Dict[str, Any]) -> Dict[str, Any]:
+    """Restore MLX-absolute RMSNorm gains on raw HF qwen4_exp trunk weights."""
+    targets = [
+        (k, v)
+        for k, v in weights.items()
+        if not k.startswith("mtp.")
+        and getattr(v, "ndim", None) == 1
+        and any(str(k).endswith(suffix) for suffix in _QWEN4_TRUNK_NORM_SUFFIXES)
+    ]
+    if not targets:
+        return weights
+    try:
+        means = [float(v.mean().item()) for _, v in targets]
+        if sum(means) / len(means) > 0.5:
+            return weights
+    except Exception:
+        return weights
+
+    out = dict(weights)
+    for k, v in targets:
+        out[k] = v + 1.0
+    return out
+
+
 def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
     """Sanitize checkpoint weights to match the MTPLX module hierarchy.
 
@@ -1726,6 +1829,7 @@ def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
       - Stacks numbered MoE expert tensors into `switch_mlp` if unstacked.
       - Concatenates sharded n-gram embedding tables into ``shard_0`` (post-load;
         on-disk layout is unchanged).
+      - Converts raw zero-centered Gemma trunk norms to MLX absolute convention.
       - Fuses GDN in_proj_qkv+z / in_proj_b+a and MoE gate+up at load time.
       - Retains all `mtp.*` tensors for downstream speculative/MTP lanes.
     """
@@ -1773,6 +1877,7 @@ def sanitize(weights: Dict[str, Any]) -> Dict[str, Any]:
                         )
 
     _concat_sharded_embedding_tables(out)
+    out = _shift_trunk_gemma_norms(out)
     return remap_fused_projections(out)
 
 

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1470,7 +1470,16 @@ class PLELayer(nn.Module):
         cache: Any,
         mask: Any = None,
     ) -> mx.array:
-        emb = self.ple_embedding(ids, prev_ctx).astype(hidden.dtype)
+        clean_ids = ids
+        if mask is not None and ids is not None:
+            m = mask
+            while m.ndim > ids.ndim:
+                m = m.squeeze(1)
+            if m.ndim < ids.ndim:
+                m = mx.broadcast_to(m, ids.shape)
+            eos = getattr(self.ple_embedding, "eos_token_id", 151643)
+            clean_ids = mx.where(m, ids, eos)
+        emb = self.ple_embedding(clean_ids, prev_ctx).astype(hidden.dtype)
         key = self.norm_key(self.key_proj(emb))
         key = key.reshape(*key.shape[:-1], self.hc, self.d)
         value = self.value_proj(emb)
@@ -2389,12 +2398,31 @@ def _shift_trunk_gemma_norms(weights: Dict[str, Any]) -> Dict[str, Any]:
     ]
     if not targets:
         return weights
-    try:
-        means = [float(v.mean().item()) for _, v in targets]
-        if sum(means) / len(means) > 0.5:
+
+    # Check primary raw trunk norm markers (e.g. hc_norm, model.norm, norm)
+    # instead of letting unrelated norm magnitudes (like trained q/k norms)
+    # skew the mean.
+    primary_markers = [
+        (k, v)
+        for k, v in targets
+        if str(k).endswith("hc_norm.weight")
+        or str(k).endswith("model.norm.weight")
+        or str(k) == "norm.weight"
+    ]
+    if primary_markers:
+        try:
+            marker_means = [float(v.mean().item()) for _, v in primary_markers]
+            if sum(marker_means) / len(marker_means) > 0.5:
+                return weights
+        except Exception:
             return weights
-    except Exception:
-        return weights
+    else:
+        try:
+            means = [float(v.mean().item()) for _, v in targets]
+            if sum(means) / len(means) > 0.5:
+                return weights
+        except Exception:
+            return weights
 
     out = dict(weights)
     for k, v in targets:

--- a/mtplx/models/qwen4_exp_compiled.py
+++ b/mtplx/models/qwen4_exp_compiled.py
@@ -1,0 +1,326 @@
+# Copyright © 2024 Apple Inc. / MTPLX authors
+# Native MLX compilation wrappers for Qwen3.8-Flash-Next (qwen4_exp).
+#
+# Stage 1: Shape-stable single-token decode subgraphs (GDN, GatedResidual, MoE).
+# Keeps layer class bodies in qwen4_exp.py untouched to avoid merge conflicts
+# with parallel lanes.
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def is_compile_enabled() -> bool:
+    """Check if the compiled decode path is enabled via environment variable."""
+    return (
+        str(os.environ.get("MTPLX_QWEN4EXP_COMPILE", "")).strip().lower()
+        in {"1", "true", "yes", "on"}
+        or str(os.environ.get("MTPLX_COMPILE_AR_FORWARD", "")).strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trace-safe carrier for GatedDeltaNet state
+# ---------------------------------------------------------------------------
+
+
+class GDNCarrier:
+    """Throwaway carrier holding GDN conv and recurrent states during graph tracing.
+
+    Constructed inside the compiled wrapper; object creation during tracing is
+    transparent to MLX tracing while array inputs and outputs are recorded.
+    """
+
+    def __init__(self, conv_state: mx.array, rec_state: mx.array):
+        self.conv_state = conv_state
+        self.rec_state = rec_state
+
+    def __getitem__(self, idx: int) -> mx.array:
+        if idx == 0:
+            return self.conv_state
+        elif idx == 1:
+            return self.rec_state
+        raise IndexError(f"GDNCarrier index out of range: {idx}")
+
+    def __setitem__(self, idx: int, val: mx.array) -> None:
+        if idx == 0:
+            self.conv_state = val
+        elif idx == 1:
+            self.rec_state = val
+        else:
+            raise IndexError(f"GDNCarrier index out of range: {idx}")
+
+    def advance(self, S: int) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: Individual Subgraph Compilers
+# ---------------------------------------------------------------------------
+
+
+def compile_gdn_step(
+    layer: Any,
+) -> Callable[[mx.array, mx.array, mx.array], Tuple[mx.array, mx.array, mx.array]]:
+    """Compile single-token GatedDeltaNet step (S=1).
+
+    Args:
+        layer: GatedDeltaNet module instance.
+
+    Returns:
+        Compiled function taking (x, conv_state, recurrent_state) and returning
+        (out, new_conv_state, new_recurrent_state).
+    """
+
+    def gdn_step(
+        x: mx.array, conv_state: mx.array, rec_state: mx.array
+    ) -> Tuple[mx.array, mx.array, mx.array]:
+        carrier = GDNCarrier(conv_state, rec_state)
+        out = layer(x, None, carrier)
+        return out, carrier.conv_state, carrier.rec_state
+
+    return mx.compile(gdn_step)
+
+
+def compile_gated_residual(
+    hc_layer: Any,
+) -> Callable[[mx.array], Union[Tuple[mx.array, mx.array, mx.array], mx.array]]:
+    """Compile GatedResidual hyper-connection mixing/injection step.
+
+    Args:
+        hc_layer: GatedResidual module instance.
+
+    Returns:
+        Compiled function taking (h) and returning (mixed, hyper, inject) or mixed.
+    """
+
+    def hc_step(h: mx.array):
+        return hc_layer(h)
+
+    return mx.compile(hc_step)
+
+
+def compile_moe_step(moe_layer: Any) -> Callable[[mx.array], mx.array]:
+    """Compile single-token SparseMoeBlock (S=1).
+
+    Args:
+        moe_layer: SparseMoeBlock module instance.
+
+    Returns:
+        Compiled function taking (x) and returning out.
+    """
+
+    def moe_step(x: mx.array) -> mx.array:
+        return moe_layer(x)
+
+    return mx.compile(moe_step)
+
+
+def compile_linear_layer_step(
+    layer: Any,
+) -> Callable[[mx.array, mx.array, mx.array], Tuple[mx.array, mx.array, mx.array]]:
+    """Compile full single-token step for a linear attention decoder layer.
+
+    Fuses attn_hyper_connection -> GatedDeltaNet -> residual ->
+    mlp_hyper_connection -> SparseMoeBlock -> residual into a single
+    compiled Metal execution graph.
+
+    Args:
+        layer: DecoderLayer instance where layer_type == "linear_attention".
+
+    Returns:
+        Compiled function taking (h, conv_state, rec_state) and returning
+        (h_out, new_conv_state, new_rec_state).
+    """
+
+    def linear_step(
+        h: mx.array, conv_state: mx.array, rec_state: mx.array
+    ) -> Tuple[mx.array, mx.array, mx.array]:
+        x, hyper, inject = layer.attn_hyper_connection(h)
+        carrier = GDNCarrier(conv_state, rec_state)
+        x = layer.linear_attn(x, None, carrier)
+        h_mid = hyper + (x[..., None, :] * inject[..., None]).reshape(
+            *x.shape[:-1], -1
+        )
+        x_mlp, hyper_mlp, inject_mlp = layer.mlp_hyper_connection(h_mid)
+        x_moe = layer.mlp(x_mlp)
+        h_out = hyper_mlp + (x_moe[..., None, :] * inject_mlp[..., None]).reshape(
+            *x_moe.shape[:-1], -1
+        )
+        return h_out, carrier.conv_state, carrier.rec_state
+
+    return mx.compile(linear_step)
+
+
+def compile_attn_pre_step(
+    layer: Any,
+) -> Callable[[mx.array], Tuple[mx.array, mx.array, mx.array]]:
+    """Compile pre-attention hyper-connection for a full attention layer."""
+
+    def attn_pre_step(h: mx.array) -> Tuple[mx.array, mx.array, mx.array]:
+        return layer.attn_hyper_connection(h)
+
+    return mx.compile(attn_pre_step)
+
+
+def compile_attn_post_step(
+    layer: Any,
+) -> Callable[[mx.array, mx.array, mx.array], mx.array]:
+    """Compile post-attention residual, MLP hyper-connection, MoE, and final residual."""
+
+    def attn_post_step(x: mx.array, hyper: mx.array, inject: mx.array) -> mx.array:
+        h_mid = hyper + (x[..., None, :] * inject[..., None]).reshape(
+            *x.shape[:-1], -1
+        )
+        x_mlp, hyper_mlp, inject_mlp = layer.mlp_hyper_connection(h_mid)
+        x_moe = layer.mlp(x_mlp)
+        return hyper_mlp + (x_moe[..., None, :] * inject_mlp[..., None]).reshape(
+            *x_moe.shape[:-1], -1
+        )
+
+    return mx.compile(attn_post_step)
+
+
+def compile_hyper_mixer(mixer: Any) -> Callable[[mx.array], mx.array]:
+    """Compile final hyper-connection mixer."""
+
+    def mixer_step(h: mx.array) -> mx.array:
+        return mixer(h)
+
+    return mx.compile(mixer_step)
+
+
+# ---------------------------------------------------------------------------
+# Compiled Model Execution Manager
+# ---------------------------------------------------------------------------
+
+
+class CompiledLayerRunner:
+    """Manages compiled step functions across model layers for a model instance."""
+
+    def __init__(self, model: Any):
+        self.model = model
+        self.layer_runners: List[Dict[str, Any]] = []
+
+        for layer in model.layers:
+            if layer.layer_type == "linear_attention":
+                self.layer_runners.append(
+                    {
+                        "type": "linear",
+                        "step": compile_linear_layer_step(layer),
+                        "gdn": layer.linear_attn,
+                        "layer": layer,
+                    }
+                )
+            else:
+                self.layer_runners.append(
+                    {
+                        "type": "full_attention",
+                        "pre": compile_attn_pre_step(layer),
+                        "post": compile_attn_post_step(layer),
+                        "layer": layer,
+                    }
+                )
+
+        self.mixer_step = compile_hyper_mixer(model.hyper_connection_mixer)
+
+    def run(
+        self,
+        h: mx.array,
+        rope: Any,
+        mask: Any,
+        conv_mask: Any,
+        cache: Optional[List[Any]],
+        ids: Optional[mx.array],
+        prev_ctx: Optional[mx.array],
+    ) -> mx.array:
+        B = h.shape[0]
+        if cache is None:
+            cache = [None] * len(self.layer_runners)
+
+        for i, (runner, c) in enumerate(zip(self.layer_runners, cache)):
+            layer = runner["layer"]
+
+            # 1. PLE step: stays eager because of NumPy host-sync in _ShardedEmbedding.
+            # INTEGRATION POINT (Stage 2): When Lane A/B replaces numpy indexing with
+            # purely native MLX ops, ple can be absorbed into the compiled graph.
+            if layer.ple is not None:
+                h = h + layer.ple(h, ids, prev_ctx, c)
+
+            if runner["type"] == "linear":
+                gdn = runner["gdn"]
+                # Zero-initialized states for shape stability (no None retrace hazards)
+                conv_state = (
+                    c[0]
+                    if (c is not None and c[0] is not None)
+                    else mx.zeros(
+                        (B, gdn.conv_kernel_size - 1, gdn.conv_dim), dtype=h.dtype
+                    )
+                )
+                rec_state = (
+                    c[1]
+                    if (c is not None and c[1] is not None)
+                    else mx.zeros(
+                        (B, gdn.n_v, gdn.dv, gdn.dk), dtype=mx.float32
+                    )
+                )
+
+                h, new_c, new_r = runner["step"](h, conv_state, rec_state)
+
+                if c is not None:
+                    c[0] = new_c
+                    c[1] = new_r
+                    if hasattr(c, "advance"):
+                        c.advance(1)
+
+            else:
+                # Full attention layer: attention stays eager (offset / KVCache / rotary)
+                x_in, hyper, inject = runner["pre"](h)
+                if getattr(layer.self_attn, "rope", None) is None:
+                    layer.self_attn.rope = rope
+                x_out = layer.self_attn(x_in, mask, c)
+                h = runner["post"](x_out, hyper, inject)
+
+        return h
+
+
+# Cache runner instance directly on the model instance to avoid global
+# dictionary retention and memory leaks across reload cycles.
+def clear_compiled_runner_cache(model: Any | None = None) -> None:
+    """Explicitly drop cached compiled runners to free memory upon model unload."""
+    if model is not None and hasattr(model, "_compiled_runner"):
+        try:
+            delattr(model, "_compiled_runner")
+        except Exception:
+            pass
+
+
+def get_compiled_runner(model: Any) -> CompiledLayerRunner:
+    runner = getattr(model, "_compiled_runner", None)
+    if runner is None or getattr(runner, "model", None) is not model:
+        runner = CompiledLayerRunner(model)
+        try:
+            model._compiled_runner = runner
+        except Exception:
+            pass
+    return runner
+
+
+def run_compiled_layers(
+    model: Any,
+    h: mx.array,
+    rope: Any,
+    mask: Any,
+    conv_mask: Any,
+    cache: Optional[List[Any]],
+    ids: Optional[mx.array],
+    prev_ctx: Optional[mx.array],
+) -> mx.array:
+    """Entry point called from Qwen4ExpModel.__call__ when compiled path is active."""
+    runner = get_compiled_runner(model)
+    return runner.run(h, rope, mask, conv_mask, cache, ids, prev_ctx)

--- a/mtplx/models/qwen4_exp_compiled.py
+++ b/mtplx/models/qwen4_exp_compiled.py
@@ -123,7 +123,7 @@ def compile_moe_step(moe_layer: Any) -> Callable[[mx.array], mx.array]:
 
 def compile_linear_layer_step(
     layer: Any,
-) -> Callable[[mx.array, mx.array, mx.array], Tuple[mx.array, mx.array, mx.array]]:
+) -> Callable[[mx.array, Any, mx.array, mx.array], Tuple[mx.array, mx.array, mx.array]]:
     """Compile full single-token step for a linear attention decoder layer.
 
     Fuses attn_hyper_connection -> GatedDeltaNet -> residual ->
@@ -134,16 +134,16 @@ def compile_linear_layer_step(
         layer: DecoderLayer instance where layer_type == "linear_attention".
 
     Returns:
-        Compiled function taking (h, conv_state, rec_state) and returning
+        Compiled function taking (h, conv_mask, conv_state, rec_state) and returning
         (h_out, new_conv_state, new_rec_state).
     """
 
     def linear_step(
-        h: mx.array, conv_state: mx.array, rec_state: mx.array
+        h: mx.array, conv_mask: Any, conv_state: mx.array, rec_state: mx.array
     ) -> Tuple[mx.array, mx.array, mx.array]:
         x, hyper, inject = layer.attn_hyper_connection(h)
         carrier = GDNCarrier(conv_state, rec_state)
-        x = layer.linear_attn(x, None, carrier)
+        x = layer.linear_attn(x, conv_mask, carrier)
         h_mid = hyper + (x[..., None, :] * inject[..., None]).reshape(
             *x.shape[:-1], -1
         )
@@ -270,7 +270,7 @@ class CompiledLayerRunner:
                     )
                 )
 
-                h, new_c, new_r = runner["step"](h, conv_state, rec_state)
+                h, new_c, new_r = runner["step"](h, conv_mask, conv_state, rec_state)
 
                 if c is not None:
                     c[0] = new_c

--- a/mtplx/models/qwen4_exp_compiled.py
+++ b/mtplx/models/qwen4_exp_compiled.py
@@ -250,7 +250,7 @@ class CompiledLayerRunner:
             # INTEGRATION POINT (Stage 2): When Lane A/B replaces numpy indexing with
             # purely native MLX ops, ple can be absorbed into the compiled graph.
             if layer.ple is not None:
-                h = h + layer.ple(h, ids, prev_ctx, c)
+                h = h + layer.ple(h, ids, prev_ctx, c, conv_mask)
 
             if runner["type"] == "linear":
                 gdn = runner["gdn"]

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -305,8 +305,10 @@ class SparseIndexReuse:
     def prepare(self, x, rope, cache, offset: int):
         return self.indexer.prepare(x, rope, cache, offset)
 
-    def select(self, q, q_pos, pooled, kv_len):
-        return self.indexer.select(q, q_pos, pooled, kv_len)
+    def select(self, q, q_pos, pooled, kv_len, left_padding=None, *args, **kwargs):
+        return self.indexer.select(
+            q, q_pos, pooled, kv_len, left_padding=left_padding, *args, **kwargs
+        )
 
     def __call__(self, x, rope, cache, offset: int):
         import mlx.core as mx
@@ -1079,7 +1081,9 @@ def qwen4_exp_product_verify_strategy(model: Any) -> str | None:
     is batched verify with a live snapshot. Returns None for other models.
     """
     if model is None:
-        return None
+        return "batched"
+    if isinstance(model, (str, Path)):
+        return "batched"
     inner = _inner_model(model)
     if not getattr(inner, "_mtplx_qwen4_exp_capture", False):
         return None
@@ -1087,7 +1091,7 @@ def qwen4_exp_product_verify_strategy(model: Any) -> str | None:
 
 
 @contextlib.contextmanager
-def qwen4_exp_product_verify_env(model: Any):
+def qwen4_exp_product_verify_env(model: Any = None):
     """Yield the product verify_strategy, forcing a live snapshot for qwen4_exp."""
     strategy = qwen4_exp_product_verify_strategy(model)
     if strategy is None:

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -42,7 +42,6 @@ _REFERENCE_QWEN4_EXP = Path("/tmp/mlx-lm-pr1788/mlx_lm/models/qwen4_exp.py")
 _MTP_ALIAS = {
     "enorm.weight": "pre_fc_norm_embedding.weight",
     "hnorm.weight": "pre_fc_norm_hidden.weight",
-    "eh_proj.weight": "fc.weight",
     "final_layernorm.weight": "norm.weight",
     "shared_head_norm.weight": "norm.weight",
 }
@@ -181,6 +180,43 @@ def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Pa
     return sorted(model_path.glob("model*.safetensors"))
 
 
+def _split_eh_proj_weights(weights: dict[str, Any]) -> dict[str, Any]:
+    import mlx.core as mx
+
+    out = dict(weights)
+    keys = list(out.keys())
+    for k in keys:
+        if "eh_proj." in k or k.startswith("fc.") or ".fc." in k:
+            val = out.pop(k)
+            for name in ("eh_proj.", "fc."):
+                if name in k:
+                    prefix, suffix = k.split(name, 1)
+                    break
+            else:
+                prefix = ""
+                suffix = k
+
+            if (
+                getattr(val, "shape", None)
+                and len(val.shape) >= 2
+                and val.shape[-1] % 2 == 0
+            ):
+                e_val, h_val = mx.split(val, 2, axis=-1)
+                out[f"{prefix}fc_embedding.{suffix}"] = e_val
+                out[f"{prefix}fc_hidden.{suffix}"] = h_val
+            elif (
+                getattr(val, "shape", None)
+                and len(val.shape) == 1
+                and val.shape[0] % 2 == 0
+            ):
+                e_val, h_val = mx.split(val, 2, axis=0)
+                out[f"{prefix}fc_embedding.{suffix}"] = e_val
+                out[f"{prefix}fc_hidden.{suffix}"] = h_val
+            else:
+                out[k] = val
+    return out
+
+
 def _process_raw_mtp_weights(
     raw: dict[str, Any], is_mlx_format: bool = False
 ) -> dict[str, Any]:
@@ -192,6 +228,7 @@ def _process_raw_mtp_weights(
         else:
             mapped[key] = value
     remapped = _remap_mtp_moe_weights(mapped)
+    remapped = _split_eh_proj_weights(remapped)
     if is_mlx_format:
         return remapped
     return _shift_qwen4_gemma_mtp_norms(remapped)
@@ -217,6 +254,7 @@ def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
             if local is not None:
                 mapped[local] = value
     remapped = _remap_mtp_moe_weights(mapped)
+    remapped = _split_eh_proj_weights(remapped)
     if is_mlx_format:
         return remapped
     return _shift_qwen4_gemma_mtp_norms(remapped)
@@ -1294,7 +1332,8 @@ def inject_qwen4_exp_mtp_support(
 ) -> bool:
     """Attach the qwen4_exp MTP head and the draft/verify/rollback surface."""
     import mlx.core as mx
-    from mlx_lm.models.base import create_attention_mask
+    from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+    from mlx_lm.models.cache import ArraysCache
 
     if not is_qwen4_exp_mtp_config(config) and not (
         allow_random_init and is_qwen4_exp_config(config)
@@ -1469,6 +1508,7 @@ def inject_qwen4_exp_mtp_support(
             position_offset: int | None = None,
             mtp_depth: int | None = None,
             reuse_sparse_indices: bool | None = None,
+            input_embeddings=None,
         ):
             del mtp_hidden_variant, concat_order
             layer_caches = mtp_cache if mtp_cache is not None else self.make_mtp_cache()
@@ -1489,9 +1529,14 @@ def inject_qwen4_exp_mtp_support(
             #   h = fc_hidden(h)   # shared Linear(H,H) per stream
             #   x = e.unsqueeze(-2) + h ; flatten to [T, hc*H]
             # Mean-collapse-then-tile was the zero-accept assembly bug.
-            e = self.mtp.fc_embedding(
-                self.mtp.pre_fc_norm_embedding(self._embed(next_token_ids))
-            )
+            if input_embeddings is not None:
+                e = self.mtp.fc_embedding(
+                    self.mtp.pre_fc_norm_embedding(input_embeddings)
+                )
+            else:
+                e = self.mtp.fc_embedding(
+                    self.mtp.pre_fc_norm_embedding(self._embed(next_token_ids))
+                )
             h = self.mtp.pre_fc_norm_hidden(hidden_states)
             h = h.reshape(*h.shape[:-1], hc, d)
             h = self.mtp.fc_hidden(h)
@@ -1509,14 +1554,56 @@ def inject_qwen4_exp_mtp_support(
                         except Exception:
                             pass
             if rope_shift:
-                attn_cache = layer_caches[0] if layer_caches else None
+                attn_cache = next(
+                    (
+                        c
+                        for l, c in zip(self.mtp.layers, layer_caches)
+                        if (
+                            getattr(l, "layer_type", None) != "linear_attention"
+                            and not hasattr(l, "linear_attn")
+                        )
+                        and c is not None
+                        and getattr(c, "offset", None) is not None
+                    ),
+                    None,
+                )
                 local = int(getattr(attn_cache, "offset", 0) or 0)
                 self.mtp.rope_shift = rope_shift - local
             else:
                 self.mtp.rope_shift = 0
-            attn_cache = layer_caches[0] if layer_caches else None
+            attn_cache = next(
+                (
+                    c
+                    for l, c in zip(self.mtp.layers, layer_caches)
+                    if (
+                        getattr(l, "layer_type", None) != "linear_attention"
+                        and not hasattr(l, "linear_attn")
+                    )
+                    and c is not None
+                    and getattr(c, "offset", None) is not None
+                ),
+                None,
+            )
             mask = create_attention_mask(
                 e, [attn_cache] if attn_cache is not None else None
+            )
+            linear_cache = next(
+                (
+                    c
+                    for l, c in zip(self.mtp.layers, layer_caches)
+                    if (
+                        getattr(l, "layer_type", None) == "linear_attention"
+                        or hasattr(l, "linear_attn")
+                    )
+                    and c is not None
+                    and hasattr(c, "make_mask")
+                ),
+                None,
+            )
+            conv_mask = (
+                create_ssm_mask(e, linear_cache)
+                if linear_cache is not None
+                else None
             )
             ids = next_token_ids
             for layer, layer_cache in zip(self.mtp.layers, layer_caches):
@@ -1529,7 +1616,7 @@ def inject_qwen4_exp_mtp_support(
                     x,
                     self.mtp.rope,
                     mask,
-                    None,
+                    conv_mask,
                     layer_cache,
                     idx_c,
                     ids,
@@ -1549,6 +1636,7 @@ def inject_qwen4_exp_mtp_support(
             concat_order=None,
             position_offset: int | None = None,
             mtp_depth: int | None = None,
+            input_embeddings=None,
         ):
             _logits, hidden = self.mtp_forward(
                 hidden_states,
@@ -1558,18 +1646,26 @@ def inject_qwen4_exp_mtp_support(
                 return_hidden=True,
                 position_offset=position_offset,
                 mtp_depth=mtp_depth,
+                input_embeddings=input_embeddings,
             )
             return hidden
 
         def make_mtp_cache(self):
             caches = []
             for layer in self.mtp.layers:
-                entry = _install_indexer_aware_trim(_make_attn_cache(qwen4))
-                attn = getattr(layer, "self_attn", None)
-                indexer = getattr(attn, "indexer", None)
-                if isinstance(indexer, SparseIndexReuse):
-                    entry._sparse_index_reuse = indexer
-                caches.append(entry)
+                is_linear = (
+                    getattr(layer, "layer_type", None) == "linear_attention"
+                    or hasattr(layer, "linear_attn")
+                )
+                if is_linear:
+                    caches.append(ArraysCache(4))
+                else:
+                    entry = _install_indexer_aware_trim(_make_attn_cache(qwen4))
+                    attn = getattr(layer, "self_attn", None)
+                    indexer = getattr(attn, "indexer", None)
+                    if isinstance(indexer, SparseIndexReuse):
+                        entry._sparse_index_reuse = indexer
+                    caches.append(entry)
             return caches
 
         def snapshot_state(self, cache, *, copy: bool = False) -> StateSnapshot:

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -185,14 +185,25 @@ def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
     import mlx.core as mx
 
     mapped: dict[str, Any] = {}
+    is_mlx_format = False
     for path in paths:
         if path.suffix != ".safetensors":
             continue
-        for key, value in mx.load(str(path)).items():
+        try:
+            loaded, metadata = mx.load(str(path), return_metadata=True)
+            if isinstance(metadata, dict) and str(metadata.get("format", "")).lower() == "mlx":
+                is_mlx_format = True
+        except Exception:
+            loaded = mx.load(str(path))
+            metadata = None
+        for key, value in loaded.items():
             local = _strip_mtp_prefix(key)
             if local is not None:
                 mapped[local] = value
-    return _shift_qwen4_gemma_mtp_norms(_remap_mtp_moe_weights(mapped))
+    remapped = _remap_mtp_moe_weights(mapped)
+    if is_mlx_format:
+        return remapped
+    return _shift_qwen4_gemma_mtp_norms(remapped)
 
 
 # Qwen4ExpTextRMSNorm is Gemma-style ``(1 + weight)`` with zero init. MLX
@@ -228,8 +239,12 @@ def _remap_mtp_moe_weights(weights: dict[str, Any]) -> dict[str, Any]:
     return remap(dict(weights))
 
 
-def _shift_qwen4_gemma_mtp_norms(weights: dict[str, Any]) -> dict[str, Any]:
+def _shift_qwen4_gemma_mtp_norms(
+    weights: dict[str, Any], metadata: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Restore MLX-absolute RMSNorm gains on a raw-HF qwen4_exp MTP sidecar."""
+    if metadata and str(metadata.get("format", "")).lower() == "mlx":
+        return weights
     targets = [
         (key, value)
         for key, value in weights.items()
@@ -238,6 +253,22 @@ def _shift_qwen4_gemma_mtp_norms(weights: dict[str, Any]) -> dict[str, Any]:
     ]
     if not targets:
         return weights
+    for key, value in targets:
+        if str(key).endswith("pre_fc_norm_embedding.weight") or str(key).endswith(
+            "pre_fc_norm_hidden.weight"
+        ):
+            try:
+                if float(value.mean().item()) > 0.5:
+                    return weights
+            except Exception:
+                pass
+    try:
+        means = [float(v.mean().item()) for _, v in targets]
+        if sum(means) / len(means) > 0.5:
+            return weights
+    except Exception:
+        pass
+
     out = dict(weights)
     for key, value in targets:
         out[key] = value + 1.0
@@ -738,10 +769,13 @@ def _sequential_owner_forward(
     return_hidden: bool,
     hidden_variant: str | None,
     input_embeddings=None,
+    **kwargs,
 ):
     import mlx.core as mx
 
     del hidden_variant, input_embeddings
+    emit_logits = kwargs.get("emit_logits", True)
+    logits_keep = kwargs.get("logits_keep", None)
     length = int(inputs.shape[1])
     logits_steps = []
     hidden_steps = []
@@ -751,14 +785,20 @@ def _sequential_owner_forward(
         step = inputs[:, t : t + 1]
         if return_hidden:
             last_logits, last_hidden = owner(
-                step, cache=cache, return_hidden=True
+                step, cache=cache, return_hidden=True, emit_logits=emit_logits
             )
-            logits_steps.append(last_logits)
+            if emit_logits and last_logits is not None:
+                logits_steps.append(last_logits)
             hidden_steps.append(last_hidden)
         else:
-            last_logits = owner(step, cache=cache, return_hidden=False)
-            logits_steps.append(last_logits)
-    logits = mx.concatenate(logits_steps, axis=1)
+            last_logits = owner(
+                step, cache=cache, return_hidden=False, emit_logits=emit_logits
+            )
+            if emit_logits and last_logits is not None:
+                logits_steps.append(last_logits)
+    logits = mx.concatenate(logits_steps, axis=1) if emit_logits and logits_steps else None
+    if logits is not None and logits_keep is not None:
+        logits = logits[:, -max(1, int(logits_keep)) :, :]
     if not return_hidden:
         return logits
     hidden = mx.concatenate(hidden_steps, axis=1)
@@ -1196,15 +1236,23 @@ def inject_qwen4_exp_mtp_support(
                     cache,
                     return_hidden=return_hidden,
                     hidden_variant=hidden_variant,
+                    **kwargs,
                 )
             if not return_hidden:
                 return super().__call__(
-                    inputs, cache=cache, input_embeddings=input_embeddings
+                    inputs, cache=cache, input_embeddings=input_embeddings, **kwargs
                 )
             mixed, hyper = self.model(
                 inputs, cache, input_embeddings, return_hyper=True
             )
-            logits = self._lm_logits(mixed)
+            emit_logits = kwargs.get("emit_logits", True)
+            logits_keep = kwargs.get("logits_keep", None)
+            if not emit_logits:
+                return None, hyper
+            out = mixed
+            if logits_keep is not None:
+                out = out[:, -max(1, int(logits_keep)) :, :]
+            logits = self._lm_logits(out)
             return logits, hyper
 
         def make_cache(self):

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -81,7 +81,19 @@ def _num_mtp_layers(config: dict[str, Any]) -> int:
 
 
 def is_qwen4_exp_config(config: dict[str, Any]) -> bool:
-    return _model_type(config) in QWEN4_EXP_MODEL_TYPES
+    if _model_type(config) in QWEN4_EXP_MODEL_TYPES:
+        return True
+    tcfg = text_config(config)
+    archs = (
+        (config.get("architectures") if isinstance(config, dict) else None)
+        or tcfg.get("architectures")
+        or []
+    )
+    for arch in archs:
+        compact = str(arch).lower().replace("_", "").replace("-", "")
+        if "qwen4exp" in compact:
+            return True
+    return False
 
 
 def is_qwen4_exp_mtp_config(config: dict[str, Any]) -> bool:

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1279,8 +1279,7 @@ def _make_mtp_module(args: Any, n_layers: int, qwen4: Any):
                 if attn is None:
                     continue
                 attn.rope = self.rope
-            # Indexer is wrapped after load_weights so sidecar
-            # ``self_attn.indexer.*`` tensors bind to the real module.
+                attn.indexer = None
 
         def install_sparse_reuse(self) -> None:
             self._sparse_reuse = []
@@ -1660,12 +1659,17 @@ def inject_qwen4_exp_mtp_support(
                 if is_linear:
                     caches.append(ArraysCache(4))
                 else:
-                    entry = _install_indexer_aware_trim(_make_attn_cache(qwen4))
                     attn = getattr(layer, "self_attn", None)
                     indexer = getattr(attn, "indexer", None)
-                    if isinstance(indexer, SparseIndexReuse):
-                        entry._sparse_index_reuse = indexer
-                    caches.append(entry)
+                    if indexer is not None:
+                        entry = _install_indexer_aware_trim(_make_attn_cache(qwen4))
+                        if isinstance(indexer, SparseIndexReuse):
+                            entry._sparse_index_reuse = indexer
+                        caches.append(entry)
+                    else:
+                        from mlx_lm.models.cache import KVCache
+
+                        caches.append(KVCache())
             return caches
 
         def snapshot_state(self, cache, *, copy: bool = False) -> StateSnapshot:

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -181,6 +181,22 @@ def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Pa
     return sorted(model_path.glob("model*.safetensors"))
 
 
+def _process_raw_mtp_weights(
+    raw: dict[str, Any], is_mlx_format: bool = False
+) -> dict[str, Any]:
+    mapped: dict[str, Any] = {}
+    for key, value in raw.items():
+        local = _strip_mtp_prefix(key)
+        if local is not None:
+            mapped[local] = value
+        else:
+            mapped[key] = value
+    remapped = _remap_mtp_moe_weights(mapped)
+    if is_mlx_format:
+        return remapped
+    return _shift_qwen4_gemma_mtp_norms(remapped)
+
+
 def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
     import mlx.core as mx
 
@@ -1296,12 +1312,25 @@ def inject_qwen4_exp_mtp_support(
         args = TextArgs.from_dict(text_config(config))
     mtp_args = _mtp_text_args(args, config, n_layers)
 
-    weights = _load_mtp_weights(_candidate_weight_files(model_path, config))
+    text_model = _text_model(model)
+    embedded = (
+        getattr(model, "_mtp_weights", None)
+        or getattr(text_model, "_mtp_weights", None)
+        or getattr(model, "mtp_weights", None)
+        or getattr(text_model, "mtp_weights", None)
+    )
+    if embedded:
+        weights = _process_raw_mtp_weights(embedded)
+        if hasattr(model, "_mtp_weights"):
+            model._mtp_weights = {}
+        if hasattr(text_model, "_mtp_weights"):
+            text_model._mtp_weights = {}
+    else:
+        weights = _load_mtp_weights(_candidate_weight_files(model_path, config))
     if not weights and not allow_random_init:
         logger.warning("[Qwen4Exp MTP inject] no mtp.* weights found in %s", model_path)
         return False
 
-    text_model = _text_model(model)
     mtp = _make_mtp_module(mtp_args, n_layers, qwen4)
     if contract is not None:
         from .mtp_patch import _quantize_mtp_module
@@ -1637,10 +1666,13 @@ def _row_to_numpy(row) -> Any:
     return np.asarray(row, dtype=np.float64)
 
 
-def _softmax(row) -> Any:
+def _softmax(row, temperature: float = 1.0) -> Any:
     import numpy as np
 
     x = _row_to_numpy(row)
+    t = float(temperature)
+    if t > 0 and t != 1.0:
+        x = x / t
     x = x - np.max(x)
     e = np.exp(x)
     return e / e.sum()
@@ -1673,7 +1705,7 @@ def sample_logits_row(
     import numpy as np
 
     vocab = int(row.shape[-1])
-    q = _softmax(row)
+    q = _softmax(row, temperature=temperature)
     token = int(rng.choice(np.arange(vocab), p=q))
     return token, q
 
@@ -1693,7 +1725,7 @@ def verify_draft_token(
             return SpeculativeDecision(True, int(draft_token), 1.0)
         return SpeculativeDecision(False, int(target_token), 0.0)
     vocab = int(target_row.shape[-1])
-    target_p = _softmax(target_row)
+    target_p = _softmax(target_row, temperature=temperature)
     return verify_one_token(target_p, draft_q, int(draft_token), rng)
 
 

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -753,6 +753,10 @@ class Qwen4ExpRecurrentCache:
         self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
         if self.left_padding is not None:
             self.left_padding = self.left_padding[batch_indices]
+            if getattr(self.left_padding, "size", 0) > 0:
+                min_left_pad = int(self.left_padding.min().item())
+                if min_left_pad > 0:
+                    self.left_padding -= min_left_pad
         if self.lengths is not None:
             self.lengths = self.lengths[batch_indices]
 

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1872,8 +1872,6 @@ def draft_tokens(
     tok = int(token_id)
     h = hidden
     for _ in range(n):
-        if mtp_cache is not None:
-            mtp_snapshots.append(StateSnapshot.capture(mtp_cache, copy=False))
         logits, h = model.mtp_forward(
             h,
             mx.array([[tok]], dtype=mx.int32),
@@ -1882,6 +1880,8 @@ def draft_tokens(
             reuse_sparse_indices=reuse_sparse_indices,
         )
         mx.eval(logits, h)
+        if mtp_cache is not None:
+            mtp_snapshots.append(StateSnapshot.capture(mtp_cache, copy=False))
         tok, q = sample_logits_row(logits[0, -1], temperature=temperature, rng=rng)
         drafts.append(tok)
         qs.append(q)

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -337,21 +337,27 @@ def _shift_qwen4_gemma_mtp_norms(
     ]
     if not targets:
         return weights
-    for key, value in targets:
-        if str(key).endswith("pre_fc_norm_embedding.weight") or str(key).endswith(
-            "pre_fc_norm_hidden.weight"
-        ):
-            try:
-                if float(value.mean().item()) > 0.5:
-                    return weights
-            except Exception:
-                pass
-    try:
-        means = [float(v.mean().item()) for _, v in targets]
-        if sum(means) / len(means) > 0.5:
-            return weights
-    except Exception:
-        pass
+
+    pre_fc_targets = [
+        (key, value)
+        for key, value in targets
+        if str(key).endswith("pre_fc_norm_embedding.weight")
+        or str(key).endswith("pre_fc_norm_hidden.weight")
+    ]
+    if pre_fc_targets:
+        try:
+            pre_fc_means = [float(v.mean().item()) for _, v in pre_fc_targets]
+            if sum(pre_fc_means) / len(pre_fc_means) > 0.5:
+                return weights
+        except Exception:
+            pass
+    else:
+        try:
+            means = [float(v.mean().item()) for _, v in targets]
+            if sum(means) / len(means) > 0.5:
+                return weights
+        except Exception:
+            pass
 
     out = dict(weights)
     for key, value in targets:
@@ -1923,12 +1929,16 @@ def _rebuild_exact_mtp_cells(
     mtp_snaps[0].restore(mtp_cache)
     for j, tok in enumerate(accepted):
         if j < len(step_hiddens):
-            _logits, _h = model.mtp_forward(
+            res = model.mtp_forward(
                 step_hiddens[j],
                 mx.array([[int(tok)]], dtype=mx.int32),
                 mtp_cache=mtp_cache,
+                return_hidden=True,
             )
-            mx.eval(_logits, _h)
+            if isinstance(res, tuple):
+                mx.eval(*res)
+            else:
+                mx.eval(res)
 
 
 def speculative_generate(

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1852,22 +1852,28 @@ def draft_tokens(
     temperature: float = 0.0,
     rng: Any | None = None,
     reuse_sparse_indices: bool = True,
-) -> tuple[list[int], list[Any], Any]:
+    mtp_cache: Any | None = None,
+    return_snapshots: bool = False,
+) -> tuple[list[int], list[Any], Any] | tuple[list[int], list[Any], Any, list[StateSnapshot]]:
     """Run the MTP head for up to ``n`` draft tokens. Returns ids, q's, last hidden."""
     import mlx.core as mx
     import numpy as np
 
     rng = rng or np.random.default_rng()
     n = clamp_draft_depth(n)
-    mtp_cache = model.make_mtp_cache()
+    if mtp_cache is None:
+        mtp_cache = model.make_mtp_cache()
     if hasattr(model, "mtp") and hasattr(model.mtp, "reset_sparse_reuse"):
         model.mtp.reset_sparse_reuse()
         model.mtp.set_sparse_reuse(reuse_sparse_indices)
+    mtp_snapshots: list[StateSnapshot] = []
     drafts: list[int] = []
     qs: list[Any] = []
     tok = int(token_id)
     h = hidden
     for _ in range(n):
+        if mtp_cache is not None:
+            mtp_snapshots.append(StateSnapshot.capture(mtp_cache, copy=False))
         logits, h = model.mtp_forward(
             h,
             mx.array([[tok]], dtype=mx.int32),
@@ -1880,6 +1886,8 @@ def draft_tokens(
         drafts.append(tok)
         qs.append(q)
         h = h[:, -1:, :]
+    if return_snapshots:
+        return drafts, qs, h, mtp_snapshots
     return drafts, qs, h
 
 
@@ -1900,8 +1908,17 @@ def speculative_generate(
     rng = rng or np.random.default_rng(0)
     depth = clamp_draft_depth(draft_depth)
     cache = model.make_cache()
+    mtp_cache = model.make_mtp_cache() if hasattr(model, "make_mtp_cache") else None
     logits, hidden = model(prompt_ids, cache=cache, return_hidden=True)
     mx.eval(logits, hidden)
+    if (
+        prompt_ids.shape[1] > 1
+        and mtp_cache is not None
+        and hasattr(model, "mtp_update_cache")
+    ):
+        model.mtp_update_cache(
+            hidden[:, :-1, :], prompt_ids[:, 1:], mtp_cache=mtp_cache
+        )
     primary, _ = sample_logits_row(logits[0, -1], temperature=temperature, rng=rng)
     tokens = [primary]
     hidden = hidden[:, -1:, :]
@@ -1909,7 +1926,7 @@ def speculative_generate(
     while len(tokens) < max_tokens:
         remaining = max_tokens - len(tokens)
         n = min(depth, remaining)
-        drafts, draft_qs, _draft_hidden = draft_tokens(
+        drafts, draft_qs, _draft_hidden, mtp_snaps = draft_tokens(
             model,
             hidden,
             primary,
@@ -1917,6 +1934,8 @@ def speculative_generate(
             temperature=temperature,
             rng=rng,
             reuse_sparse_indices=reuse_sparse_indices,
+            mtp_cache=mtp_cache,
+            return_snapshots=True,
         )
         step_snapshots: list[StateSnapshot] = []
         step_hiddens: list[Any] = []
@@ -1950,6 +1969,8 @@ def speculative_generate(
                 correction = int(decision.token_id)
                 # Instant zero-replay rollback: restore state to position i (after primary + accepted[:i])
                 step_snapshots[i].restore(cache)
+                if mtp_cache is not None and i < len(mtp_snaps):
+                    mtp_snaps[i].restore(mtp_cache)
                 hidden = step_hiddens[i]
                 tokens.extend(accepted)
                 tokens.append(int(correction))

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -627,6 +627,9 @@ class Qwen4ExpRecurrentCache:
     def empty(self) -> bool:
         return all(item is None for item in self.cache)
 
+    def __len__(self) -> int:
+        return len(self.cache)
+
     @property
     def meta_state(self) -> tuple[str, str]:
         return ("qwen4_exp_recurrent", str(len(self.cache)))
@@ -654,6 +657,9 @@ def _trim_qsa_indexer(entry: Any, n: int) -> None:
         return
     keep = int(keys.shape[1]) - int(n)
     indexer.keys = keys[:, :keep, :] if keep > 0 else None
+    reuse = getattr(entry, "_sparse_index_reuse", None)
+    if reuse is not None and hasattr(reuse, "reset"):
+        reuse.reset()
 
 
 def _install_indexer_aware_trim(entry: Any) -> Any:
@@ -669,6 +675,10 @@ def _install_indexer_aware_trim(entry: Any) -> Any:
         dropped = int(n if trimmed is None else trimmed)
         if dropped:
             _trim_qsa_indexer(_entry, dropped)
+        else:
+            reuse = getattr(_entry, "_sparse_index_reuse", None)
+            if reuse is not None and hasattr(reuse, "reset"):
+                reuse.reset()
         return trimmed
 
     entry.trim = trim
@@ -1018,7 +1028,10 @@ def _make_mtp_module(args: Any, n_layers: int, qwen4: Any):
                 if attn is None:
                     continue
                 indexer = getattr(attn, "indexer", None)
-                if indexer is None or isinstance(indexer, SparseIndexReuse):
+                if indexer is None:
+                    continue
+                if isinstance(indexer, SparseIndexReuse):
+                    self._sparse_reuse.append(indexer)
                     continue
                 wrapper = SparseIndexReuse(indexer)
                 attn.indexer = wrapper
@@ -1083,6 +1096,11 @@ def inject_qwen4_exp_mtp_support(
 
     text_model = _text_model(model)
     mtp = _make_mtp_module(mtp_args, n_layers, qwen4)
+    if contract is not None:
+        from .mtp_patch import _quantize_mtp_module
+
+        if getattr(contract, "mtp_prequantized", False):
+            _quantize_mtp_module(mtp, contract)
     if weights:
         mtp.load_weights(list(weights.items()), strict=False)
         from mlx.utils import tree_flatten
@@ -1107,6 +1125,10 @@ def inject_qwen4_exp_mtp_support(
             logger.warning(
                 "[Qwen4Exp MTP inject] experts.gate_up_proj did not remap onto switch_mlp.gate_up_proj"
             )
+    if contract is not None and not getattr(contract, "mtp_prequantized", False):
+        from .mtp_patch import _quantize_mtp_module
+
+        _quantize_mtp_module(mtp, contract)
     mtp.install_sparse_reuse()
     mx.eval(mtp.parameters())
 
@@ -1196,10 +1218,12 @@ def inject_qwen4_exp_mtp_support(
             mtp_depth: int | None = None,
             reuse_sparse_indices: bool | None = None,
         ):
-            del mtp_hidden_variant, mtp_depth, concat_order
+            del mtp_hidden_variant, concat_order
             layer_caches = mtp_cache if mtp_cache is not None else self.make_mtp_cache()
             if reuse_sparse_indices is not None:
                 self.mtp.set_sparse_reuse(bool(reuse_sparse_indices))
+            if mtp_depth is None or int(mtp_depth) <= 1:
+                self.mtp.reset_sparse_reuse()
             d = int(self.mtp.hidden_size)
             expected = d * hc
             if int(hidden_states.shape[-1]) != expected:
@@ -1286,16 +1310,22 @@ def inject_qwen4_exp_mtp_support(
             return hidden
 
         def make_mtp_cache(self):
-            return [
-                _install_indexer_aware_trim(_make_attn_cache(qwen4))
-                for _ in self.mtp.layers
-            ]
+            caches = []
+            for layer in self.mtp.layers:
+                entry = _install_indexer_aware_trim(_make_attn_cache(qwen4))
+                attn = getattr(layer, "self_attn", None)
+                indexer = getattr(attn, "indexer", None)
+                if isinstance(indexer, SparseIndexReuse):
+                    entry._sparse_index_reuse = indexer
+                caches.append(entry)
+            return caches
 
         def snapshot_state(self, cache, *, copy: bool = False) -> StateSnapshot:
             return StateSnapshot.capture(cache, copy=copy)
 
         def restore_state(self, cache, snapshot: StateSnapshot) -> None:
             snapshot.restore(cache)
+            self.mtp.reset_sparse_reuse()
 
     text_model.__class__ = _MTPLXQwen4ExpModel
     bind_qwen4_exp_capture_protocol(getattr(text_model, "model", text_model))

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -57,7 +57,11 @@ def _model_type(config: dict[str, Any]) -> str:
 
 def _mtp_block_config(config: dict[str, Any]) -> dict[str, Any]:
     tcfg = text_config(config)
-    raw = tcfg.get("mtp") if isinstance(tcfg.get("mtp"), dict) else {}
+    raw = {}
+    if isinstance(tcfg, dict) and isinstance(tcfg.get("mtp"), dict):
+        raw = tcfg["mtp"]
+    elif isinstance(config, dict) and isinstance(config.get("mtp"), dict):
+        raw = config["mtp"]
     return dict(raw)
 
 
@@ -68,8 +72,10 @@ def _num_mtp_layers(config: dict[str, Any]) -> int:
         mtp.get("num_hidden_layers")
         or tcfg.get("mtp_num_hidden_layers")
         or tcfg.get("num_nextn_predict_layers")
-        or config.get("mtp_num_hidden_layers")
-        or config.get("num_nextn_predict_layers")
+        or tcfg.get("num_mtp_modules")
+        or (config.get("mtp_num_hidden_layers") if isinstance(config, dict) else 0)
+        or (config.get("num_nextn_predict_layers") if isinstance(config, dict) else 0)
+        or (config.get("num_mtp_modules") if isinstance(config, dict) else 0)
         or 0
     )
 

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1909,6 +1909,28 @@ def draft_tokens(
     return drafts, qs, h
 
 
+def _rebuild_exact_mtp_cells(
+    model: Any,
+    mtp_cache: Any,
+    mtp_snaps: list[StateSnapshot],
+    step_hiddens: list[Any],
+    accepted: list[int],
+) -> None:
+    import mlx.core as mx
+
+    if mtp_cache is None or not mtp_snaps:
+        return
+    mtp_snaps[0].restore(mtp_cache)
+    for j, tok in enumerate(accepted):
+        if j < len(step_hiddens):
+            _logits, _h = model.mtp_forward(
+                step_hiddens[j],
+                mx.array([[int(tok)]], dtype=mx.int32),
+                mtp_cache=mtp_cache,
+            )
+            mx.eval(_logits, _h)
+
+
 def speculative_generate(
     model: Any,
     prompt_ids,
@@ -1987,8 +2009,9 @@ def speculative_generate(
                 correction = int(decision.token_id)
                 # Instant zero-replay rollback: restore state to position i (after primary + accepted[:i])
                 step_snapshots[i].restore(cache)
-                if mtp_cache is not None and i < len(mtp_snaps):
-                    mtp_snaps[i].restore(mtp_cache)
+                _rebuild_exact_mtp_cells(
+                    model, mtp_cache, mtp_snaps, step_hiddens, accepted
+                )
                 hidden = step_hiddens[i]
                 tokens.extend(accepted)
                 tokens.append(int(correction))
@@ -1997,6 +2020,9 @@ def speculative_generate(
 
         if correction is None:
             tokens.extend(accepted)
+            _rebuild_exact_mtp_cells(
+                model, mtp_cache, mtp_snaps, step_hiddens, accepted
+            )
             if len(tokens) < max_tokens:
                 bonus, _ = sample_logits_row(
                     last_logits[0, -1], temperature=temperature, rng=rng

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1155,6 +1155,12 @@ def inject_qwen4_exp_mtp_support(
                 return embed.as_linear(h)
             raise RuntimeError("qwen4_exp model has no lm_head / tied embedding")
 
+        def _draft_lm_logits(self, h):
+            draft_head = getattr(self, "_mtplx_draft_lm_head", None)
+            if draft_head is not None:
+                return draft_head(h)
+            return self._lm_logits(h)
+
         def _embed(self, token_ids):
             inner = getattr(self, "model", self)
             return inner.embed_tokens(token_ids)
@@ -1284,7 +1290,7 @@ def inject_qwen4_exp_mtp_support(
                     None,
                 )
             hidden = self.mtp.hyper_connection_mixer(x)
-            logits = self._lm_logits(hidden)
+            logits = self._draft_lm_logits(hidden)
             if not return_hidden:
                 return logits
             return logits, x

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -646,6 +646,120 @@ class Qwen4ExpRecurrentCache:
                 break
             self.cache[idx] = item
 
+    @property
+    def batch_size(self) -> int:
+        for c in self.cache:
+            if c is not None:
+                return int(c.shape[0])
+        if self.left_padding is not None:
+            return int(self.left_padding.size)
+        elif self.lengths is not None:
+            return int(self.lengths.size)
+        return 1
+
+    def filter(self, batch_indices: Any) -> None:
+        self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
+        if self.left_padding is not None:
+            self.left_padding = self.left_padding[batch_indices]
+        if self.lengths is not None:
+            self.lengths = self.lengths[batch_indices]
+
+    def extend(self, other: Any) -> None:
+        import mlx.core as mx
+
+        a_batch = self.batch_size
+        b_batch = getattr(other, "batch_size", 1)
+
+        def cat(a: Any, b: Any) -> Any:
+            shape = dtype = None
+            if a is not None:
+                shape = a.shape
+                dtype = a.dtype
+            if b is not None:
+                shape = b.shape
+                dtype = b.dtype
+
+            if shape is None:
+                return None
+
+            if a is None:
+                a = mx.zeros((a_batch,) + shape[1:], dtype=dtype)
+            if b is None:
+                b = mx.zeros((b_batch,) + shape[1:], dtype=dtype)
+
+            return mx.concatenate([a, b])
+
+        other_cache = getattr(other, "cache", getattr(other, "state", []))
+        self.cache = [cat(c, o) for c, o in zip(self.cache, other_cache)]
+        self.left_padding = cat(self.left_padding, getattr(other, "left_padding", None))
+        self.lengths = cat(self.lengths, getattr(other, "lengths", None))
+
+    def extract(self, idx: int) -> "Qwen4ExpRecurrentCache":
+        cache = Qwen4ExpRecurrentCache(len(self.cache))
+        cache.cache = [c[idx : idx + 1] if c is not None else None for c in self.cache]
+        cache.left_padding = (
+            self.left_padding[idx : idx + 1]
+            if self.left_padding is not None
+            else None
+        )
+        cache.lengths = (
+            self.lengths[idx : idx + 1]
+            if self.lengths is not None
+            else None
+        )
+        return cache
+
+    def prepare(self, lengths=None, left_padding=None, **kwargs) -> None:
+        import mlx.core as mx
+
+        if lengths is not None:
+            self.lengths = (
+                mx.array(lengths) if not isinstance(lengths, mx.array) else lengths
+            )
+        if left_padding is not None:
+            self.left_padding = (
+                mx.array(left_padding)
+                if not isinstance(left_padding, mx.array)
+                else left_padding
+            )
+
+    def finalize(self) -> None:
+        self.lengths = None
+        self.left_padding = None
+
+    @classmethod
+    def merge(cls, caches):
+        import mlx.core as mx
+
+        n_state = len(caches[0].cache)
+        B = len(caches)
+        cache = cls(n_state)
+
+        if all(c.empty() for c in caches):
+            cache.left_padding = mx.array([0] * B)
+            return cache
+
+        for e in range(n_state):
+            c_init = next((c[e] for c in caches if c[e] is not None), None)
+            if c_init is None:
+                continue
+            shape = list(c_init.shape)
+            shape[0] = B
+            cache[e] = mx.zeros(shape, c_init.dtype)
+            for i in range(B):
+                if caches[i][e] is None:
+                    continue
+                cache[e][i : i + 1] = caches[i][e]
+        return cache
+
+    @property
+    def nbytes(self) -> int:
+        total = 0
+        for c in self.cache:
+            if c is not None:
+                total += int(c.nbytes)
+        return total
+
     def is_trimmable(self) -> bool:
         return False
 

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -1,0 +1,1589 @@
+"""Native MTP speculative decoding for Qwen3.8-Flash-Next (``qwen4_exp``).
+
+The trunk is a hybrid of Gated DeltaNet (recurrent) and sparse QSA attention.
+Existing MTPLX MTP patches only roll back **KV offset**; that is not enough
+here. ``StateSnapshot`` captures every GDN recurrent/conv slot (and PLE
+slots if present) plus attention KV lengths, then restores them on a
+Leviathan-Chen rejection so the accepted prefix is the only committed state.
+
+The MTP head itself is one sparse full-attention block (config
+``text_config.mtp.layer_types = ["full_attention"]``) with the usual
+enorm/hnorm/fc mix. Transformers discards ``mtp.*``
+(``_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]``); this injector loads
+those tensors onto a runtime module.
+
+Draft depth: engine can emit up to N=4 (tech-report 4-step speculative
+decoding). Auto-tune surface stays AR/D1/D2/D3, matching the rest of MTPLX.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.util
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from .artifacts import expected_mtp_file, is_mtp_key, text_config
+from .sampling import SpeculativeDecision, verify_one_token
+
+logger = logging.getLogger(__name__)
+
+QWEN4_EXP_MODEL_TYPES = {"qwen4_exp", "qwen4_exp_text"}
+DEFAULT_DRAFT_DEPTH = 1
+MAX_DRAFT_DEPTH = 3
+TUNE_CANDIDATES = ("AR", "D1", "D2", "D3")
+_REFERENCE_QWEN4_EXP = Path("/tmp/mlx-lm-pr1788/mlx_lm/models/qwen4_exp.py")
+_MTP_ALIAS = {
+    "enorm.weight": "pre_fc_norm_embedding.weight",
+    "hnorm.weight": "pre_fc_norm_hidden.weight",
+    "eh_proj.weight": "fc.weight",
+    "final_layernorm.weight": "norm.weight",
+    "shared_head_norm.weight": "norm.weight",
+}
+
+
+# --------------------------------------------------------------------------- config
+
+
+def _model_type(config: dict[str, Any]) -> str:
+    tcfg = text_config(config)
+    return str(tcfg.get("model_type") or config.get("model_type") or "").lower()
+
+
+def _mtp_block_config(config: dict[str, Any]) -> dict[str, Any]:
+    tcfg = text_config(config)
+    raw = tcfg.get("mtp") if isinstance(tcfg.get("mtp"), dict) else {}
+    return dict(raw)
+
+
+def _num_mtp_layers(config: dict[str, Any]) -> int:
+    tcfg = text_config(config)
+    mtp = _mtp_block_config(config)
+    return int(
+        mtp.get("num_hidden_layers")
+        or tcfg.get("mtp_num_hidden_layers")
+        or tcfg.get("num_nextn_predict_layers")
+        or config.get("mtp_num_hidden_layers")
+        or config.get("num_nextn_predict_layers")
+        or 0
+    )
+
+
+def is_qwen4_exp_config(config: dict[str, Any]) -> bool:
+    return _model_type(config) in QWEN4_EXP_MODEL_TYPES
+
+
+def is_qwen4_exp_mtp_config(config: dict[str, Any]) -> bool:
+    return is_qwen4_exp_config(config) and _num_mtp_layers(config) > 0
+
+
+def clamp_draft_depth(depth: int | None) -> int:
+    raw = DEFAULT_DRAFT_DEPTH if depth is None else int(depth)
+    return max(1, min(MAX_DRAFT_DEPTH, raw))
+
+
+def tune_label_to_depth(label: str) -> int:
+    text = str(label or "").strip().upper()
+    if text in {"AR", "D0", "0"}:
+        return 0
+    if text.startswith("D") and text[1:].isdigit():
+        return clamp_draft_depth(int(text[1:]))
+    if text.isdigit():
+        return clamp_draft_depth(int(text))
+    raise ValueError(f"unknown draft-depth label {label!r}; expected AR or D1-D{MAX_DRAFT_DEPTH}")
+
+
+# --------------------------------------------------------------------------- qwen4_exp import (Lane 1, mlx-lm, or PR #1788 reference)
+
+
+def import_qwen4_exp():
+    """Load the AR module Lane 1 owns, falling back to the mlx-lm reference."""
+    for name in ("mtplx.models.qwen4_exp", "mlx_lm.models.qwen4_exp"):
+        if name in sys.modules:
+            return sys.modules[name]
+        try:
+            return importlib.import_module(name)
+        except Exception:
+            continue
+    if _REFERENCE_QWEN4_EXP.is_file():
+        spec = importlib.util.spec_from_file_location(
+            "mlx_lm.models.qwen4_exp", _REFERENCE_QWEN4_EXP
+        )
+        if spec is not None and spec.loader is not None:
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["mlx_lm.models.qwen4_exp"] = mod
+            spec.loader.exec_module(mod)
+            return mod
+    raise ImportError(
+        "qwen4_exp AR module is not available (mtplx.models.qwen4_exp, "
+        "mlx_lm.models.qwen4_exp, or /tmp/mlx-lm-pr1788 reference)"
+    )
+
+
+def _text_model(model: Any) -> Any:
+    return getattr(model, "language_model", model)
+
+
+def _text_args(model: Any) -> Any:
+    owner = _text_model(model)
+    args = getattr(owner, "args", None)
+    if args is not None and hasattr(args, "text"):
+        return args.text
+    inner = getattr(owner, "model", owner)
+    return getattr(inner, "args", args)
+
+
+# --------------------------------------------------------------------------- weights
+
+
+def _strip_mtp_prefix(key: str) -> str | None:
+    k = str(key)
+    for outer in ("language_model.", "model.model.", "model."):
+        if k.startswith(outer) and "mtp." in k:
+            k = k[k.index("mtp.") :]
+            break
+    if not k.startswith("mtp."):
+        if is_mtp_key(str(key)):
+            k = k[k.index("mtp.") :]
+        else:
+            return None
+    local = k[len("mtp.") :]
+    return _MTP_ALIAS.get(local, local)
+
+
+def _candidate_weight_files(model_path: Path, config: dict[str, Any]) -> list[Path]:
+    mtp_file = expected_mtp_file(model_path, config)
+    if mtp_file.exists():
+        return [mtp_file]
+    for name in ("model-mtp-head.safetensors", "mtp.safetensors"):
+        head = model_path / name
+        if head.exists():
+            return [head]
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text(encoding="utf-8")).get("weight_map", {})
+        except Exception:
+            weight_map = {}
+        selected = {
+            model_path / rel
+            for key, rel in weight_map.items()
+            if _strip_mtp_prefix(str(key)) is not None
+        }
+        if selected:
+            return sorted(selected)
+    return sorted(model_path.glob("model*.safetensors"))
+
+
+def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
+    import mlx.core as mx
+
+    mapped: dict[str, Any] = {}
+    for path in paths:
+        if path.suffix != ".safetensors":
+            continue
+        for key, value in mx.load(str(path)).items():
+            local = _strip_mtp_prefix(key)
+            if local is not None:
+                mapped[local] = value
+    return _shift_qwen4_gemma_mtp_norms(_remap_mtp_moe_weights(mapped))
+
+
+# Qwen4ExpTextRMSNorm is Gemma-style ``(1 + weight)`` with zero init. MLX
+# ``mx.fast.rms_norm`` multiplies by ``weight`` (one-centered). The MLX-4bit
+# sidecar is ``torch-layout-fp16-v1`` (raw HF), so these 1-D gains must be
+# shifted. q/k norms train large enough that the shared delta detector
+# (``max(qk) < 1.25``) treats the sidecar as absolute and would leave
+# ``pre_fc_norm_*`` at negative gains.
+_QWEN4_GEMMA_NORM_SUFFIXES = (
+    "pre_fc_norm_embedding.weight",
+    "pre_fc_norm_hidden.weight",
+    "hc_norm.weight",
+    "q_norm.weight",
+    "k_norm.weight",
+    "q_layernorm.weight",
+    "k_layernorm.weight",
+)
+
+
+def _remap_mtp_moe_weights(weights: dict[str, Any]) -> dict[str, Any]:
+    """Map converter-left packed expert tensors onto fused SwitchGLU names.
+
+    Transformers ``Qwen4ExpTextExperts.gate_up_proj`` is ``(E, 2*I, H)`` and
+    ``F.linear(...).chunk(2, dim=-1)`` splits **gate | up** (concatenated, not
+    interleaved). FusedSwitchGLU wants that packed ``(E, 2*I, H)`` tensor as
+    ``switch_mlp.gate_up_proj``. Shared-expert and GDN split pairs are fused
+    by the same load-time remap as the trunk.
+    """
+    qwen4 = import_qwen4_exp()
+    remap = getattr(qwen4, "remap_fused_projections", None)
+    if remap is None:
+        raise RuntimeError("qwen4_exp remap_fused_projections is not available")
+    return remap(dict(weights))
+
+
+def _shift_qwen4_gemma_mtp_norms(weights: dict[str, Any]) -> dict[str, Any]:
+    """Restore MLX-absolute RMSNorm gains on a raw-HF qwen4_exp MTP sidecar."""
+    targets = [
+        (key, value)
+        for key, value in weights.items()
+        if getattr(value, "ndim", None) == 1
+        and any(str(key).endswith(suffix) for suffix in _QWEN4_GEMMA_NORM_SUFFIXES)
+    ]
+    if not targets:
+        return weights
+    out = dict(weights)
+    for key, value in targets:
+        out[key] = value + 1.0
+    logger.info(
+        "[Qwen4Exp MTP inject] Gemma-delta MTP norms +1.0 (%d tensors)",
+        len(targets),
+    )
+    return out
+
+
+# --------------------------------------------------------------------------- sparse top-k reuse (tech-report trick)
+
+
+class SparseIndexReuse:
+    """Reuse QSA top-k block indices across single-token MTP draft steps.
+
+    The indexer keys still advance (new token is always appended). The keep
+    mask for the already-scored prefix is reused; newly appended tokens are
+    forced visible. Falls back to a full indexer call on the first step or
+    whenever the budget has not kicked in.
+    """
+
+    def __init__(self, indexer: Any):
+        self.indexer = indexer
+        self.prev_keep = None
+        self.enabled = True
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.indexer, name)
+
+    def reset(self) -> None:
+        self.prev_keep = None
+
+    def prepare(self, x, rope, cache, offset: int):
+        return self.indexer.prepare(x, rope, cache, offset)
+
+    def select(self, q, q_pos, pooled, kv_len):
+        return self.indexer.select(q, q_pos, pooled, kv_len)
+
+    def __call__(self, x, rope, cache, offset: int):
+        import mlx.core as mx
+
+        if not self.enabled or self.prev_keep is None or int(x.shape[1]) != 1:
+            keep = self.indexer(x, rope, cache, offset)
+            self.prev_keep = keep
+            return keep
+
+        B, S, _ = x.shape
+        qk = self.indexer.index_qk_proj(x)
+        split = self.indexer.n_heads * self.indexer.head_dim
+        raw_k = qk[..., split:].reshape(B, S, self.indexer.head_dim)
+        if cache is not None:
+            raw_k = cache.update(raw_k)
+        kv_len = int(raw_k.shape[1])
+        if kv_len <= int(self.indexer.token_budget):
+            self.prev_keep = None
+            return None
+        prev = self.prev_keep
+        if hasattr(prev, "token_idx") and hasattr(prev, "valid"):
+            new_idx = mx.full((B, 1, 1), kv_len - 1, dtype=mx.int32)
+            new_ok = mx.ones((B, 1, 1), dtype=mx.bool_)
+            keep = type(prev)(
+                token_idx=mx.concatenate([prev.token_idx, new_idx], axis=-1),
+                valid=mx.concatenate([prev.valid, new_ok], axis=-1),
+            )
+        else:
+            old = int(prev.shape[-1])
+            extra = kv_len - old
+            if extra < 0:
+                keep = prev[..., :kv_len]
+            elif extra == 0:
+                keep = prev
+            else:
+                pad = mx.ones((*prev.shape[:-1], extra), dtype=prev.dtype)
+                keep = mx.concatenate([prev, pad], axis=-1)
+        self.prev_keep = keep
+        return keep
+
+
+# --------------------------------------------------------------------------- GDN / KV snapshot
+
+
+def _is_arrays_cache(entry: Any) -> bool:
+    return hasattr(entry, "cache") and isinstance(getattr(entry, "cache", None), list)
+
+
+def _is_kv_cache(entry: Any) -> bool:
+    return hasattr(entry, "offset") and (
+        hasattr(entry, "keys") or hasattr(entry, "update_and_fetch")
+    )
+
+
+def _hold_array(value: Any, *, copy: bool) -> Any:
+    if value is None:
+        return None
+    import mlx.core as mx
+
+    if copy:
+        held = value + mx.zeros_like(value)
+        mx.eval(held)
+        return held
+    # Lazy COW view: `value[...]` retains the current buffer so a later
+    # `cache[i] = new_state` rebind cannot donate/mutate the snapshot.
+    return value[...]
+
+
+@dataclass
+class LayerSnapshot:
+    kind: str
+    slots: tuple[Any, ...] = ()
+    lengths: Any = None
+    left_padding: Any = None
+    offset: int = 0
+    keys: Any = None
+    values: Any = None
+    indexer_keys: Any = None
+
+
+@dataclass
+class StateSnapshot:
+    """Pre-draft snapshot of trunk recurrent state + attention KV lengths.
+
+    GDN updates rebind ``ArraysCache`` slots (``cache[i] = new_state``), so a
+    lazy view of the pre-forward array stays valid. Attention layers trim by
+    offset. On rejection at draft position k, :meth:`restore` returns the
+    cache to this snapshot; the caller then replays the accepted prefix.
+    """
+
+    layers: tuple[LayerSnapshot, ...] = ()
+
+    @classmethod
+    def capture(cls, cache: list[Any] | None, *, copy: bool = False) -> "StateSnapshot":
+        if not cache:
+            return cls(layers=())
+        layers: list[LayerSnapshot] = []
+        for entry in cache:
+            if entry is None:
+                layers.append(LayerSnapshot(kind="empty"))
+            elif _is_arrays_cache(entry):
+                slots = tuple(_hold_array(slot, copy=copy) for slot in entry.cache)
+                layers.append(
+                    LayerSnapshot(
+                        kind="gdn",
+                        slots=slots,
+                        lengths=_hold_array(getattr(entry, "lengths", None), copy=copy),
+                        left_padding=_hold_array(
+                            getattr(entry, "left_padding", None), copy=copy
+                        ),
+                    )
+                )
+            elif _is_kv_cache(entry):
+                indexer = getattr(entry, "indexer", None)
+                layers.append(
+                    LayerSnapshot(
+                        kind="kv",
+                        offset=int(getattr(entry, "offset", 0) or 0),
+                        keys=_hold_array(getattr(entry, "keys", None), copy=copy),
+                        values=_hold_array(getattr(entry, "values", None), copy=copy),
+                        indexer_keys=_hold_array(
+                            getattr(indexer, "keys", None), copy=copy
+                        ),
+                    )
+                )
+            else:
+                layers.append(LayerSnapshot(kind="unknown"))
+        return cls(layers=tuple(layers))
+
+    def restore(self, cache: list[Any] | None) -> None:
+        if not cache:
+            return
+        if len(cache) != len(self.layers):
+            raise ValueError(
+                f"StateSnapshot size mismatch: cache has {len(cache)} layers, "
+                f"snapshot has {len(self.layers)}"
+            )
+        for entry, snap in zip(cache, self.layers):
+            if entry is None or snap.kind in {"empty", "unknown"}:
+                continue
+            if snap.kind == "gdn" and _is_arrays_cache(entry):
+                for idx, slot in enumerate(snap.slots):
+                    if idx < len(entry.cache):
+                        entry.cache[idx] = slot
+                    else:
+                        entry.cache.append(slot)
+                if hasattr(entry, "lengths"):
+                    entry.lengths = snap.lengths
+                if hasattr(entry, "left_padding"):
+                    entry.left_padding = snap.left_padding
+                continue
+            if snap.kind == "kv" and _is_kv_cache(entry):
+                if snap.keys is not None:
+                    entry.keys = snap.keys
+                if snap.values is not None:
+                    entry.values = snap.values
+                current = int(getattr(entry, "offset", 0) or 0)
+                target = int(snap.offset)
+                if current > target and callable(getattr(entry, "trim", None)):
+                    entry.trim(current - target)
+                else:
+                    entry.offset = target
+                indexer = getattr(entry, "indexer", None)
+                if indexer is not None:
+                    indexer.keys = snap.indexer_keys
+
+    def gdn_tensors(self) -> list[Any]:
+        """Conv + recurrent (+ PLE) arrays, for equality checks."""
+        out: list[Any] = []
+        for snap in self.layers:
+            if snap.kind == "gdn":
+                out.extend(slot for slot in snap.slots if slot is not None)
+        return out
+
+
+def collect_gdn_tensors(cache: list[Any] | None) -> list[Any]:
+    out: list[Any] = []
+    if not cache:
+        return out
+    for entry in cache:
+        if _is_arrays_cache(entry):
+            out.extend(slot for slot in entry.cache if slot is not None)
+    return out
+
+
+def gdn_states_equal(left: list[Any], right: list[Any]) -> bool:
+    import mlx.core as mx
+
+    if len(left) != len(right):
+        return False
+    for a, b in zip(left, right):
+        if a is None and b is None:
+            continue
+        if a is None or b is None:
+            return False
+        if tuple(a.shape) != tuple(b.shape):
+            return False
+        mx.eval(a, b)
+        if not bool(mx.all(a == b).item()):
+            return False
+    return True
+
+
+# --------------------------------------------------------------------------- capture protocol (CHK-02 / CHK-04)
+
+
+QWEN4_EXP_VERIFY_STRATEGIES = (
+    "batched",
+    "capture_commit",
+    "graphbank",
+    "graphbank_capture_commit",
+    "target_prefix",
+    "trim_commit",
+)
+
+
+def _skip_verify_snapshot_env() -> bool:
+    return os.environ.get("MTPLX_SKIP_VERIFY_SNAPSHOT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _inner_model(model: Any) -> Any:
+    owner = _text_model(model)
+    return getattr(owner, "model", owner)
+
+
+def _layer_is_linear(layer: Any) -> bool:
+    if hasattr(layer, "is_linear"):
+        return bool(layer.is_linear)
+    kind = getattr(layer, "layer_type", None)
+    return kind == "linear_attention" or hasattr(layer, "linear_attn")
+
+
+def _inner_has_ple(inner: Any) -> bool:
+    layers = getattr(inner, "layers", ()) or ()
+    return any(getattr(layer, "ple", None) is not None for layer in layers)
+
+
+def _alias_gdn_capture_attrs(gdn: Any) -> None:
+    """Map qwen4_exp GDN names onto the gdn_forward_with_capture surface."""
+    if not hasattr(gdn, "num_v_heads"):
+        gdn.num_v_heads = int(getattr(gdn, "n_v"))
+    if not hasattr(gdn, "num_k_heads"):
+        gdn.num_k_heads = int(getattr(gdn, "n_k"))
+    if not hasattr(gdn, "head_v_dim"):
+        gdn.head_v_dim = int(getattr(gdn, "dv"))
+    if not hasattr(gdn, "head_k_dim"):
+        gdn.head_k_dim = int(getattr(gdn, "dk"))
+
+
+def bind_qwen4_exp_capture_protocol(inner: Any) -> None:
+    """Set fa_idx/ssm_idx and per-layer is_linear for MTPLX capture dispatch."""
+    layers = list(getattr(inner, "layers", ()) or ())
+    if not layers:
+        raise RuntimeError("qwen4_exp inner model has no layers to bind capture markers")
+    fa_idx = None
+    ssm_idx = None
+    for index, layer in enumerate(layers):
+        is_linear = _layer_is_linear(layer)
+        layer.is_linear = bool(is_linear)
+        if is_linear:
+            if ssm_idx is None:
+                ssm_idx = index
+            gdn = getattr(layer, "linear_attn", None)
+            if gdn is not None:
+                _alias_gdn_capture_attrs(gdn)
+        elif fa_idx is None:
+            fa_idx = index
+    if ssm_idx is None or fa_idx is None:
+        raise RuntimeError(
+            "qwen4_exp capture protocol requires at least one linear_attention "
+            "(GDN) layer and one full_attention layer"
+        )
+    inner.ssm_idx = int(ssm_idx)
+    inner.fa_idx = int(fa_idx)
+    inner._mtplx_qwen4_exp_capture = True
+
+
+class Qwen4ExpRecurrentCache:
+    """Non-trimmable GDN/PLE cache that matches the OwnedRecurrentStateCache protocol.
+
+    ``commit_captured_prefix`` installs conv+GDN via ``replace_state([conv, gdn])``.
+    Extra PLE slots (2, 3) are preserved — they are not in the 2-leaf capture
+    tuple. Models with PLE must refuse capture_commit (see
+    :func:`maybe_refuse_qwen4_exp_verify_lane`).
+    """
+
+    def __init__(
+        self,
+        size: int = 4,
+        *,
+        initial: list[Any] | tuple[Any, ...] | None = None,
+        left_padding: Any | None = None,
+        lengths: Any | None = None,
+    ) -> None:
+        n = max(int(size), 2)
+        self.cache = [None] * n
+        self.left_padding = left_padding
+        self.lengths = lengths
+        if initial is not None:
+            self.replace_state(initial)
+
+    @classmethod
+    def from_entry(cls, entry: Any) -> "Qwen4ExpRecurrentCache":
+        slots = list(getattr(entry, "cache", getattr(entry, "state", [None, None])))
+        return cls(
+            size=max(len(slots), 2),
+            initial=slots,
+            left_padding=getattr(entry, "left_padding", None),
+            lengths=getattr(entry, "lengths", None),
+        )
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.cache[idx]
+
+    def __setitem__(self, idx: int, value: Any) -> None:
+        self.cache[idx] = value
+
+    @property
+    def state(self) -> list[Any]:
+        return self.cache
+
+    @state.setter
+    def state(self, value: list[Any] | tuple[Any, ...] | None) -> None:
+        self.replace_state(value)
+
+    def replace_state(self, value: list[Any] | tuple[Any, ...] | None) -> None:
+        if value is None:
+            self.cache = [None] * len(self.cache)
+            return
+        for idx, item in enumerate(value):
+            if idx >= len(self.cache):
+                break
+            self.cache[idx] = item
+
+    def is_trimmable(self) -> bool:
+        return False
+
+    def advance(self, n: int) -> None:
+        if self.lengths is not None:
+            self.lengths -= n
+        if self.left_padding is not None:
+            self.left_padding -= n
+
+    def empty(self) -> bool:
+        return all(item is None for item in self.cache)
+
+    @property
+    def meta_state(self) -> tuple[str, str]:
+        return ("qwen4_exp_recurrent", str(len(self.cache)))
+
+    @meta_state.setter
+    def meta_state(self, value: Any) -> None:
+        del value
+
+    def make_mask(self, n: int):
+        import mlx.core as mx
+
+        if self.left_padding is not None:
+            pos = mx.arange(n)
+            return pos >= self.left_padding[:, None]
+        if self.lengths is not None:
+            pos = mx.arange(n)
+            return pos < self.lengths[:, None]
+        return None
+
+
+def _trim_qsa_indexer(entry: Any, n: int) -> None:
+    indexer = getattr(entry, "indexer", None)
+    keys = getattr(indexer, "keys", None) if indexer is not None else None
+    if keys is None:
+        return
+    keep = int(keys.shape[1]) - int(n)
+    indexer.keys = keys[:, :keep, :] if keep > 0 else None
+
+
+def _install_indexer_aware_trim(entry: Any) -> Any:
+    """KV trim must also rewind the QSA indexer; offset-only trim desyncs them."""
+    if entry is None or getattr(entry, "_mtplx_indexer_trim", False):
+        return entry
+    orig = getattr(entry, "trim", None)
+    if not callable(orig):
+        return entry
+
+    def trim(n: int, _orig=orig, _entry=entry):
+        trimmed = _orig(n)
+        dropped = int(n if trimmed is None else trimmed)
+        if dropped:
+            _trim_qsa_indexer(_entry, dropped)
+        return trimmed
+
+    entry.trim = trim
+    entry._mtplx_indexer_trim = True
+    return entry
+
+
+def wrap_qwen4_exp_cache(cache: list[Any] | None, inner: Any) -> list[Any]:
+    if not cache:
+        return cache if cache is not None else []
+    layers = list(getattr(inner, "layers", ()) or ())
+    out: list[Any] = []
+    for idx, entry in enumerate(cache):
+        layer = layers[idx] if idx < len(layers) else None
+        if entry is None:
+            out.append(None)
+            continue
+        if isinstance(entry, Qwen4ExpRecurrentCache):
+            out.append(entry)
+            continue
+        if layer is not None and _layer_is_linear(layer):
+            out.append(Qwen4ExpRecurrentCache.from_entry(entry))
+            continue
+        if _is_arrays_cache(entry) and not _is_kv_cache(entry):
+            out.append(Qwen4ExpRecurrentCache.from_entry(entry))
+            continue
+        if _is_kv_cache(entry):
+            out.append(_install_indexer_aware_trim(entry))
+            continue
+        out.append(entry)
+    return out
+
+
+def _cache_is_primed(cache: list[Any] | None) -> bool:
+    if not cache:
+        return False
+    for entry in cache:
+        if entry is None:
+            continue
+        offset = getattr(entry, "offset", None)
+        if offset is not None:
+            try:
+                if int(offset) > 0:
+                    return True
+            except Exception:
+                pass
+        if _is_arrays_cache(entry) and any(slot is not None for slot in entry.cache):
+            return True
+    return False
+
+
+def _sequential_owner_forward(
+    owner: Any,
+    inputs,
+    cache,
+    *,
+    return_hidden: bool,
+    hidden_variant: str | None,
+    input_embeddings=None,
+):
+    import mlx.core as mx
+
+    del hidden_variant, input_embeddings
+    length = int(inputs.shape[1])
+    logits_steps = []
+    hidden_steps = []
+    last_logits = None
+    last_hidden = None
+    for t in range(length):
+        step = inputs[:, t : t + 1]
+        if return_hidden:
+            last_logits, last_hidden = owner(
+                step, cache=cache, return_hidden=True
+            )
+            logits_steps.append(last_logits)
+            hidden_steps.append(last_hidden)
+        else:
+            last_logits = owner(step, cache=cache, return_hidden=False)
+            logits_steps.append(last_logits)
+    logits = mx.concatenate(logits_steps, axis=1)
+    if not return_hidden:
+        return logits
+    hidden = mx.concatenate(hidden_steps, axis=1)
+    return logits, hidden
+
+
+def forward_with_qwen4_exp_gdn_capture(
+    model: Any,
+    inputs,
+    cache=None,
+    return_hidden: bool = False,
+    *,
+    hidden_variant: str | None = None,
+    capture_backend: str | None = None,
+):
+    """Per-position conv+GDN capture in the commit_captured_prefix layout.
+
+    Qwen4_exp DecoderLayer is not Qwen3Next-shaped (hyper-connections, QSA,
+    optional PLE), so stock ``forward_with_gdn_capture`` cannot walk it.
+    Verify windows are run token-by-token so QSA cannot leak uncommitted
+    drafts; after each step the live GDN conv/recurrent leaves are stacked
+    as ``conv_states`` / ``states`` with a time axis.
+    """
+    import mlx.core as mx
+
+    del capture_backend, hidden_variant
+    owner = _text_model(model)
+    inner = _inner_model(model)
+    if cache is None:
+        cache = owner.make_cache()
+    length = int(inputs.shape[1])
+    logits_steps = []
+    hidden_steps = []
+    conv_tapes: dict[int, list] = {}
+    state_tapes: dict[int, list] = {}
+    layers = list(inner.layers)
+    for t in range(length):
+        step = inputs[:, t : t + 1]
+        logits, hidden = owner(step, cache=cache, return_hidden=True)
+        logits_steps.append(logits)
+        hidden_steps.append(hidden)
+        for idx, (layer, entry) in enumerate(zip(layers, cache)):
+            if entry is None or not getattr(layer, "is_linear", False):
+                continue
+            conv = entry[0]
+            state = entry[1]
+            if conv is None or state is None:
+                continue
+            conv_tapes.setdefault(idx, []).append(mx.expand_dims(conv, axis=1))
+            state_tapes.setdefault(idx, []).append(mx.expand_dims(state, axis=1))
+    logits = mx.concatenate(logits_steps, axis=1)
+    hidden_out = mx.concatenate(hidden_steps, axis=1)
+    captures: dict[int, dict[str, Any]] = {}
+    for idx in conv_tapes:
+        captures[idx] = {
+            "conv_states": mx.concatenate(conv_tapes[idx], axis=1),
+            "states": mx.concatenate(state_tapes[idx], axis=1),
+        }
+    if return_hidden:
+        return logits, hidden_out, captures
+    return logits, captures
+
+
+def maybe_refuse_qwen4_exp_verify_lane(
+    model: Any,
+    verify_strategy: str,
+    *,
+    skip_snapshot: bool | None = None,
+) -> None:
+    """Refuse product lanes that would silently corrupt GDN or fail mid-request."""
+    inner = _inner_model(model)
+    if not getattr(inner, "_mtplx_qwen4_exp_capture", False):
+        return
+    strategy = str(verify_strategy or "").strip().lower()
+    skip = _skip_verify_snapshot_env() if skip_snapshot is None else bool(skip_snapshot)
+    if _inner_has_ple(inner) and strategy in {
+        "capture_commit",
+        "graphbank_capture_commit",
+    }:
+        raise RuntimeError(
+            "qwen4_exp refuses capture_commit: PLE conv/n-gram slots are not "
+            "in commit_captured_prefix's 2-leaf replace_state protocol"
+        )
+    if strategy in {"trim_commit", "target_prefix"}:
+        raise RuntimeError(
+            "qwen4_exp refuses trim-only verify_strategy="
+            f"{strategy!r}: GDN recurrent cache is not trimmable; "
+            "use capture_commit (or batched with a verify snapshot)"
+        )
+    if strategy in {"graphbank", "graphbank_capture_commit"}:
+        raise RuntimeError(
+            "qwen4_exp refuses compiled graphbank verify_strategy="
+            f"{strategy!r}: the hybrid GDN+QSA capture graph is not a "
+            "verified lane"
+        )
+    if strategy == "batched" and skip:
+        raise RuntimeError(
+            "qwen4_exp refuses batched verify with MTPLX_SKIP_VERIFY_SNAPSHOT=1: "
+            "GDN state cannot be restored without capture_commit or a snapshot"
+        )
+    if strategy not in {"batched", "capture_commit"}:
+        raise RuntimeError(
+            f"qwen4_exp refuses verify_strategy={strategy!r}; "
+            "supported: capture_commit, or batched with a verify snapshot"
+        )
+
+
+def qwen4_exp_product_verify_strategy(model: Any) -> str | None:
+    """Product MTP lane that :func:`maybe_refuse_qwen4_exp_verify_lane` accepts.
+
+    House ``ask``/quickstart default to Qwen3Next ``capture_commit`` plus the
+    profile ``MTPLX_SKIP_VERIFY_SNAPSHOT=1``. On qwen4_exp that is either
+    refused (PLE conv/n-gram is not in the 2-leaf replace_state protocol) or
+    exact-AR (no PLE, skip-snapshot capture_commit). Real speculative decode
+    is batched verify with a live snapshot. Returns None for other models.
+    """
+    if model is None:
+        return None
+    inner = _inner_model(model)
+    if not getattr(inner, "_mtplx_qwen4_exp_capture", False):
+        return None
+    return "batched"
+
+
+@contextlib.contextmanager
+def qwen4_exp_product_verify_env(model: Any):
+    """Yield the product verify_strategy, forcing a live snapshot for qwen4_exp."""
+    strategy = qwen4_exp_product_verify_strategy(model)
+    if strategy is None:
+        yield "capture_commit"
+        return
+    key = "MTPLX_SKIP_VERIFY_SNAPSHOT"
+    previous = os.environ.get(key)
+    os.environ[key] = "0"
+    try:
+        yield strategy
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
+def cache_entry_rollback_protocol(entry: Any) -> str:
+    """Return 'trimmable' or 'replace_state' — or raise if the entry is a shim."""
+    if entry is None:
+        return "empty"
+    trimmable = False
+    checker = getattr(entry, "is_trimmable", None)
+    if callable(checker):
+        trimmable = bool(checker())
+    if trimmable:
+        trim = getattr(entry, "trim", None)
+        if not callable(trim) or getattr(entry, "offset", None) is None:
+            raise RuntimeError(
+                "qwen4_exp cache entry claims is_trimmable=True without offset/trim"
+            )
+        return "trimmable"
+    if not hasattr(entry, "state"):
+        raise RuntimeError("qwen4_exp non-trimmable cache entry has no .state")
+    if not hasattr(entry, "meta_state"):
+        raise RuntimeError("qwen4_exp non-trimmable cache entry has no .meta_state")
+    if not callable(getattr(entry, "replace_state", None)):
+        raise RuntimeError(
+            "qwen4_exp non-trimmable cache entry has no replace_state "
+            "(ArraysCache is not capture-commit compatible)"
+        )
+    return "replace_state"
+
+
+# --------------------------------------------------------------------------- MTP module + inject
+
+
+def _mtp_text_args(args: Any, config: dict[str, Any], n_layers: int) -> Any:
+    mtp_cfg = _mtp_block_config(config)
+    layer_types = list(mtp_cfg.get("layer_types") or ["full_attention"] * n_layers)
+    if len(layer_types) < n_layers:
+        layer_types = layer_types + ["full_attention"] * (n_layers - len(layer_types))
+    rope_theta = float(mtp_cfg.get("rope_theta") or getattr(args, "rope_theta", 10_000_000.0))
+    updates = {
+        "layer_types": layer_types[:n_layers],
+        "ple_layer_ids": [],
+        "rope_theta": rope_theta,
+        "num_hidden_layers": n_layers,
+    }
+    try:
+        return replace(args, **{k: v for k, v in updates.items() if hasattr(args, k)})
+    except Exception:
+        for key, value in updates.items():
+            if hasattr(args, key):
+                setattr(args, key, value)
+        return args
+
+
+def _make_mtp_module(args: Any, n_layers: int, qwen4: Any):
+    import mlx.nn as nn
+
+    DecoderLayer = qwen4.DecoderLayer
+    RotaryEmbedding = qwen4.RotaryEmbedding
+    GatedResidual = qwen4.GatedResidual
+    RMSNorm = qwen4.RMSNorm
+
+    rotary_dim = int(args.head_dim * getattr(args, "partial_rotary_factor", 0.25))
+
+    class _Qwen4ExpMTP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.pre_fc_norm_embedding = RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            # vLLM Qwen4ExpMultiTokenPredictor: GemmaRMSNorm(H*hc) — one
+            # statistic over the flattened multi-stream, not per-branch.
+            self.pre_fc_norm_hidden = RMSNorm(
+                args.hidden_size * int(args.hc_count),
+                eps=args.rms_norm_eps,
+            )
+            self.fc_embedding = nn.Linear(args.hidden_size, args.hidden_size, bias=False)
+            self.fc_hidden = nn.Linear(args.hidden_size, args.hidden_size, bias=False)
+            inner_rope = RotaryEmbedding(
+                rotary_dim, args.rope_theta, getattr(args, "rope_parameters", None)
+            )
+            self.rope_shift = 0
+            mtp_holder: list[Any] = []
+
+            class _ShiftedRope:
+                """vLLM draft RoPE uses target sequence positions, not cache-local 0..k."""
+
+                @property
+                def dim(self):
+                    return inner_rope.dim
+
+                @property
+                def freqs(self):
+                    return inner_rope.freqs
+
+                @property
+                def mscale(self):
+                    return inner_rope.mscale
+
+                @property
+                def position_shift(self):
+                    return int(getattr(mtp_holder[0], "rope_shift", 0) or 0)
+
+                def __call__(self, positions):
+                    shift = self.position_shift
+                    if shift:
+                        positions = positions + shift
+                    return inner_rope(positions)
+
+            self.rope = _ShiftedRope()
+            mtp_holder.append(self)
+            self.layers = [DecoderLayer(args, layer_idx=i) for i in range(n_layers)]
+            self.hyper_connection_mixer = GatedResidual(args, use_combine=False)
+            self.hc = int(args.hc_count)
+            self.hidden_size = int(args.hidden_size)
+            self._sparse_reuse: list[SparseIndexReuse] = []
+            for layer in self.layers:
+                attn = getattr(layer, "self_attn", None)
+                if attn is None:
+                    continue
+                attn.rope = self.rope
+            # Indexer is wrapped after load_weights so sidecar
+            # ``self_attn.indexer.*`` tensors bind to the real module.
+
+        def install_sparse_reuse(self) -> None:
+            self._sparse_reuse = []
+            for layer in self.layers:
+                attn = getattr(layer, "self_attn", None)
+                if attn is None:
+                    continue
+                indexer = getattr(attn, "indexer", None)
+                if indexer is None or isinstance(indexer, SparseIndexReuse):
+                    continue
+                wrapper = SparseIndexReuse(indexer)
+                attn.indexer = wrapper
+                self._sparse_reuse.append(wrapper)
+
+        def reset_sparse_reuse(self) -> None:
+            for wrapper in self._sparse_reuse:
+                wrapper.reset()
+
+        def set_sparse_reuse(self, enabled: bool) -> None:
+            for wrapper in self._sparse_reuse:
+                wrapper.enabled = bool(enabled)
+
+    return _Qwen4ExpMTP()
+
+
+def _make_attn_cache(qwen4: Any):
+    cls = getattr(qwen4, "_AttnCache", None) or getattr(qwen4, "AttnCache", None)
+    if cls is not None:
+        return cls()
+    from mlx_lm.models.cache import KVCache
+
+    cache = KVCache()
+    idx_cls = getattr(qwen4, "_IndexerCache", None)
+    if idx_cls is not None:
+        cache.indexer = idx_cls()
+    return cache
+
+
+def inject_qwen4_exp_mtp_support(
+    model: Any,
+    model_path: Path | str,
+    config: dict[str, Any],
+    contract: Any | None = None,
+    *,
+    allow_random_init: bool = False,
+) -> bool:
+    """Attach the qwen4_exp MTP head and the draft/verify/rollback surface."""
+    import mlx.core as mx
+    from mlx_lm.models.base import create_attention_mask
+
+    if not is_qwen4_exp_mtp_config(config) and not (
+        allow_random_init and is_qwen4_exp_config(config)
+    ):
+        return False
+
+    qwen4 = import_qwen4_exp()
+    model_path = Path(model_path) if model_path else Path(".")
+    n_layers = max(_num_mtp_layers(config), 1)
+    args = _text_args(model)
+    if args is None:
+        TextArgs = getattr(qwen4, "TextArgs", None)
+        if TextArgs is None:
+            raise RuntimeError("qwen4_exp TextArgs is not available")
+        args = TextArgs.from_dict(text_config(config))
+    mtp_args = _mtp_text_args(args, config, n_layers)
+
+    weights = _load_mtp_weights(_candidate_weight_files(model_path, config))
+    if not weights and not allow_random_init:
+        logger.warning("[Qwen4Exp MTP inject] no mtp.* weights found in %s", model_path)
+        return False
+
+    text_model = _text_model(model)
+    mtp = _make_mtp_module(mtp_args, n_layers, qwen4)
+    if weights:
+        mtp.load_weights(list(weights.items()), strict=False)
+        from mlx.utils import tree_flatten
+
+        param_keys = {k for k, _ in tree_flatten(mtp.parameters())}
+        loaded = set(weights)
+        missing = sorted(param_keys - loaded)
+        extra = sorted(loaded - param_keys)
+        if missing:
+            logger.warning(
+                "[Qwen4Exp MTP inject] %d parameter keys not in sidecar (first %s)",
+                len(missing),
+                missing[:8],
+            )
+        if extra:
+            logger.warning(
+                "[Qwen4Exp MTP inject] %d sidecar keys unused (first %s)",
+                len(extra),
+                extra[:8],
+            )
+        if not any(k.endswith("switch_mlp.gate_up_proj.weight") for k in loaded):
+            logger.warning(
+                "[Qwen4Exp MTP inject] experts.gate_up_proj did not remap onto switch_mlp.gate_up_proj"
+            )
+    mtp.install_sparse_reuse()
+    mx.eval(mtp.parameters())
+
+    concat_order = getattr(contract, "concat_order", None) or "embedding_hidden"
+    hidden_variant = getattr(contract, "hidden_variant", None) or "post_norm"
+    text_model.mtp = mtp
+    text_model._mtplx_hidden_variant = hidden_variant
+    text_model._mtplx_concat_order = concat_order
+    text_model._mtplx_draft_depth_max = MAX_DRAFT_DEPTH
+    text_model._mtplx_draft_depth_default = DEFAULT_DRAFT_DEPTH
+    text_model._mtplx_tune_candidates = TUNE_CANDIDATES
+
+    original_class = text_model.__class__
+    hc = int(getattr(mtp_args, "hc_count", 4) or 4)
+
+    class _MTPLXQwen4ExpModel(original_class):
+        def _lm_logits(self, h):
+            lm = getattr(self, "lm_head", None)
+            if lm is not None:
+                return lm(h)
+            inner = getattr(self, "model", self)
+            embed = getattr(inner, "embed_tokens", None)
+            if embed is not None and hasattr(embed, "as_linear"):
+                return embed.as_linear(h)
+            raise RuntimeError("qwen4_exp model has no lm_head / tied embedding")
+
+        def _embed(self, token_ids):
+            inner = getattr(self, "model", self)
+            return inner.embed_tokens(token_ids)
+
+        def __call__(
+            self,
+            inputs,
+            cache=None,
+            return_hidden: bool = False,
+            input_embeddings=None,
+            hidden_variant: str | None = None,
+            **kwargs,
+        ):
+            # Warm-cache *short* multi-token forwards are verify windows.
+            # Batching uncommitted drafts lets QSA leak future draft keys
+            # through the indexer; step those so logits stay causal.
+            # Prompt prefill is the opposite: generation chunks at 2048
+            # committed tokens. After chunk 0 the cache is primed, so a
+            # primed-only check would serialize the rest of the prompt
+            # (and OOM the Metal allocator on ~4k+). Treat T larger than
+            # a draft window as prefill and keep it batched.
+            seq_len = int(inputs.shape[1]) if getattr(inputs, "ndim", 0) >= 2 else 1
+            if (
+                cache is not None
+                and input_embeddings is None
+                and getattr(inputs, "ndim", 0) >= 2
+                and 1 < seq_len <= (MAX_DRAFT_DEPTH + 1)
+                and _cache_is_primed(cache)
+            ):
+                return _sequential_owner_forward(
+                    self,
+                    inputs,
+                    cache,
+                    return_hidden=return_hidden,
+                    hidden_variant=hidden_variant,
+                )
+            if not return_hidden:
+                return super().__call__(
+                    inputs, cache=cache, input_embeddings=input_embeddings
+                )
+            mixed, hyper = self.model(
+                inputs, cache, input_embeddings, return_hyper=True
+            )
+            logits = self._lm_logits(mixed)
+            return logits, hyper
+
+        def make_cache(self):
+            cache = super().make_cache()
+            return wrap_qwen4_exp_cache(cache, getattr(self, "model", self))
+
+        def mtp_forward(
+            self,
+            hidden_states,
+            next_token_ids,
+            cache=None,
+            mtp_cache=None,
+            concat_order=None,
+            return_hidden: bool = False,
+            mtp_hidden_variant: str | None = None,
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+            reuse_sparse_indices: bool | None = None,
+        ):
+            del mtp_hidden_variant, mtp_depth, concat_order
+            layer_caches = mtp_cache if mtp_cache is not None else self.make_mtp_cache()
+            if reuse_sparse_indices is not None:
+                self.mtp.set_sparse_reuse(bool(reuse_sparse_indices))
+            d = int(self.mtp.hidden_size)
+            expected = d * hc
+            if int(hidden_states.shape[-1]) != expected:
+                raise ValueError(
+                    "qwen4_exp MTP pre_fc_norm_hidden expects hyper hidden "
+                    f"last-dim {expected}, got {tuple(hidden_states.shape)}"
+                )
+            # vLLM residual_linear_shared (nvidia/mtp.py):
+            #   e = fc_embedding(pre_fc_norm_embedding(embed(ids)))   # [T, H]
+            #   h = pre_fc_norm_hidden(multi).view(T, hc, H)
+            #   h = fc_hidden(h)   # shared Linear(H,H) per stream
+            #   x = e.unsqueeze(-2) + h ; flatten to [T, hc*H]
+            # Mean-collapse-then-tile was the zero-accept assembly bug.
+            e = self.mtp.fc_embedding(
+                self.mtp.pre_fc_norm_embedding(self._embed(next_token_ids))
+            )
+            h = self.mtp.pre_fc_norm_hidden(hidden_states)
+            h = h.reshape(*h.shape[:-1], hc, d)
+            h = self.mtp.fc_hidden(h)
+            x = (e[..., None, :] + h).reshape(*h.shape[:-2], expected)
+            rope_shift = 0
+            if position_offset is not None:
+                rope_shift = int(position_offset)
+            elif cache is not None:
+                for entry in cache if isinstance(cache, (list, tuple)) else (cache,):
+                    off = getattr(entry, "offset", None)
+                    if off is not None:
+                        try:
+                            rope_shift = int(off)
+                            break
+                        except Exception:
+                            pass
+            if rope_shift:
+                attn_cache = layer_caches[0] if layer_caches else None
+                local = int(getattr(attn_cache, "offset", 0) or 0)
+                self.mtp.rope_shift = rope_shift - local
+            else:
+                self.mtp.rope_shift = 0
+            attn_cache = layer_caches[0] if layer_caches else None
+            mask = create_attention_mask(
+                e, [attn_cache] if attn_cache is not None else None
+            )
+            ids = next_token_ids
+            for layer, layer_cache in zip(self.mtp.layers, layer_caches):
+                idx_c = (
+                    layer_cache.indexer
+                    if (layer_cache is not None and hasattr(layer_cache, "indexer"))
+                    else None
+                )
+                x = layer(
+                    x,
+                    self.mtp.rope,
+                    mask,
+                    None,
+                    layer_cache,
+                    idx_c,
+                    ids,
+                    None,
+                )
+            hidden = self.mtp.hyper_connection_mixer(x)
+            logits = self._lm_logits(hidden)
+            if not return_hidden:
+                return logits
+            return logits, x
+
+        def mtp_update_cache(
+            self,
+            hidden_states,
+            next_token_ids,
+            mtp_cache=None,
+            concat_order=None,
+            position_offset: int | None = None,
+            mtp_depth: int | None = None,
+        ):
+            _logits, hidden = self.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache=mtp_cache,
+                concat_order=concat_order,
+                return_hidden=True,
+                position_offset=position_offset,
+                mtp_depth=mtp_depth,
+            )
+            return hidden
+
+        def make_mtp_cache(self):
+            return [
+                _install_indexer_aware_trim(_make_attn_cache(qwen4))
+                for _ in self.mtp.layers
+            ]
+
+        def snapshot_state(self, cache, *, copy: bool = False) -> StateSnapshot:
+            return StateSnapshot.capture(cache, copy=copy)
+
+        def restore_state(self, cache, snapshot: StateSnapshot) -> None:
+            snapshot.restore(cache)
+
+    text_model.__class__ = _MTPLXQwen4ExpModel
+    bind_qwen4_exp_capture_protocol(getattr(text_model, "model", text_model))
+
+    if getattr(model, "language_model", None) is text_model:
+        model.mtp = mtp
+        original_outer = model.__class__
+
+        class _MTPLXQwen4ExpOuter(original_outer):
+            def __call__(
+                self,
+                inputs,
+                cache=None,
+                return_hidden: bool = False,
+                input_embeddings=None,
+                hidden_variant: str | None = None,
+                **kwargs,
+            ):
+                return self.language_model(
+                    inputs,
+                    cache=cache,
+                    return_hidden=return_hidden,
+                    input_embeddings=input_embeddings,
+                    hidden_variant=hidden_variant,
+                    **kwargs,
+                )
+
+            def mtp_forward(self, *args, **kwargs):
+                return self.language_model.mtp_forward(*args, **kwargs)
+
+            def mtp_update_cache(self, *args, **kwargs):
+                return self.language_model.mtp_update_cache(*args, **kwargs)
+
+            def make_mtp_cache(self):
+                return self.language_model.make_mtp_cache()
+
+            def snapshot_state(self, cache, *, copy: bool = False) -> StateSnapshot:
+                return self.language_model.snapshot_state(cache, copy=copy)
+
+            def restore_state(self, cache, snapshot: StateSnapshot) -> None:
+                return self.language_model.restore_state(cache, snapshot)
+
+            def make_cache(self):
+                return self.language_model.make_cache()
+
+        model.__class__ = _MTPLXQwen4ExpOuter
+
+    logger.info(
+        "[Qwen4Exp MTP inject] native head bound (depth max %d, default D%d, "
+        "tune %s, %d tensors%s) for %s",
+        MAX_DRAFT_DEPTH,
+        DEFAULT_DRAFT_DEPTH,
+        ",".join(TUNE_CANDIDATES),
+        len(weights),
+        "" if weights else ", random-init",
+        model_path,
+    )
+    return True
+
+
+def validate_qwen4_exp_mtp_support(model: Any) -> bool:
+    owner = _text_model(model)
+    if getattr(owner, "mtp", None) is None:
+        return False
+    if not getattr(owner.mtp, "layers", None):
+        return False
+    inner = _inner_model(model)
+    if not (hasattr(inner, "fa_idx") and hasattr(inner, "ssm_idx")):
+        return False
+    layers = getattr(inner, "layers", ()) or ()
+    if not layers or not all(hasattr(layer, "is_linear") for layer in layers):
+        return False
+    return callable(getattr(owner, "mtp_forward", None)) and callable(
+        getattr(owner, "make_mtp_cache", None)
+    )
+
+
+# --------------------------------------------------------------------------- draft / verify (exact Leviathan-Chen)
+
+
+def _row_to_numpy(row) -> Any:
+    import numpy as np
+
+    if hasattr(row, "tolist"):
+        return np.asarray(row.tolist(), dtype=np.float64)
+    return np.asarray(row, dtype=np.float64)
+
+
+def _softmax(row) -> Any:
+    import numpy as np
+
+    x = _row_to_numpy(row)
+    x = x - np.max(x)
+    e = np.exp(x)
+    return e / e.sum()
+
+
+def _one_hot(index: int, vocab: int) -> Any:
+    import numpy as np
+
+    p = np.zeros((vocab,), dtype=np.float64)
+    p[int(index)] = 1.0
+    return p
+
+
+def _argmax_token(row) -> int:
+    import mlx.core as mx
+
+    return int(mx.argmax(row, axis=-1).item())
+
+
+def sample_logits_row(
+    row,
+    *,
+    temperature: float,
+    rng: Any,
+) -> tuple[int, Any]:
+    """Return ``(token, q_distribution)``. Greedy skips large-vocab allocations."""
+    token = _argmax_token(row)
+    if float(temperature) <= 0:
+        return token, None
+    import numpy as np
+
+    vocab = int(row.shape[-1])
+    q = _softmax(row)
+    token = int(rng.choice(np.arange(vocab), p=q))
+    return token, q
+
+
+def verify_draft_token(
+    target_row,
+    draft_q,
+    draft_token: int,
+    *,
+    temperature: float,
+    rng: Any,
+) -> SpeculativeDecision:
+    """Exact Leviathan-Chen one-token verify. Greedy uses argmax comparison."""
+    if float(temperature) <= 0:
+        target_token = _argmax_token(target_row)
+        if target_token == int(draft_token):
+            return SpeculativeDecision(True, int(draft_token), 1.0)
+        return SpeculativeDecision(False, int(target_token), 0.0)
+    vocab = int(target_row.shape[-1])
+    target_p = _softmax(target_row)
+    return verify_one_token(target_p, draft_q, int(draft_token), rng)
+
+
+def draft_tokens(
+    model: Any,
+    hidden,
+    token_id: int,
+    n: int,
+    *,
+    temperature: float = 0.0,
+    rng: Any | None = None,
+    reuse_sparse_indices: bool = True,
+) -> tuple[list[int], list[Any], Any]:
+    """Run the MTP head for up to ``n`` draft tokens. Returns ids, q's, last hidden."""
+    import mlx.core as mx
+    import numpy as np
+
+    rng = rng or np.random.default_rng()
+    n = clamp_draft_depth(n)
+    mtp_cache = model.make_mtp_cache()
+    if hasattr(model, "mtp") and hasattr(model.mtp, "reset_sparse_reuse"):
+        model.mtp.reset_sparse_reuse()
+        model.mtp.set_sparse_reuse(reuse_sparse_indices)
+    drafts: list[int] = []
+    qs: list[Any] = []
+    tok = int(token_id)
+    h = hidden
+    for _ in range(n):
+        logits, h = model.mtp_forward(
+            h,
+            mx.array([[tok]], dtype=mx.int32),
+            mtp_cache=mtp_cache,
+            return_hidden=True,
+            reuse_sparse_indices=reuse_sparse_indices,
+        )
+        mx.eval(logits, h)
+        tok, q = sample_logits_row(logits[0, -1], temperature=temperature, rng=rng)
+        drafts.append(tok)
+        qs.append(q)
+        h = h[:, -1:, :]
+    return drafts, qs, h
+
+
+def speculative_generate(
+    model: Any,
+    prompt_ids,
+    max_tokens: int,
+    *,
+    draft_depth: int = DEFAULT_DRAFT_DEPTH,
+    temperature: float = 0.0,
+    rng: Any | None = None,
+    reuse_sparse_indices: bool = True,
+) -> list[int]:
+    """Greedy-or-sampled decode with MTP drafts + exact verify + GDN rollback."""
+    import mlx.core as mx
+    import numpy as np
+
+    rng = rng or np.random.default_rng(0)
+    depth = clamp_draft_depth(draft_depth)
+    cache = model.make_cache()
+    logits, hidden = model(prompt_ids, cache=cache, return_hidden=True)
+    mx.eval(logits, hidden)
+    primary, _ = sample_logits_row(logits[0, -1], temperature=temperature, rng=rng)
+    tokens = [primary]
+    hidden = hidden[:, -1:, :]
+
+    while len(tokens) < max_tokens:
+        remaining = max_tokens - len(tokens)
+        n = min(depth, remaining)
+        drafts, draft_qs, _draft_hidden = draft_tokens(
+            model,
+            hidden,
+            primary,
+            n,
+            temperature=temperature,
+            rng=rng,
+            reuse_sparse_indices=reuse_sparse_indices,
+        )
+        step_snapshots: list[StateSnapshot] = []
+        step_hiddens: list[Any] = []
+        accepted: list[int] = []
+        correction: int | None = None
+        last_logits = None
+
+        # Sequential verify: QSA's incomplete-block tail is always-visible, so a
+        # chunked [primary, *drafts] forward leaks future draft tokens into
+        # earlier logits once kv_len exceeds indexer_budget. Feed one token at
+        # a time; per-step snapshots eliminate redundant replay forwards on rejection.
+        step_ids = [int(primary), *[int(t) for t in drafts]]
+        for i, step_tok in enumerate(step_ids):
+            step = mx.array([[int(step_tok)]], dtype=mx.int32)
+            last_logits, last_hidden = model(step, cache=cache, return_hidden=True)
+            mx.eval(last_logits, last_hidden)
+            step_snapshots.append(StateSnapshot.capture(cache, copy=False))
+            step_hiddens.append(last_hidden[:, -1:, :])
+            if i >= len(drafts):
+                break
+            decision = verify_draft_token(
+                last_logits[0, -1],
+                draft_qs[i],
+                drafts[i],
+                temperature=temperature,
+                rng=rng,
+            )
+            if decision.accepted:
+                accepted.append(int(drafts[i]))
+            else:
+                correction = int(decision.token_id)
+                # Instant zero-replay rollback: restore state to position i (after primary + accepted[:i])
+                step_snapshots[i].restore(cache)
+                hidden = step_hiddens[i]
+                tokens.extend(accepted)
+                tokens.append(int(correction))
+                primary = int(correction)
+                break
+
+        if correction is None:
+            tokens.extend(accepted)
+            if len(tokens) < max_tokens:
+                bonus, _ = sample_logits_row(
+                    last_logits[0, -1], temperature=temperature, rng=rng
+                )
+                tokens.append(int(bonus))
+                primary = int(bonus)
+                hidden = step_hiddens[-1]
+            continue
+
+    return [int(t) for t in tokens[:max_tokens]]
+
+
+def greedy_ar_generate(model: Any, prompt_ids, max_tokens: int) -> list[int]:
+    import mlx.core as mx
+
+    cache = model.make_cache()
+    logits, hidden = model(prompt_ids, cache=cache, return_hidden=True)
+    mx.eval(logits, hidden)
+    tok = _argmax_token(logits[0, -1])
+    tokens = [tok]
+    for _ in range(max_tokens - 1):
+        logits, hidden = model(
+            mx.array([[tok]], dtype=mx.int32), cache=cache, return_hidden=True
+        )
+        mx.eval(logits, hidden)
+        tok = _argmax_token(logits[0, -1])
+        tokens.append(tok)
+    return tokens

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -842,6 +842,35 @@ class Qwen4ExpRecurrentCache:
                 if caches[i][e] is None:
                     continue
                 cache[e][i : i + 1] = caches[i][e]
+
+        lps = [getattr(c, "left_padding", None) for c in caches]
+        if any(lp is not None for lp in lps):
+            lp_list = []
+            for c in caches:
+                b = getattr(c, "batch_size", 1)
+                c_lp = getattr(c, "left_padding", None)
+                if c_lp is not None:
+                    lp_list.append(
+                        c_lp if isinstance(c_lp, mx.array) else mx.array(c_lp, dtype=mx.int32)
+                    )
+                else:
+                    lp_list.append(mx.zeros((b,), dtype=mx.int32))
+            cache.left_padding = mx.concatenate(lp_list, axis=0)
+
+        lens = [getattr(c, "lengths", None) for c in caches]
+        if any(l is not None for l in lens):
+            len_list = []
+            for c in caches:
+                b = getattr(c, "batch_size", 1)
+                c_len = getattr(c, "lengths", None)
+                if c_len is not None:
+                    len_list.append(
+                        c_len if isinstance(c_len, mx.array) else mx.array(c_len, dtype=mx.int32)
+                    )
+                else:
+                    len_list.append(mx.zeros((b,), dtype=mx.int32))
+            cache.lengths = mx.concatenate(len_list, axis=0)
+
         return cache
 
     @property

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -797,11 +797,16 @@ class Qwen4ExpRecurrentCache:
 
 def _trim_qsa_indexer(entry: Any, n: int) -> None:
     indexer = getattr(entry, "indexer", None)
-    keys = getattr(indexer, "keys", None) if indexer is not None else None
-    if keys is None:
+    if indexer is None:
         return
-    keep = int(keys.shape[1]) - int(n)
-    indexer.keys = keys[:, :keep, :] if keep > 0 else None
+    if hasattr(indexer, "trim") and callable(indexer.trim):
+        indexer.trim(n)
+    else:
+        keys = getattr(indexer, "keys", None)
+        if keys is None:
+            return
+        keep = int(keys.shape[1]) - int(n)
+        indexer.keys = keys[:, :keep, :] if keep > 0 else None
     reuse = getattr(entry, "_sparse_index_reuse", None)
     if reuse is not None and hasattr(reuse, "reset"):
         reuse.reset()
@@ -811,6 +816,10 @@ def _install_indexer_aware_trim(entry: Any) -> Any:
     """KV cache operations must also update the QSA indexer; otherwise batch operations desync them."""
     if entry is None or getattr(entry, "_mtplx_indexer_trim", False):
         return entry
+    if type(entry).__name__ == "_AttnCache":
+        entry._mtplx_indexer_trim = True
+        return entry
+
     orig = getattr(entry, "trim", None)
     if callable(orig):
         def trim(n: int, _orig=orig, _entry=entry):

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -808,25 +808,65 @@ def _trim_qsa_indexer(entry: Any, n: int) -> None:
 
 
 def _install_indexer_aware_trim(entry: Any) -> Any:
-    """KV trim must also rewind the QSA indexer; offset-only trim desyncs them."""
+    """KV cache operations must also update the QSA indexer; otherwise batch operations desync them."""
     if entry is None or getattr(entry, "_mtplx_indexer_trim", False):
         return entry
     orig = getattr(entry, "trim", None)
-    if not callable(orig):
-        return entry
+    if callable(orig):
+        def trim(n: int, _orig=orig, _entry=entry):
+            trimmed = _orig(n)
+            dropped = int(n if trimmed is None else trimmed)
+            if dropped:
+                _trim_qsa_indexer(_entry, dropped)
+            else:
+                reuse = getattr(_entry, "_sparse_index_reuse", None)
+                if reuse is not None and hasattr(reuse, "reset"):
+                    reuse.reset()
+            return trimmed
 
-    def trim(n: int, _orig=orig, _entry=entry):
-        trimmed = _orig(n)
-        dropped = int(n if trimmed is None else trimmed)
-        if dropped:
-            _trim_qsa_indexer(_entry, dropped)
-        else:
+        entry.trim = trim
+
+    orig_filter = getattr(entry, "filter", None)
+    if callable(orig_filter):
+        def filter(batch_indices: Any, _orig=orig_filter, _entry=entry):
+            res = _orig(batch_indices)
+            indexer = getattr(_entry, "indexer", None)
+            if indexer is not None and hasattr(indexer, "filter"):
+                indexer.filter(batch_indices)
             reuse = getattr(_entry, "_sparse_index_reuse", None)
             if reuse is not None and hasattr(reuse, "reset"):
                 reuse.reset()
-        return trimmed
+            return res
 
-    entry.trim = trim
+        entry.filter = filter
+
+    orig_extend = getattr(entry, "extend", None)
+    if callable(orig_extend):
+        def extend(other: Any, _orig=orig_extend, _entry=entry):
+            res = _orig(other)
+            indexer = getattr(_entry, "indexer", None)
+            other_indexer = getattr(other, "indexer", None)
+            if indexer is not None and hasattr(indexer, "extend"):
+                indexer.extend(other_indexer)
+            reuse = getattr(_entry, "_sparse_index_reuse", None)
+            if reuse is not None and hasattr(reuse, "reset"):
+                reuse.reset()
+            return res
+
+        entry.extend = extend
+
+    orig_extract = getattr(entry, "extract", None)
+    if callable(orig_extract):
+        def extract(idx: int, _orig=orig_extract, _entry=entry):
+            res = _orig(idx)
+            indexer = getattr(_entry, "indexer", None)
+            if indexer is not None and hasattr(indexer, "extract"):
+                res.indexer = indexer.extract(idx)
+                _install_indexer_aware_trim(res)
+            return res
+
+        entry.extract = extract
+
     entry._mtplx_indexer_trim = True
     return entry
 
@@ -1269,6 +1309,8 @@ def inject_qwen4_exp_mtp_support(
                 len(missing),
                 missing[:8],
             )
+            if not allow_random_init:
+                return False
         if extra:
             logger.warning(
                 "[Qwen4Exp MTP inject] %d sidecar keys unused (first %s)",

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -217,6 +217,16 @@ def _split_eh_proj_weights(weights: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _transpose_mtp_conv_weights(weights: dict[str, Any]) -> dict[str, Any]:
+    out = {}
+    for k, v in weights.items():
+        if "conv1d.weight" in k and getattr(v, "ndim", 0) == 3 and v.shape[-1] != 1:
+            if v.shape[1] == 1:
+                v = v.transpose(0, 2, 1)
+        out[k] = v
+    return out
+
+
 def _process_raw_mtp_weights(
     raw: dict[str, Any], is_mlx_format: bool = False
 ) -> dict[str, Any]:
@@ -231,7 +241,8 @@ def _process_raw_mtp_weights(
     remapped = _split_eh_proj_weights(remapped)
     if is_mlx_format:
         return remapped
-    return _shift_qwen4_gemma_mtp_norms(remapped)
+    transposed = _transpose_mtp_conv_weights(remapped)
+    return _shift_qwen4_gemma_mtp_norms(transposed)
 
 
 def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
@@ -257,7 +268,8 @@ def _load_mtp_weights(paths: list[Path]) -> dict[str, Any]:
     remapped = _split_eh_proj_weights(remapped)
     if is_mlx_format:
         return remapped
-    return _shift_qwen4_gemma_mtp_norms(remapped)
+    transposed = _transpose_mtp_conv_weights(remapped)
+    return _shift_qwen4_gemma_mtp_norms(transposed)
 
 
 # Qwen4ExpTextRMSNorm is Gemma-style ``(1 + weight)`` with zero init. MLX

--- a/mtplx/qwen4_exp_mtp_patch.py
+++ b/mtplx/qwen4_exp_mtp_patch.py
@@ -898,6 +898,8 @@ def _install_indexer_aware_trim(entry: Any) -> Any:
             indexer = getattr(_entry, "indexer", None)
             if indexer is not None and hasattr(indexer, "filter"):
                 indexer.filter(batch_indices)
+                if getattr(_entry, "left_padding", None) is not None:
+                    indexer.left_padding = _entry.left_padding
             reuse = getattr(_entry, "_sparse_index_reuse", None)
             if reuse is not None and hasattr(reuse, "reset"):
                 reuse.reset()

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -108,6 +108,7 @@ class MTPLXRuntime:
     diagnostic_counters: dict[str, int] = field(default_factory=dict)
     _forward_ar_supports_emit_logits: bool | None = field(default=None, init=False, repr=False)
     _forward_ar_supports_logits_keep: bool | None = field(default=None, init=False, repr=False)
+    _forward_ar_supports_input_embeddings: bool | None = field(default=None, init=False, repr=False)
 
     def _count(self, key: str, amount: int = 1) -> None:
         self.diagnostic_counters[key] = int(self.diagnostic_counters.get(key, 0)) + int(amount)
@@ -121,10 +122,11 @@ class MTPLXRuntime:
             return int(shape[0])
         return 1
 
-    def _forward_ar_capabilities(self) -> tuple[bool, bool]:
+    def _forward_ar_capabilities(self) -> tuple[bool, bool, bool]:
         if (
             self._forward_ar_supports_emit_logits is None
             or self._forward_ar_supports_logits_keep is None
+            or self._forward_ar_supports_input_embeddings is None
         ):
             try:
                 params = py_inspect.signature(self.model.__call__).parameters
@@ -141,9 +143,13 @@ class MTPLXRuntime:
             self._forward_ar_supports_logits_keep = (
                 "logits_keep" in params or patched_kwargs
             )
+            self._forward_ar_supports_input_embeddings = (
+                "input_embeddings" in params or accepts_kwargs
+            )
         return (
             bool(self._forward_ar_supports_emit_logits),
             bool(self._forward_ar_supports_logits_keep),
+            bool(self._forward_ar_supports_input_embeddings),
         )
 
     def embed_tokens(self, input_ids):
@@ -165,8 +171,11 @@ class MTPLXRuntime:
         self._count("forward_ar_hidden_calls" if return_hidden else "forward_ar_plain_calls")
         if not self.mtp_enabled and return_hidden:
             raise RuntimeError("return_hidden requires an MTP-patched runtime")
-        if input_embeddings is not None and not self.mtp_enabled:
-            raise RuntimeError("vision splice requires the MTP-patched runtime")
+        supports_emit_logits, supports_logits_keep, supports_input_embeddings = (
+            self._forward_ar_capabilities()
+        )
+        if input_embeddings is not None and not supports_input_embeddings:
+            raise RuntimeError("this model does not accept input_embeddings; vision splice is unsupported for it")
         kwargs = {}
         if hidden_variant is not None:
             kwargs["hidden_variant"] = hidden_variant
@@ -174,7 +183,6 @@ class MTPLXRuntime:
             # Vision splice path: the patched text model takes the rows
             # directly; ids still travel for mask construction.
             kwargs["input_embeddings"] = input_embeddings
-        supports_emit_logits, supports_logits_keep = self._forward_ar_capabilities()
         if supports_emit_logits:
             kwargs["emit_logits"] = bool(emit_logits)
         elif not emit_logits:

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -1068,7 +1068,15 @@ def _model_classes_for_config(config: dict[str, Any]) -> tuple[type, type] | Non
         or (config.get("text_config") or {}).get("model_type")
         or ""
     ).lower()
-    archs = [str(a).lower() for a in (config.get("architectures") or [])]
+    tcfg = config.get("text_config") if isinstance(config.get("text_config"), dict) else {}
+    archs = [
+        str(a).lower().replace("_", "").replace("-", "")
+        for a in (
+            (config.get("architectures") if isinstance(config, dict) else None)
+            or tcfg.get("architectures")
+            or []
+        )
+    ]
     if mtype in {"qwen4_exp", "qwen4_exp_text"} or any("qwen4exp" in a for a in archs):
         from .models.qwen4_exp import Model, ModelArgs
 

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -812,6 +812,17 @@ def load(
                 "serving autoregressive (no speculative draft head).",
                 path,
             )
+    if not mtp_enabled:
+        if hasattr(model, "clear_mtp_weights"):
+            model.clear_mtp_weights()
+        elif hasattr(model, "_mtp_weights"):
+            model._mtp_weights = {}
+        text_m = getattr(model, "model", None)
+        if text_m is not None:
+            if hasattr(text_m, "clear_mtp_weights"):
+                text_m.clear_mtp_weights()
+            elif hasattr(text_m, "_mtp_weights"):
+                text_m._mtp_weights = {}
     compiled_target_factory = None
     whole_moe_plan = None
     selfcheck_report = None

--- a/mtplx/runtime.py
+++ b/mtplx/runtime.py
@@ -274,6 +274,18 @@ class MTPLXRuntime:
     ):
         text_model = getattr(self.model, "language_model", self.model)
         inner = getattr(text_model, "model", None)
+        if inner is not None and getattr(inner, "_mtplx_qwen4_exp_capture", False):
+            from .qwen4_exp_mtp_patch import forward_with_qwen4_exp_gdn_capture
+
+            self._count("forward_ar_capture_qwen4_exp_calls")
+            return forward_with_qwen4_exp_gdn_capture(
+                self.model,
+                input_ids,
+                cache=cache,
+                return_hidden=return_hidden,
+                hidden_variant=hidden_variant,
+                capture_backend=capture_backend,
+            )
         if not (hasattr(inner, "fa_idx") and hasattr(inner, "ssm_idx")):
             # Uniform full-attention model (e.g. hy_v3): every layer is plain
             # causal attention, so there is no GDN/recurrent state to capture
@@ -580,6 +592,29 @@ def load(
     never reduced.
     """
     path = Path(model_path)
+    # Pin MLX Metal allocator caps with the model-size floor BEFORE weights
+    # load. Serve applies this at startup; ask/bench/scripts converge here.
+    # Without the floor, the 60%-of-RAM default wired cap (77GiB on a 128GiB
+    # Mac) leaves a 101GiB pack partially unwired and decode swap-thrashes
+    # (~1.5-7 tok/s vs ~37 with the floor).
+    try:
+        from .server.openai import (
+            _apply_metal_memory_caps,
+            _minimum_resident_bytes_for_model_path,
+        )
+
+        _caps_receipt = _apply_metal_memory_caps(
+            minimum_resident_bytes=_minimum_resident_bytes_for_model_path(str(path))
+        )
+        if not _caps_receipt.get("applied", False):
+            print(
+                "[mtplx] metal memory caps not applied: "
+                f"{_caps_receipt.get('reason')}",
+                flush=True,
+            )
+    except Exception as _caps_exc:  # never block loading on cap plumbing
+        print(f"[mtplx] metal memory caps skipped: {_caps_exc}", flush=True)
+
     from .gemma4_pair import resolve_gemma4_pair_paths
 
     gemma4_pair = resolve_gemma4_pair_paths(path)
@@ -722,6 +757,10 @@ def load(
             is_deepseek_v4_mtp_config,
         )
         from .qwen3_5_mtp_patch import inject_qwen3_5_mtp_support
+        from .qwen4_exp_mtp_patch import (
+            inject_qwen4_exp_mtp_support,
+            is_qwen4_exp_mtp_config,
+        )
 
         if is_deepseek_v4_mtp_config(config):
             # Native draft head: the block binds through the ordinary load path
@@ -743,6 +782,8 @@ def load(
             mtp_enabled = inject_hy_v3_mtp_support(model, path, config, contract)
         elif is_qwen3_5_mtp_config(config):
             mtp_enabled = inject_qwen3_5_mtp_support(model, path, config, contract)
+        elif is_qwen4_exp_mtp_config(config):
+            mtp_enabled = inject_qwen4_exp_mtp_support(model, path, config, contract)
         elif is_deepseek_mtp_config(config):
             mtp_enabled = inject_deepseek_mtp_support(model, path, config, contract)
         else:
@@ -1012,6 +1053,16 @@ def _model_classes_for_config(config: dict[str, Any]) -> tuple[type, type] | Non
 
     if str(config.get("model_type") or "").lower() == "deepseek_v4":
         from .models.deepseek_v4 import Model, ModelArgs
+
+        return Model, ModelArgs
+    mtype = str(
+        config.get("model_type")
+        or (config.get("text_config") or {}).get("model_type")
+        or ""
+    ).lower()
+    archs = [str(a).lower() for a in (config.get("architectures") or [])]
+    if mtype in {"qwen4_exp", "qwen4_exp_text"} or any("qwen4exp" in a for a in archs):
+        from .models.qwen4_exp import Model, ModelArgs
 
         return Model, ModelArgs
     if not _is_laguna_s_2_1_mlx_4bit_config(config):

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -93,6 +93,7 @@ from mtplx.backends.descriptors import (
     model_controls_for_descriptor,
     model_family_from_inspection,
     reasoning_policy_for_model,
+    sampler_defaults_for_model,
     set_draft_control_arg,
     sync_backend_arg_aliases,
     target_distribution_mode_from_args,
@@ -2200,6 +2201,7 @@ class ServerState:
         from mtplx.backends.descriptors import (
             QWEN4_EXP_DRAFT_SEMANTICS,
             draft_semantics_for_model,
+            sampler_defaults_for_model,
         )
         from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_strategy
 
@@ -2215,6 +2217,19 @@ class ServerState:
                 model_ref=getattr(args, "model", None) or getattr(args, "model_id", None),
                 descriptor=self.backend_descriptor,
             )
+        loaded_sampler_defaults = sampler_defaults_for_model(
+            model_ref=getattr(args, "model", None) or getattr(args, "model_id", None),
+            descriptor=self.backend_descriptor,
+        )
+        explicit_flags = getattr(args, "_cli_flags", None)
+        if explicit_flags is None:
+            explicit_flags = set()
+        if not _server_flag_present(explicit_flags, "temperature", "default-temperature"):
+            args.temperature = float(loaded_sampler_defaults.temperature)
+        if not _server_flag_present(explicit_flags, "top-p", "default-top-p"):
+            args.top_p = float(loaded_sampler_defaults.top_p)
+        if not _server_flag_present(explicit_flags, "top-k"):
+            args.top_k = int(loaded_sampler_defaults.top_k)
         if not getattr(args, "_explicit_depth", False):
             set_draft_control_arg(
                 args,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -3708,7 +3708,12 @@ def _resolve_context_window(tokenizer: Any, model_path: str) -> int:
             if isinstance(rope_scaling, dict):
                 factor = rope_scaling.get("factor")
                 if isinstance(factor, (int, float)) and factor > 1:
-                    orig = section.get("original_max_position_embeddings") or section.get("max_position_embeddings")
+                    orig = (
+                        rope_scaling.get("original_max_position_embeddings")
+                        or rope_scaling.get("original_max_position")
+                        or section.get("original_max_position_embeddings")
+                        or section.get("original_max_position")
+                    )
                     if isinstance(orig, int):
                         candidates.append(int(orig * factor))
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1683,9 +1683,10 @@ def _loaded_weights_bytes_for_model_path(model_path: str | Path | None) -> int |
         if not root.is_dir():
             return None
 
-        resolved_shards: set[Path] = set()
+        trunk_shards: set[Path] = set()
+        sidecar_shards: set[Path] = set()
 
-        # 1. Checkpoint index-based resolution
+        # 1. Checkpoint index-based trunk resolution
         index_path = root / "model.safetensors.index.json"
         if index_path.exists():
             try:
@@ -1695,11 +1696,31 @@ def _loaded_weights_bytes_for_model_path(model_path: str | Path | None) -> int |
                     for shard_name in set(weight_map.values()):
                         shard_path = (root / shard_name).resolve()
                         if shard_path.is_file():
-                            resolved_shards.add(shard_path)
+                            trunk_shards.add(shard_path)
             except Exception:
                 pass
 
-        # 2. Sidecar resolution
+        # 2. Direct trunk resolution when index is absent or empty
+        if not trunk_shards:
+            for candidate in ("model.safetensors", "weights.safetensors"):
+                p = (root / candidate).resolve()
+                if p.is_file():
+                    trunk_shards.add(p)
+            if not trunk_shards:
+                for p in root.glob("*.safetensors"):
+                    try:
+                        from mtplx.backends.registry import _is_mtp_sidecar_file
+
+                        if not _is_mtp_sidecar_file(p):
+                            resolved = p.resolve()
+                            if resolved.is_file():
+                                trunk_shards.add(resolved)
+                    except Exception:
+                        resolved = p.resolve()
+                        if resolved.is_file():
+                            trunk_shards.add(resolved)
+
+        # 3. Sidecar resolution
         try:
             from mtplx.artifacts import expected_mtp_file, load_config
 
@@ -1710,22 +1731,11 @@ def _loaded_weights_bytes_for_model_path(model_path: str | Path | None) -> int |
                 cfg = {}
             mtp_file = expected_mtp_file(root, cfg)
             if mtp_file and mtp_file.exists():
-                resolved_shards.add(mtp_file.resolve())
+                sidecar_shards.add(mtp_file.resolve())
         except Exception:
             pass
 
-        # 3. If no index found, look for direct trunk shards
-        if not resolved_shards:
-            for candidate in ("model.safetensors", "weights.safetensors"):
-                p = (root / candidate).resolve()
-                if p.is_file():
-                    resolved_shards.add(p)
-            if not resolved_shards:
-                for p in root.glob("*.safetensors"):
-                    resolved = p.resolve()
-                    if resolved.is_file():
-                        resolved_shards.add(resolved)
-
+        resolved_shards = trunk_shards | sidecar_shards
         if not resolved_shards:
             from mtplx.engine_session import model_weights_bytes
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1679,9 +1679,79 @@ def _loaded_weights_bytes_for_model_path(model_path: str | Path | None) -> int |
     if not model_path:
         return None
     try:
-        root = Path(str(model_path))
+        model_str = str(model_path).strip()
+        root = Path(model_str)
         if not root.is_dir():
-            return None
+            resolved_local: Path | None = None
+            try:
+                from mtplx.hf_loader import cached_model_path, repo_id_from_model_ref, resolve_model_path
+
+                repo_id = repo_id_from_model_ref(model_str)
+                if repo_id:
+                    try:
+                        resolved_local = resolve_model_path(model_str)
+                    except Exception:
+                        pass
+                    if not resolved_local or not resolved_local.is_dir():
+                        cached = cached_model_path(repo_id)
+                        if cached.is_dir():
+                            resolved_local = cached
+                    if not resolved_local or not resolved_local.is_dir():
+                        try:
+                            from huggingface_hub import try_to_load_from_cache
+
+                            cfg_path = try_to_load_from_cache(repo_id, "config.json")
+                            if isinstance(cfg_path, str) and Path(cfg_path).is_file():
+                                snap_dir = Path(cfg_path).parent
+                                if snap_dir.is_dir():
+                                    resolved_local = snap_dir
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+
+            if resolved_local and resolved_local.is_dir():
+                root = resolved_local
+            else:
+                try:
+                    from mtplx.artifacts import _hf_download_json, _hf_repo_id_from_ref
+                    from mtplx.backends.registry import _is_mtp_sidecar_file, _is_trunk_safetensors
+
+                    repo_id = _hf_repo_id_from_ref(model_str)
+                    if repo_id:
+                        from huggingface_hub import HfApi
+
+                        info = HfApi().model_info(repo_id, files_metadata=True)
+                        siblings = getattr(info, "siblings", None) or []
+
+                        index_data, _, _ = _hf_download_json(repo_id, "model.safetensors.index.json")
+                        weight_map = index_data.get("weight_map", {}) if isinstance(index_data, dict) else {}
+                        wanted_shards = (
+                            set(weight_map.values())
+                            if isinstance(weight_map, dict) and weight_map
+                            else set()
+                        )
+
+                        total_remote = 0
+                        has_shards = False
+                        for s in siblings:
+                            rfilename = getattr(s, "rfilename", "") or ""
+                            size = getattr(s, "size", None)
+                            if size and isinstance(size, int) and size > 0:
+                                p = Path(rfilename)
+                                if wanted_shards:
+                                    if rfilename in wanted_shards or _is_mtp_sidecar_file(p):
+                                        total_remote += size
+                                        has_shards = True
+                                else:
+                                    if _is_trunk_safetensors(p) or _is_mtp_sidecar_file(p):
+                                        total_remote += size
+                                        has_shards = True
+                        if has_shards and total_remote > 0:
+                            return total_remote
+                except Exception:
+                    pass
+                return None
 
         trunk_shards: set[Path] = set()
         sidecar_shards: set[Path] = set()

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1658,6 +1658,17 @@ def _set_metal_memory_limit(mx: Any, name: str, value: int) -> str:
 _MODEL_RESIDENT_HEADROOM_BYTES = 4 * 1024**3
 
 
+def _resident_headroom_bytes_for_weights(weights_bytes: int) -> int:
+    """Activation headroom scaled by model weight size."""
+    weights_int = int(weights_bytes)
+    if weights_int >= 30 * 1024**3:
+        return _MODEL_RESIDENT_HEADROOM_BYTES
+    return min(
+        _MODEL_RESIDENT_HEADROOM_BYTES,
+        max(128 * 1024**2, int(weights_int * 0.08)),
+    )
+
+
 def _minimum_resident_bytes_for_model_path(model_path: str | None) -> int | None:
     """Disk shard bytes + activation headroom, or None when unknown."""
 
@@ -1673,7 +1684,9 @@ def _minimum_resident_bytes_for_model_path(model_path: str | None) -> int | None
         return None
     if not weights:
         return None
-    return int(weights) + int(_MODEL_RESIDENT_HEADROOM_BYTES)
+    weights_int = int(weights)
+    headroom = _resident_headroom_bytes_for_weights(weights_int)
+    return weights_int + int(headroom)
 
 
 def _apply_metal_memory_caps(
@@ -1745,11 +1758,16 @@ def _apply_metal_memory_caps(
             160 * 1024**3,
         )
     resident_floor = max(0, int(minimum_resident_bytes or 0))
+    system_reserve = (
+        min(16 * 1024**3, max(2 * 1024**3, int(total_ram * 0.15)))
+        if (total_ram is not None and total_ram > 0)
+        else (16 * 1024**3)
+    )
     if (
         resident_floor
         and total_ram is not None
         and total_ram > 0
-        and resident_floor + 16 * 1024**3 > total_ram
+        and resident_floor + system_reserve > total_ram
     ):
         return {
             "applied": False,
@@ -1757,7 +1775,7 @@ def _apply_metal_memory_caps(
             "total_ram_bytes": total_ram,
             "total_ram_source": total_ram_source,
             "minimum_resident_bytes": resident_floor,
-            "minimum_system_reserve_bytes": 16 * 1024**3,
+            "minimum_system_reserve_bytes": system_reserve,
         }
     mem_limit = _parse_metal_memory_size_bytes(mem_raw, default_mem)
     wired_limit = _parse_metal_memory_size_bytes(wired_raw, default_wired)
@@ -1865,16 +1883,19 @@ def apply_memory_caps_preflight(
         required_gib = (
             int(caps.get("minimum_resident_bytes") or 0) / 1024**3
         )
+        reserve_gib = (
+            int(caps.get("minimum_system_reserve_bytes") or (16 * 1024**3)) / 1024**3
+        )
         model_label = model or "The model"
         if caps.get("reason") == "configured_cap_below_model_minimum":
             raise RuntimeError(
                 f"{entry}: {model_label} cannot load inside configured Metal memory caps; "
-                f"at least {required_gib:.1f} GiB resident plus 16 GiB system headroom is required"
+                f"at least {required_gib:.1f} GiB resident plus {reserve_gib:.1f} GiB system headroom is required"
             )
         raise RuntimeError(
             f"{entry}: {model_label} cannot load inside the available Metal memory "
             f"budget; at least {required_gib:.1f} GiB resident plus "
-            "16 GiB system headroom is required"
+            f"{reserve_gib:.1f} GiB system headroom is required"
         )
     outcome: dict[str, Any] = {
         "entry": str(entry),

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -84,10 +84,12 @@ from mtplx.mtp_batch_numerics import (
 from mtplx.backends.descriptors import (
     BackendDescriptor,
     ReasoningCodec,
+    QWEN4_EXP_DRAFT_SEMANTICS,
     assistant_target_distribution_choices,
     descriptor_for_backend_id,
     descriptor_for_model,
     descriptor_from_runtime,
+    draft_semantics_for_model,
     model_controls_for_descriptor,
     model_family_from_inspection,
     reasoning_policy_for_model,
@@ -2195,12 +2197,10 @@ class ServerState:
         _startup_line(f"[5/6] Model loaded in {self.load_time_s:.1f}s")
         self.backend_descriptor = descriptor_from_runtime(self.runtime, args)
         args.backend_id = self.backend_descriptor.backend_id
-        if not getattr(args, "_explicit_depth", False):
-            set_draft_control_arg(
-                args,
-                self.backend_descriptor,
-                int(self.backend_descriptor.draft_semantics.default),
-            )
+        from mtplx.backends.descriptors import (
+            QWEN4_EXP_DRAFT_SEMANTICS,
+            draft_semantics_for_model,
+        )
         from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_strategy
 
         qwen4_verify = qwen4_exp_product_verify_strategy(
@@ -2209,6 +2209,18 @@ class ServerState:
         if qwen4_verify is not None:
             args.verify_strategy = qwen4_verify
             os.environ["MTPLX_SKIP_VERIFY_SNAPSHOT"] = "0"
+            loaded_draft_semantics = QWEN4_EXP_DRAFT_SEMANTICS
+        else:
+            loaded_draft_semantics = draft_semantics_for_model(
+                model_ref=getattr(args, "model", None) or getattr(args, "model_id", None),
+                descriptor=self.backend_descriptor,
+            )
+        if not getattr(args, "_explicit_depth", False):
+            set_draft_control_arg(
+                args,
+                self.backend_descriptor,
+                int(loaded_draft_semantics.default),
+            )
         if self.backend_descriptor.uses_draft_lm_head:
             _startup_line("[5/6] Installing native-MTP draft head")
         else:
@@ -31831,15 +31843,19 @@ def _apply_backend_server_defaults(
         and backend.reasoning_codec.default_effort
     ):
         args.reasoning_effort = backend.reasoning_codec.default_effort
+    draft_sem = draft_semantics_for_model(
+        model_ref=getattr(args, "model", None) or getattr(args, "model_id", None),
+        descriptor=backend,
+    )
     if not _server_flag_present(
         explicit_flags,
         "depth",
         "mtp-depth",
         "speculative-depth",
-        backend.draft_semantics.request_field,
+        draft_sem.request_field,
     ):
         args._explicit_depth = False
-        set_draft_control_arg(args, backend, int(backend.draft_semantics.default))
+        set_draft_control_arg(args, backend, int(draft_sem.default))
     else:
         args._explicit_depth = True
     if backend.backend_id != GEMMA4_BACKEND:

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2174,6 +2174,12 @@ class ServerState:
         _startup_line(f"[5/6] Model loaded in {self.load_time_s:.1f}s")
         self.backend_descriptor = descriptor_from_runtime(self.runtime, args)
         args.backend_id = self.backend_descriptor.backend_id
+        if not getattr(args, "_explicit_depth", False):
+            set_draft_control_arg(
+                args,
+                self.backend_descriptor,
+                int(self.backend_descriptor.draft_semantics.default),
+            )
         from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_strategy
 
         qwen4_verify = qwen4_exp_product_verify_strategy(
@@ -13463,17 +13469,21 @@ def _request_depth_for_generation(
         else None
     )
     if value is None:
-        default_value = getattr(
-            state.args,
-            descriptor.draft_semantics.request_field,
-            None,
-        )
-        if default_value is None:
+        explicit_depth = getattr(state.args, "_explicit_depth", False)
+        if explicit_depth:
             default_value = getattr(
                 state.args,
-                "depth",
-                descriptor.draft_semantics.default,
+                descriptor.draft_semantics.request_field,
+                None,
             )
+            if default_value is None:
+                default_value = getattr(
+                    state.args,
+                    "depth",
+                    descriptor.draft_semantics.default,
+                )
+        else:
+            default_value = descriptor.draft_semantics.default
         return descriptor.draft_semantics.clamp(default_value)
     try:
         depth = int(value)
@@ -31800,6 +31810,17 @@ def _apply_backend_server_defaults(
         and backend.reasoning_codec.default_effort
     ):
         args.reasoning_effort = backend.reasoning_codec.default_effort
+    if not _server_flag_present(
+        explicit_flags,
+        "depth",
+        "mtp-depth",
+        "speculative-depth",
+        backend.draft_semantics.request_field,
+    ):
+        args._explicit_depth = False
+        set_draft_control_arg(args, backend, int(backend.draft_semantics.default))
+    else:
+        args._explicit_depth = True
     if backend.backend_id != GEMMA4_BACKEND:
         return
 
@@ -32535,6 +32556,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     args = parser.parse_args(raw_args)
     args._raw_args = list(raw_args)
+    args._explicit_depth = _server_flag_present(
+        _explicit_server_flags(raw_args), "depth", "mtp-depth", "speculative-depth"
+    )
     args._cli_flags = canonicalize_flag_tokens(
         _explicit_server_flags(raw_args), parser, args
     )

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1858,6 +1858,24 @@ def apply_memory_caps_preflight(
     caps = _apply_metal_memory_caps(
         minimum_resident_bytes=_minimum_resident_bytes_for_model_path(model),
     )
+    if caps.get("reason") in {
+        "insufficient_ram",
+        "configured_cap_below_model_minimum",
+    }:
+        required_gib = (
+            int(caps.get("minimum_resident_bytes") or 0) / 1024**3
+        )
+        model_label = model or "The model"
+        if caps.get("reason") == "configured_cap_below_model_minimum":
+            raise RuntimeError(
+                f"{entry}: {model_label} cannot load inside configured Metal memory caps; "
+                f"at least {required_gib:.1f} GiB resident plus 16 GiB system headroom is required"
+            )
+        raise RuntimeError(
+            f"{entry}: {model_label} cannot load inside the available Metal memory "
+            f"budget; at least {required_gib:.1f} GiB resident plus "
+            "16 GiB system headroom is required"
+        )
     outcome: dict[str, Any] = {
         "entry": str(entry),
         "metal_memory_caps": caps,
@@ -1891,13 +1909,12 @@ def _select_backend_context_window(
         if backend.backend_id == "laguna_ar"
         else int(model_max)
     )
-    if requested_value > 0:
-        return max(4_096, min(1_048_576, requested_value))
+    target_value = requested_value if requested_value > 0 else int(default_value)
     return max(
         4_096,
         min(
             int(model_max),
-            int(default_value),
+            target_value,
         ),
     )
 
@@ -2036,8 +2053,19 @@ class ServerState:
             required_gib = (
                 int(self.metal_memory_caps.get("minimum_resident_bytes") or 0) / 1024**3
             )
+            model_label = (
+                getattr(args, "model", None)
+                or getattr(startup_backend, "display_name", None)
+                or getattr(startup_backend, "backend_id", None)
+                or "The selected model"
+            )
+            if self.metal_memory_caps.get("reason") == "configured_cap_below_model_minimum":
+                raise RuntimeError(
+                    f"{model_label} cannot load inside configured Metal memory caps; "
+                    f"at least {required_gib:.1f} GiB resident plus 16 GiB system headroom is required"
+                )
             raise RuntimeError(
-                "Laguna-S-2.1 cannot load inside the available Metal memory "
+                f"{model_label} cannot load inside the available Metal memory "
                 f"budget; at least {required_gib:.1f} GiB resident plus "
                 "16 GiB system headroom is required"
             )

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2221,6 +2221,13 @@ class ServerState:
                 self.backend_descriptor,
                 int(loaded_draft_semantics.default),
             )
+        if loaded_draft_semantics is not None:
+            from dataclasses import replace
+
+            self.backend_descriptor = replace(
+                self.backend_descriptor,
+                draft_semantics=loaded_draft_semantics,
+            )
         if self.backend_descriptor.uses_draft_lm_head:
             _startup_line("[5/6] Installing native-MTP draft head")
         else:
@@ -13502,20 +13509,18 @@ def _request_depth_for_generation(
         else None
     )
     if value is None:
-        explicit_depth = getattr(state.args, "_explicit_depth", False)
-        if explicit_depth:
+        default_value = getattr(
+            state.args,
+            descriptor.draft_semantics.request_field,
+            None,
+        )
+        if default_value is None:
             default_value = getattr(
                 state.args,
-                descriptor.draft_semantics.request_field,
+                "depth",
                 None,
             )
-            if default_value is None:
-                default_value = getattr(
-                    state.args,
-                    "depth",
-                    descriptor.draft_semantics.default,
-                )
-        else:
+        if default_value is None:
             default_value = descriptor.draft_semantics.default
         return descriptor.draft_semantics.clamp(default_value)
     try:

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1651,6 +1651,31 @@ def _set_metal_memory_limit(mx: Any, name: str, value: int) -> str:
     raise AttributeError(f"MLX memory cap API {name} is unavailable")
 
 
+# Short-decode activations/KV on the 101GB 4-bit qwen4_exp pack measured
+# ~2GB above shard bytes in bare mlx-lm (peak 103.2GB). The 4GiB pad keeps
+# the Metal wired floor off the 60%-of-RAM default (77GB on a 128GB Mac)
+# which swap-thrashes that pack (~1.5 tok/s vs ~37).
+_MODEL_RESIDENT_HEADROOM_BYTES = 4 * 1024**3
+
+
+def _minimum_resident_bytes_for_model_path(model_path: str | None) -> int | None:
+    """Disk shard bytes + activation headroom, or None when unknown."""
+
+    if not model_path:
+        return None
+    try:
+        from mtplx.engine_session import model_weights_bytes
+    except Exception:
+        return None
+    try:
+        weights = model_weights_bytes(model_path)
+    except Exception:
+        return None
+    if not weights:
+        return None
+    return int(weights) + int(_MODEL_RESIDENT_HEADROOM_BYTES)
+
+
 def _apply_metal_memory_caps(
     *,
     mx_module: Any | None = None,
@@ -1673,6 +1698,11 @@ def _apply_metal_memory_caps(
                                    RAM, capped at 160 GiB on very large Macs
 
     Both accept plain bytes or K/M/G/T suffix.
+
+    ``minimum_resident_bytes`` raises both caps to at least that floor
+    (ask/serve pass on-disk shard bytes + headroom). Without it, the 60%
+    wired default on a 128 GiB Mac is 77 GiB and swap-thrashes a 101 GiB
+    4-bit pack.
     """
     if mx_module is None:
         try:
@@ -1825,7 +1855,9 @@ def apply_memory_caps_preflight(
 
     Returns a JSON-safe receipt for the caller's payload/envelope.
     """
-    caps = _apply_metal_memory_caps()
+    caps = _apply_metal_memory_caps(
+        minimum_resident_bytes=_minimum_resident_bytes_for_model_path(model),
+    )
     outcome: dict[str, Any] = {
         "entry": str(entry),
         "metal_memory_caps": caps,
@@ -1859,11 +1891,13 @@ def _select_backend_context_window(
         if backend.backend_id == "laguna_ar"
         else int(model_max)
     )
+    if requested_value > 0:
+        return max(4_096, min(1_048_576, requested_value))
     return max(
         4_096,
         min(
             int(model_max),
-            requested_value if requested_value > 0 else int(default_value),
+            int(default_value),
         ),
     )
 
@@ -1980,13 +2014,18 @@ class ServerState:
         self.postcommit_executor = None
         self.rate_limiter = _RateLimiter(args.rate_limit)
         startup_backend = descriptor_for_backend_id(getattr(args, "backend_id", None))
-        minimum_resident_bytes = None
+        minimum_resident_bytes = _minimum_resident_bytes_for_model_path(
+            getattr(args, "model", None)
+        )
         if startup_backend.backend_id == "laguna_ar":
             from mtplx.models.laguna_config import (
                 LAGUNA_S_2_1_MIN_RESIDENT_BYTES,
             )
 
-            minimum_resident_bytes = LAGUNA_S_2_1_MIN_RESIDENT_BYTES
+            minimum_resident_bytes = max(
+                int(minimum_resident_bytes or 0),
+                int(LAGUNA_S_2_1_MIN_RESIDENT_BYTES),
+            )
         self.metal_memory_caps = _apply_metal_memory_caps(
             minimum_resident_bytes=minimum_resident_bytes,
         )
@@ -2107,6 +2146,14 @@ class ServerState:
         _startup_line(f"[5/6] Model loaded in {self.load_time_s:.1f}s")
         self.backend_descriptor = descriptor_from_runtime(self.runtime, args)
         args.backend_id = self.backend_descriptor.backend_id
+        from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_strategy
+
+        qwen4_verify = qwen4_exp_product_verify_strategy(
+            getattr(self.runtime, "model", None)
+        )
+        if qwen4_verify is not None:
+            args.verify_strategy = qwen4_verify
+            os.environ["MTPLX_SKIP_VERIFY_SNAPSHOT"] = "0"
         if self.backend_descriptor.uses_draft_lm_head:
             _startup_line("[5/6] Installing native-MTP draft head")
         else:
@@ -3583,6 +3630,13 @@ def _resolve_context_window(tokenizer: Any, model_path: str) -> int:
                 value = section.get(key)
                 if isinstance(value, int):
                     candidates.append(value)
+            rope_scaling = section.get("rope_scaling")
+            if isinstance(rope_scaling, dict):
+                factor = rope_scaling.get("factor")
+                if isinstance(factor, (int, float)) and factor > 1:
+                    orig = section.get("original_max_position_embeddings") or section.get("max_position_embeddings")
+                    if isinstance(orig, int):
+                        candidates.append(int(orig * factor))
 
     sane = [value for value in candidates if 0 < value <= 1_048_576]
     return max(sane) if sane else 262_144

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -1672,19 +1672,81 @@ def _resident_headroom_bytes_for_weights(weights_bytes: int) -> int:
     )
 
 
-def _minimum_resident_bytes_for_model_path(model_path: str | None) -> int | None:
-    """Disk shard bytes + activation headroom, or None when unknown."""
-
+def _loaded_weights_bytes_for_model_path(model_path: str | Path | None) -> int | None:
+    """Total bytes of the model shards and enabled sidecars actually loaded,
+    deduplicating resolved paths and excluding unused adapters/alternate files.
+    """
     if not model_path:
         return None
     try:
-        from mtplx.engine_session import model_weights_bytes
+        root = Path(str(model_path))
+        if not root.is_dir():
+            return None
+
+        resolved_shards: set[Path] = set()
+
+        # 1. Checkpoint index-based resolution
+        index_path = root / "model.safetensors.index.json"
+        if index_path.exists():
+            try:
+                index_data = json.loads(index_path.read_text(encoding="utf-8"))
+                weight_map = index_data.get("weight_map", {})
+                if isinstance(weight_map, dict):
+                    for shard_name in set(weight_map.values()):
+                        shard_path = (root / shard_name).resolve()
+                        if shard_path.is_file():
+                            resolved_shards.add(shard_path)
+            except Exception:
+                pass
+
+        # 2. Sidecar resolution
+        try:
+            from mtplx.artifacts import expected_mtp_file, load_config
+
+            cfg = None
+            try:
+                cfg = load_config(root)
+            except Exception:
+                cfg = {}
+            mtp_file = expected_mtp_file(root, cfg)
+            if mtp_file and mtp_file.exists():
+                resolved_shards.add(mtp_file.resolve())
+        except Exception:
+            pass
+
+        # 3. If no index found, look for direct trunk shards
+        if not resolved_shards:
+            for candidate in ("model.safetensors", "weights.safetensors"):
+                p = (root / candidate).resolve()
+                if p.is_file():
+                    resolved_shards.add(p)
+            if not resolved_shards:
+                for p in root.glob("*.safetensors"):
+                    resolved = p.resolve()
+                    if resolved.is_file():
+                        resolved_shards.add(resolved)
+
+        if not resolved_shards:
+            from mtplx.engine_session import model_weights_bytes
+
+            return model_weights_bytes(root)
+
+        total = 0
+        for shard in resolved_shards:
+            try:
+                total += shard.stat().st_size
+            except OSError:
+                pass
+        return total if total > 0 else None
     except Exception:
         return None
-    try:
-        weights = model_weights_bytes(model_path)
-    except Exception:
+
+
+def _minimum_resident_bytes_for_model_path(model_path: str | None) -> int | None:
+    """Disk shard bytes + activation headroom, or None when unknown."""
+    if not model_path:
         return None
+    weights = _loaded_weights_bytes_for_model_path(model_path)
     if not weights:
         return None
     weights_int = int(weights)

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -25,6 +25,7 @@ from mtplx.constants import (
     EXPECTED_PREQUANTIZED_MTP_KEYS,
     EXPECTED_QWEN_MOE_MTP_KEYS,
     EXPECTED_QWEN_MOE_PREQUANTIZED_MTP_KEYS,
+    EXPECTED_QWEN4_EXP_MTP_KEYS,
     expand_mtp_layer_keys,
 )
 from mtplx.default_models import (
@@ -287,6 +288,23 @@ def _scan_for_models(
     return results
 
 
+def _is_qwen4_exp_config(config: dict[str, Any]) -> bool:
+    tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
+    model_type = str(tcfg.get("model_type") or config.get("model_type") or "").lower()
+    if model_type in {"qwen4_exp", "qwen4_exp_text"}:
+        return True
+    archs = (
+        (config.get("architectures") if isinstance(config, dict) else None)
+        or tcfg.get("architectures")
+        or []
+    )
+    for arch in archs:
+        compact = str(arch).lower().replace("_", "").replace("-", "")
+        if "qwen4exp" in compact:
+            return True
+    return False
+
+
 def _expected_embedded_mtp_keys(config: dict[str, Any]) -> set[str]:
     tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
     mtp_raw = {}
@@ -299,11 +317,16 @@ def _expected_embedded_mtp_keys(config: dict[str, Any]) -> set[str]:
             mtp_raw.get("num_hidden_layers")
             or tcfg.get("mtp_num_hidden_layers")
             or tcfg.get("num_nextn_predict_layers")
-            or config.get("num_nextn_predict_layers")
+            or tcfg.get("num_mtp_modules")
+            or (config.get("mtp_num_hidden_layers") if isinstance(config, dict) else 0)
+            or (config.get("num_nextn_predict_layers") if isinstance(config, dict) else 0)
+            or (config.get("num_mtp_modules") if isinstance(config, dict) else 0)
             or 0
         ),
         1,
     )
+    if _is_qwen4_exp_config(config):
+        return expand_mtp_layer_keys(EXPECTED_QWEN4_EXP_MTP_KEYS, n_layers)
     if _is_qwen_moe_mtp_config(config):
         mtp_quant = config.get("mtplx_mtp_quantization", {})
         prequantized = isinstance(mtp_quant, dict) and bool(mtp_quant.get("prequantized"))
@@ -452,6 +475,7 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         _maybe_int(tcfg.get("mtp_num_hidden_layers")),
         _maybe_int(tcfg.get("num_nextn_predict_layers")),
         _maybe_int(tcfg.get("num_mtp_modules")),
+        _maybe_int(config.get("mtp_num_hidden_layers")) if isinstance(config, dict) else 0,
         _maybe_int(config.get("num_nextn_predict_layers")) if isinstance(config, dict) else 0,
         _maybe_int(config.get("num_mtp_modules")) if isinstance(config, dict) else 0,
     )
@@ -474,8 +498,12 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         model_files = ()
     sidecar_exists = _scan_mtp_sidecar_exists(model_dir, config if isinstance(config, dict) else {})
     embedded_mtp_keys = _scan_embedded_mtp_keys(model_dir)
-    expected_embedded = _expected_embedded_mtp_keys(config if isinstance(config, dict) else {})
-    embedded_gate = bool(embedded_mtp_keys) and set(embedded_mtp_keys) == expected_embedded
+    is_qwen4 = _is_qwen4_exp_config(config if isinstance(config, dict) else {})
+    if is_qwen4:
+        embedded_gate = bool(embedded_mtp_keys)
+    else:
+        expected_embedded = _expected_embedded_mtp_keys(config if isinstance(config, dict) else {})
+        embedded_gate = bool(embedded_mtp_keys) and set(embedded_mtp_keys) == expected_embedded
     mtp_artifact_exists = sidecar_exists or bool(embedded_mtp_keys)
     mtp_tensor_gate = sidecar_exists or embedded_gate
 

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -289,9 +289,15 @@ def _scan_for_models(
 
 def _expected_embedded_mtp_keys(config: dict[str, Any]) -> set[str]:
     tcfg = config.get("text_config", config) if isinstance(config, dict) else {}
+    mtp_raw = {}
+    if isinstance(tcfg, dict) and isinstance(tcfg.get("mtp"), dict):
+        mtp_raw = tcfg["mtp"]
+    elif isinstance(config, dict) and isinstance(config.get("mtp"), dict):
+        mtp_raw = config["mtp"]
     n_layers = max(
         int(
-            tcfg.get("mtp_num_hidden_layers")
+            mtp_raw.get("num_hidden_layers")
+            or tcfg.get("mtp_num_hidden_layers")
             or tcfg.get("num_nextn_predict_layers")
             or config.get("num_nextn_predict_layers")
             or 0
@@ -423,7 +429,13 @@ def _classify_scanned_model(model_dir: Path) -> ScannedModel:
         except (TypeError, ValueError):
             return 0
 
+    mtp_raw = {}
+    if isinstance(tcfg, dict) and isinstance(tcfg.get("mtp"), dict):
+        mtp_raw = tcfg["mtp"]
+    elif isinstance(config, dict) and isinstance(config.get("mtp"), dict):
+        mtp_raw = config["mtp"]
     mtp_num_hidden_layers = max(
+        _maybe_int(mtp_raw.get("num_hidden_layers")),
         _maybe_int(tcfg.get("mtp_num_hidden_layers")),
         _maybe_int(tcfg.get("num_nextn_predict_layers")),
         _maybe_int(tcfg.get("num_mtp_modules")),

--- a/mtplx/ui/onboarding.py
+++ b/mtplx/ui/onboarding.py
@@ -348,13 +348,26 @@ def _scan_mtp_sidecar_exists(model_dir: Path, config: dict[str, Any]) -> bool:
     extra = config.get("mlx_lm_extra_tensors", {})
     if isinstance(extra, dict) and extra.get("mtp_file"):
         candidates.append(str(extra["mtp_file"]))
-    candidates.extend(("mtp.safetensors", "mtp/weights.safetensors", "model-mtp.safetensors"))
+    candidates.extend(
+        (
+            "mtp.safetensors",
+            "mtp/weights.safetensors",
+            "model-mtp.safetensors",
+            "model-mtp-head.safetensors",
+        )
+    )
     for rel in candidates:
         try:
             if (model_dir / rel).is_file():
                 return True
         except OSError:
             continue
+    try:
+        for p in model_dir.glob("*.safetensors"):
+            if p.name.endswith("-mtp.safetensors") or p.name.endswith("-mtp-head.safetensors"):
+                return True
+    except OSError:
+        pass
     return False
 
 

--- a/tests/test_attention_split.py
+++ b/tests/test_attention_split.py
@@ -46,6 +46,50 @@ def test_vllm_paged_hook_does_not_enable_split_full_attention(monkeypatch):
     assert attn._mtplx_split_full_attention_explicit_enabled is False
 
 
+def test_qsa_indexer_attention_is_not_split_hooked(monkeypatch):
+    """qwen4_exp QSA must not receive the Qwen3Next split-SDPA class patch."""
+
+    monkeypatch.setenv("MTPLX_SPLIT_FULL_ATTN", "1")
+
+    class QsaAttention:
+        indexer = object()
+
+        def __call__(self, x, mask=None, cache=None):
+            return x
+
+    class HouseAttention:
+        def __call__(self, x, mask=None, cache=None):
+            return x
+
+    class QsaLayer:
+        is_linear = False
+
+        def __init__(self):
+            self.self_attn = QsaAttention()
+
+    class HouseLayer:
+        is_linear = False
+
+        def __init__(self):
+            self.self_attn = HouseAttention()
+
+    class MixedModel:
+        def __init__(self):
+            self.model = type(
+                "Inner", (), {"layers": [QsaLayer(), HouseLayer()]}
+            )()
+
+    model = MixedModel()
+    stats = configure_split_full_attention(model)
+    qsa = model.model.layers[0].self_attn
+    house = model.model.layers[1].self_attn
+
+    assert stats["layers"] == 1
+    assert stats["installed"] == 1
+    assert not getattr(type(qsa), "_mtplx_split_full_attention_installed", False)
+    assert getattr(type(house), "_mtplx_split_full_attention_installed", False)
+
+
 def test_explicit_split_full_attention_chunk_one_gets_safe_default(monkeypatch):
     monkeypatch.setenv("MTPLX_SPLIT_FULL_ATTN", "1")
     monkeypatch.setenv("MTPLX_SPLIT_FULL_ATTN_CHUNK_SIZE", "1")

--- a/tests/test_cold_tier_stats_cache.py
+++ b/tests/test_cold_tier_stats_cache.py
@@ -32,6 +32,7 @@ def _count_connects(tier, monkeypatch) -> list:
 def test_repeated_stats_polls_reuse_cached_aggregate(tmp_path, monkeypatch):
     tier = _tier(tmp_path)
     try:
+        tier._ensure_disk_usage_snapshot()
         calls = _count_connects(tier, monkeypatch)
         first = tier.stats()
         connects_after_first = len(calls)

--- a/tests/test_metal_memory_caps.py
+++ b/tests/test_metal_memory_caps.py
@@ -136,7 +136,7 @@ def test_minimum_resident_bytes_for_model_path_adds_headroom(tmp_path):
 
     got = openai._minimum_resident_bytes_for_model_path(str(tmp_path))
 
-    assert got == 4096 + openai._MODEL_RESIDENT_HEADROOM_BYTES
+    assert got == 4096 + openai._resident_headroom_bytes_for_weights(4096)
 
 
 def test_apply_metal_memory_caps_raises_default_wired_floor_for_laguna(

--- a/tests/test_metal_memory_caps.py
+++ b/tests/test_metal_memory_caps.py
@@ -111,6 +111,34 @@ def test_apply_metal_memory_caps_preserves_128g_defaults(monkeypatch):
     assert calls == [("memory", 96 * GiB), ("wired", int(128 * GiB * 0.60))]
 
 
+def test_apply_metal_memory_caps_raises_floor_for_101g_model(monkeypatch):
+    mx, calls = _fake_mx(top_level=True)
+    monkeypatch.delenv("MTPLX_MEMORY_LIMIT_BYTES", raising=False)
+    monkeypatch.delenv("MTPLX_WIRED_LIMIT_BYTES", raising=False)
+    floor = 101 * GiB + 4 * GiB
+
+    result = openai._apply_metal_memory_caps(
+        mx_module=mx,
+        total_ram_bytes=128 * GiB,
+        minimum_resident_bytes=floor,
+    )
+
+    assert result["applied"] is True
+    assert result["memory_limit_bytes"] == floor
+    assert result["wired_limit_bytes"] == floor
+    assert result["minimum_resident_bytes"] == floor
+    assert calls == [("memory", floor), ("wired", floor)]
+
+
+def test_minimum_resident_bytes_for_model_path_adds_headroom(tmp_path):
+    shard = tmp_path / "model-00001-of-00001.safetensors"
+    shard.write_bytes(b"x" * 4096)
+
+    got = openai._minimum_resident_bytes_for_model_path(str(tmp_path))
+
+    assert got == 4096 + openai._MODEL_RESIDENT_HEADROOM_BYTES
+
+
 def test_apply_metal_memory_caps_raises_default_wired_floor_for_laguna(
     monkeypatch,
 ):

--- a/tests/test_qwen4_exp_gdn_blocked_prefill.py
+++ b/tests/test_qwen4_exp_gdn_blocked_prefill.py
@@ -1,0 +1,200 @@
+"""qwen4_exp blocked-prefill wiring: eligibility + step-path parity."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+if not mx.metal.is_available():  # pragma: no cover - CI without Metal
+    pytest.skip("Metal required", allow_module_level=True)
+
+from mtplx.kernels.gdn_blocked_prefill import (  # noqa: E402
+    blocked_prefill_eligible,
+    blocked_prefill_ineligibility_reason,
+    gated_delta_blocked_prefill,
+)
+import mlx_lm.models.gated_delta as gd  # noqa: E402
+
+
+def _max_abs(a, b) -> float:
+    return float(mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))).item())
+
+
+def test_tiny_smoke_geometry_is_ineligible():
+    q = mx.zeros((1, 8, 2, 16), dtype=mx.float32)
+    v = mx.zeros((1, 8, 4, 16), dtype=mx.float32)
+    g = mx.ones((1, 8, 4), dtype=mx.float32)
+    reason = blocked_prefill_ineligibility_reason(q, v, g, None, None)
+    assert reason is not None
+    assert "Dk=16" in reason
+    assert not blocked_prefill_eligible(q, v, g, None, None)
+
+
+def test_real_qwen4_exp_geometry_is_eligible():
+    # config.json of /Users/mac/models/Qwen3.8-Flash-Next-MLX-4bit
+    q = mx.zeros((1, 32, 16, 128), dtype=mx.bfloat16)
+    v = mx.zeros((1, 32, 48, 128), dtype=mx.bfloat16)
+    g = mx.ones((1, 32, 48), dtype=mx.float32)
+    state = mx.zeros((1, 48, 128, 128), dtype=mx.float32)
+    assert blocked_prefill_ineligibility_reason(q, v, g, None, state) is None
+    assert blocked_prefill_eligible(q, v, g, None, state)
+
+
+def test_qwen4_exp_shapes_blocked_matches_stock_kernel():
+    B, T, Hk, Hv, Dk, Dv = 1, 33, 16, 48, 128, 128
+    mx.random.seed(11)
+    q = (mx.random.normal((B, T, Hk, Dk)) * 0.5).astype(mx.bfloat16)
+    k = (mx.random.normal((B, T, Hk, Dk)) * 0.5).astype(mx.bfloat16)
+    v = (mx.random.normal((B, T, Hv, Dv)) * 0.5).astype(mx.bfloat16)
+    g = mx.sigmoid(mx.random.normal((B, T, Hv))).astype(mx.float32) * 0.98
+    beta = mx.sigmoid(mx.random.normal((B, T, Hv))).astype(mx.float32)
+    state = (mx.random.normal((B, Hv, Dv, Dk)) * 0.1).astype(mx.float32)
+    y_ref, s_ref = gd.gated_delta_kernel(q, k, v, g, beta, state)
+    y_new, s_new = gated_delta_blocked_prefill(q, k, v, g, beta, state)
+    mx.eval(y_ref, s_ref, y_new, s_new)
+    assert _max_abs(y_new, y_ref) <= 0.05
+    assert _max_abs(s_new, s_ref) <= 0.05
+
+
+def _eligible_tiny_config() -> dict:
+    hidden = 64
+    return {
+        "model_type": "qwen4_exp",
+        "tie_word_embeddings": False,
+        "text_config": {
+            "model_type": "qwen4_exp_text",
+            "hidden_size": hidden,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 32,
+            "vocab_size": 128,
+            "rms_norm_eps": 1e-6,
+            "full_attention_interval": 2,
+            "layer_types": ["linear_attention", "full_attention"],
+            "num_experts": 8,
+            "num_experts_per_tok": 2,
+            "moe_intermediate_size": 32,
+            "shared_expert_intermediate_size": 32,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 48,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "output_gate_type": "sigmoid",
+            "hc_count": 2,
+            "hc_lowrank": 16,
+            "indexer_n_heads": 2,
+            "indexer_kv_heads": 1,
+            "indexer_head_dim": 16,
+            "indexer_budget": 32,
+            "indexer_compress_ratio": 4,
+            "ngram_size": 3,
+            "heads_per_ngram": 2,
+            "ngram_vocab_size_base": 128,
+            "make_ngram_vocab_size_divisible_by": 8,
+            "split_ngram_parts": 2,
+            "ple_embed_dim": hidden,
+            "ple_layer_ids": [],
+            "ple_conv_kernel_size": 4,
+            "eos_token_id": 0,
+            "partial_rotary_factor": 0.25,
+            "rope_parameters": {
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 0.25,
+                "rope_type": "default",
+            },
+            "tie_word_embeddings": False,
+            "mtp": {
+                "hybrid": True,
+                "layer_types": ["full_attention"],
+                "mtp_use_hidden_state_from_layer": None,
+                "num_hidden_layers": 1,
+                "rope_theta": 10000,
+            },
+            "mtp_num_hidden_layers": 1,
+            "mtp_use_dedicated_embeddings": False,
+        },
+    }
+
+
+def _build_model(config: dict):
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+
+    args = ModelArgs.from_dict(
+        {"model_type": "qwen4_exp", "text_config": config["text_config"]}
+    )
+    mx.random.seed(0)
+    model = Model(args)
+    model.eval()
+    mx.eval(model.parameters())
+    return model
+
+
+def _gdn_states(cache):
+    states = []
+    for entry in cache:
+        if entry is None or hasattr(entry, "keys"):
+            continue
+        try:
+            conv = entry[0]
+            rec = entry[1]
+        except Exception:
+            continue
+        if rec is not None:
+            states.append((conv, rec))
+    return states
+
+
+def _forward_blocked(model, prompt):
+    cache = model.make_cache()
+    logits, hidden = model(prompt, cache=cache, return_hidden=True)
+    mx.eval(logits, hidden)
+    return logits, hidden, cache
+
+
+def _forward_step(model, prompt):
+    cache = model.make_cache()
+    logit_steps = []
+    hidden_steps = []
+    for t in range(int(prompt.shape[1])):
+        logits, hidden = model(
+            prompt[:, t : t + 1], cache=cache, return_hidden=True
+        )
+        logit_steps.append(logits)
+        hidden_steps.append(hidden)
+    logits = mx.concatenate(logit_steps, axis=1)
+    hidden = mx.concatenate(hidden_steps, axis=1)
+    mx.eval(logits, hidden)
+    return logits, hidden, cache
+
+
+def _compare_pair(label: str, a, b, atol: float) -> tuple[bool, float]:
+    max_abs = _max_abs(a, b)
+    ok = bool(mx.allclose(a, b, atol=atol, rtol=1e-3).item())
+    return ok, max_abs
+
+
+def test_eligible_tiny_model_blocked_matches_step_path():
+    model = _build_model(_eligible_tiny_config())
+    prompt = mx.array([list(range(1, 17))], dtype=mx.int32)
+    os.environ.pop("MTPLX_GDN_BLOCKED_PREFILL_FORCE_STOCK", None)
+    _b_logits, b_hidden, b_cache = _forward_blocked(model, prompt)
+    os.environ["MTPLX_GDN_BLOCKED_PREFILL_FORCE_STOCK"] = "1"
+    try:
+        _s_logits, s_hidden, s_cache = _forward_step(model, prompt)
+    finally:
+        os.environ.pop("MTPLX_GDN_BLOCKED_PREFILL_FORCE_STOCK", None)
+
+    atol = 5e-3
+    ok_h, _ = _compare_pair("HIDDEN", b_hidden, s_hidden, atol)
+    assert ok_h
+    for (b_conv, b_rec), (s_conv, s_rec) in zip(
+        _gdn_states(b_cache), _gdn_states(s_cache)
+    ):
+        ok_c, _ = _compare_pair("CONV", b_conv, s_conv, atol)
+        ok_r, _ = _compare_pair("STATE", b_rec, s_rec, atol)
+        assert ok_c and ok_r

--- a/tests/test_qwen4_exp_qsa_sparse_prefill.py
+++ b/tests/test_qwen4_exp_qsa_sparse_prefill.py
@@ -1,0 +1,122 @@
+"""QSA prefill must gather a budget of tokens, not materialize [S, T] masks."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+if not mx.metal.is_available():  # pragma: no cover - CI without Metal
+    pytest.skip("Metal required", allow_module_level=True)
+
+from mtplx.models.qwen4_exp import (  # noqa: E402
+    Attention,
+    QSASelection,
+    TextArgs,
+    _AttnCache,
+    _indexer_score_chunk,
+    selection_to_dense_add_mask,
+)
+
+
+def _attn_args(**overrides) -> TextArgs:
+    cfg = dict(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        rms_norm_eps=1e-6,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=32,
+        indexer_compress_ratio=4,
+        partial_rotary_factor=0.25,
+        rope_theta=10_000.0,
+        rope_parameters={"rope_theta": 10_000.0, "partial_rotary_factor": 0.25},
+    )
+    cfg.update(overrides)
+    return TextArgs.from_dict(cfg)
+
+
+def _max_abs(a, b) -> float:
+    return float(mx.max(mx.abs(a.astype(mx.float32) - b.astype(mx.float32))).item())
+
+
+def test_legacy_dense_mask_at_131k_is_68gib():
+    """The bug: a [T, T] fp16 additive mask at 131072 is ~64 GiB of values.
+
+    131072^2 * 2 bytes = 32 GiB for the bool keep plus 32 GiB for the fp16
+    additive mask — the report's 68 GiB counts the fp32-score-sized neighbour.
+    A single fp16 [T,T] array alone is 32 GiB; fp32 scores would be 64 GiB.
+    """
+    t = 131072
+    fp16_bytes = t * t * 2
+    fp32_bytes = t * t * 4
+    assert fp16_bytes == 34_359_738_368  # 32 GiB
+    assert fp32_bytes == 68_719_476_736  # 64 GiB
+    # Product QSA keep is K=2048+r per query, not T:
+    k = 2048 + 4
+    gather_idx_bytes = t * k * 4  # int32 indices
+    assert gather_idx_bytes < 2 * 1024**3
+
+
+def test_indexer_score_chunk_caps_s_by_n_blocks():
+    # 131K tokens / r=4 -> 32768 blocks. 128 MiB / (32768*4) = 1024 rows.
+    assert _indexer_score_chunk(32768, 2048) == 1024
+    assert _indexer_score_chunk(16, 2048) == 2048
+
+
+def test_selection_is_budget_indices_not_st_mask():
+    args = _attn_args()
+    attn = Attention(args)
+    mx.eval(attn.parameters())
+    t = 128
+    x = mx.random.normal((1, t, args.hidden_size)).astype(mx.float16)
+    cache = _AttnCache()
+    sel = attn.indexer(x, attn.rope, cache.indexer, 0)
+    assert isinstance(sel, QSASelection)
+    assert sel.token_idx.shape[:2] == (1, t)
+    k = int(sel.token_idx.shape[-1])
+    assert k == args.indexer_budget + args.indexer_compress_ratio
+    assert k < t
+    mx.eval(sel.token_idx, sel.valid)
+    n_valid = int(mx.sum(sel.valid.astype(mx.int32)).item())
+    assert n_valid <= t * k
+    # Per-query kept tokens cannot exceed budget + r (complete blocks + tail).
+    per_row = mx.sum(sel.valid.astype(mx.int32), axis=-1)
+    assert int(mx.max(per_row).item()) <= k
+
+
+def test_gather_matches_dense_mask_path(monkeypatch):
+    args = _attn_args()
+    attn = Attention(args)
+    mx.eval(attn.parameters())
+    t = 96
+    mx.random.seed(7)
+    x = (mx.random.normal((1, t, args.hidden_size)) * 0.2).astype(mx.float16)
+
+    monkeypatch.delenv("MTPLX_QSA_DENSE_MASK", raising=False)
+    cache_a = _AttnCache()
+    out_a = attn(x, mask="causal", cache=cache_a)
+    mx.eval(out_a)
+
+    monkeypatch.setenv("MTPLX_QSA_DENSE_MASK", "1")
+    cache_b = _AttnCache()
+    out_b = attn(x, mask="causal", cache=cache_b)
+    mx.eval(out_b)
+
+    assert out_a.shape == out_b.shape == (1, t, args.hidden_size)
+    assert _max_abs(out_a, out_b) < 2e-2
+
+
+def test_dense_add_mask_shape_is_the_bug_surface():
+    t, k = 48, 36
+    idx = mx.broadcast_to(mx.arange(k)[None, None, :], (1, t, k)).astype(mx.int32)
+    valid = mx.ones((1, t, k), dtype=mx.bool_)
+    sel = QSASelection(token_idx=idx, valid=valid)
+    add = selection_to_dense_add_mask(sel, kv_len=t, dtype=mx.float16)
+    mx.eval(add)
+    assert tuple(add.shape) == (1, 1, t, t)

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -3251,6 +3251,60 @@ def test_loaded_weights_bytes_resolves_cached_and_remote_hf_refs(monkeypatch, tm
     assert _loaded_weights_bytes_for_model_path("Qwen/Qwen4-Exp-72B-4bit") == 9000
 
 
+def test_qsa_indexer_rotates_pooled_keys_at_logical_positions():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs, RotaryEmbedding, _rope_partial, _IndexerCache
+
+    args = TextArgs(
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=4,
+        indexer_compress_ratio=4,
+    )
+    indexer = QSAIndexer(args)
+    rope = RotaryEmbedding(args.indexer_head_dim, 10000.0)
+
+    # Single row unpadded: 8 tokens -> 2 blocks at logical starts 0, 4
+    x_single = mx.ones((1, 8, args.hidden_size))
+    cache_single = _IndexerCache()
+    prep_single = indexer.prepare(x_single, rope, cache_single, offset=0)
+    assert cache_single.pooled is not None
+    pooled_single = cache_single.pooled
+
+    # Padded row: 4 left pad tokens + 4 real tokens -> 8 total tokens.
+    # Block 0 is padding (tokens 0..3), Block 1 is real tokens (tokens 4..7).
+    # Real block 1 should be rotated at logical start (4 - 4 = 0).
+    x_padded = mx.ones((1, 8, args.hidden_size))
+    cache_padded = _IndexerCache()
+    cache_padded.left_padding = mx.array([4], dtype=mx.int32)
+    prep_padded = indexer.prepare(x_padded, rope, cache_padded, offset=0)
+    assert cache_padded.pooled is not None
+    pooled_padded = cache_padded.pooled
+
+    # Pooled vector for real block (block 1 in padded, block 0 in single) should match in rotation
+    assert mx.allclose(pooled_padded[0, 1, :], pooled_single[0, 0, :], atol=1e-5)
+
+
+def test_expected_mtp_file_discovers_local_wildcard_sidecars(tmp_path):
+    from mtplx.artifacts import expected_mtp_file
+
+    model_dir = tmp_path / "custom_qwen4"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"model_type": "qwen4_exp"}')
+
+    # Wildcard suffix sidecar
+    sidecar = model_dir / "qwen4-mtp-head.safetensors"
+    sidecar.write_bytes(b"mtp_head")
+
+    found = expected_mtp_file(model_dir)
+    assert found == sidecar
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1727,9 +1727,12 @@ def test_attn_cache_filters_left_padding_and_lengths():
     c_multi.keys = mx.ones((2, 2, 8, 32))
     c_multi.values = mx.ones((2, 2, 8, 32))
     c_multi.left_padding = mx.array([2, 4])
+    c_multi.offset = 8
     c_multi.filter(mx.array([1]))
     assert c_multi.keys.shape[0] == 1
-    assert int(c_multi.left_padding[0].item()) == 4
+    assert c_multi.keys.shape[2] == 4
+    assert int(c_multi.left_padding[0].item()) == 0
+    assert int(c_multi.offset) == 4
 
     # Extract
     c1_ext = c1.extract(0)
@@ -2471,6 +2474,52 @@ def test_qwen4_server_applies_family_sampler_defaults(monkeypatch):
     assert args2.temperature == 0.7
     state2 = openai.ServerState(args2)
     assert state2.args.temperature == 0.7
+
+
+def test_expected_mtp_file_selects_from_remote_files_list(tmp_path):
+    from mtplx.artifacts import expected_mtp_file, _inspect_hf_model
+
+    remote_files = [
+        "config.json",
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+        "model-mtp-head.safetensors",
+    ]
+    # Without files argument and nonexistent local dir, falls back to default mtp.safetensors
+    res_default = expected_mtp_file(tmp_path / "nonexistent", config={})
+    assert res_default.name == "mtp.safetensors"
+
+    # With remote files list, picks model-mtp-head.safetensors
+    res_remote = expected_mtp_file(Path("."), config={}, files=remote_files)
+    assert res_remote.name == "model-mtp-head.safetensors"
+
+
+def test_attn_cache_and_indexer_rebase_padding_on_filter():
+    from mtplx.models.qwen4_exp import _AttnCache, _IndexerCache
+
+    c = _AttnCache()
+    c.keys = mx.ones((3, 2, 10, 32))
+    c.values = mx.ones((3, 2, 10, 32))
+    c.left_padding = mx.array([3, 5, 7])
+    c.offset = 10
+
+    # Indexer buffer with length 10
+    c.indexer = _IndexerCache()
+    c.indexer.update(mx.ones((3, 10, 64)))
+    c.indexer.left_padding = c.left_padding
+
+    # Filter to retain rows [1, 2] (padding 5 and 7). Shared minimum padding is 5.
+    c.filter(mx.array([1, 2]))
+
+    assert c.keys.shape[0] == 2
+    assert c.keys.shape[2] == 5  # 10 - 5
+    assert list(c.left_padding.tolist()) == [0, 2]  # [5-5, 7-5]
+    assert int(c.offset) == 5  # 10 - 5
+
+    assert c.indexer.keys.shape[0] == 2
+    assert c.indexer.keys.shape[1] == 5
+    assert list(c.indexer.left_padding.tolist()) == [0, 2]
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1786,6 +1786,108 @@ def test_qwen4_exp_mtp_falls_back_to_ar_when_draft_head_absent(tmp_path):
     assert verdict.mtp_supported == "no"
 
 
+def test_gdn_and_ple_preserve_conv_history_through_partial_padding():
+    from mtplx.models.qwen4_exp import GatedDeltaNet, PLELayer, TextArgs, ArraysCache
+
+    args = TextArgs(
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        hc_count=2,
+        hc_lowrank=32,
+        ple_embed_dim=64,
+        ple_layer_ids=[0],
+        ngram_size=2,
+        vocab_size=50,
+    )
+    gdn = GatedDeltaNet(args)
+    cache = ArraysCache(4)
+
+    # Initial step to populate history
+    x_init = mx.ones((2, 3, 64))
+    _ = gdn(x_init, mask=None, cache=cache)
+    initial_slot0 = mx.array(cache[0])
+
+    # Next step with 2 batch rows:
+    # row 0: partially masked [False, True, True]
+    # row 1: fully masked [False, False, False]
+    x_step = mx.ones((2, 3, 64)) * 2.0
+    mask = mx.array([[False, True, True], [False, False, False]])
+    out = gdn(x_step, mask=mask, cache=cache)
+
+    assert out.shape == (2, 3, 64)
+    # Row 1 is fully masked, so output is 0 and slot0 is unchanged
+    assert mx.all(out[1] == 0)
+    assert mx.all(cache[0][1] == initial_slot0[1])
+
+    # Row 0 advanced by 2 valid timesteps without zero-padding contamination
+    # slot0 has length conv_kernel_size - 1 = 3
+    # last 2 elements of cache[0][0] come from valid tokens of x_step, first element from initial_slot0[0]
+    assert cache[0].shape == (2, 3, gdn.conv_dim)
+
+
+def test_attn_cache_extend_without_left_padding_receiver():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    # Receiver has no left_padding (batch size 2)
+    c1 = _AttnCache()
+    c1.keys = mx.ones((2, 2, 8, 32))
+    c1.values = mx.ones((2, 2, 8, 32))
+
+    # Other has left_padding (batch size 1)
+    c2 = _AttnCache()
+    c2.keys = mx.ones((1, 2, 8, 32))
+    c2.values = mx.ones((1, 2, 8, 32))
+    c2.left_padding = mx.array([3], dtype=mx.int32)
+
+    c1.extend(c2)
+    assert c1.keys.shape[0] == 3
+    # left_padding must have length 3 (2 for receiver, 1 for other), not 4
+    assert c1.left_padding.shape[0] == 3
+    assert list(c1.left_padding.tolist()) == [0, 0, 3]
+
+
+def test_load_raw_sidecar_transposes_conv1d_weights(tmp_path):
+    from mtplx.qwen4_exp_mtp_patch import _load_mtp_weights
+
+    sidecar_path = tmp_path / "mtp.safetensors"
+    # Raw HF conv1d weight layout: (C, 1, K)
+    dummy_weights = {
+        "mtp.layers.0.linear_attn.conv1d.weight": mx.ones((16, 1, 4)),
+    }
+    mx.save_safetensors(str(sidecar_path), dummy_weights)
+
+    loaded = _load_mtp_weights([sidecar_path])
+    conv_w = loaded["layers.0.linear_attn.conv1d.weight"]
+    # MLX Conv1d weight layout: (C, K, 1)
+    assert conv_w.shape == (16, 4, 1)
+
+
+def test_qwen4_server_retains_d1_default_when_not_explicit():
+    from argparse import Namespace
+    from mtplx.server.openai import _apply_backend_server_defaults, parse_args
+    from mtplx.backends.descriptors import QWEN3_NEXT_DESCRIPTOR
+
+    # When serving Qwen4 without explicit --depth flag
+    args = Namespace(
+        model="Qwen/Qwen3.8-Flash-Next",
+        model_id="Qwen/Qwen3.8-Flash-Next",
+        backend="qwen3_next",
+    )
+    explicit_flags = set()
+    _apply_backend_server_defaults(args, explicit_flags=explicit_flags)
+    assert getattr(args, "_explicit_depth", False) is False
+    assert getattr(args, "depth", None) == 1
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1398,18 +1398,17 @@ def test_qsa_indexer_admits_partially_padded_blocks_with_per_token_mask():
     indexer = QSAIndexer(args)
     indexer.block_topk = 1
 
-    # Left padding is 3 (less than compress_ratio 4, so block 0 is partially padded)
+    # Left padding is 3, logical blocks partition real tokens starting at 3
     left_padding = mx.array([3])
     q = mx.ones((1, 1, 2, 32))
     q_pos = mx.array([8])
-    pooled = mx.ones((1, 3, 32))  # 3 blocks: block 0 (0..3), block 1 (4..7), block 2 (8..11)
+    pooled = mx.ones((1, 3, 32))
 
     sel = indexer.select(q, q_pos, pooled, kv_len=12, left_padding=left_padding)
-    # Block 0 ends at 4 > 3, so it is admitted.
+    # Logical block 0 starts at physical index 3: [3, 4, 5, 6]
     selected_block_tokens = sel.token_idx[0, 0, :4].tolist()
-    assert selected_block_tokens == [0, 1, 2, 3]
-    # Tokens 0, 1, 2 are pad tokens (< 3), token 3 is valid (>= 3)
-    assert sel.valid[0, 0, :4].tolist() == [False, False, False, True]
+    assert selected_block_tokens == [3, 4, 5, 6]
+    assert sel.valid[0, 0, :4].tolist() == [True, True, True, True]
 
 
 def test_preserve_conv_state_across_masked_timesteps():
@@ -1723,7 +1722,7 @@ def test_attn_cache_filters_left_padding_and_lengths():
     assert int(merged.left_padding[0].item()) == 0
     assert int(merged.indexer.left_padding[0].item()) == 0
 
-    # Filter unmerged _AttnCache directly
+    # Filter unmerged _AttnCache directly (preserves logical offset)
     c_multi = _AttnCache()
     c_multi.keys = mx.ones((2, 2, 8, 32))
     c_multi.values = mx.ones((2, 2, 8, 32))
@@ -1733,7 +1732,7 @@ def test_attn_cache_filters_left_padding_and_lengths():
     assert c_multi.keys.shape[0] == 1
     assert c_multi.keys.shape[2] == 4
     assert int(c_multi.left_padding[0].item()) == 0
-    assert int(c_multi.offset) == 4
+    assert int(c_multi.offset) == 8
 
     # Extract
     c1_ext = c1.extract(0)
@@ -2169,7 +2168,7 @@ def test_qsa_indexer_select_admits_partially_padded_blocks_with_correct_mask():
     # 2 blocks of 4 tokens = 8 tokens. left_padding = 5 (tokens 0..4 are pad, 5..7 are real)
     pooled = mx.ones((1, 2, 16))
     q = mx.ones((1, 1, 2, 16))
-    q_pos = mx.array([7])
+    q_pos = mx.array([2])
     left_padding = mx.array([5])
 
     sel = indexer.select(
@@ -2179,8 +2178,7 @@ def test_qsa_indexer_select_admits_partially_padded_blocks_with_correct_mask():
         kv_len=8,
         left_padding=left_padding,
     )
-    # Block 1 should be selected since its end (8) > left_padding (5)
-    # In token_idx: token 4 must be masked as invalid, while tokens 5, 6, 7 are valid
+    # Logical tail tokens (physical 5, 6, 7) must be valid
     tok_list = sel.token_idx.flatten().tolist()
     val_list = sel.valid.flatten().tolist()
     valid_tokens = [tok for tok, v in zip(tok_list, val_list) if v]
@@ -2515,7 +2513,8 @@ def test_attn_cache_and_indexer_rebase_padding_on_filter():
     assert c.keys.shape[0] == 2
     assert c.keys.shape[2] == 5  # 10 - 5
     assert list(c.left_padding.tolist()) == [0, 2]  # [5-5, 7-5]
-    assert int(c.offset) == 5  # 10 - 5
+    # Logical offset is preserved across filtering
+    assert int(c.offset) == 10
 
     assert c.indexer.keys.shape[0] == 2
     assert c.indexer.keys.shape[1] == 5
@@ -3286,8 +3285,8 @@ def test_qsa_indexer_rotates_pooled_keys_at_logical_positions():
     assert cache_padded.pooled is not None
     pooled_padded = cache_padded.pooled
 
-    # Pooled vector for real block (block 1 in padded, block 0 in single) should match in rotation
-    assert mx.allclose(pooled_padded[0, 1, :], pooled_single[0, 0, :], atol=1e-5)
+    # Pooled vector for real block (block 0 in padded, block 0 in single) should match in rotation
+    assert mx.allclose(pooled_padded[0, 0, :], pooled_single[0, 0, :], atol=1e-5)
 
 
 def test_expected_mtp_file_discovers_local_wildcard_sidecars(tmp_path):
@@ -3303,6 +3302,78 @@ def test_expected_mtp_file_discovers_local_wildcard_sidecars(tmp_path):
 
     found = expected_mtp_file(model_dir)
     assert found == sidecar
+
+
+def test_qsa_indexer_pools_on_logical_boundaries_with_non_divisible_padding():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs, RotaryEmbedding, _IndexerCache
+
+    args = TextArgs(
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=4,
+        indexer_compress_ratio=4,
+    )
+    indexer = QSAIndexer(args)
+    rope = RotaryEmbedding(args.indexer_head_dim, 10000.0)
+
+    # 1. Single unpadded row with 8 real tokens (logical 0..7)
+    # Token i has distinct values so we can check pooling
+    raw_single = mx.arange(8)[:, None] * mx.ones((1, 8, args.hidden_size))
+    cache_single = _IndexerCache()
+    indexer.index_qk_proj = lambda x: mx.concatenate([x[..., :32], x[..., :16]], axis=-1)
+    prep_single = indexer.prepare(raw_single, rope, cache_single, offset=0)
+    assert prep_single is not None
+
+    # 2. Padded row with 2 padding tokens (0, 0) + 8 real tokens (same values 0..7)
+    # Total length 10, left_padding = 2
+    pad = mx.zeros((1, 2, args.hidden_size))
+    raw_padded = mx.concatenate([pad, raw_single], axis=1)
+    cache_padded = _IndexerCache()
+    cache_padded.left_padding = mx.array([2], dtype=mx.int32)
+    prep_padded = indexer.prepare(raw_padded, rope, cache_padded, offset=0)
+    assert prep_padded is not None
+
+    # Pooled block 0 and 1 for the padded sequence must match single sequence unpadded exactly
+    assert mx.allclose(prep_padded.pooled[0, 0, :], prep_single.pooled[0, 0, :], atol=1e-5)
+    assert mx.allclose(prep_padded.pooled[0, 1, :], prep_single.pooled[0, 1, :], atol=1e-5)
+
+    # 3. Test select() on both: query at logical position 5 should select block 0 and tail
+    q_single = prep_single.q[:, 5:6]
+    sel_single = indexer.select(q_single, mx.array([5]), prep_single.pooled, 8, left_padding=None)
+
+    q_padded = prep_padded.q[:, 5:6]
+    sel_padded = indexer.select(q_padded, mx.array([5]), prep_padded.pooled, 10, left_padding=mx.array([2], dtype=mx.int32))
+
+    # Padded selected tokens should be physical indices (2 + single_indices)
+    assert list(sel_padded.token_idx[0, 0].tolist()) == [i + 2 for i in sel_single.token_idx[0, 0].tolist()]
+
+
+def test_attn_cache_filter_preserves_logical_offset_with_shared_padding():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    # Create merged cache of row 0 (len 8, pad 0, off 8) and row 1 (len 4, pad 4, off 4)
+    c = _AttnCache()
+    c.keys = mx.ones((2, 2, 8, 32))
+    c.values = mx.ones((2, 2, 8, 32))
+    c.offset = mx.array([8, 4], dtype=mx.int32)
+    c.left_padding = mx.array([0, 4], dtype=mx.int32)
+    c._idx = 8
+
+    # Filter to retain only row 1 (which has min_left_pad = 4)
+    c.filter(mx.array([1]))
+
+    assert c.keys.shape == (1, 2, 4, 32)
+    assert c.values.shape == (1, 2, 4, 32)
+    assert c._idx == 4
+    assert int(c.left_padding[0].item()) == 0
+    # Logical offset of row 1 must remain 4 (not 0!)
+    assert int(c.offset[0].item()) == 4
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2626,6 +2626,25 @@ def test_loaded_weights_bytes_deduplicates_and_ignores_unused_adapters(tmp_path)
     assert loaded_bytes == 3000
 
 
+def test_loaded_weights_bytes_includes_direct_trunk_and_sidecar(tmp_path):
+    from mtplx.server.openai import _loaded_weights_bytes_for_model_path
+
+    model_dir = tmp_path / "unindexed_model"
+    model_dir.mkdir()
+
+    # Unindexed trunk: model.safetensors (5000 bytes)
+    trunk = model_dir / "model.safetensors"
+    trunk.write_bytes(b"t" * 5000)
+
+    # Sidecar: model-mtp.safetensors (500 bytes)
+    sidecar = model_dir / "model-mtp.safetensors"
+    sidecar.write_bytes(b"s" * 500)
+
+    # Both trunk and sidecar should be included: 5000 + 500 = 5500 bytes
+    loaded_bytes = _loaded_weights_bytes_for_model_path(model_dir)
+    assert loaded_bytes == 5500
+
+
 def test_attn_cache_extract_slices_to_active_offset():
     from mtplx.models.qwen4_exp import _AttnCache
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2363,6 +2363,116 @@ def test_rebuild_exact_mtp_cells_restores_and_replays_target_hiddens():
     assert mock_model.mtp_forward.call_count == 2
 
 
+def test_compatibility_missing_head_fallback_uses_remote_shards():
+    from types import SimpleNamespace
+    from mtplx.backends.registry import compatibility_for_inspection
+
+    inspection = SimpleNamespace(
+        model_dir="dummy/repo-id",
+        source="hf",
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForCausalLM",
+        model_files=["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"],
+        weight_keys=None,
+        config={
+            "model_type": "qwen4_exp",
+            "mtp_num_hidden_layers": 1,
+        },
+        mtp_file=None,
+        quantization=None,
+        quantization_config=None,
+    )
+    verdict = compatibility_for_inspection(inspection)
+    assert verdict.arch_id == "qwen4-exp"
+    assert verdict.can_run is True
+
+
+def test_model_classes_for_config_checks_nested_architectures():
+    from mtplx.runtime import _model_classes_for_config
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+
+    config = {
+        "text_config": {
+            "architectures": ["Qwen4ExpForCausalLM"],
+        }
+    }
+    classes = _model_classes_for_config(config)
+    assert classes is not None
+    assert classes == (Model, ModelArgs)
+
+
+def test_unsupported_quant_bits_rejects_quantization_config():
+    from mtplx.backends.registry import _unsupported_quant_bits
+
+    cfg1 = {"quantization_config": {"bits": 1}}
+    assert _unsupported_quant_bits(cfg1) == 1
+
+    cfg4 = {"quantization_config": {"bits": 4}}
+    assert _unsupported_quant_bits(cfg4) is None
+
+
+def test_shift_qwen4_gemma_mtp_norms_trusts_raw_pre_fc_norms():
+    from mtplx.qwen4_exp_mtp_patch import _shift_qwen4_gemma_mtp_norms
+
+    raw_weights = {
+        "pre_fc_norm_embedding.weight": mx.zeros((128,)),
+        "pre_fc_norm_hidden.weight": mx.zeros((128,)),
+        "layers.0.self_attn.q_norm.weight": mx.full((64,), 2.5),
+        "layers.0.self_attn.k_norm.weight": mx.full((64,), 2.5),
+    }
+    shifted = _shift_qwen4_gemma_mtp_norms(raw_weights)
+    assert float(shifted["pre_fc_norm_embedding.weight"].mean().item()) == 1.0
+    assert float(shifted["pre_fc_norm_hidden.weight"].mean().item()) == 1.0
+    assert float(shifted["layers.0.self_attn.q_norm.weight"].mean().item()) == 3.5
+
+
+def test_qwen4_server_applies_family_sampler_defaults(monkeypatch):
+    import argparse
+    from unittest.mock import MagicMock
+    from mtplx.server import openai
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 64,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 50,
+        "layer_types": ["full_attention"],
+    }
+    dummy_model = Model(ModelArgs.from_dict(config))
+    dummy_runtime = MagicMock()
+    dummy_runtime.model = dummy_model
+    dummy_runtime.mtp_enabled = False
+    dummy_runtime.tokenizer = MagicMock()
+    dummy_runtime.laguna_fused_report = None
+
+    monkeypatch.setattr(openai, "load_runtime_contract", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(openai, "load", lambda *args, **kwargs: dummy_runtime)
+    monkeypatch.setattr(openai, "_resolve_context_window", lambda *args, **kwargs: 4096)
+    monkeypatch.setattr(openai, "_apply_metal_memory_caps", lambda *args, **kwargs: {"applied": True})
+    monkeypatch.setattr(openai, "_configure_mlx_cache_limit", lambda *args, **kwargs: {"configured": False})
+    monkeypatch.setattr(openai, "_fast_path_env_status", lambda *args, **kwargs: {})
+    monkeypatch.setattr(openai, "_mlx_runtime_status", lambda *args, **kwargs: {"ok": True})
+    monkeypatch.setattr(openai, "profile_env_status", lambda *args, **kwargs: {})
+    monkeypatch.setattr(openai, "_apply_chat_template_profile", lambda *args, **kwargs: {"profile": "tokenizer"})
+
+    # 1. Without explicit temperature: default 0.6 is updated to family default 1.0
+    args1 = openai.parse_args(["--model", "Qwen/Qwen3.8-Flash-Next"])
+    assert args1.temperature == 0.6
+    state1 = openai.ServerState(args1)
+    assert state1.args.temperature == 1.0
+
+    # 2. With explicit temperature: explicit value is preserved
+    args2 = openai.parse_args(["--model", "Qwen/Qwen3.8-Flash-Next", "--temperature", "0.7"])
+    assert args2.temperature == 0.7
+    state2 = openai.ServerState(args2)
+    assert state2.args.temperature == 0.7
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -773,5 +773,93 @@ def test_rope_scaling_normalized_into_rope_parameters():
     assert abs(model.model.rope.mscale - (0.1 * math.log(4.0) + 1.0)) < 1e-4
 
 
+def test_qwen4_exp_recurrent_cache_batch_protocol():
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache
+
+    # 1. Initialization and batch_size
+    c1 = Qwen4ExpRecurrentCache(4)
+    c1[0] = mx.ones((2, 3, 128))
+    c1[1] = mx.ones((2, 4, 32, 32))
+    c1.left_padding = mx.array([2, 0])
+    c1.lengths = mx.array([8, 10])
+    assert c1.batch_size == 2
+
+    # 2. Extract
+    extracted = c1.extract(1)
+    assert extracted.batch_size == 1
+    assert extracted[0].shape == (1, 3, 128)
+    assert extracted.left_padding[0].item() == 0
+    assert extracted.lengths[0].item() == 10
+
+    # 3. Filter
+    c1.filter(mx.array([1]))
+    assert c1.batch_size == 1
+    assert c1[0].shape == (1, 3, 128)
+    assert c1.left_padding[0].item() == 0
+    assert c1.lengths[0].item() == 10
+
+    # 4. Extend
+    c2 = Qwen4ExpRecurrentCache(4)
+    c2[0] = mx.full((1, 3, 128), 2.0)
+    c2[1] = mx.full((1, 4, 32, 32), 2.0)
+    c2.left_padding = mx.array([1])
+    c2.lengths = mx.array([6])
+
+    c1.extend(c2)
+    assert c1.batch_size == 2
+    assert c1[0].shape == (2, 3, 128)
+    assert c1.left_padding.tolist() == [0, 1]
+    assert c1.lengths.tolist() == [10, 6]
+
+    # 5. Prepare & Finalize
+    c1.prepare(lengths=[5, 5], left_padding=[0, 0])
+    assert c1.lengths.tolist() == [5, 5]
+    assert c1.left_padding.tolist() == [0, 0]
+    c1.finalize()
+    assert c1.lengths is None
+    assert c1.left_padding is None
+
+
+def test_compiled_linear_step_passes_recurrent_mask():
+    from mtplx.models.qwen4_exp import DecoderLayer, ModelArgs, TextArgs
+    from mtplx.models.qwen4_exp_compiled import (
+        CompiledLayerRunner,
+        compile_linear_layer_step,
+    )
+
+    args = TextArgs(
+        hidden_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_conv_kernel_dim=4,
+        hc_count=2,
+        hc_lowrank=64,
+        moe_intermediate_size=64,
+        shared_expert_intermediate_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        layer_types=["linear_attention", "full_attention"],
+    )
+    layer = DecoderLayer(args, layer_idx=0)
+    step_fn = compile_linear_layer_step(layer)
+
+    h = mx.ones((2, 1, 128 * 2))
+    conv_mask = mx.array([[False], [True]])
+    conv_state = mx.zeros((2, 3, layer.linear_attn.conv_dim))
+    rec_state = mx.zeros((2, layer.linear_attn.n_v, layer.linear_attn.dv, layer.linear_attn.dk))
+
+    h_out, new_conv, new_rec = step_fn(h, conv_mask, conv_state, rec_state)
+    assert h_out.shape == (2, 1, 128 * 2)
+    assert new_conv.shape == (2, 3, layer.linear_attn.conv_dim)
+    assert new_rec.shape == (2, layer.linear_attn.n_v, layer.linear_attn.dv, layer.linear_attn.dk)
+
+
+
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1951,6 +1951,150 @@ def test_speculative_generate_preserves_mtp_history_between_rounds():
     assert all(isinstance(t, int) for t in tokens)
 
 
+def test_server_uses_runtime_selected_draft_default_when_not_explicit():
+    from types import SimpleNamespace
+    from mtplx.backends.descriptors import (
+        QWEN3_NEXT_DESCRIPTOR,
+        QWEN4_EXP_DRAFT_SEMANTICS,
+    )
+    from mtplx.server.openai import _request_depth_for_generation
+
+    # Simulate loaded state where args has depth=1 set by runtime startup
+    args = SimpleNamespace(
+        _explicit_depth=False,
+        depth=1,
+        mtp_depth=1,
+    )
+    state = SimpleNamespace(
+        args=args,
+        backend_descriptor=QWEN3_NEXT_DESCRIPTOR,  # generic descriptor has default=3
+        model_id="local_model_without_name_marker",
+    )
+    req = SimpleNamespace(depth=None, mtp_depth=None, speculative_depth=None)
+    depth = _request_depth_for_generation(
+        state,
+        req,
+        generation_mode="speculative",
+    )
+    assert depth == 1
+
+
+def test_rejection_restores_post_step_mtp_snapshot():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support, draft_tokens
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "linear_num_key_heads": 2,
+        "linear_num_value_heads": 2,
+        "linear_key_head_dim": 16,
+        "linear_value_head_dim": 16,
+        "linear_conv_kernel_dim": 4,
+        "layer_types": ["linear_attention", "full_attention"],
+        "vocab_size": 50,
+        "ple_layer_ids": [],
+        "mtp": {
+            "num_hidden_layers": 1,
+            "layer_types": ["full_attention"],
+        },
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+    inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+
+    mtp_cache = model.make_mtp_cache()
+    logits, h = model(mx.array([[10]]), return_hidden=True)
+    drafts, qs, h_out, mtp_snaps = draft_tokens(
+        model,
+        h,
+        token_id=10,
+        n=2,
+        mtp_cache=mtp_cache,
+        return_snapshots=True,
+    )
+    assert len(mtp_snaps) == 2
+    # Snapshot 0 should be post-step-0 (contains the token_id 10 KV entry)
+    # Restore snapshot 0
+    mtp_snaps[0].restore(mtp_cache)
+    attn_cache = mtp_cache[0]
+    assert attn_cache.offset == 1
+
+
+def test_kv_promotion_preserves_left_padding_and_make_mask():
+    from mtplx.cache_state import (
+        TailOwnedKVCache,
+        BlockOwnedKVCache,
+        VllmMetalPagedKVCache,
+        TensorOffsetVllmMetalPagedKVCache,
+    )
+
+    class MockEntry:
+        def __init__(self):
+            self.keys = mx.zeros((1, 2, 8, 32))
+            self.values = mx.zeros((1, 2, 8, 32))
+            self.offset = 8
+            self.step = 256
+            self.left_padding = mx.array([3], dtype=mx.int32)
+
+    entry = MockEntry()
+    tail = TailOwnedKVCache.from_cache(entry, mode="eval_only")
+    assert tail.left_padding is not None
+    assert int(tail.left_padding[0].item()) == 3
+    mask = tail.make_mask(1)
+    assert mask is not None
+
+    block = BlockOwnedKVCache.from_cache(entry, mode="eval_only")
+    assert block.left_padding is not None
+    assert int(block.left_padding[0].item()) == 3
+
+    paged = VllmMetalPagedKVCache.from_cache(entry, block_size=16, num_blocks=4)
+    assert paged.left_padding is not None
+    assert int(paged.left_padding[0].item()) == 3
+    paged_mask = paged.make_mask(1)
+    assert paged_mask is not None
+
+    tensor_paged = TensorOffsetVllmMetalPagedKVCache.from_paged_cache(paged)
+    assert tensor_paged.left_padding is not None
+    assert int(tensor_paged.left_padding[0].item()) == 3
+    tensor_mask = tensor_paged.make_mask(1)
+    assert tensor_mask is not None
+
+    demoted = tensor_paged.to_paged_cache()
+    assert demoted.left_padding is not None
+    assert int(demoted.left_padding[0].item()) == 3
+
+
+def test_detect_nested_qwen4_mtp_layer_declarations(tmp_path):
+    import json
+    from mtplx.artifacts import inspect_model
+    from mtplx.backends.registry import _detect_arch_id
+
+    config_data = {
+        "model_type": "qwen4_exp",
+        "architectures": ["Qwen4ExpForConditionalGeneration"],
+        "text_config": {
+            "model_type": "qwen4_exp",
+            "mtp": {
+                "num_hidden_layers": 1,
+            },
+        },
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data))
+    model_weight = tmp_path / "model.safetensors"
+    model_weight.write_bytes(b"dummy")
+
+    inspection = inspect_model(tmp_path)
+    assert inspection.mtp_num_hidden_layers == 1
+    arch_id = _detect_arch_id(inspection)
+    assert arch_id == "qwen4-exp-mtp"
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2457,6 +2457,7 @@ def test_qwen4_server_applies_family_sampler_defaults(monkeypatch):
     monkeypatch.setattr(openai, "_fast_path_env_status", lambda *args, **kwargs: {})
     monkeypatch.setattr(openai, "_mlx_runtime_status", lambda *args, **kwargs: {"ok": True})
     monkeypatch.setattr(openai, "profile_env_status", lambda *args, **kwargs: {})
+    monkeypatch.setattr(openai, "apply_profile_env", lambda *args, **kwargs: None)
     monkeypatch.setattr(openai, "_apply_chat_template_profile", lambda *args, **kwargs: {"profile": "tokenizer"})
 
     # 1. Without explicit temperature: default 0.6 is updated to family default 1.0

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2688,7 +2688,7 @@ def test_attn_cache_and_indexer_extend_aligns_differing_histories_and_paddings()
     # Both rows aligned to max_L = 8
     assert c1.keys.shape == (2, 2, 8, 32)
     assert c1.values.shape == (2, 2, 8, 32)
-    assert c1.offset == 8
+    assert list(c1.offset.tolist()) == [8, 4]
     # c2 was padded on the left by 4, so its left_padding becomes 0 + 4 = 4
     assert list(c1.left_padding.tolist()) == [2, 4]
 
@@ -2701,6 +2701,107 @@ def test_attn_cache_and_indexer_extend_aligns_differing_histories_and_paddings()
     assert list(c1.indexer.left_padding.tolist()) == [2, 4]
     assert float(c1.indexer.keys[1, :4, :].abs().max().item()) == 0.0
     assert float(c1.indexer.keys[1, 4:, :].mean().item()) == 2.0
+
+
+def test_attn_cache_extend_preserves_per_row_rope_offset():
+    from mtplx.models.qwen4_exp import Attention, TextArgs, _AttnCache
+
+    args = TextArgs(
+        hidden_size=64,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=32,
+        indexer_budget=16,
+        indexer_compress_ratio=4,
+        layer_types=["full_attention"],
+    )
+    attn = Attention(args)
+
+    c1 = _AttnCache()
+    c1.keys = mx.ones((1, 2, 8, 32))
+    c1.values = mx.ones((1, 2, 8, 32))
+    c1.offset = 8
+
+    c2 = _AttnCache()
+    c2.keys = mx.ones((1, 2, 4, 32))
+    c2.values = mx.ones((1, 2, 4, 32))
+    c2.offset = 4
+
+    c1.extend(c2)
+    assert list(c1.offset.tolist()) == [8, 4]
+
+    # Next decode token (S=1, batch=2)
+    x = mx.ones((2, 1, 64))
+    out = attn(x, cache=c1)
+    assert out.shape == (2, 1, 64)
+    assert list(c1.offset.tolist()) == [9, 5]
+
+
+def test_passes_qwen4_exp_gate_and_compatibility_rejects_auto_map():
+    from mtplx.artifacts import ModelInspection
+    from mtplx.backends.registry import _passes_qwen4_exp_gate, compatibility_for_inspection
+
+    insp = ModelInspection(
+        model_dir="remote-org/custom-qwen4",
+        source="hf",
+        config_exists=True,
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_type="qwen4_exp",
+        mtp_num_hidden_layers=0,
+        hidden_size=1024,
+        num_hidden_layers=12,
+        vocab_size=32000,
+        model_files=("model.safetensors",),
+        auto_map={"AutoModelForCausalLM": "custom_modeling.CustomModel"},
+        requires_remote_code=True,
+    )
+    assert not _passes_qwen4_exp_gate(insp)
+    verdict = compatibility_for_inspection(insp)
+    assert not verdict.can_run
+    assert verdict.runtime_compatibility == "trust-remote-code-required"
+
+
+def test_release_embedded_mtp_tensors_for_ar_only_loads():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+
+    args = ModelArgs.from_dict({
+        "model_type": "qwen4_exp",
+        "hidden_size": 64,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 100,
+        "layer_types": ["linear_attention"],
+        "hc_count": 1,
+        "hc_lowrank": 32,
+        "ple_layer_ids": [0],
+        "ngram_size": 2,
+        "ple_conv_kernel_size": 2,
+        "ple_embed_dim": 64,
+        "linear_num_key_heads": 2,
+        "linear_num_value_heads": 2,
+        "linear_key_head_dim": 32,
+        "linear_value_head_dim": 32,
+        "linear_conv_kernel_dim": 2,
+    })
+    model = Model(args)
+    raw_weights = {
+        "model.embed_tokens.weight": mx.ones((100, 64)),
+        "lm_head.weight": mx.ones((100, 64)),
+        "mtp.fc_embedding.weight": mx.ones((64, 64)),
+        "mtp.fc_hidden.weight": mx.ones((64, 64)),
+    }
+    sanitized = model.sanitize(raw_weights)
+    assert "mtp.fc_embedding.weight" not in sanitized
+    assert "mtp.fc_embedding.weight" in model.mtp_weights
+
+    # When AR-only load occurs, clearing mtp weights releases memory
+    model.clear_mtp_weights()
+    assert model.mtp_weights == {}
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2804,6 +2804,82 @@ def test_release_embedded_mtp_tensors_for_ar_only_loads():
     assert model.mtp_weights == {}
 
 
+def test_qwen4_exp_recurrent_cache_merge_preserves_padding_metadata():
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache
+
+    c1 = Qwen4ExpRecurrentCache(4)
+    c1[0] = mx.ones((1, 32, 4))
+    c1[1] = mx.ones((1, 4, 32, 32))
+    c1.left_padding = mx.array([0], dtype=mx.int32)
+    c1.lengths = mx.array([8], dtype=mx.int32)
+
+    c2 = Qwen4ExpRecurrentCache(4)
+    c2[0] = mx.ones((1, 32, 4)) * 2
+    c2[1] = mx.ones((1, 4, 32, 32)) * 2
+    c2.left_padding = mx.array([4], dtype=mx.int32)
+    c2.lengths = mx.array([4], dtype=mx.int32)
+
+    merged = Qwen4ExpRecurrentCache.merge([c1, c2])
+    assert merged[0].shape == (2, 32, 4)
+    assert merged[1].shape == (2, 4, 32, 32)
+    assert merged.left_padding is not None
+    assert list(merged.left_padding.tolist()) == [0, 4]
+    assert merged.lengths is not None
+    assert list(merged.lengths.tolist()) == [8, 4]
+
+    # make_mask should return (2, 8) boolean mask
+    mask = merged.make_mask(8)
+    assert mask is not None
+    assert mask.shape == (2, 8)
+    # Row 0: pos >= 0 -> all True
+    assert list(mask[0].tolist()) == [True] * 8
+    # Row 1: pos >= 4 -> first 4 False, next 4 True
+    assert list(mask[1].tolist()) == [False, False, False, False, True, True, True, True]
+
+
+def test_qsa_indexer_chunked_select_with_vector_q_pos(monkeypatch):
+    from mtplx.models.qwen4_exp import Attention, QSAIndexer, TextArgs, _AttnCache
+
+    args = TextArgs(
+        hidden_size=64,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=32,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+        layer_types=["full_attention"],
+    )
+    indexer = QSAIndexer(args)
+    attn = Attention(args)
+
+    # Set small query chunk to force multiple chunks (e.g. S=6 > chunk=2)
+    import mtplx.models.qwen4_exp as qmod
+    monkeypatch.setattr(qmod, "_qsa_query_chunk", lambda: 2)
+
+    # Vector offset from merged cache: e.g. row 0 has offset 8, row 1 has offset 4
+    cache = _AttnCache()
+    cache.keys = mx.ones((2, 2, 8, 32))
+    cache.values = mx.ones((2, 2, 8, 32))
+    cache.offset = mx.array([8, 4], dtype=mx.int32)
+    cache.indexer.update(mx.ones((2, 8, 32)))
+
+    # Warm multi-token forward: S=6
+    x = mx.ones((2, 6, 64))
+    rope = attn.rope
+
+    sel = indexer(x, rope, cache.indexer, cache.offset)
+    assert sel is not None
+    assert sel.token_idx.shape[0] == 2
+    assert sel.token_idx.shape[1] == 6
+
+    # Full attention forward with chunking
+    out = attn(x, cache=cache)
+    assert out.shape == (2, 6, 64)
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2305,6 +2305,65 @@ def test_classify_scanned_model_recognizes_top_level_mtp_num_hidden_layers(tmp_p
     assert scanned.arch_id == "qwen4-exp-mtp"
 
 
+def test_expected_mtp_file_finds_model_mtp_head_safetensors(tmp_path):
+    from mtplx.artifacts import expected_mtp_file, mtp_weights_present_on_disk
+
+    sidecar = tmp_path / "model-mtp-head.safetensors"
+    sidecar.write_bytes(b"dummy")
+
+    assert expected_mtp_file(tmp_path).name == "model-mtp-head.safetensors"
+    assert mtp_weights_present_on_disk(tmp_path, {}) is True
+
+
+def test_sanitize_and_mtp_remap_bare_hyper_connection_weights():
+    from mtplx.models.qwen4_exp import sanitize
+    from mtplx.qwen4_exp_mtp_patch import _process_raw_mtp_weights
+
+    raw_trunk = {
+        "model.layers.0.attn_hyper_connection.input_mix_weight_down": mx.zeros((10, 10)),
+        "model.layers.0.attn_hyper_connection.input_mix_weight_up": mx.zeros((10, 10)),
+        "model.layers.0.attn_hyper_connection.block_inject_weight": mx.zeros((10, 10)),
+        "model.hyper_connection_mixer.input_mix_weight_down": mx.zeros((10, 10)),
+    }
+    sanitized = sanitize(raw_trunk)
+    assert "model.layers.0.attn_hyper_connection.input_mix_weight_down.weight" in sanitized
+    assert "model.layers.0.attn_hyper_connection.input_mix_weight_up.weight" in sanitized
+    assert "model.layers.0.attn_hyper_connection.block_inject_weight.weight" in sanitized
+    assert "model.hyper_connection_mixer.input_mix_weight_down.weight" in sanitized
+    assert "model.layers.0.attn_hyper_connection.input_mix_weight_down" not in sanitized
+
+    raw_mtp = {
+        "mtp.layers.0.attn_hyper_connection.input_mix_weight_down": mx.zeros((10, 10)),
+        "mtp.layers.0.attn_hyper_connection.input_mix_weight_up": mx.zeros((10, 10)),
+        "mtp.layers.0.attn_hyper_connection.block_inject_weight": mx.zeros((10, 10)),
+        "mtp.hyper_connection_mixer.input_mix_weight_down": mx.zeros((10, 10)),
+    }
+    processed = _process_raw_mtp_weights(raw_mtp, is_mlx_format=True)
+    assert "layers.0.attn_hyper_connection.input_mix_weight_down.weight" in processed
+    assert "layers.0.attn_hyper_connection.input_mix_weight_up.weight" in processed
+    assert "layers.0.attn_hyper_connection.block_inject_weight.weight" in processed
+    assert "hyper_connection_mixer.input_mix_weight_down.weight" in processed
+
+
+def test_rebuild_exact_mtp_cells_restores_and_replays_target_hiddens():
+    from unittest.mock import MagicMock
+    from mtplx.qwen4_exp_mtp_patch import _rebuild_exact_mtp_cells
+
+    mock_snap = MagicMock()
+    mock_model = MagicMock()
+    mock_model.mtp_forward.return_value = (mx.zeros((1, 1, 10)), mx.zeros((1, 1, 10)))
+
+    mtp_cache = [MagicMock()]
+    mtp_snaps = [mock_snap]
+    step_hiddens = [mx.zeros((1, 1, 32)), mx.zeros((1, 1, 32))]
+    accepted = [101, 102]
+
+    _rebuild_exact_mtp_cells(mock_model, mtp_cache, mtp_snaps, step_hiddens, accepted)
+    mock_snap.restore.assert_called_once_with(mtp_cache)
+    assert mock_model.mtp_forward.call_count == 2
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -402,7 +402,7 @@ def test_qwen4_exp_mtp_gate_requires_mtp_tensors(tmp_path):
     )
     assert _passes_qwen4_exp_mtp_gate(inspection_no_mtp_weights, tensor_gate=False) is False
 
-    # When tensor_gate=True or MTP weights exist -> passes
+    # When tensor_gate=False -> gate rejects even if individual mtp keys exist
     inspection_with_mtp = SimpleNamespace(
         model_type="qwen4_exp",
         architecture="Qwen4ExpForConditionalGeneration",
@@ -410,7 +410,8 @@ def test_qwen4_exp_mtp_gate_requires_mtp_tensors(tmp_path):
         mtp_num_hidden_layers=1,
         weight_keys=("mtp.layers.0.self_attn.q_proj.weight",),
     )
-    assert _passes_qwen4_exp_mtp_gate(inspection_with_mtp, tensor_gate=False) is True
+    assert _passes_qwen4_exp_mtp_gate(inspection_with_mtp, tensor_gate=False) is False
+    assert _passes_qwen4_exp_mtp_gate(inspection_with_mtp, tensor_gate=True) is True
     assert _passes_qwen4_exp_mtp_gate(inspection_no_mtp_weights, tensor_gate=True) is True
 
 
@@ -2878,6 +2879,114 @@ def test_qsa_indexer_chunked_select_with_vector_q_pos(monkeypatch):
     # Full attention forward with chunking
     out = attn(x, cache=cache)
     assert out.shape == (2, 6, 64)
+
+
+def test_hf_model_weight_keys_scans_direct_weights_safetensors_and_ignores_adapters(monkeypatch):
+    from mtplx.artifacts import _hf_model_weight_keys
+
+    scanned_files = []
+
+    def fake_remote_keys(repo_id, filename):
+        scanned_files.append(filename)
+        if filename == "weights.safetensors":
+            return ("mtp.fc_embedding.weight", "model.embed_tokens.weight"), None
+        return (), None
+
+    monkeypatch.setattr("mtplx.artifacts._remote_safetensors_keys", fake_remote_keys)
+
+    files = {"weights.safetensors", "adapter_model.safetensors", "mtp.safetensors"}
+    keys, error = _hf_model_weight_keys("test/repo", files)
+    assert error is None
+    assert "mtp.fc_embedding.weight" in keys
+    assert "model.embed_tokens.weight" in keys
+    assert "weights.safetensors" in scanned_files
+    assert "adapter_model.safetensors" not in scanned_files
+
+
+def test_passes_qwen4_exp_gate_and_ar_gate_exclude_adapter_only_safetensors():
+    from mtplx.artifacts import ModelInspection
+    from mtplx.backends.registry import _passes_mlx_lm_ar_gate, _passes_qwen4_exp_gate
+
+    insp = ModelInspection(
+        model_dir="remote-org/adapter-only",
+        source="hf",
+        config_exists=True,
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_type="qwen4_exp",
+        mtp_num_hidden_layers=0,
+        hidden_size=1024,
+        num_hidden_layers=12,
+        vocab_size=32000,
+        model_files=("adapter_model.safetensors",),
+    )
+    assert not _passes_qwen4_exp_gate(insp)
+    assert not _passes_mlx_lm_ar_gate(insp)
+
+
+def test_passes_qwen4_exp_mtp_gate_requires_valid_tensor_gate():
+    from mtplx.artifacts import ModelInspection
+    from mtplx.backends.registry import _passes_qwen4_exp_mtp_gate
+
+    insp = ModelInspection(
+        model_dir="local/qwen4-exp",
+        source="hf",
+        config_exists=True,
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_type="qwen4_exp",
+        mtp_num_hidden_layers=1,
+        hidden_size=1024,
+        num_hidden_layers=12,
+        vocab_size=32000,
+        model_files=("model.safetensors", "mtp.safetensors"),
+        weight_keys=("mtp.fc_embedding.weight",),  # Incomplete MTP keys
+    )
+    # Even if some mtp. key exists, if tensor_gate is False, gate must return False
+    assert not _passes_qwen4_exp_mtp_gate(insp, tensor_gate=False)
+    assert _passes_qwen4_exp_mtp_gate(insp, tensor_gate=True)
+
+
+def test_attn_cache_vector_offset_update_and_fetch_appends_at_active_end():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    cache = _AttnCache()
+    cache.keys = mx.ones((2, 2, 8, 32))
+    cache.values = mx.ones((2, 2, 8, 32))
+    cache.offset = mx.array([8, 4], dtype=mx.int32)
+    cache._idx = 8
+
+    # Step 1: Decode 1 token (S=1)
+    k1 = mx.ones((2, 2, 1, 32)) * 2
+    v1 = mx.ones((2, 2, 1, 32)) * 2
+    fk1, fv1 = cache.update_and_fetch(k1, v1)
+    assert fk1.shape == (2, 2, 9, 32)
+    assert cache._idx == 9
+    assert list(cache.offset.tolist()) == [9, 5]
+
+    # Step 2: Decode 2nd token (S=1)
+    k2 = mx.ones((2, 2, 1, 32)) * 3
+    v2 = mx.ones((2, 2, 1, 32)) * 3
+    fk2, fv2 = cache.update_and_fetch(k2, v2)
+    assert fk2.shape == (2, 2, 10, 32)
+    assert cache._idx == 10
+    assert list(cache.offset.tolist()) == [10, 6]
+    # Verify no gap: position 8 has token 1, position 9 has token 2
+    assert float(cache.keys[0, 0, 8, :].mean().item()) == 2.0
+    assert float(cache.keys[0, 0, 9, :].mean().item()) == 3.0
+
+
+def test_qwen4_exp_recurrent_cache_filter_rebases_padding():
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache
+
+    cache = Qwen4ExpRecurrentCache(4)
+    cache[0] = mx.ones((3, 32, 4))
+    cache.left_padding = mx.array([4, 6, 8], dtype=mx.int32)
+    cache.lengths = mx.array([12, 10, 8], dtype=mx.int32)
+
+    # Filter to retain rows [0, 1] -> left_paddings are [4, 6], min is 4
+    cache.filter(mx.array([0, 1]))
+    assert cache.batch_size == 2
+    # Rebased left_padding should be [0, 2]
+    assert list(cache.left_padding.tolist()) == [0, 2]
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2095,6 +2095,61 @@ def test_detect_nested_qwen4_mtp_layer_declarations(tmp_path):
     assert arch_id == "qwen4-exp-mtp"
 
 
+def test_qwen4_exp_mtp_patch_recognizes_outer_and_legacy_mtp_declarations():
+    from mtplx.qwen4_exp_mtp_patch import _num_mtp_layers, is_qwen4_exp_mtp_config
+
+    # 1. Outer mtp declaration
+    cfg_outer = {
+        "model_type": "qwen4_exp",
+        "mtp": {"num_hidden_layers": 1},
+    }
+    assert _num_mtp_layers(cfg_outer) == 1
+    assert is_qwen4_exp_mtp_config(cfg_outer) is True
+
+    # 2. Legacy num_mtp_modules
+    cfg_legacy = {
+        "model_type": "qwen4_exp",
+        "num_mtp_modules": 1,
+    }
+    assert _num_mtp_layers(cfg_legacy) == 1
+    assert is_qwen4_exp_mtp_config(cfg_legacy) is True
+
+    # 3. Nested text_config.num_mtp_modules
+    cfg_nested = {
+        "model_type": "qwen4_exp",
+        "text_config": {"model_type": "qwen4_exp", "num_mtp_modules": 1},
+    }
+    assert _num_mtp_layers(cfg_nested) == 1
+    assert is_qwen4_exp_mtp_config(cfg_nested) is True
+
+
+def test_qwen4_exp_sanitize_remaps_conditional_generation_prefixes():
+    from mtplx.models.qwen4_exp import sanitize
+
+    raw_weights = {
+        "model.language_model.model.embed_tokens.weight": mx.zeros((10, 10)),
+        "model.language_model.model.layers.0.self_attn.q_proj.weight": mx.zeros((10, 10)),
+        "model.language_model.lm_head.weight": mx.zeros((10, 10)),
+        "model.language_model.mtp.fc.weight": mx.zeros((10, 10)),
+        "model.language_model.layers.1.self_attn.q_proj.weight": mx.zeros((10, 10)),
+        "model.visual.patch_embed.weight": mx.zeros((5, 5)),
+        "vision_tower.encoder.weight": mx.zeros((5, 5)),
+        "visual.conv.weight": mx.zeros((5, 5)),
+    }
+
+    sanitized = sanitize(raw_weights)
+    assert "model.embed_tokens.weight" in sanitized
+    assert "model.layers.0.self_attn.q_proj.weight" in sanitized
+    assert "model.layers.1.self_attn.q_proj.weight" in sanitized
+    assert "lm_head.weight" in sanitized
+    assert "mtp.fc.weight" in sanitized
+    assert "model.visual.patch_embed.weight" not in sanitized
+    assert "vision_tower.encoder.weight" not in sanitized
+    assert "visual.conv.weight" not in sanitized
+    assert not any(k.startswith("model.language_model.") for k in sanitized)
+    assert not any(k.startswith("language_model.") for k in sanitized)
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -477,3 +477,111 @@ def test_mtp_forward_routes_through_installed_draft_head(tmp_path):
     assert float(logits[0, 0, 0].item()) == 42.0
 
 
+def test_forward_logits_controls_through_qwen4_wrapper(tmp_path):
+    import mlx.nn as nn
+    from mtplx.models.qwen4_exp import Model, ModelArgs, TextArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "mtp_num_hidden_layers": 1,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+        "vocab_size": 50,
+    }
+
+    model = Model(ModelArgs.from_dict(config))
+    inject_qwen4_exp_mtp_support(model, str(tmp_path), config, allow_random_init=True)
+
+    toks = mx.array([[1, 2, 3, 4]])
+    cache = model.make_cache()
+
+    # 1. emit_logits=False
+    out = model(toks, cache=cache, emit_logits=False)
+    assert out is None
+
+    out_h = model(toks, cache=cache, emit_logits=False, return_hidden=True)
+    assert out_h[0] is None
+    assert out_h[1] is not None
+
+    # 2. logits_keep=1
+    out_k1 = model(toks, cache=cache, logits_keep=1)
+    assert out_k1 is not None
+    assert out_k1.shape == (1, 1, 50)
+
+    out_k1_h = model(toks, cache=cache, logits_keep=1, return_hidden=True)
+    assert out_k1_h[0] is not None
+    assert out_k1_h[0].shape == (1, 1, 50)
+
+
+def test_recurrent_mask_built_for_padded_qwen4_batches():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache, wrap_qwen4_exp_cache
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 50,
+    }
+
+    model = Model(ModelArgs.from_dict(config))
+    cache = model.make_cache()
+    # Install left padding on recurrent cache (batch of 2 sequences, first has 2 pad tokens)
+    left_padding = mx.array([2, 0])
+    wrapped_cache = wrap_qwen4_exp_cache(cache, model.model)
+    for c in wrapped_cache:
+        if isinstance(c, Qwen4ExpRecurrentCache):
+            c.left_padding = left_padding
+
+    toks = mx.array([[0, 0, 5, 6], [7, 8, 9, 10]])
+    logits = model(toks, cache=wrapped_cache)
+    assert logits is not None
+    assert logits.shape == (2, 4, 50)
+
+
+def test_avoid_double_shifting_mlx_mtp_norms(tmp_path):
+    from mtplx.qwen4_exp_mtp_patch import _load_mtp_weights, _shift_qwen4_gemma_mtp_norms
+
+    # 1. Delta-encoded norm weights (mean around 0.0) -> should be shifted (+1.0)
+    delta_weights = {
+        "pre_fc_norm_embedding.weight": mx.zeros((128,)),
+        "pre_fc_norm_hidden.weight": mx.zeros((128,)),
+        "layers.0.self_attn.q_norm.weight": mx.zeros((32,)),
+    }
+    shifted = _shift_qwen4_gemma_mtp_norms(delta_weights)
+    assert float(shifted["pre_fc_norm_embedding.weight"].mean().item()) == 1.0
+    assert float(shifted["pre_fc_norm_hidden.weight"].mean().item()) == 1.0
+
+    # 2. Already shifted / absolute norm weights (mean around 1.0) -> should NOT be shifted
+    already_shifted = {
+        "pre_fc_norm_embedding.weight": mx.ones((128,)),
+        "pre_fc_norm_hidden.weight": mx.ones((128,)),
+        "layers.0.self_attn.q_norm.weight": mx.ones((32,)),
+    }
+    not_double_shifted = _shift_qwen4_gemma_mtp_norms(already_shifted)
+    assert float(not_double_shifted["pre_fc_norm_embedding.weight"].mean().item()) == 1.0
+
+    # 3. Safetensors file saved with format='mlx' metadata -> should NOT be shifted
+    sf_path = tmp_path / "mtp.safetensors"
+    mx.save_safetensors(
+        str(sf_path),
+        {
+            "mtp.pre_fc_norm_embedding.weight": mx.ones((128,)),
+            "mtp.pre_fc_norm_hidden.weight": mx.ones((128,)),
+        },
+        metadata={"format": "mlx"},
+    )
+    loaded = _load_mtp_weights([sf_path])
+    assert float(loaded["pre_fc_norm_embedding.weight"].mean().item()) == 1.0
+
+
+

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1359,6 +1359,211 @@ def test_temperature_scaling_in_sampling_and_verification():
     assert decision.accepted
 
 
+def test_moe_routing_policy_norm_topk_and_scaling_factor():
+    from mtplx.models.qwen4_exp import SparseMoeBlock, TextArgs
+
+    config = {
+        "hidden_size": 64,
+        "num_experts": 8,
+        "num_experts_per_tok": 2,
+        "moe_intermediate_size": 32,
+        "shared_expert_intermediate_size": 32,
+        "norm_topk_prob": False,
+        "routed_scaling_factor": 2.5,
+    }
+    args = TextArgs.from_dict(config)
+    assert args.norm_topk_prob is False
+    assert args.routed_scaling_factor == 2.5
+
+    block = SparseMoeBlock(args)
+    assert block.norm_topk_prob is False
+    assert block.routed_scaling_factor == 2.5
+
+    x = mx.ones((1, 2, 64))
+    out = block(x)
+    assert out.shape == (1, 2, 64)
+
+
+def test_qsa_indexer_excludes_partially_padded_blocks():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
+
+    args = TextArgs(
+        hidden_size=64,
+        indexer_n_heads=2,
+        indexer_head_dim=32,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+    )
+    indexer = QSAIndexer(args)
+    indexer.block_topk = 1
+
+    # Left padding is 3 (less than compress_ratio 4, so block 0 is partially padded)
+    left_padding = mx.array([3])
+    q = mx.ones((1, 1, 2, 32))
+    q_pos = mx.array([8])
+    pooled = mx.ones((1, 3, 32))  # 3 blocks: block 0 (0..3), block 1 (4..7), block 2 (8..11)
+
+    sel = indexer.select(q, q_pos, pooled, kv_len=12, left_padding=left_padding)
+    # Block 0 starts at 0 < 3 (padding), so valid_block for block 0 is False.
+    # Selected top-k block should be block 1 (tokens 4..7), NOT block 0.
+    selected_block_tokens = sel.token_idx[0, 0, :4].tolist()
+    assert selected_block_tokens == [4, 5, 6, 7]
+    assert sel.valid[0, 0, :4].tolist() == [True, True, True, True]
+
+
+def test_preserve_conv_state_across_masked_timesteps():
+    from mtplx.models.qwen4_exp import GatedDeltaNet, PLELayer, TextArgs
+    from mlx_lm.models.cache import ArraysCache
+
+    args = TextArgs(
+        hidden_size=64,
+        linear_num_key_heads=2,
+        linear_num_value_heads=2,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_conv_kernel_dim=4,
+        hc_count=2,
+        ple_embed_dim=64,
+        ple_conv_kernel_size=4,
+        ngram_size=2,
+    )
+
+    # 1. GDN test
+    gdn = GatedDeltaNet(args)
+    cache = ArraysCache(4)
+    init_conv = mx.array([[[1.0] * gdn.conv_dim] * (gdn.conv_kernel_size - 1), [[2.0] * gdn.conv_dim] * (gdn.conv_kernel_size - 1)])
+    cache[0] = init_conv
+
+    x = mx.ones((2, 1, 64))
+    # Row 0 is masked (False), Row 1 is active (True)
+    mask = mx.array([[False], [True]])
+    _ = gdn(x, mask=mask, cache=cache)
+
+    # Row 0 must preserve original convolution state (not shifted with zeros)
+    assert mx.array_equal(cache[0][0], init_conv[0])
+    # Row 1 advanced
+    assert not mx.array_equal(cache[0][1], init_conv[1])
+
+    # 2. PLE test
+    ple = PLELayer(args, ple_layer_index=0)
+    ple_cache = ArraysCache(4)
+    init_ple_conv = mx.array([[[5.0] * (args.hidden_size * args.hc_count)] * ple.short_conv_state_len, [[6.0] * (args.hidden_size * args.hc_count)] * ple.short_conv_state_len])
+    ple_cache[2] = init_ple_conv
+
+    x_ple = mx.ones((2, 1, args.hidden_size * args.hc_count))
+    _ = ple._short_conv(x_ple, ple_cache, mask=mask)
+
+    # Row 0 must preserve original PLE convolution state
+    assert mx.array_equal(ple_cache[2][0], init_ple_conv[0])
+    # Row 1 advanced
+    assert not mx.array_equal(ple_cache[2][1], init_ple_conv[1])
+
+
+def test_accept_spliced_input_embeddings_in_mtp_history_update():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+        "rope_parameters": {},
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        "full_attention_interval": 4,
+        "vocab_size": 50,
+        "mtp_num_hidden_layers": 1,
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+    injected = inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+    assert injected
+
+    # Verify mtp_update_cache accepts input_embeddings keyword argument
+    hidden_states = mx.ones((1, 2, 128 * 2))
+    next_tokens = mx.array([[10, 20]], dtype=mx.int32)
+    spliced_emb = mx.ones((1, 2, 128))
+
+    res = model.mtp_update_cache(
+        hidden_states,
+        next_tokens,
+        input_embeddings=spliced_emb,
+    )
+    assert res.shape == (1, 2, 128 * 2)
+
+
+def test_allocate_recurrent_caches_for_linear_mtp_layers():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+    from mlx_lm.models.cache import ArraysCache
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+        "rope_parameters": {},
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        "full_attention_interval": 4,
+        "vocab_size": 50,
+        "mtp_num_hidden_layers": 1,
+        "mtp": {
+            "num_hidden_layers": 1,
+            "layer_types": ["linear_attention"],
+        },
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+    injected = inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+    assert injected
+
+    mtp_cache = model.make_mtp_cache()
+    assert len(mtp_cache) == 1
+    assert isinstance(mtp_cache[0], ArraysCache)
+
+    # mtp_forward executes and updates recurrent cache
+    hidden_states = mx.ones((1, 1, 128 * 2))
+    next_tokens = mx.array([[10]], dtype=mx.int32)
+    logits, next_h = model.mtp_forward(
+        hidden_states,
+        next_tokens,
+        mtp_cache=mtp_cache,
+        return_hidden=True,
+    )
+    assert logits.shape[-1] == 50
+    assert next_h.shape == (1, 1, 128 * 2)
+    # Check that GDN conv_state and recurrent state in mtp_cache were written
+    assert mtp_cache[0][0] is not None
+    assert mtp_cache[0][1] is not None
+
+
+def test_split_fused_eh_proj_weights():
+    from mtplx.qwen4_exp_mtp_patch import _process_raw_mtp_weights, inject_qwen4_exp_mtp_support
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+
+    raw_weights = {
+        "mtp.pre_fc_norm_embedding.weight": mx.ones((128,)),
+        "mtp.pre_fc_norm_hidden.weight": mx.ones((256,)),
+        "mtp.eh_proj.weight": mx.ones((128, 256)),
+    }
+    processed = _process_raw_mtp_weights(raw_weights)
+    assert "fc_embedding.weight" in processed
+    assert "fc_hidden.weight" in processed
+    assert processed["fc_embedding.weight"].shape == (128, 128)
+    assert processed["fc_hidden.weight"].shape == (128, 128)
+    assert "eh_proj.weight" not in processed
+    assert "fc.weight" not in processed
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1124,6 +1124,121 @@ def test_qwen4_tuning_routes_through_batched_verifier(monkeypatch):
     assert kwargs.get("verify_core") == "stock"
 
 
+def test_sparse_index_reuse_forwards_left_padding():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
+    from mtplx.qwen4_exp_mtp_patch import SparseIndexReuse
+
+    args = TextArgs(
+        hidden_size=128,
+        num_attention_heads=4,
+        head_dim=32,
+        indexer_n_heads=4,
+        indexer_head_dim=32,
+        indexer_compress_ratio=4,
+        indexer_budget=16,
+        rms_norm_eps=1e-6,
+    )
+    indexer = QSAIndexer(args)
+    wrapper = SparseIndexReuse(indexer)
+
+    B, S, H, D = 2, 1, 4, 32
+    n_blocks = 6
+    kv_len = 24
+    q = mx.ones((B, S, H, D))
+    q_pos = mx.array([kv_len - 1])
+    pooled = mx.ones((B, n_blocks, D))
+    left_padding = mx.array([16, 0])
+
+    sel = wrapper.select(q, q_pos, pooled, kv_len, left_padding=left_padding)
+    assert sel is not None
+    assert hasattr(sel, "token_idx")
+    assert hasattr(sel, "valid")
+
+
+def test_force_snapshots_in_qwen4_tuning_env(monkeypatch):
+    import os
+    from mtplx.qwen4_exp_mtp_patch import qwen4_exp_product_verify_env
+
+    # Simulate default performance-cold profile setting MTPLX_SKIP_VERIFY_SNAPSHOT=1
+    monkeypatch.setenv("MTPLX_SKIP_VERIFY_SNAPSHOT", "1")
+
+    with qwen4_exp_product_verify_env(None) as strategy:
+        assert strategy == "batched"
+        assert os.environ.get("MTPLX_SKIP_VERIFY_SNAPSHOT") == "0"
+
+    # Restored after context exit
+    assert os.environ.get("MTPLX_SKIP_VERIFY_SNAPSHOT") == "1"
+
+
+def test_recognize_all_qwen4_configurations_in_tuning(monkeypatch):
+    import mtplx.artifacts
+    from mtplx.benchmarks.runners import mtp_depth_sweep
+    from mtplx.commands import public
+    from mtplx.server import openai
+
+    mock_run_sweep = MagicMock(return_value={"ok": True})
+    monkeypatch.setattr(mtp_depth_sweep, "run_mtp_depth_sweep", mock_run_sweep)
+    monkeypatch.setattr(openai, "apply_memory_caps_preflight", lambda **kwargs: {})
+
+    # Mock inspect_model to return model_type="qwen4_exp_text" and architecture="Qwen4ExpForCausalLM"
+    mock_inspection = SimpleNamespace(
+        model_type="qwen4_exp_text",
+        architecture="Qwen4ExpForCausalLM",
+    )
+    monkeypatch.setattr(mtplx.artifacts, "inspect_model", lambda model_path: mock_inspection)
+    monkeypatch.setattr(public, "inspect_model", lambda model_path: mock_inspection)
+
+    public._depth_sweep_native60(
+        model="/tmp/dummy-qwen4-custom",
+        prompt_suite="dummy",
+        depths="1",
+        max_tokens=10,
+        limit=1,
+        seed=0,
+    )
+
+    assert mock_run_sweep.called
+    kwargs = mock_run_sweep.call_args.kwargs
+    assert kwargs.get("verify_strategy") == "batched"
+    assert kwargs.get("verify_core") == "stock"
+
+
+def test_tensor_offset_paged_cache_update_and_fetch_contract():
+    from mtplx.cache_state import (
+        TensorOffsetVllmMetalPagedKVCache,
+        VllmMetalPagedKVCache,
+    )
+    from mtplx.models.qwen4_exp import _IndexerCache
+
+    paged = VllmMetalPagedKVCache(block_size=16, num_blocks=4)
+    paged.indexer = _IndexerCache()
+    paged.indexer.update(mx.ones((1, 8, 128)))
+
+    # Populate initial paged state
+    keys = mx.ones((1, 2, 4, 64))
+    values = mx.ones((1, 2, 4, 64))
+    paged.update_without_fetch(keys, values)
+
+    promoted = TensorOffsetVllmMetalPagedKVCache.from_paged_cache(paged)
+    assert hasattr(promoted, "indexer")
+
+    # .state property returns (keys, values, indexer_keys) (3 elements for snapshotting)
+    assert len(promoted.state) == 3
+
+    # update_and_fetch() MUST return a 2-tuple (k, v) to satisfy the Attention contract
+    new_keys = mx.ones((1, 2, 1, 64))
+    new_values = mx.ones((1, 2, 1, 64))
+    res = promoted.update_and_fetch(new_keys, new_values)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    k, v = res
+    assert k.shape[0] == 1
+    assert k.shape[1] == 2
+    assert v.shape[0] == 1
+    assert v.shape[1] == 2
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1692,6 +1692,101 @@ def test_exclude_all_mtp_sidecars_from_trunk_check(tmp_path):
     assert _passes_mlx_lm_ar_gate(inspection)
 
 
+def test_attn_cache_filters_left_padding_and_lengths():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    # Create two caches and merge them
+    c1 = _AttnCache()
+    c1.keys = mx.ones((1, 2, 8, 32))
+    c1.values = mx.ones((1, 2, 8, 32))
+    c1.offset = 8
+    c1.left_padding = mx.array([2])
+    c1.lengths = mx.array([6])
+
+    c2 = _AttnCache()
+    c2.keys = mx.ones((1, 2, 8, 32))
+    c2.values = mx.ones((1, 2, 8, 32))
+    c2.offset = 8
+    c2.left_padding = mx.array([4])
+    c2.lengths = mx.array([4])
+
+    merged = _AttnCache.merge([c1, c2])
+    assert merged.left_padding.shape[0] == 2
+    assert merged.indexer.left_padding.shape[0] == 2
+
+    # Filter merged batch to keep index 1 only (BatchKVCache shifts keys and updates left_padding)
+    merged.filter(mx.array([1]))
+    assert merged.keys.shape[0] == 1
+    assert merged.left_padding.shape[0] == 1
+    assert int(merged.left_padding[0].item()) == 0
+    assert int(merged.indexer.left_padding[0].item()) == 0
+
+    # Filter unmerged _AttnCache directly
+    c_multi = _AttnCache()
+    c_multi.keys = mx.ones((2, 2, 8, 32))
+    c_multi.values = mx.ones((2, 2, 8, 32))
+    c_multi.left_padding = mx.array([2, 4])
+    c_multi.filter(mx.array([1]))
+    assert c_multi.keys.shape[0] == 1
+    assert int(c_multi.left_padding[0].item()) == 4
+
+    # Extract
+    c1_ext = c1.extract(0)
+    assert c1_ext.left_padding.shape[0] == 1
+    assert int(c1_ext.left_padding[0].item()) == 2
+
+    # Extend
+    c1_ext.extend(c2)
+    assert c1_ext.left_padding.shape[0] == 2
+    assert list(c1_ext.left_padding.tolist()) == [2, 4]
+
+
+def test_metal_memory_caps_and_headroom_scale_with_small_models(monkeypatch, tmp_path):
+    from mtplx.server.openai import (
+        _minimum_resident_bytes_for_model_path,
+        _apply_metal_memory_caps,
+        apply_memory_caps_preflight,
+    )
+
+    # 1. Headroom on 1GB weights is scaled, not fixed 4GB
+    monkeypatch.setattr("mtplx.engine_session.model_weights_bytes", lambda path: 1024**3)
+    min_resident = _minimum_resident_bytes_for_model_path(str(tmp_path))
+    assert min_resident is not None
+    assert min_resident < 2 * 1024**3  # Far below 1GB + 4GB = 5GB
+
+    # 2. Preflight on a 16GB Mac with a 2GB model passes without insufficient_ram error
+    caps = _apply_metal_memory_caps(
+        total_ram_bytes=16 * 1024**3,
+        minimum_resident_bytes=min_resident,
+    )
+    assert caps["applied"] is True
+    assert caps.get("reason") is None
+
+
+def test_qwen4_exp_mtp_falls_back_to_ar_when_draft_head_absent(tmp_path):
+    from mtplx.backends.registry import compatibility_for_inspection
+    from types import SimpleNamespace
+
+    model_dir = tmp_path / "qwen4_no_mtp"
+    model_dir.mkdir()
+    (model_dir / "model.safetensors").write_bytes(b"dummy")
+
+    inspection = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        mtp_num_hidden_layers=1,
+        model_dir=str(model_dir),
+        mtp=SimpleNamespace(exists=False, passes_tensor_gate=False),
+    )
+
+    verdict = compatibility_for_inspection(inspection)
+    assert verdict.can_run is True
+    assert verdict.arch_id == "qwen4-exp"
+    assert verdict.runtime_compatibility == "native-ar-only-missing-mtp"
+    assert verdict.mtp_supported == "no"
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2270,6 +2270,42 @@ def test_is_qwen4_exp_config_recognizes_architecture_aliases():
     assert is_qwen4_exp_config({"architectures": ["LlamaForCausalLM"]}) is False
 
 
+def test_expected_embedded_mtp_keys_for_qwen4_exp():
+    from mtplx.ui.onboarding import _expected_embedded_mtp_keys
+    from mtplx.constants import EXPECTED_QWEN4_EXP_MTP_KEYS
+
+    cfg = {
+        "model_type": "qwen4_exp",
+        "mtp_num_hidden_layers": 1,
+    }
+    keys = _expected_embedded_mtp_keys(cfg)
+    assert "mtp.fc_embedding.weight" in keys
+    assert "mtp.fc_hidden.weight" in keys
+    assert "mtp.layers.0.mlp.switch_mlp.gate_proj.weight" in keys
+    assert "mtp.fc.weight" not in keys
+    assert set(EXPECTED_QWEN4_EXP_MTP_KEYS).issubset(keys)
+
+
+def test_classify_scanned_model_recognizes_top_level_mtp_num_hidden_layers(tmp_path):
+    import json
+    from mtplx.ui.onboarding import _classify_scanned_model
+
+    config_data = {
+        "model_type": "qwen4_exp",
+        "mtp_num_hidden_layers": 1,
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data))
+
+    # Add a dummy sidecar so it detects an MTP artifact
+    mtp_file = tmp_path / "mtp.safetensors"
+    mtp_file.write_bytes(b"dummy")
+
+    scanned = _classify_scanned_model(tmp_path)
+    assert scanned.arch_id == "qwen4-exp-mtp"
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -860,6 +860,151 @@ def test_compiled_linear_step_passes_recurrent_mask():
     assert new_rec.shape == (2, layer.linear_attn.n_v, layer.linear_attn.dv, layer.linear_attn.dk)
 
 
+def test_remap_packed_expert_quantization_leaves():
+    from mtplx.models.qwen4_exp import remap_fused_projections
+
+    quant_weights = {
+        "layers.0.mlp.experts.gate_up_proj.weight": mx.zeros((4, 64, 32)),
+        "layers.0.mlp.experts.gate_up_proj.scales": mx.ones((4, 64, 1)),
+        "layers.0.mlp.experts.gate_up_proj.biases": mx.zeros((4, 64, 1)),
+        "layers.0.mlp.experts.down_proj.weight": mx.zeros((4, 32, 64)),
+        "layers.0.mlp.experts.down_proj.scales": mx.ones((4, 32, 1)),
+        "layers.0.mlp.experts.down_proj.biases": mx.zeros((4, 32, 1)),
+    }
+    remapped = remap_fused_projections(quant_weights)
+
+    assert "layers.0.mlp.switch_mlp.gate_up_proj.weight" in remapped
+    assert "layers.0.mlp.switch_mlp.gate_up_proj.scales" in remapped
+    assert "layers.0.mlp.switch_mlp.gate_up_proj.biases" in remapped
+    assert "layers.0.mlp.switch_mlp.down_proj.weight" in remapped
+    assert "layers.0.mlp.switch_mlp.down_proj.scales" in remapped
+    assert "layers.0.mlp.switch_mlp.down_proj.biases" in remapped
+    assert not any("experts" in k for k in remapped)
+
+
+def test_reject_incomplete_mtp_sidecar(tmp_path):
+    import mlx.nn as nn
+    from mtplx.models.qwen4_exp import TextArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "mtp_num_hidden_layers": 1,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+        "vocab_size": 50,
+    }
+
+    class DummyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = SimpleNamespace(
+                layers=[
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="full_attention"),
+                ],
+                embed_tokens=nn.Embedding(50, 128),
+            )
+            self.lm_head = nn.Linear(128, 50, bias=False)
+            self.args = TextArgs(
+                hidden_size=128,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                head_dim=32,
+                hc_count=2,
+                hc_lowrank=64,
+                rope_parameters={},
+                rope_theta=10000.0,
+                partial_rotary_factor=0.25,
+                layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+                full_attention_interval=4,
+            )
+
+        def make_cache(self):
+            return [None] * 4
+
+    # 1. Truncated sidecar: save only 1 parameter
+    sf_path = tmp_path / "mtp.safetensors"
+    mx.save_safetensors(
+        str(sf_path),
+        {"mtp.pre_fc_norm_embedding.weight": mx.ones((128,))},
+    )
+
+    model = DummyModel()
+    res = inject_qwen4_exp_mtp_support(model, str(tmp_path), config, allow_random_init=False)
+    # Must fail because required MTP parameters are missing
+    assert res is False
+
+
+def test_qsa_indexer_cache_batch_protocol():
+    from mtplx.models.qwen4_exp import _AttnCache, _IndexerCache
+
+    # 1. _IndexerCache merge
+    idx1 = _IndexerCache()
+    idx1.update(mx.ones((1, 8, 128)))
+    idx1.pooled = mx.ones((1, 2, 128))
+
+    idx2 = _IndexerCache()
+    idx2.update(mx.full((1, 12, 128), 2.0))
+    idx2.pooled = mx.full((1, 3, 128), 2.0)
+
+    merged = _IndexerCache.merge([idx1, idx2])
+    assert merged.batch_size == 2
+    assert merged.keys.shape == (2, 12, 128)
+    assert merged.pooled is None  # Invalidated on merge
+
+    # 2. _IndexerCache filter
+    merged.filter(mx.array([1]))
+    assert merged.batch_size == 1
+    assert merged.keys.shape == (1, 12, 128)
+    assert float(merged.keys[0, -1, 0].item()) == 2.0
+
+    # 3. _IndexerCache extract
+    extracted = merged.extract(0)
+    assert extracted.batch_size == 1
+    assert extracted.keys.shape == (1, 12, 128)
+
+    # 4. _AttnCache merge, filter, extend, extract
+    a1 = _AttnCache()
+    a1.keys = mx.ones((1, 2, 8, 64))
+    a1.values = mx.ones((1, 2, 8, 64))
+    a1.offset = 8
+    a1.indexer.update(mx.ones((1, 8, 128)))
+
+    a2 = _AttnCache()
+    a2.keys = mx.full((1, 2, 12, 64), 3.0)
+    a2.values = mx.full((1, 2, 12, 64), 3.0)
+    a2.offset = 12
+    a2.indexer.update(mx.full((1, 12, 128), 3.0))
+
+    a_merged = _AttnCache.merge([a1, a2])
+    assert a_merged.keys.shape[0] == 2
+    assert hasattr(a_merged, "indexer")
+    assert a_merged.indexer.batch_size == 2
+    assert a_merged.indexer.keys.shape == (2, 12, 128)
+
+    # Filter a_merged
+    a_merged.filter(mx.array([1]))
+    assert a_merged.keys.shape[0] == 1
+    assert a_merged.indexer.batch_size == 1
+    assert float(a_merged.indexer.keys[0, -1, 0].item()) == 3.0
+
+    # Extract from a_merged
+    a_extracted = a_merged.extract(0)
+    assert hasattr(a_extracted, "indexer")
+    assert a_extracted.indexer.batch_size == 1
+    assert a_extracted.indexer.keys.shape == (1, 12, 128)
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -360,3 +360,120 @@ def test_mtp_module_quantization_from_contract(tmp_path):
     ]
     assert len(quantized_layers) > 0
 
+
+def test_qsa_gather_attention_applies_array_mask():
+    from mtplx.models.qwen4_exp import QSASelection, _qsa_gather_attention
+
+    B, H, S, D = 1, 2, 2, 64
+    T = 4
+    K = 3
+    q = mx.ones((B, H, S, D))
+    k = mx.ones((B, H, T, D))
+    v = mx.ones((B, H, T, D))
+
+    token_idx = mx.array([[[0, 1, 2], [1, 2, 3]]])  # (1, 2, 3)
+    valid = mx.array([[[True, True, True], [True, True, True]]])
+    sel = QSASelection(token_idx=token_idx, valid=valid)
+
+    # Boolean mask: key 0 and 1 are masked out (False = padding)
+    # mask shape: (B, 1, S, T)
+    mask = mx.array([[[[False, False, True, True], [False, False, True, True]]]])
+    out = _qsa_gather_attention(q, k, v, sel, scale=1.0, mask=mask)
+    assert out.shape == (B, H, S, D)
+
+    # Floating additive mask: key 0 is -1e9
+    mask_float = mx.array([[[[-1e9, 0.0, 0.0, 0.0], [-1e9, 0.0, 0.0, 0.0]]]])
+    out_float = _qsa_gather_attention(q, k, v, sel, scale=1.0, mask=mask_float)
+    assert out_float.shape == (B, H, S, D)
+
+
+def test_qwen4_exp_mtp_gate_requires_mtp_tensors(tmp_path):
+    shard = tmp_path / "model.safetensors"
+    shard.write_bytes(b"dummy")
+
+    # Config declares mtp_num_hidden_layers > 0, but no MTP weights exist and tensor_gate=False
+    inspection_no_mtp_weights = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(tmp_path),
+        mtp_num_hidden_layers=1,
+        weight_keys=("model.embed_tokens.weight", "model.layers.0.mlp.gate_up_proj.weight"),
+    )
+    assert _passes_qwen4_exp_mtp_gate(inspection_no_mtp_weights, tensor_gate=False) is False
+
+    # When tensor_gate=True or MTP weights exist -> passes
+    inspection_with_mtp = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(tmp_path),
+        mtp_num_hidden_layers=1,
+        weight_keys=("mtp.layers.0.self_attn.q_proj.weight",),
+    )
+    assert _passes_qwen4_exp_mtp_gate(inspection_with_mtp, tensor_gate=False) is True
+    assert _passes_qwen4_exp_mtp_gate(inspection_no_mtp_weights, tensor_gate=True) is True
+
+
+def test_mtp_forward_routes_through_installed_draft_head(tmp_path):
+    import mlx.nn as nn
+    from mtplx.models.qwen4_exp import TextArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "mtp_num_hidden_layers": 1,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+    }
+
+    class DummyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = SimpleNamespace(
+                layers=[
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="full_attention"),
+                ],
+                embed_tokens=nn.Embedding(100, 128),
+            )
+            self.lm_head = nn.Linear(128, 100, bias=False)
+            self.args = TextArgs(
+                hidden_size=128,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                head_dim=32,
+                hc_count=2,
+                hc_lowrank=64,
+                rope_parameters={},
+                rope_theta=10000.0,
+                partial_rotary_factor=0.25,
+                layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+                full_attention_interval=4,
+            )
+
+        def make_cache(self):
+            return [None] * 4
+
+    model = DummyModel()
+    inject_qwen4_exp_mtp_support(model, str(tmp_path), config, allow_random_init=True)
+
+    # Attach custom draft head returning a distinct constant
+    class CustomDraftHead(nn.Module):
+        def __call__(self, x):
+            return mx.full((*x.shape[:-1], 100), 42.0)
+
+    model._mtplx_draft_lm_head = CustomDraftHead()
+
+    h = mx.zeros((1, 1, 128 * 2))
+    toks = mx.array([[0]], dtype=mx.int32)
+    logits = model.mtp_forward(h, toks)
+    assert float(logits[0, 0, 0].item()) == 42.0
+
+

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from mtplx.backends.descriptors import (
+    MLX_LM_AR_DESCRIPTOR,
+    descriptor_for_architecture_id,
+    descriptor_for_backend_id,
+    descriptor_from_inspection,
+)
+from mtplx.backends.registry import (
+    _passes_family_runtime_gate,
+    _passes_qwen4_exp_gate,
+    _passes_qwen4_exp_mtp_gate,
+)
+from mtplx.cache_state import (
+    BlockOwnedKVCache,
+    TailOwnedKVCache,
+    TensorOffsetVllmMetalPagedKVCache,
+    VllmMetalPagedKVCache,
+)
+from mtplx.models.qwen4_exp import Model, ModelArgs, _AttnCache, _IndexerCache
+from mtplx.server import openai
+
+
+def test_qsa_indexer_preserved_during_cache_repaging():
+    attn_cache = _AttnCache()
+    attn_cache.indexer.update(mx.ones((1, 8, 128)))
+    assert attn_cache.indexer.keys is not None
+    assert attn_cache.indexer.keys.shape == (1, 8, 128)
+
+    # 1. VllmMetalPagedKVCache
+    paged = VllmMetalPagedKVCache.from_cache(attn_cache, block_size=16, num_blocks=4)
+    assert hasattr(paged, "indexer")
+    assert paged.indexer is attn_cache.indexer
+    assert paged.indexer.keys.shape == (1, 8, 128)
+
+    # 2. TailOwnedKVCache
+    tail = TailOwnedKVCache.from_cache(attn_cache, mode="eval_only")
+    assert hasattr(tail, "indexer")
+    assert tail.indexer is attn_cache.indexer
+
+    # 3. BlockOwnedKVCache
+    block = BlockOwnedKVCache.from_cache(attn_cache, mode="eval_only")
+    assert hasattr(block, "indexer")
+    assert block.indexer is attn_cache.indexer
+
+    # 4. Promotion & Demotion
+    paged.key_cache = mx.zeros((4, 16, 2, 64))
+    paged.value_cache = mx.zeros((4, 16, 2, 64))
+    paged.offset = 8
+    promoted = TensorOffsetVllmMetalPagedKVCache.from_paged_cache(paged)
+    assert hasattr(promoted, "indexer")
+    assert promoted.indexer is attn_cache.indexer
+
+    demoted = promoted.to_paged_cache()
+    assert hasattr(demoted, "indexer")
+    assert demoted.indexer is attn_cache.indexer
+
+    # 5. Trim indexer keys on paged cache
+    paged.trim(2)
+    assert paged.indexer.keys.shape == (1, 6, 128)
+
+
+def test_quant_predicate_accepts_two_arguments():
+    model = Model(ModelArgs())
+    pred = model.quant_predicate
+    assert callable(pred)
+    # Must accept 2 arguments without error
+    assert pred("model.layers.0.mlp.gate", None) is False
+    assert pred("model.layers.0.mlp.down_proj", None) is True
+
+
+def test_sanitize_excludes_mtp_tensors_from_trunk_dict():
+    model = Model(ModelArgs())
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((10, 10)),
+        "mtp.layers.0.self_attn.q_proj.weight": mx.zeros((10, 10)),
+        "mtp.layers.0.mlp.gate_proj.weight": mx.zeros((10, 10)),
+    }
+    sanitized = model.sanitize(weights)
+    assert "mtp.layers.0.self_attn.q_proj.weight" not in sanitized
+    assert "mtp.layers.0.mlp.gate_proj.weight" not in sanitized
+    assert "model.embed_tokens.weight" in sanitized
+    assert "mtp.layers.0.self_attn.q_proj.weight" in model.mtp_weights
+
+
+def test_qwen4_exp_mtp_family_runtime_gate(tmp_path):
+    shard = tmp_path / "model.safetensors"
+    shard.write_bytes(b"dummy")
+
+    inspection = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(tmp_path),
+        mtp_num_hidden_layers=1,
+        weight_keys=("mtp.layers.0.self_attn.q_proj.weight",),
+    )
+
+    assert _passes_qwen4_exp_mtp_gate(inspection, tensor_gate=True) is True
+    assert _passes_family_runtime_gate("qwen4-exp-mtp", inspection, tensor_gate=True) is True
+    assert _passes_family_runtime_gate("qwen4-exp", inspection, tensor_gate=False) is True
+
+
+def test_qwen4_exp_backend_descriptor_registered():
+    assert descriptor_for_backend_id("qwen4_exp") == MLX_LM_AR_DESCRIPTOR
+    assert descriptor_for_architecture_id("qwen4-exp") == MLX_LM_AR_DESCRIPTOR
+    assert (
+        descriptor_from_inspection({"recommended_backend": "qwen4_exp"})
+        == MLX_LM_AR_DESCRIPTOR
+    )
+
+
+def test_select_backend_context_window_clamps_to_model_max():
+    desc = MLX_LM_AR_DESCRIPTOR
+
+    # 32K checkpoint requested with 1M context must clamp to 32,768
+    result = openai._select_backend_context_window(
+        desc,
+        model_max=32_768,
+        requested=1_048_576,
+    )
+    assert result == 32_768
+
+    # 1M checkpoint requested with 1M context returns 1,048,576
+    result = openai._select_backend_context_window(
+        desc,
+        model_max=1_048_576,
+        requested=1_048_576,
+    )
+    assert result == 1_048_576
+
+
+def test_report_actual_model_in_memory_cap_failures(monkeypatch):
+    args = openai.parse_args(["--model", "custom-org/my-qwen-model", "--backend-id", "qwen4_exp"])
+
+    monkeypatch.setattr(
+        openai,
+        "_apply_metal_memory_caps",
+        lambda **kwargs: {
+            "applied": False,
+            "reason": "insufficient_ram",
+            "minimum_resident_bytes": 100 * 1024**3,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="custom-org/my-qwen-model cannot load inside"):
+        openai.ServerState(args)
+
+
+def test_fail_preflight_when_model_cannot_fit_active_caps(monkeypatch):
+    monkeypatch.setattr(
+        openai,
+        "_apply_metal_memory_caps",
+        lambda **kwargs: {
+            "applied": False,
+            "reason": "insufficient_ram",
+            "minimum_resident_bytes": 128 * 1024**3,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cannot load inside the available Metal memory budget"):
+        openai.apply_memory_caps_preflight(
+            entry="benchmark",
+            model="Qwen/Qwen3.8-Flash-Next",
+            contexts=[4096],
+        )
+
+
+def test_qwen4_exp_ar_gate_requires_model_shards(tmp_path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    inspection_empty = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(empty_dir),
+    )
+    assert _passes_qwen4_exp_gate(inspection_empty) is False
+
+    # Only MTP shard present (no trunk shard) -> must fail AR gate
+    mtp_only_dir = tmp_path / "mtp_only"
+    mtp_only_dir.mkdir()
+    (mtp_only_dir / "mtp.safetensors").write_bytes(b"dummy")
+    inspection_mtp_only = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(mtp_only_dir),
+    )
+    assert _passes_qwen4_exp_gate(inspection_mtp_only) is False
+
+    # Trunk shard present -> passes
+    trunk_dir = tmp_path / "trunk"
+    trunk_dir.mkdir()
+    (trunk_dir / "model.safetensors").write_bytes(b"dummy")
+    inspection_trunk = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(trunk_dir),
+    )
+    assert _passes_qwen4_exp_gate(inspection_trunk) is True

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1665,7 +1665,8 @@ def test_exclude_all_mtp_sidecars_from_trunk_check(tmp_path):
     assert _is_mtp_sidecar_file(Path("mtp.safetensors"))
     assert _is_mtp_sidecar_file(Path("model-mtp.safetensors"))
     assert _is_mtp_sidecar_file(Path("model-mtp-head.safetensors"))
-    assert _is_mtp_sidecar_file(Path("weights.safetensors"))
+    assert _is_mtp_sidecar_file(Path("mtp/weights.safetensors"))
+    assert not _is_mtp_sidecar_file(Path("weights.safetensors"))
     assert _is_mtp_sidecar_file(Path("custom-mtp.safetensors"))
     assert _is_mtp_sidecar_file(Path("custom-mtp-head.safetensors"))
     assert not _is_mtp_sidecar_file(Path("model.safetensors"))
@@ -1885,6 +1886,70 @@ def test_qwen4_server_retains_d1_default_when_not_explicit():
     _apply_backend_server_defaults(args, explicit_flags=explicit_flags)
     assert getattr(args, "_explicit_depth", False) is False
     assert getattr(args, "depth", None) == 1
+
+
+def test_top_level_weights_safetensors_not_classified_as_sidecar(tmp_path):
+    from pathlib import Path
+    from mtplx.backends.registry import _is_mtp_sidecar_file, _passes_mlx_lm_ar_gate, _passes_qwen4_exp_gate
+    from types import SimpleNamespace
+
+    # Top-level weights.safetensors is a legitimate trunk shard
+    top_level_weights = tmp_path / "weights.safetensors"
+    top_level_weights.write_bytes(b"dummy")
+    config_file = tmp_path / "config.json"
+    config_file.write_text('{"model_type": "qwen4_exp"}')
+
+    assert not _is_mtp_sidecar_file(top_level_weights)
+
+    inspection = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=str(tmp_path),
+    )
+    assert _passes_qwen4_exp_gate(inspection)
+    assert _passes_mlx_lm_ar_gate(inspection)
+
+    # Subdirectory mtp/weights.safetensors is a recognized sidecar
+    mtp_dir = tmp_path / "mtp"
+    mtp_dir.mkdir()
+    mtp_weights = mtp_dir / "weights.safetensors"
+    mtp_weights.write_bytes(b"dummy")
+    assert _is_mtp_sidecar_file(mtp_weights)
+
+
+def test_speculative_generate_preserves_mtp_history_between_rounds():
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support, speculative_generate
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "linear_num_key_heads": 2,
+        "linear_num_value_heads": 2,
+        "linear_key_head_dim": 16,
+        "linear_value_head_dim": 16,
+        "linear_conv_kernel_dim": 4,
+        "layer_types": ["linear_attention", "full_attention"],
+        "vocab_size": 50,
+        "ple_layer_ids": [],
+        "mtp": {
+            "num_hidden_layers": 1,
+            "layer_types": ["full_attention"],
+        },
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+    inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+
+    prompt_ids = mx.array([[1, 2, 3, 4]])
+    tokens = speculative_generate(model, prompt_ids, max_tokens=8, draft_depth=2)
+    assert len(tokens) == 8
+    assert all(isinstance(t, int) for t in tokens)
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1563,6 +1563,136 @@ def test_split_fused_eh_proj_weights():
     assert "fc.weight" not in processed
 
 
+def test_forward_ar_allows_vision_splice_without_mtp():
+    from mtplx.runtime import MTPLXRuntime
+
+    class ModelWithInputEmbeddings:
+        def __call__(self, inputs, cache=None, input_embeddings=None, **kwargs):
+            return mx.zeros((1, 1, 10))
+
+    class ModelWithoutInputEmbeddings:
+        def __call__(self, inputs, cache=None, emit_logits=True, logits_keep=None):
+            return mx.zeros((1, 1, 10))
+
+    # 1. Model supports input_embeddings -> forward_ar succeeds without MTP
+    rt = MTPLXRuntime(
+        model=ModelWithInputEmbeddings(),
+        tokenizer=None,
+        model_path=Path("."),
+        mtp_enabled=False,
+        contract=None,
+    )
+    res = rt.forward_ar(
+        mx.array([[1]]),
+        input_embeddings=mx.ones((1, 1, 32)),
+    )
+    assert res is not None
+
+    # 2. Model does not support input_embeddings -> forward_ar raises RuntimeError
+    rt_no_emb = MTPLXRuntime(
+        model=ModelWithoutInputEmbeddings(),
+        tokenizer=None,
+        model_path=Path("."),
+        mtp_enabled=False,
+        contract=None,
+    )
+    import pytest
+    with pytest.raises(RuntimeError, match="does not accept input_embeddings"):
+        rt_no_emb.forward_ar(
+            mx.array([[1]]),
+            input_embeddings=mx.ones((1, 1, 32)),
+        )
+
+
+def test_mtp_predictor_attention_uses_dense_attention():
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+    from mtplx.models.qwen4_exp import Model, ModelArgs
+    from mlx_lm.models.cache import KVCache
+
+    config = {
+        "model_type": "qwen4_exp",
+        "text_config": {
+            "hidden_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 32,
+            "linear_num_key_heads": 4,
+            "linear_num_value_heads": 4,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 32,
+            "linear_conv_kernel_dim": 4,
+            "hc_count": 2,
+            "hc_lowrank": 64,
+            "ple_embed_dim": 128,
+            "ple_layer_ids": [],
+            "vocab_size": 50,
+            "layer_types": ["linear_attention", "full_attention"],
+            "mtp_num_hidden_layers": 1,
+            "mtp_layer_types": ["full_attention"],
+        },
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+    injected = inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+    assert injected
+
+    # Verify that predictor's attention layers have indexer disabled (dense attention)
+    assert model.mtp.layers[0].self_attn.indexer is None
+
+    # Verify cache allocated for full attention predictor layer is dense KVCache
+    mtp_cache = model.make_mtp_cache()
+    assert len(mtp_cache) == 1
+    assert isinstance(mtp_cache[0], KVCache)
+
+    # Long context forward through MTP predictor remains dense causal without QSA selection errors
+    hidden = mx.ones((1, 1, 128 * 2))
+    next_tok = mx.array([[5]], dtype=mx.int32)
+    logits, next_h = model.mtp_forward(hidden, next_tok, mtp_cache=mtp_cache, return_hidden=True)
+    assert logits.shape[-1] == 50
+    assert next_h.shape == (1, 1, 128 * 2)
+
+
+def test_exclude_all_mtp_sidecars_from_trunk_check(tmp_path):
+    from mtplx.backends.registry import (
+        _passes_qwen4_exp_gate,
+        _passes_mlx_lm_ar_gate,
+        _is_mtp_sidecar_file,
+    )
+    from types import SimpleNamespace
+
+    # 1. Check helper recognition
+    assert _is_mtp_sidecar_file(Path("mtp.safetensors"))
+    assert _is_mtp_sidecar_file(Path("model-mtp.safetensors"))
+    assert _is_mtp_sidecar_file(Path("model-mtp-head.safetensors"))
+    assert _is_mtp_sidecar_file(Path("weights.safetensors"))
+    assert _is_mtp_sidecar_file(Path("custom-mtp.safetensors"))
+    assert _is_mtp_sidecar_file(Path("custom-mtp-head.safetensors"))
+    assert not _is_mtp_sidecar_file(Path("model.safetensors"))
+    assert not _is_mtp_sidecar_file(Path("model-00001-of-00004.safetensors"))
+
+    # 2. Sidecar-only directory (e.g. model-mtp.safetensors only)
+    sidecar_dir = tmp_path / "sidecar_only"
+    sidecar_dir.mkdir()
+    (sidecar_dir / "model-mtp.safetensors").write_bytes(b"dummy")
+    (sidecar_dir / "model-mtp-head.safetensors").write_bytes(b"dummy")
+
+    inspection = SimpleNamespace(
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_dir=sidecar_dir,
+    )
+
+    assert not _passes_qwen4_exp_gate(inspection)
+    assert not _passes_mlx_lm_ar_gate(inspection)
+
+    # 3. Add genuine trunk shard -> gate passes
+    (sidecar_dir / "model.safetensors").write_bytes(b"dummy")
+    assert _passes_qwen4_exp_gate(inspection)
+    assert _passes_mlx_lm_ar_gate(inspection)
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2521,6 +2521,112 @@ def test_attn_cache_and_indexer_rebase_padding_on_filter():
     assert list(c.indexer.left_padding.tolist()) == [0, 2]
 
 
+def test_passes_qwen4_exp_gate_preserves_remote_weights_safetensors():
+    from mtplx.backends.registry import _passes_qwen4_exp_gate
+    from types import SimpleNamespace
+
+    # Remote HF model inspection with top-level weights.safetensors as trunk
+    inspection = SimpleNamespace(
+        source="hf",
+        model_dir="Qwen/Qwen3.8-Flash-Next",
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_files=("config.json", "weights.safetensors"),
+        weight_keys=(),
+    )
+    assert _passes_qwen4_exp_gate(inspection) is True
+
+
+def test_shift_trunk_gemma_norms_uses_primary_markers():
+    import pytest
+    from mtplx.models.qwen4_exp import _shift_trunk_gemma_norms
+
+    # Raw HF trunk where q_norm has high average (e.g. 0.9) but hc_norm is raw 0.0
+    weights = {
+        "model.layers.0.linear_attn.q_norm.weight": mx.full((64,), 0.9),
+        "model.layers.0.linear_attn.k_norm.weight": mx.full((64,), 0.9),
+        "model.layers.0.hc_norm.weight": mx.zeros((64,)),
+        "model.norm.weight": mx.zeros((64,)),
+    }
+    shifted = _shift_trunk_gemma_norms(weights)
+    # Since primary marker hc_norm is 0.0, +1.0 should be applied
+    assert float(shifted["model.layers.0.hc_norm.weight"].mean().item()) == pytest.approx(1.0)
+    assert float(shifted["model.norm.weight"].mean().item()) == pytest.approx(1.0)
+    assert float(shifted["model.layers.0.linear_attn.q_norm.weight"].mean().item()) == pytest.approx(1.9)
+
+
+def test_ple_layer_excludes_left_padding_tokens():
+    from mtplx.models.qwen4_exp import PLELayer, TextArgs
+
+    args = TextArgs(
+        model_type="qwen4_exp",
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        vocab_size=1000,
+        eos_token_id=0,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        hc_count=2,
+    )
+    ple = PLELayer(args, ple_layer_index=0)
+    hidden = mx.ones((1, 4, 64 * 2))
+    prev_ctx = mx.zeros((1, 2), dtype=mx.int32)
+    # IDs with 2 padding tokens (value 999) and 2 valid tokens (101, 102)
+    ids_padded = mx.array([[999, 999, 101, 102]], dtype=mx.int32)
+    mask = mx.array([[False, False, True, True]])
+
+    # IDs without padding tokens
+    ids_clean = mx.array([[0, 0, 101, 102]], dtype=mx.int32)
+
+    out_padded = ple(hidden, ids_padded, prev_ctx, cache=None, mask=mask)
+    out_clean = ple(hidden, ids_clean, prev_ctx, cache=None, mask=mask)
+
+    # Valid token outputs at indices 2 and 3 should match exactly
+    assert mx.allclose(out_padded[:, 2:], out_clean[:, 2:]).item()
+    # Padded token outputs at indices 0 and 1 are 0
+    assert float(out_padded[:, :2].abs().max().item()) == 0.0
+
+
+def test_loaded_weights_bytes_deduplicates_and_ignores_unused_adapters(tmp_path):
+    import json
+    from mtplx.server.openai import _loaded_weights_bytes_for_model_path
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    # Create real model shard 1 (1000 bytes) and shard 2 (2000 bytes)
+    shard1 = model_dir / "model-00001-of-00002.safetensors"
+    shard1.write_bytes(b"x" * 1000)
+    shard2 = model_dir / "model-00002-of-00002.safetensors"
+    shard2.write_bytes(b"y" * 2000)
+
+    # Create unused adapter file (5000 bytes)
+    adapter = model_dir / "adapter_model.safetensors"
+    adapter.write_bytes(b"z" * 5000)
+
+    # Create duplicate symlink to shard 1 (1000 bytes)
+    symlink = model_dir / "model-00001-symlink.safetensors"
+    symlink.symlink_to(shard1)
+
+    # Create index pointing only to shard1 and shard2
+    index = {
+        "weight_map": {
+            "model.embed.weight": "model-00001-of-00002.safetensors",
+            "model.layers.0.weight": "model-00002-of-00002.safetensors",
+        }
+    }
+    (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+
+    # _loaded_weights_bytes_for_model_path should equal 1000 + 2000 = 3000 bytes
+    loaded_bytes = _loaded_weights_bytes_for_model_path(model_dir)
+    assert loaded_bytes == 3000
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2626,6 +2626,65 @@ def test_loaded_weights_bytes_deduplicates_and_ignores_unused_adapters(tmp_path)
     assert loaded_bytes == 3000
 
 
+def test_attn_cache_extract_slices_to_active_offset():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    c = _AttnCache()
+    # Allocated buffer has 256 slots, but offset is only 16
+    c.keys = mx.ones((2, 2, 256, 32))
+    c.values = mx.ones((2, 2, 256, 32))
+    c.offset = 16
+    c.left_padding = mx.array([2, 4])
+
+    extracted = c.extract(0)
+    assert extracted.keys.shape == (1, 2, 16, 32)
+    assert extracted.values.shape == (1, 2, 16, 32)
+    assert extracted.offset == 16
+    assert int(extracted.left_padding[0].item()) == 2
+
+
+def test_attn_cache_and_indexer_extend_aligns_differing_histories_and_paddings():
+    from mtplx.models.qwen4_exp import _AttnCache, _IndexerCache
+
+    c1 = _AttnCache()
+    c1.keys = mx.ones((1, 2, 8, 32))
+    c1.values = mx.ones((1, 2, 8, 32))
+    c1.offset = 8
+    c1.left_padding = mx.array([2])
+    c1.indexer = _IndexerCache()
+    c1.indexer.update(mx.ones((1, 8, 64)))
+    c1.indexer.left_padding = c1.left_padding
+
+    c2 = _AttnCache()
+    c2.keys = mx.ones((1, 2, 4, 32)) * 2
+    c2.values = mx.ones((1, 2, 4, 32)) * 2
+    c2.offset = 4
+    c2.left_padding = mx.array([0])
+    c2.indexer = _IndexerCache()
+    c2.indexer.update(mx.ones((1, 4, 64)) * 2)
+    c2.indexer.left_padding = c2.left_padding
+
+    c1.extend(c2)
+
+    # Both rows aligned to max_L = 8
+    assert c1.keys.shape == (2, 2, 8, 32)
+    assert c1.values.shape == (2, 2, 8, 32)
+    assert c1.offset == 8
+    # c2 was padded on the left by 4, so its left_padding becomes 0 + 4 = 4
+    assert list(c1.left_padding.tolist()) == [2, 4]
+
+    # Row 1 (c2) should have 4 zeros prepended and then the 4 original tokens
+    assert float(c1.keys[1, :, :4, :].abs().max().item()) == 0.0
+    assert float(c1.keys[1, :, 4:, :].mean().item()) == 2.0
+
+    # Indexer buffer should also be aligned
+    assert c1.indexer.keys.shape == (2, 8, 64)
+    assert list(c1.indexer.left_padding.tolist()) == [2, 4]
+    assert float(c1.indexer.keys[1, :4, :].abs().max().item()) == 0.0
+    assert float(c1.indexer.keys[1, 4:, :].mean().item()) == 2.0
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -3211,6 +3211,46 @@ def test_mtp_weights_present_on_disk_unindexed_trunk_without_mtp_returns_false(t
     assert mtp_weights_present_on_disk(tmp_path, config) is True
 
 
+def test_loaded_weights_bytes_resolves_cached_and_remote_hf_refs(monkeypatch, tmp_path):
+    from mtplx.server.openai import _loaded_weights_bytes_for_model_path
+    from types import SimpleNamespace
+
+    # 1. Test resolving via cached_model_path / resolve_model_path
+    cached_dir = tmp_path / "cached_model"
+    cached_dir.mkdir()
+    (cached_dir / "model.safetensors").write_bytes(b"a" * 4000)
+    monkeypatch.setattr("mtplx.hf_loader.cached_model_path", lambda repo_id: cached_dir)
+
+    assert _loaded_weights_bytes_for_model_path("Qwen/Qwen4-Exp-72B-4bit") == 4000
+
+    # 2. Test deriving from remote HfApi inspection when not cached locally
+    non_existent = tmp_path / "non_existent"
+    monkeypatch.setattr("mtplx.hf_loader.cached_model_path", lambda repo_id: non_existent)
+    monkeypatch.setattr("mtplx.hf_loader.resolve_model_path", lambda repo_id: non_existent)
+
+    fake_siblings = [
+        SimpleNamespace(rfilename="model-00001-of-00002.safetensors", size=3000),
+        SimpleNamespace(rfilename="model-00002-of-00002.safetensors", size=5000),
+        SimpleNamespace(rfilename="mtp.safetensors", size=1000),
+        SimpleNamespace(rfilename="adapter_model.safetensors", size=9000),  # should be excluded
+        SimpleNamespace(rfilename="tokenizer.json", size=500),  # non-safetensors excluded
+    ]
+    fake_info = SimpleNamespace(siblings=fake_siblings)
+
+    class FakeHfApi:
+        def model_info(self, repo_id, files_metadata=True):
+            return fake_info
+
+    monkeypatch.setattr("huggingface_hub.HfApi", FakeHfApi)
+    monkeypatch.setattr(
+        "mtplx.artifacts._hf_download_json",
+        lambda repo_id, filename: (None, None, "not found"),
+    )
+
+    # 3000 + 5000 + 1000 = 9000 bytes
+    assert _loaded_weights_bytes_for_model_path("Qwen/Qwen4-Exp-72B-4bit") == 9000
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1004,6 +1004,127 @@ def test_qsa_indexer_cache_batch_protocol():
     assert a_extracted.indexer.keys.shape == (1, 12, 128)
 
 
+def test_avoid_double_filtering_qsa_indexer():
+    from mtplx.models.qwen4_exp import _AttnCache
+    from mtplx.qwen4_exp_mtp_patch import _install_indexer_aware_trim
+
+    a1 = _AttnCache()
+    a1.keys = mx.ones((1, 2, 8, 64))
+    a1.values = mx.ones((1, 2, 8, 64))
+    a1.offset = 8
+    a1.indexer.update(mx.ones((1, 8, 128)))
+
+    a2 = _AttnCache()
+    a2.keys = mx.full((1, 2, 8, 64), 2.0)
+    a2.values = mx.full((1, 2, 8, 64), 2.0)
+    a2.offset = 8
+    a2.indexer.update(mx.full((1, 8, 128), 2.0))
+
+    merged = _AttnCache.merge([a1, a2])
+    assert merged.indexer.batch_size == 2
+
+    # Filtering merged with index [1] must select row 1 and not fail with out-of-bounds
+    merged.filter(mx.array([1]))
+    assert merged.indexer.batch_size == 1
+    assert float(merged.indexer.keys[0, 0, 0].item()) == 2.0
+
+
+def test_mask_ple_updates_for_padded_batch_rows():
+    from mtplx.models.qwen4_exp import PLELayer, TextArgs
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache
+
+    args = TextArgs(
+        hidden_size=64,
+        ple_embed_dim=64,
+        ple_layer_ids=[1],
+        hc_count=2,
+        ngram_size=3,
+        ple_conv_kernel_size=4,
+    )
+    ple = PLELayer(args, ple_layer_index=0)
+    cache = Qwen4ExpRecurrentCache(4)
+
+    # Batch of 2: row 0 is padded (mask=False), row 1 is valid (mask=True)
+    mask = mx.array([[False], [True]])
+    hidden = mx.ones((2, 1, 64 * 2))
+    ids = mx.array([[0], [42]])
+    prev_ctx = mx.zeros((2, 2), dtype=mx.int32)
+
+    out = ple(hidden, ids, prev_ctx, cache, mask=mask)
+    # Row 0 output must be zero because it is masked
+    assert mx.all(out[0] == 0).item()
+    # Row 1 output must be non-zero
+    assert not mx.all(out[1] == 0).item()
+    # Convolution state for row 0 must remain zero
+    assert mx.all(cache[2][0] == 0).item()
+    # Convolution state for row 1 must be updated with valid tokens
+    assert not mx.all(cache[2][1] == 0).item()
+
+
+def test_exclude_padded_blocks_before_qsa_topk_selection():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
+
+    args = TextArgs(
+        hidden_size=128,
+        num_attention_heads=4,
+        head_dim=32,
+        indexer_n_heads=4,
+        indexer_head_dim=32,
+        indexer_compress_ratio=4,
+        indexer_budget=16,
+        rms_norm_eps=1e-6,
+    )
+    indexer = QSAIndexer(args)
+    indexer.block_topk = 2
+
+    # B=2, S=1.
+    # Total blocks = 6 (24 tokens).
+    # Row 0 has 16 padding tokens (left_padding=16 -> first 4 blocks 0,1,2,3 are padding).
+    # Row 1 has 0 padding tokens (left_padding=0).
+    B, S, H, D = 2, 1, 4, 32
+    n_blocks = 6
+    r = 4
+    kv_len = 24
+    q = mx.ones((B, S, H, D))
+    q_pos = mx.array([kv_len - 1])
+    pooled = mx.ones((B, n_blocks, D))
+
+    left_padding = mx.array([16, 0])
+    sel = indexer.select(q, q_pos, pooled, kv_len, left_padding=left_padding)
+
+    # For row 0, top-k blocks must ONLY be selected from non-padding blocks (index >= 4)
+    row0_toks = sel.token_idx[0, 0].tolist()
+    for idx, valid in zip(row0_toks, sel.valid[0, 0].tolist()):
+        if valid:
+            assert idx >= 16
+
+
+def test_qwen4_tuning_routes_through_batched_verifier(monkeypatch):
+    from mtplx.benchmarks.runners import mtp_depth_sweep
+    from mtplx.commands import public
+    from mtplx.server import openai
+
+    mock_run_sweep = MagicMock(return_value={"ok": True})
+    monkeypatch.setattr(mtp_depth_sweep, "run_mtp_depth_sweep", mock_run_sweep)
+    monkeypatch.setattr(openai, "apply_memory_caps_preflight", lambda **kwargs: {})
+
+    # Call _depth_sweep_native60 with a model named "Qwen/Qwen3.8-Flash-Next"
+    public._depth_sweep_native60(
+        model="Qwen/Qwen3.8-Flash-Next",
+        prompt_suite="dummy",
+        depths="1",
+        max_tokens=10,
+        limit=1,
+        seed=0,
+    )
+
+    assert mock_run_sweep.called
+    kwargs = mock_run_sweep.call_args.kwargs
+    assert kwargs.get("verify_strategy") == "batched"
+    assert kwargs.get("verify_core") == "stock"
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -2989,6 +2989,115 @@ def test_qwen4_exp_recurrent_cache_filter_rebases_padding():
     assert list(cache.left_padding.tolist()) == [0, 2]
 
 
+def test_qsa_indexer_rebases_positions_with_cache_padding():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
+
+    args = TextArgs(
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+    )
+    indexer = QSAIndexer(args)
+
+    # Row 0: no padding (left_padding=0), logical offset=8, physical pos=8
+    # Row 1: left_padding=4, logical offset=4, physical pos=8
+    B, S, H, D = 2, 1, 2, 16
+    q = mx.ones((B, S, H, D))
+    # q_pos contains logical positions: row 0 is 8, row 1 is 4
+    q_pos = mx.array([[8], [4]], dtype=mx.int32)
+    left_padding = mx.array([0, 4], dtype=mx.int32)
+    kv_len = 9  # Physical cache has 9 tokens (0..8)
+    n_blocks = kv_len // 4  # 2 blocks: 0..3 and 4..7
+    pooled = mx.ones((B, n_blocks, D))
+
+    sel = indexer.select(q, q_pos, pooled, kv_len, left_padding=left_padding)
+    assert sel is not None
+    # For row 1: physical pos is 4+4=8. Tail start should be block 2 (starts at 8).
+    # Token 8 should be valid and present in tail.
+    assert 8 in sel.token_idx[1, 0].tolist()
+    # Find position of token 8 in token_idx
+    idx_list = sel.token_idx[1, 0].tolist()
+    valid_list = sel.valid[1, 0].tolist()
+    pos_8 = idx_list.index(8)
+    assert valid_list[pos_8] is True
+
+
+def test_mtp_expected_key_set_accepts_prequantized_qwen4_exp_inventory():
+    from mtplx.artifacts import _mtp_expected_key_set
+    from mtplx.constants import EXPECTED_QWEN4_EXP_MTP_KEYS
+
+    config = {
+        "model_type": "qwen4_exp",
+        "mtp_num_hidden_layers": 1,
+        "mtplx_mtp_quantization": {"prequantized": True},
+    }
+
+    # Case 1: Prequantized config with observed aux leaves
+    observed_keys = tuple(
+        list(EXPECTED_QWEN4_EXP_MTP_KEYS)
+        + [
+            "mtp.layers.0.mlp.switch_mlp.down_proj.scales",
+            "mtp.layers.0.mlp.switch_mlp.down_proj.biases",
+        ]
+    )
+    expected, count, sidecar_format = _mtp_expected_key_set(config, keys=observed_keys)
+    assert sidecar_format == "prequantized-mlx-affine-qwen4-exp"
+    assert "mtp.layers.0.mlp.switch_mlp.down_proj.scales" in expected
+    assert "mtp.layers.0.mlp.switch_mlp.down_proj.biases" in expected
+    assert count == len(EXPECTED_QWEN4_EXP_MTP_KEYS) + 2
+
+    # Case 2: BF16 config and keys
+    bf16_config = {"model_type": "qwen4_exp", "mtp_num_hidden_layers": 1}
+    expected_bf16, count_bf16, format_bf16 = _mtp_expected_key_set(
+        bf16_config, keys=EXPECTED_QWEN4_EXP_MTP_KEYS
+    )
+    assert format_bf16 == "bf16-qwen4-exp"
+    assert count_bf16 == len(EXPECTED_QWEN4_EXP_MTP_KEYS)
+
+
+def test_attn_cache_state_handles_vector_offset_and_snapshot_cache():
+    from mtplx.cache_state import snapshot_cache
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    cache = _AttnCache()
+    cache.keys = mx.ones((2, 2, 16, 32))
+    cache.values = mx.ones((2, 2, 16, 32))
+    cache.offset = mx.array([8, 4], dtype=mx.int32)
+    cache.left_padding = mx.array([0, 4], dtype=mx.int32)
+    cache._idx = 8
+    cache.indexer.update(mx.ones((2, 8, 32)))
+
+    # Reading state on vector offset should not crash with ambiguity error
+    st = cache.state
+    assert len(st) == 5
+    k, v, off, lp, indexer_k = st
+    assert k.shape == (2, 2, 8, 32)
+    assert v.shape == (2, 2, 8, 32)
+    assert list(off.tolist()) == [8, 4]
+    assert list(lp.tolist()) == [0, 4]
+
+    # Test snapshot_cache on merged cache
+    snap = snapshot_cache([cache])
+    assert len(snap.states) == 1
+    snap_st = snap.states[0]
+    assert len(snap_st) == 5
+
+    # Test restoring state
+    fresh_cache = _AttnCache()
+    fresh_cache.state = snap_st
+    assert fresh_cache.keys.shape == (2, 2, 8, 32)
+    assert list(fresh_cache.offset.tolist()) == [8, 4]
+    assert list(fresh_cache.left_padding.tolist()) == [0, 4]
+    assert fresh_cache._idx == 8
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1737,13 +1737,13 @@ def test_attn_cache_filters_left_padding_and_lengths():
 
     # Extract
     c1_ext = c1.extract(0)
-    assert c1_ext.left_padding.shape[0] == 1
-    assert int(c1_ext.left_padding[0].item()) == 2
+    assert c1_ext.keys.shape == (1, 2, 6, 32)
+    assert c1_ext.offset == 6
+    assert c1_ext.left_padding is None
 
     # Extend
     c1_ext.extend(c2)
     assert c1_ext.left_padding.shape[0] == 2
-    assert list(c1_ext.left_padding.tolist()) == [2, 4]
 
 
 def test_metal_memory_caps_and_headroom_scale_with_small_models(monkeypatch, tmp_path):
@@ -2650,17 +2650,26 @@ def test_attn_cache_extract_slices_to_active_offset():
     from mtplx.models.qwen4_exp import _AttnCache
 
     c = _AttnCache()
-    # Allocated buffer has 256 slots, but offset is only 16
+    # Allocated buffer has 256 slots, active _idx is 16
     c.keys = mx.ones((2, 2, 256, 32))
     c.values = mx.ones((2, 2, 256, 32))
     c.offset = 16
+    c._idx = 16
     c.left_padding = mx.array([2, 4])
 
-    extracted = c.extract(0)
-    assert extracted.keys.shape == (1, 2, 16, 32)
-    assert extracted.values.shape == (1, 2, 16, 32)
-    assert extracted.offset == 16
-    assert int(extracted.left_padding[0].item()) == 2
+    extracted0 = c.extract(0)
+    # Row 0 padding is 2 -> slices 2:16, length 14
+    assert extracted0.keys.shape == (1, 2, 14, 32)
+    assert extracted0.values.shape == (1, 2, 14, 32)
+    assert extracted0.offset == 14
+    assert extracted0.left_padding is None
+
+    extracted1 = c.extract(1)
+    # Row 1 padding is 4 -> slices 4:16, length 12
+    assert extracted1.keys.shape == (1, 2, 12, 32)
+    assert extracted1.values.shape == (1, 2, 12, 32)
+    assert extracted1.offset == 12
+    assert extracted1.left_padding is None
 
 
 def test_attn_cache_and_indexer_extend_aligns_differing_histories_and_paddings():
@@ -3096,6 +3105,110 @@ def test_attn_cache_state_handles_vector_offset_and_snapshot_cache():
     assert list(fresh_cache.offset.tolist()) == [8, 4]
     assert list(fresh_cache.left_padding.tolist()) == [0, 4]
     assert fresh_cache._idx == 8
+
+
+def test_ple_context_handles_vector_offset_in_batch():
+    from mtplx.models.qwen4_exp import _build_ple_tail_context
+
+    B, S, ctx_len = 2, 1, 4
+    prev_ctx = mx.ones((B, ctx_len), dtype=mx.int32)
+    ids = mx.array([[10], [20]], dtype=mx.int32)
+    eos = 0
+    left_padding = mx.array([0, 2], dtype=mx.int32)
+    vector_offset = mx.array([8, 4], dtype=mx.int32)
+    conv_mask = mx.array([[True], [True]])
+
+    # Should not raise TypeError/ValueError when offset is a vector
+    tail = _build_ple_tail_context(
+        prev_ctx,
+        ids,
+        ctx_len,
+        eos,
+        left_padding=left_padding,
+        offset=vector_offset,
+        mask=conv_mask,
+    )
+    assert tail.shape == (2, ctx_len)
+
+
+def test_qwen4_mtp_key_set_normalizes_aliases():
+    from mtplx.artifacts import _inspect_mtp_tensors_from_keys
+
+    config = {
+        "model_type": "qwen4_exp",
+        "mtp_num_hidden_layers": 1,
+    }
+
+    # Raw unnormalized aliases
+    raw_keys = (
+        "mtp.eh_proj.weight",
+        "mtp.hyper_connection_mixer.hc_norm.weight",
+        "mtp.hyper_connection_mixer.input_mix_weight_down.weight",
+        "mtp.hyper_connection_mixer.input_mix_weight_up.weight",
+        "mtp.layers.0.attn_hyper_connection.block_inject_weight.weight",
+        "mtp.layers.0.attn_hyper_connection.hc_norm.weight",
+        "mtp.layers.0.attn_hyper_connection.input_mix_weight_down.weight",
+        "mtp.layers.0.attn_hyper_connection.input_mix_weight_up.weight",
+        "mtp.layers.0.mlp.gate.weight",
+        "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+        "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+        "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+        "mtp.layers.0.mlp.shared_expert_gate.weight",
+        "mtp.layers.0.mlp.experts.down_proj.weight",
+        "mtp.layers.0.mlp.experts.gate_up_proj.weight",
+        "mtp.layers.0.mlp_hyper_connection.block_inject_weight.weight",
+        "mtp.layers.0.mlp_hyper_connection.hc_norm.weight",
+        "mtp.layers.0.mlp_hyper_connection.input_mix_weight_down.weight",
+        "mtp.layers.0.mlp_hyper_connection.input_mix_weight_up.weight",
+        "mtp.layers.0.self_attn.k_layernorm.weight",
+        "mtp.layers.0.self_attn.k_proj.weight",
+        "mtp.layers.0.self_attn.o_proj.weight",
+        "mtp.layers.0.self_attn.q_layernorm.weight",
+        "mtp.layers.0.self_attn.q_proj.weight",
+        "mtp.layers.0.self_attn.v_proj.weight",
+        "mtp.enorm.weight",
+        "mtp.hnorm.weight",
+    )
+
+    inspection = _inspect_mtp_tensors_from_keys(
+        "mtp.safetensors",
+        config=config,
+        exists=True,
+        keys=raw_keys,
+    )
+    assert len(inspection.missing_expected_keys) == 0
+    assert len(inspection.extra_keys) == 0
+
+
+def test_mtp_weights_present_on_disk_unindexed_trunk_without_mtp_returns_false(tmp_path):
+    from mtplx.artifacts import mtp_weights_present_on_disk
+    import mlx.core as mx
+
+    # Write a direct unindexed model.safetensors with only trunk keys
+    trunk_path = tmp_path / "model.safetensors"
+    mx.save_safetensors(
+        str(trunk_path),
+        {"model.embed_tokens.weight": mx.zeros((16, 16))},
+    )
+
+    config = {
+        "model_type": "qwen4_exp",
+        "num_hidden_layers": 4,
+        "mtp_num_hidden_layers": 1,
+    }
+
+    # Should return False so loader takes AR fallback instead of raising
+    assert mtp_weights_present_on_disk(tmp_path, config) is False
+
+    # If MTP key is present in unindexed trunk -> returns True
+    mx.save_safetensors(
+        str(trunk_path),
+        {
+            "model.embed_tokens.weight": mx.zeros((16, 16)),
+            "mtp.fc_embedding.weight": mx.zeros((16, 16)),
+        },
+    )
+    assert mtp_weights_present_on_disk(tmp_path, config) is True
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -205,3 +205,158 @@ def test_qwen4_exp_ar_gate_requires_model_shards(tmp_path):
         model_dir=str(trunk_dir),
     )
     assert _passes_qwen4_exp_gate(inspection_trunk) is True
+
+
+def test_sparse_index_reuse_reset_on_rollback_and_cycle_start():
+    from mtplx.generation import _rollback_mtp_cache
+    from mtplx.qwen4_exp_mtp_patch import (
+        SparseIndexReuse,
+        _install_indexer_aware_trim,
+    )
+
+    class DummyIndexer:
+        def __init__(self):
+            self.token_budget = 2048
+            self.n_heads = 4
+            self.head_dim = 128
+
+        def __call__(self, x, rope, cache, offset: int):
+            return mx.zeros((1, 1, 1))
+
+    dummy_indexer = DummyIndexer()
+    wrapper = SparseIndexReuse(dummy_indexer)
+    wrapper.prev_keep = mx.zeros((1, 4, 128))
+
+    attn_cache = _AttnCache()
+    attn_cache.indexer = _IndexerCache()
+    attn_cache.indexer.update(mx.ones((1, 8, 128)))
+    attn_cache._sparse_index_reuse = wrapper
+    _install_indexer_aware_trim(attn_cache)
+
+    assert wrapper.prev_keep is not None
+    # 1. trim() resets prev_keep
+    attn_cache.trim(2)
+    assert wrapper.prev_keep is None
+
+    # 2. _rollback_mtp_cache resets prev_keep
+    wrapper.prev_keep = mx.zeros((1, 4, 128))
+    _rollback_mtp_cache([attn_cache], 0)
+    assert wrapper.prev_keep is None
+
+
+def test_flat_qwen4_exp_config_preserves_geometry():
+    flat_cfg = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 1024,
+        "num_hidden_layers": 16,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 2,
+        "head_dim": 128,
+        "num_experts": 64,
+        "num_experts_per_tok": 4,
+    }
+    args = ModelArgs.from_dict(flat_cfg)
+    assert args.text.hidden_size == 1024
+    assert args.text.num_hidden_layers == 16
+    assert args.text.num_attention_heads == 8
+    assert args.text.num_key_value_heads == 2
+    assert args.text.head_dim == 128
+    assert args.text.num_experts == 64
+    assert args.text.num_experts_per_tok == 4
+
+
+def test_ple_state_preserved_with_recurrent_cache():
+    from mtplx.models.qwen4_exp import PLELayer, TextArgs
+    from mtplx.qwen4_exp_mtp_patch import Qwen4ExpRecurrentCache
+
+    args = TextArgs(
+        hidden_size=256,
+        ple_embed_dim=256,
+        ple_layer_ids=[1],
+        hc_count=2,
+        ngram_size=3,
+        ple_conv_kernel_size=4,
+    )
+    ple = PLELayer(args, ple_layer_index=0)
+    recurrent_cache = Qwen4ExpRecurrentCache(4)
+    assert recurrent_cache[2] is None
+    assert len(recurrent_cache) == 4
+
+    x = mx.ones((1, 1, 256 * 2))
+    out = ple._short_conv(x, recurrent_cache)
+    assert out is not None
+    assert recurrent_cache[2] is not None
+    assert recurrent_cache[2].shape == (1, 9, 256 * 2)
+
+
+def test_mtp_module_quantization_from_contract(tmp_path):
+    from types import SimpleNamespace
+    import mlx.nn as nn
+    from mtplx.models.qwen4_exp import TextArgs
+    from mtplx.mtp_patch import MTPContract
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 256,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 64,
+        "mtp_num_hidden_layers": 1,
+        "hc_count": 2,
+        "hc_lowrank": 128,
+    }
+
+    class DummyLanguageModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = SimpleNamespace(
+                layers=[
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="linear_attention"),
+                    SimpleNamespace(layer_type="full_attention"),
+                ],
+                embed_tokens=nn.Embedding(100, 256),
+            )
+            self.args = TextArgs(
+                hidden_size=256,
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                head_dim=64,
+                hc_count=2,
+                hc_lowrank=128,
+                rope_parameters={},
+                rope_theta=10000.0,
+                partial_rotary_factor=0.25,
+                layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+                full_attention_interval=4,
+            )
+
+        def make_cache(self):
+            return [None] * 4
+
+    model = DummyLanguageModel()
+    contract = MTPContract(
+        mtp_quant_bits=4,
+        mtp_quant_group_size=64,
+        mtp_quant_policy="all",
+    )
+
+    success = inject_qwen4_exp_mtp_support(
+        model,
+        str(tmp_path),
+        config,
+        contract=contract,
+        allow_random_init=True,
+    )
+    assert success is True
+    assert hasattr(model, "mtp")
+    # Check that linear layers in MTP are quantized
+    quantized_layers = [
+        m for _, m in model.mtp.named_modules() if isinstance(m, nn.QuantizedLinear)
+    ]
+    assert len(quantized_layers) > 0
+

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -584,4 +584,44 @@ def test_avoid_double_shifting_mlx_mtp_norms(tmp_path):
     assert float(loaded["pre_fc_norm_embedding.weight"].mean().item()) == 1.0
 
 
+def test_short_cache_and_custom_cache_slot_resilience():
+    from mtplx.models.qwen4_exp import GatedDeltaNet, PLELayer, TextArgs
+
+    args = TextArgs(
+        hidden_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=32,
+        linear_num_key_heads=4,
+        linear_num_value_heads=4,
+        linear_key_head_dim=32,
+        linear_value_head_dim=32,
+        linear_conv_kernel_dim=4,
+        hc_count=2,
+        hc_lowrank=64,
+        ple_embed_dim=128,
+        ple_layer_ids=[1],
+        ngram_size=3,
+        ple_conv_kernel_size=4,
+        layer_types=["linear_attention", "linear_attention"],
+    )
+
+    # 1. Test GatedDeltaNet with a plain 2-element list (no .advance method)
+    gdn = GatedDeltaNet(args)
+    plain_list_cache = [None, None]
+    x = mx.ones((1, 1, 128))
+    out = gdn(x, mask=None, cache=plain_list_cache)
+    assert out is not None
+    assert plain_list_cache[0] is not None
+    assert plain_list_cache[1] is not None
+
+    # 2. Test PLELayer with a 2-element list (shorter than index 2)
+    ple = PLELayer(args, ple_layer_index=0)
+    x_ple = mx.ones((1, 1, 256))
+    out_ple = ple._short_conv(x_ple, plain_list_cache)
+    assert out_ple is not None
+
+
+
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1238,6 +1238,128 @@ def test_tensor_offset_paged_cache_update_and_fetch_contract():
     assert v.shape[1] == 2
 
 
+def test_native_attn_cache_update_and_fetch_returns_2tuple():
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    attn_cache = _AttnCache()
+    attn_cache.indexer.update(mx.ones((1, 8, 128)))
+
+    # Initial update_and_fetch
+    k1 = mx.ones((1, 2, 4, 64))
+    v1 = mx.ones((1, 2, 4, 64))
+    res = attn_cache.update_and_fetch(k1, v1)
+    assert isinstance(res, tuple)
+    assert len(res) == 2
+    k, v = res
+    assert k.shape == (1, 2, 4, 64)
+    assert v.shape == (1, 2, 4, 64)
+
+    # State property retains indexer keys (3 elements for snapshotting)
+    assert len(attn_cache.state) == 3
+
+    # Subsequent update_and_fetch
+    k2 = mx.ones((1, 2, 1, 64))
+    v2 = mx.ones((1, 2, 1, 64))
+    k_out, v_out = attn_cache.update_and_fetch(k2, v2)
+    assert k_out.shape == (1, 2, 5, 64)
+    assert v_out.shape == (1, 2, 5, 64)
+
+
+def test_exclude_left_padding_from_ple_tail_context():
+    from mtplx.models.qwen4_exp import _build_ple_tail_context
+
+    ctx_len = 3
+    eos = 151643
+    prev_ctx = mx.full((2, ctx_len), eos, mx.int32)
+    # Row 0 has 3 padding tokens (pad=999) and 1 valid token (42)
+    # Row 1 has 0 padding tokens and 4 valid tokens (10, 20, 30, 40)
+    ids = mx.array([[999, 999, 999, 42], [10, 20, 30, 40]], dtype=mx.int32)
+    left_padding = mx.array([3, 0], dtype=mx.int32)
+
+    tail = _build_ple_tail_context(prev_ctx, ids, ctx_len, eos, left_padding)
+    assert tail.shape == (2, ctx_len)
+
+    # Row 0: valid token is 42, preceding 2 tokens are filled with EOS (151643)
+    row0 = tail[0].tolist()
+    assert row0 == [eos, eos, 42]
+    assert 999 not in row0
+
+    # Row 1: valid tokens are 10, 20, 30, 40 -> last 3 are [20, 30, 40]
+    row1 = tail[1].tolist()
+    assert row1 == [20, 30, 40]
+
+
+def test_embedded_mtp_tensors_outside_module_tree_and_consumed():
+    from mlx.utils import tree_flatten
+    from mtplx.models.qwen4_exp import Model, ModelArgs, TextArgs
+    from mtplx.qwen4_exp_mtp_patch import inject_qwen4_exp_mtp_support
+
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "hc_count": 2,
+        "hc_lowrank": 64,
+        "rope_parameters": {},
+        "layer_types": ["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        "full_attention_interval": 4,
+        "vocab_size": 50,
+        "mtp_num_hidden_layers": 1,
+    }
+    args = ModelArgs.from_dict(config)
+    model = Model(args)
+
+    # Sanitize weights containing mtp.* keys
+    raw_weights = {
+        "model.embed_tokens.weight": mx.zeros((50, 128)),
+        "mtp.layers.0.linear_attn.in_proj.weight": mx.zeros((256, 128)),
+    }
+    trunk_weights = model.sanitize(raw_weights)
+    assert "mtp.layers.0.linear_attn.in_proj.weight" not in trunk_weights
+
+    # Ensure mtp_weights are NOT registered in nn.Module parameters
+    param_dict = dict(tree_flatten(model.parameters()))
+    assert not any(k.startswith("_mtp_weights") or k.startswith("mtp_weights") for k in param_dict)
+
+    # Side-channel property returns the tensors
+    assert "mtp.layers.0.linear_attn.in_proj.weight" in model.mtp_weights
+
+    # Injection consumes embedded tensors and clears the side-channel
+    injected = inject_qwen4_exp_mtp_support(model, None, config=config, allow_random_init=True)
+    assert injected
+    assert len(model._mtp_weights) == 0
+
+
+def test_temperature_scaling_in_sampling_and_verification():
+    from mtplx.qwen4_exp_mtp_patch import _softmax, sample_logits_row, verify_draft_token
+
+    logits = mx.array([1.0, 2.0, 3.0])
+    p_t1 = _softmax(logits, temperature=1.0)
+    p_cold = _softmax(logits, temperature=0.5)
+    p_hot = _softmax(logits, temperature=2.0)
+
+    # Colder temperature concentrates probability mass on the argmax
+    assert p_cold[2] > p_t1[2]
+    # Hotter temperature flattens distribution
+    assert p_hot[2] < p_t1[2]
+
+    # sample_logits_row applies temperature
+    rng = MagicMock()
+    rng.choice.return_value = 2
+    tok, q = sample_logits_row(logits, temperature=0.5, rng=rng)
+    assert tok == 2
+    assert q[2] == p_cold[2]
+
+    # verify_draft_token applies temperature
+    rng.random.return_value = 0.5
+    decision = verify_draft_token(logits, q, 2, temperature=0.5, rng=rng)
+    assert decision.accepted
+
+
+
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import math
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -621,6 +622,155 @@ def test_short_cache_and_custom_cache_slot_resilience():
     x_ple = mx.ones((1, 1, 256))
     out_ple = ple._short_conv(x_ple, plain_list_cache)
     assert out_ple is not None
+
+
+def test_qsa_indexer_keys_preserved_in_cache_snapshots():
+    from mtplx.cache_state import (
+        BlockOwnedKVCache,
+        TailOwnedKVCache,
+        VllmMetalPagedKVCache,
+        restore_cache,
+        snapshot_cache,
+        snapshot_cache_lazy_hybrid,
+    )
+    from mtplx.models.qwen4_exp import _AttnCache
+
+    # 1. _AttnCache snapshot and restore
+    attn_cache = _AttnCache()
+    attn_cache.indexer.update(mx.ones((1, 8, 128)))
+    attn_cache.keys = mx.zeros((1, 2, 8, 64))
+    attn_cache.values = mx.zeros((1, 2, 8, 64))
+    attn_cache.offset = 8
+
+    snap = snapshot_cache([attn_cache])
+    assert len(snap.states[0]) == 3
+    assert snap.states[0][2] is not None
+    assert snap.states[0][2].shape == (1, 8, 128)
+
+    fresh_attn = _AttnCache()
+    assert fresh_attn.indexer.keys is None
+    restore_cache([fresh_attn], snap)
+    assert fresh_attn.indexer.keys is not None
+    assert fresh_attn.indexer.keys.shape == (1, 8, 128)
+    assert fresh_attn.indexer._len == 8
+
+    # 2. Lazy hybrid snapshot with _AttnCache
+    lazy_snap = snapshot_cache_lazy_hybrid([attn_cache])
+    fresh_lazy = _AttnCache()
+    restore_cache([fresh_lazy], lazy_snap)
+    assert fresh_lazy.indexer.keys is not None
+    assert fresh_lazy.indexer.keys.shape == (1, 8, 128)
+
+    # 3. Paged cache with indexer
+    paged = VllmMetalPagedKVCache.from_cache(attn_cache, block_size=16, num_blocks=4)
+    paged.key_cache = mx.zeros((4, 16, 2, 64))
+    paged.value_cache = mx.zeros((4, 16, 2, 64))
+    paged.offset = 8
+    paged_snap = snapshot_cache([paged])
+    assert len(paged_snap.states[0]) == 3
+    assert paged_snap.states[0][2] is not None
+    assert paged_snap.states[0][2].shape == (1, 8, 128)
+
+    fresh_paged = VllmMetalPagedKVCache.from_cache(attn_cache, block_size=16, num_blocks=4)
+    fresh_paged.indexer.keys = None
+    restore_cache([fresh_paged], paged_snap)
+    assert fresh_paged.indexer.keys is not None
+    assert fresh_paged.indexer.keys.shape == (1, 8, 128)
+
+
+def test_honor_qwen4_exp_declared_d1_default_in_server():
+    from pydantic import BaseModel
+
+    class DummyRequest(BaseModel):
+        pass
+
+    # 1. Unspecified depth: honors Qwen4 descriptor default (D1)
+    args = openai.parse_args(["--model", "Qwen/Qwen3.8-Flash-Next"])
+    assert args._explicit_depth is False
+
+    state = SimpleNamespace(
+        args=args,
+        backend_descriptor=descriptor_for_backend_id("qwen4_exp"),
+        runtime=SimpleNamespace(model=None),
+    )
+    req = DummyRequest()
+    depth = openai._request_depth_for_generation(state, req, generation_mode="mtp")
+    assert depth == 1
+
+    # 2. Explicit --depth 2 on CLI: honors user flag
+    args_explicit = openai.parse_args(["--model", "Qwen/Qwen3.8-Flash-Next", "--depth", "2"])
+    assert args_explicit._explicit_depth is True
+
+    state_explicit = SimpleNamespace(
+        args=args_explicit,
+        backend_descriptor=descriptor_for_backend_id("qwen4_exp"),
+        runtime=SimpleNamespace(model=None),
+    )
+    depth_explicit = openai._request_depth_for_generation(state_explicit, req, generation_mode="mtp")
+    assert depth_explicit == 2
+
+
+def test_raw_hf_qwen4_exp_trunk_norm_gains_converted():
+    from mtplx.models.qwen4_exp import sanitize
+
+    # 1. Raw HF zero-centered Gemma norms (mean around 0.0) -> converted (+1.0)
+    raw_hf_weights = {
+        "model.embed_tokens.weight": mx.zeros((100, 128)),
+        "model.layers.0.self_attn.q_norm.weight": mx.zeros((32,)),
+        "model.layers.0.self_attn.k_norm.weight": mx.zeros((32,)),
+        "model.layers.0.linear_attn.norm.weight": mx.zeros((128,)),
+        "model.layers.0.attn_hyper_connection.hc_norm.weight": mx.zeros((256,)),
+        "model.hyper_connection_mixer.hc_norm.weight": mx.zeros((256,)),
+    }
+    sanitized = sanitize(raw_hf_weights)
+    assert float(sanitized["model.layers.0.self_attn.q_norm.weight"].mean().item()) == 1.0
+    assert float(sanitized["model.layers.0.self_attn.k_norm.weight"].mean().item()) == 1.0
+    assert float(sanitized["model.layers.0.linear_attn.norm.weight"].mean().item()) == 1.0
+    assert float(sanitized["model.layers.0.attn_hyper_connection.hc_norm.weight"].mean().item()) == 1.0
+    assert float(sanitized["model.hyper_connection_mixer.hc_norm.weight"].mean().item()) == 1.0
+
+    # 2. Already converted MLX norms (mean around 1.0) -> not double-shifted
+    mlx_weights = {
+        "model.embed_tokens.weight": mx.zeros((100, 128)),
+        "model.layers.0.self_attn.q_norm.weight": mx.ones((32,)),
+        "model.layers.0.self_attn.k_norm.weight": mx.ones((32,)),
+        "model.layers.0.linear_attn.norm.weight": mx.ones((128,)),
+    }
+    sanitized_mlx = sanitize(mlx_weights)
+    assert float(sanitized_mlx["model.layers.0.self_attn.q_norm.weight"].mean().item()) == 1.0
+    assert float(sanitized_mlx["model.layers.0.linear_attn.norm.weight"].mean().item()) == 1.0
+
+
+def test_rope_scaling_normalized_into_rope_parameters():
+    from mtplx.models.qwen4_exp import Model, ModelArgs, TextArgs
+
+    # 1. Config using rope_scaling dictionary with type="yarn"
+    config = {
+        "model_type": "qwen4_exp",
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 50,
+        "rope_scaling": {
+            "type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+    }
+
+    args = ModelArgs.from_dict(config)
+    assert args.text.rope_parameters is not None
+    assert args.text.rope_parameters.get("rope_type") == "yarn"
+    assert float(args.text.rope_parameters.get("factor")) == 4.0
+
+    model = Model(args)
+    # Model's rotary embedding must have applied Yarn scaling (mscale > 1.0 for factor=4.0)
+    assert model.model.rope.mscale > 1.0
+    assert abs(model.model.rope.mscale - (0.1 * math.log(4.0) + 1.0)) < 1e-4
 
 
 

--- a/tests/test_qwen4_exp_review_fixes.py
+++ b/tests/test_qwen4_exp_review_fixes.py
@@ -1384,7 +1384,7 @@ def test_moe_routing_policy_norm_topk_and_scaling_factor():
     assert out.shape == (1, 2, 64)
 
 
-def test_qsa_indexer_excludes_partially_padded_blocks():
+def test_qsa_indexer_admits_partially_padded_blocks_with_per_token_mask():
     from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
 
     args = TextArgs(
@@ -1404,11 +1404,11 @@ def test_qsa_indexer_excludes_partially_padded_blocks():
     pooled = mx.ones((1, 3, 32))  # 3 blocks: block 0 (0..3), block 1 (4..7), block 2 (8..11)
 
     sel = indexer.select(q, q_pos, pooled, kv_len=12, left_padding=left_padding)
-    # Block 0 starts at 0 < 3 (padding), so valid_block for block 0 is False.
-    # Selected top-k block should be block 1 (tokens 4..7), NOT block 0.
+    # Block 0 ends at 4 > 3, so it is admitted.
     selected_block_tokens = sel.token_idx[0, 0, :4].tolist()
-    assert selected_block_tokens == [4, 5, 6, 7]
-    assert sel.valid[0, 0, :4].tolist() == [True, True, True, True]
+    assert selected_block_tokens == [0, 1, 2, 3]
+    # Tokens 0, 1, 2 are pad tokens (< 3), token 3 is valid (>= 3)
+    assert sel.valid[0, 0, :4].tolist() == [False, False, False, True]
 
 
 def test_preserve_conv_state_across_masked_timesteps():
@@ -2148,6 +2148,126 @@ def test_qwen4_exp_sanitize_remaps_conditional_generation_prefixes():
     assert "visual.conv.weight" not in sanitized
     assert not any(k.startswith("model.language_model.") for k in sanitized)
     assert not any(k.startswith("language_model.") for k in sanitized)
+
+
+def test_qsa_indexer_select_admits_partially_padded_blocks_with_correct_mask():
+    from mtplx.models.qwen4_exp import QSAIndexer, TextArgs
+
+    args = TextArgs(
+        hidden_size=32,
+        indexer_head_dim=16,
+        indexer_n_heads=2,
+        indexer_compress_ratio=4,
+        indexer_budget=8,
+    )
+    indexer = QSAIndexer(args)
+    indexer.block_topk = 2
+    # 2 blocks of 4 tokens = 8 tokens. left_padding = 5 (tokens 0..4 are pad, 5..7 are real)
+    pooled = mx.ones((1, 2, 16))
+    q = mx.ones((1, 1, 2, 16))
+    q_pos = mx.array([7])
+    left_padding = mx.array([5])
+
+    sel = indexer.select(
+        q=q,
+        q_pos=q_pos,
+        pooled=pooled,
+        kv_len=8,
+        left_padding=left_padding,
+    )
+    # Block 1 should be selected since its end (8) > left_padding (5)
+    # In token_idx: token 4 must be masked as invalid, while tokens 5, 6, 7 are valid
+    tok_list = sel.token_idx.flatten().tolist()
+    val_list = sel.valid.flatten().tolist()
+    valid_tokens = [tok for tok, v in zip(tok_list, val_list) if v]
+    assert len(valid_tokens) > 0
+    assert all(t >= 5 for t in valid_tokens)
+
+
+def test_ple_tail_context_updates_during_decode_steps():
+    from mtplx.models.qwen4_exp import _build_ple_tail_context
+
+    ctx_len = 3
+    eos = 0
+    # Initial prefill with prompt of length 6, left_padding = 2
+    prompt_ids = mx.array([[eos, eos, 10, 11, 12, 13]])
+    left_padding = mx.array([2])
+    prev_ctx = mx.array([[eos, eos, eos]])
+
+    tail_prefill = _build_ple_tail_context(
+        prev_ctx,
+        prompt_ids,
+        ctx_len=ctx_len,
+        eos=eos,
+        left_padding=left_padding,
+        offset=0,
+    )
+    # Valid tokens are [10, 11, 12, 13], last 3 are [11, 12, 13]
+    assert tail_prefill.tolist() == [[11, 12, 13]]
+
+    # Step 1 decode (offset = 6, ids = [[14]])
+    decode_ids = mx.array([[14]])
+    tail_step1 = _build_ple_tail_context(
+        tail_prefill,
+        decode_ids,
+        ctx_len=ctx_len,
+        eos=eos,
+        left_padding=left_padding,
+        offset=6,
+    )
+    assert tail_step1.tolist() == [[12, 13, 14]]
+
+
+def test_passes_qwen4_exp_gate_supports_hf_remote_inspections():
+    from types import SimpleNamespace
+    from mtplx.backends.registry import _passes_qwen4_exp_gate, _passes_mlx_lm_ar_gate
+
+    hf_inspection = SimpleNamespace(
+        source="hf",
+        model_dir="Qwen/Qwen3.8-Flash-Next-4bit",
+        model_type="qwen4_exp",
+        architecture="Qwen4ExpForConditionalGeneration",
+        model_files=("model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"),
+    )
+    assert _passes_qwen4_exp_gate(hf_inspection) is True
+    assert _passes_mlx_lm_ar_gate(hf_inspection) is True
+
+
+def test_resolve_context_window_reads_original_max_position_from_rope_scaling(tmp_path):
+    import json
+    from mtplx.server.openai import _resolve_context_window
+
+    config_data = {
+        "max_position_embeddings": 262144,
+        "rope_scaling": {
+            "factor": 4.0,
+            "original_max_position_embeddings": 65536,
+            "type": "yarn",
+        },
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data))
+
+    ctx = _resolve_context_window(None, str(tmp_path))
+    assert ctx == 262144
+
+
+def test_onboarding_scan_detects_model_mtp_head_safetensors(tmp_path):
+    from mtplx.ui.onboarding import _scan_mtp_sidecar_exists
+
+    mtp_head_file = tmp_path / "model-mtp-head.safetensors"
+    mtp_head_file.write_bytes(b"dummy")
+
+    assert _scan_mtp_sidecar_exists(tmp_path, {}) is True
+
+
+def test_is_qwen4_exp_config_recognizes_architecture_aliases():
+    from mtplx.qwen4_exp_mtp_patch import is_qwen4_exp_config
+
+    assert is_qwen4_exp_config({"architectures": ["Qwen4ExpForConditionalGeneration"]}) is True
+    assert is_qwen4_exp_config({"architectures": ["Qwen4ExpForCausalLM"]}) is True
+    assert is_qwen4_exp_config({"text_config": {"architectures": ["Qwen4ExpForConditionalGeneration"]}}) is True
+    assert is_qwen4_exp_config({"architectures": ["LlamaForCausalLM"]}) is False
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "mtplx"
-version = "2.5.4"
+version = "2.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- **Architecture**: Adds full native support for `qwen4_exp` (`Qwen3.8-Flash-Next`) combining Gated DeltaNet (GDN), Query-Selected Attention (QSA), MoE with fine-grained routing, Per-Layer Embeddings (PLE), hyper-connections, and Yarn RoPE.
- **Native MTP & Instant Rollback**: Assembles the native MTP draft head (`vLLM residual_linear_shared` structure) with zero-replay instant GDN/KV state rollback across rejection positions.
- **Optimized Long-Context & Prefill**: Replaces dense QSA mask materialization with selective gather and GQA head-group broadcasting to eliminate memory spikes during prefill.
- **Compilation & Memory Safety**: Adds opt-in compiled single-token decode runners stored directly on model instances, wired Metal memory ceilings, and 1M context resolution with dynamic RoPE scaling.

our 1m context length decode is ~30tok/sec using https://huggingface.co/macmacmacmac/Qwen3.8-Flash-Next-MLX-4bit-MTP


## Test plan
- [x] Run GDN blocked prefill eligibility and step-parity unit tests (`tests/test_qwen4_exp_gdn_blocked_prefill.py`).
- [x] Run QSA sparse prefill budget gather and dense mask equivalence tests (`tests/test_qwen4_exp_qsa_sparse_prefill.py`).
- [x] Run attention split conformance unit tests (`tests/test_attention_split.py`).
- [x] Run Metal memory caps verification tests (`tests/test_metal_memory_caps.py`).