### PR TITLE
fix(anthropic): input_tokens must exclude cache-read tokens in /v1/messages usage

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -4759,14 +4759,22 @@ def _anthropic_usage_from_openai_usage(usage: Any) -> dict[str, int]:
     """
 
     data = usage if isinstance(usage, dict) else {}
+    prompt_tokens = max(0, int(data.get("prompt_tokens") or 0))
+    # OpenAI usage.prompt_tokens is the GRAND TOTAL and prompt_tokens_details.cached_tokens is a
+    # SUBSET of it. Anthropic's input_tokens and cache_read_input_tokens are DISJOINT
+    # (total_input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens). Copying
+    # prompt_tokens straight into input_tokens while also reporting cache_read_input_tokens
+    # double-counts the cached prefix on every hit, so clients that sum the disjoint fields — Claude
+    # Code / Pi context and auto-compaction math — overcount by the prefix size and compact
+    # prematurely. Subtract the cached prefix; clamp defensively against malformed upstream usage.
+    cached_tokens = int((data.get("prompt_tokens_details") or {}).get("cached_tokens") or 0)
+    cached_tokens = min(max(0, cached_tokens), prompt_tokens)
     return {
-        "input_tokens": int(data.get("prompt_tokens") or 0),
+        "input_tokens": prompt_tokens - cached_tokens,
         "output_tokens": int(data.get("completion_tokens") or 0),
         # Anthropic-native mirror of the session-cache prefix hit
         # (#121/#144); Claude Code and Pi read this field directly.
-        "cache_read_input_tokens": int(
-            (data.get("prompt_tokens_details") or {}).get("cached_tokens") or 0
-        ),
+        "cache_read_input_tokens": cached_tokens,
     }
 
 

--- a/tests/test_openai_bridge.py
+++ b/tests/test_openai_bridge.py
@@ -28,6 +28,7 @@ from mtplx.server.openai import (
     _record_stream_cancellation_metric,
     _anthropic_stream_from_openai_sse,
     _anthropic_to_chat_request,
+    _anthropic_usage_from_openai_usage,
     _IncrementalTokenDecoder,
     _StreamCancelled,
     _ThinkingContentStreamSplitter,
@@ -2665,3 +2666,36 @@ def test_marathon_postcommit_protection_env_resolution(monkeypatch):
     monkeypatch.setenv("MTPLX_POSTCOMMIT_MARATHON_WAIT_S", "-3")
     assert _marathon_postcommit_protect_tokens() == 0
     assert _marathon_postcommit_wait_s() == 30.0
+
+
+def test_anthropic_usage_excludes_cache_read_from_input_tokens():
+    # OpenAI prompt_tokens is the grand total (cached is a subset); Anthropic input_tokens and
+    # cache_read_input_tokens are disjoint. On a prefix-cache hit, input_tokens must be the
+    # non-cached remainder so Claude Code / Pi context + auto-compaction math does not double-count.
+    usage = {
+        "prompt_tokens": 44202,
+        "completion_tokens": 128,
+        "prompt_tokens_details": {"cached_tokens": 42154},
+    }
+    out = _anthropic_usage_from_openai_usage(usage)
+    assert out["cache_read_input_tokens"] == 42154
+    assert out["input_tokens"] == 44202 - 42154  # 2048, not the full 44202
+    assert out["output_tokens"] == 128
+    # disjoint Anthropic fields reconstruct the OpenAI grand total
+    assert out["input_tokens"] + out["cache_read_input_tokens"] == usage["prompt_tokens"]
+
+
+def test_anthropic_usage_no_cache_hit_passes_prompt_through():
+    out = _anthropic_usage_from_openai_usage(
+        {"prompt_tokens": 1000, "completion_tokens": 10}
+    )
+    assert out["input_tokens"] == 1000
+    assert out["cache_read_input_tokens"] == 0
+
+
+def test_anthropic_usage_clamps_cached_over_prompt():
+    out = _anthropic_usage_from_openai_usage(
+        {"prompt_tokens": 100, "prompt_tokens_details": {"cached_tokens": 999}}
+    )
+    assert out["input_tokens"] == 0
+    assert out["cache_read_input_tokens"] == 100


### PR DESCRIPTION
## Summary

`_anthropic_usage_from_openai_usage` (in `mtplx/server/openai.py`) copies OpenAI `usage.prompt_tokens` straight into Anthropic `input_tokens` while also reporting `cache_read_input_tokens` from `prompt_tokens_details.cached_tokens`.

In the OpenAI schema `prompt_tokens` is the **grand total** and `cached_tokens` is a **subset** of it. In the Anthropic schema `input_tokens` and `cache_read_input_tokens` are **disjoint** — `total_input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens`. Per the [prompt-caching docs](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching), `input_tokens` is "the number of input tokens which were not read from or used to create a cache." So copying the total into `input_tokens` **double-counts the cached prefix on every cache hit**.

Clients that sum the disjoint Anthropic fields — notably Claude Code / Pi for context-window and auto-compaction math — then overcount context by the cached-prefix size, causing **premature compaction** and inflated token/billing displays. Both streaming and non-streaming `/v1/messages` are affected (the translator feeds the non-streaming response and the streamed `message_delta` usage alike). The OpenAI `/v1/chat/completions` endpoint is intentionally left unchanged — its `prompt_tokens`-includes-cached shape is the correct OpenAI contract.

**Fix:** report `input_tokens = prompt_tokens - cached_tokens` and `cache_read_input_tokens = cached_tokens`, with a defensive `cached = min(cached, prompt)` clamp against malformed upstream usage. `cache_creation_input_tokens` remains unemitted (a local prefix cache has no separate write accounting; clients read 0); `/v1/messages/count_tokens` is unaffected (no cache breakpoints).

## Verification

Added three focused unit tests to `tests/test_openai_bridge.py`:
- **cache hit** → `input_tokens` is the non-cached remainder, and `input_tokens + cache_read_input_tokens == prompt_tokens`
- **no cache** → `prompt_tokens` passes through unchanged
- **malformed `cached > prompt`** → clamped

```
$ python -m pytest tests/test_openai_bridge.py -k anthropic_usage -q
...                                                                      [100%]
3 passed
```

Real-world symptom: with a large restored prefix (44,202-token prompt, 42,154 cached), stock `input_tokens` was `44202`; Claude Code summed the disjoint fields to ~86k and auto-compacted prematurely. With the fix it reports `input_tokens=2048`.

I did not run the full CONTRIBUTING KPI / `python -m build` / `fresh_venv_smoke.sh` gate locally — this is a pure usage-arithmetic change that touches no decode/prefill path, and the machine was mid-benchmark. Happy to add whatever CI flags.

## Benchmark Evidence

N/A — no runtime/throughput path is changed (usage-accounting only).
