### PR TITLE
feat(qsa): vendored Steel sparse-GQA prefill consumer for M3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -39,3 +39,11 @@ licensed under the Apache License 2.0. See mtplx/nax_verify.py for details.
 This product includes the Apache-2.0 licensed MLX implementation for
 Laguna-S-2.1 from PipeNetwork, Copyright 2026 PipeNetwork, under
 mtplx/models/laguna.py.
+
+This product includes the Apache-2.0 licensed Qwen4 QSA sparse-GQA Steel
+Metal attention kernel from oMLX (https://github.com/jundot/omlx), PR #3244,
+revision dc312e6e905e03d21ef0c4a86289cbfa2cf857cc, Copyright 2026 OpenAI,
+vendored under native_extensions/qsa_kernels. Its 128-bit K/V staging pattern
+is adapted from mlx-serve's MIT licensed msv_attn_p256 kernel, Copyright 2026
+David Dalcu. See native_extensions/qsa_kernels/mtplx_qsa_kernels/NOTICE for
+the full provenance, the list of MTPLX modifications, and the license set.

--- a/mtplx/kernels/qsa_prefill_direct.py
+++ b/mtplx/kernels/qsa_prefill_direct.py
@@ -1,0 +1,848 @@
+"""Direct Steel sparse-GQA attention consumer for Qwen4Exp QSA prefill.
+
+This is the third consumer of the indexer's per-query ``block_ids`` /
+``block_valid`` contract, sitting between the Metal 4 MPP flash kernel
+(:mod:`mtplx.kernels.qsa_prefill_flash`, M4/M5 only) and the portable gather
+tier.  It dispatches the vendored oMLX Steel MMA kernel
+(``native_extensions/qsa_kernels``, Apache-2.0, oMLX PR #3244) which streams
+the selected four-token blocks straight out of the KV cache: no gathered
+``[S, selected, Hkv, D]`` tensor and no dense ``[S, T]`` mask.  It is the fast
+lane for M3-class GPUs, which have no G17 tensor units and therefore can never
+take the MPP path.
+
+Three properties make this module safe to have installed:
+
+* **Optional.** A missing or unloadable native extension leaves the import
+  green; :func:`qsa_prefill_direct_supported` simply returns ``False`` and the
+  model routes to gather/dense.
+* **Fail-closed, not fail-quiet.** Static unsupported geometry returns
+  ``False`` before anything is added to the graph.  A call that passed the
+  support check and dispatched the primitive is allowed to fail loudly — there
+  is no in-kernel dense retry, because a benchmark arm that silently fell back
+  is a wrong benchmark.
+* **Proven once, then trusted — and retired on failure.** ``abi_probe`` at
+  import proves the nanobind type casters match the mlx wheel, and
+  ``BUILT_AGAINST_MLX`` is compared against the imported mlx because this
+  primitive links MLX's private C++ ABI.  Symbol presence is not pipeline
+  readiness, so the *first* dispatch is evaluated eagerly: a missing/stale
+  metallib surfaces as a pipeline error at a known point rather than at an
+  arbitrary later ``mx.eval``.  The proof is PER QUERY DTYPE, because the
+  Metal kernel name embeds it (``qwen4_qsa_sparse_gqa_<type>_bk64_dc64_...``)
+  and a metallib can carry a good bfloat16 specialization beside a missing
+  float16 one; ``qsa_prefill_direct_ready`` proves both before it says True.
+  Any such failure — a receipt mismatch, a failed preflight, a failed first
+  evaluation of either dtype — disables the whole lane for the whole process,
+  so ``qsa_prefill_direct_ready`` goes False, the M3 producer auto-gate
+  disarms, and traffic routes to gather instead of re-hitting the same wall
+  on every request.  FAILED is terminal and lock-guarded: a proof that
+  succeeds after another has failed cannot reopen the lane.
+
+The Topk ABI seam
+-----------------
+The native kernel takes only ``[1, 1, S, 512]`` uint32 block ids and no
+validity tensor: validity is **positional**.  It reads exactly the first
+``min(512, (q_abs + 1) // 4)`` slots of each row.  MTPLX's public block
+contract tolerates arbitrary validity holes, so this module owns the
+narrowing: the producers must emit a chronological VALID PREFIX (ascending
+ids in ``[0, valid_count)``, padding after).  Both production selectors do —
+the eager selector sorts then zeroes the invalid tail, and the Metal selector
+orders selected blocks by ascending id followed by padded lanes — and
+``tests/test_qsa_selector_prefix_contract.py`` is the license for the kernel
+to ignore ``block_valid``.  Set ``MTPLX_QSA_PREFILL_DIRECT_VALIDATE=1`` to
+re-prove the invariant per call at the cost of a host synchronization.
+
+Environment
+-----------
+``MTPLX_QSA_PREFILL_DIRECT``
+    ``0`` kills only this consumer (gather/dense still serve).  Unset means
+    on whenever the native module is loaded and probed.
+``MTPLX_QSA_PREFILL_DIRECT_VALIDATE``
+    ``1`` runs the full per-call prefix-contract check (synchronizes).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import operator
+import os
+import sys
+import threading
+from pathlib import Path
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_BATCH = 1
+_Q_HEADS = 24
+_KV_HEADS = 2
+_GQA = 12
+_HEAD_DIM = 256
+_MAX_CONTEXT = 1_048_576
+_COMPRESS_RATIO = 4
+_TOP_K_BLOCKS = 512
+_EXPECTED_SCALE = 0.0625  # 1 / sqrt(256), exactly representable
+_SUPPORTED_DTYPES = (mx.float16, mx.bfloat16)
+
+# The one packaged Steel specialization. oMLX's production glue uses (64, 64);
+# the fast.py defaults (128, 32) are not what was measured on M3 and are not
+# instantiated in MTPLX's metallib.
+_KEY_TILE = 64
+_DIMENSION_TILE = 64
+
+__all__ = [
+    "qsa_prefill_direct",
+    "qsa_prefill_direct_build_info",
+    "qsa_prefill_direct_module_ready",
+    "qsa_prefill_direct_preflight",
+    "qsa_prefill_direct_ready",
+    "qsa_prefill_direct_supported",
+    "qsa_prefill_direct_topk_buffer",
+    "qsa_prefill_direct_unsupported_reason",
+]
+
+
+def _detach(exc: BaseException) -> BaseException:
+    """Keep the diagnostic message without retaining import caller frames."""
+
+    exc.__traceback__ = None
+    exc.__cause__ = None
+    exc.__context__ = None
+    return exc
+
+
+def _extension_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "native_extensions" / "qsa_kernels"
+
+
+def _import_extension():
+    """Import the optional native module; never raise."""
+
+    native_path = _extension_dir()
+    if native_path.is_dir() and str(native_path) not in sys.path:
+        # Source-tree builds live beside the sources (the house pattern used
+        # by mtplx/kernels/native_gdn_tail.py); an installed wheel is found
+        # on the normal path and this insert is a no-op.
+        sys.path.insert(0, str(native_path))
+    try:
+        import mtplx_qsa_kernels  # type: ignore
+    except Exception as exc:  # pragma: no cover - depends on a local build
+        built = native_path / "mtplx_qsa_kernels"
+        if built.is_dir() and any(built.glob("_ext*.so")):
+            # A built extension that fails to load is a real defect (usually
+            # an unresolved @rpath to the mlx wheel's libmlx.dylib). Leave a
+            # trace so the slow path is not silently taken forever.
+            logger.warning(
+                "%s: native QSA kernel is present but failed to load; the "
+                "direct prefill lane is disabled: %s",
+                __name__,
+                exc,
+            )
+        return None, _detach(exc)
+    return mtplx_qsa_kernels, None
+
+
+_EXT, _IMPORT_ERROR = _import_extension()
+
+
+def _verify_abi(ext, import_error):
+    """Disable the lane when the extension rejects mlx arrays.
+
+    An extension built with a nanobind whose ABI tag differs from the mlx
+    wheel's imports cleanly and lists every symbol, but its type casters live
+    in an isolated ``NB_DOMAIN``, so every call raises ``TypeError:
+    incompatible function arguments``.  Probe once at import and degrade with
+    a single warning instead of failing per layer per token.
+    """
+
+    if ext is None:
+        return ext, import_error
+    probe = getattr(ext, "abi_probe", None)
+    if probe is None:
+        logger.warning(
+            "%s: native QSA kernel has no abi_probe symbol; rebuild it from "
+            "native_extensions/qsa_kernels. Lane disabled.",
+            __name__,
+        )
+        return None, import_error
+    try:
+        probe(mx.zeros((1,)))
+    except TypeError as exc:
+        logger.warning(
+            "%s: native QSA kernel disabled — it was built with a nanobind "
+            "ABI that does not match this mlx wheel; rebuild it against the "
+            "installed mlx (see native_extensions/qsa_kernels/pyproject.toml).",
+            __name__,
+        )
+        return None, _detach(exc)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("%s: native QSA kernel probe failed: %s", __name__, exc)
+        return None, _detach(exc)
+    return ext, import_error
+
+
+_EXT, _IMPORT_ERROR = _verify_abi(_EXT, _IMPORT_ERROR)
+
+# Process-wide lifecycle for the packaged Metal specialization. MLX
+# primitives are lazy, so a missing or stale metallib fails at mx.eval, not
+# at dispatch: the lane is UNPROVEN until one real call has been evaluated,
+# and any failed proof moves it to FAILED for the rest of the process. FAILED
+# is terminal and is what makes ``ready()``/``supported()`` answer False
+# instead of arming a producer for a consumer that cannot run.
+_PIPELINE_UNPROVEN = "unproven"
+_PIPELINE_PROVEN = "proven"
+_PIPELINE_FAILED = "failed"
+_PIPELINE_STATE = _PIPELINE_UNPROVEN
+
+# The native Metal kernel name embeds the QUERY DTYPE
+# (``qwen4_qsa_sparse_gqa_<type>_bk64_dc64_...``), so proving the bfloat16
+# specialization says nothing about whether the float16 one was packaged into
+# the metallib.  Readiness therefore tracks the proved dtypes and only turns
+# ``_PIPELINE_STATE`` to PROVEN once every entry of ``_SUPPORTED_DTYPES`` has
+# run.  A failure in any one of them retires the WHOLE lane (fail-closed: a
+# half-usable lane is not a lane the router can reason about).
+_PIPELINE_PROVEN_DTYPES: frozenset[str] = frozenset()
+
+# The transitions above are check-then-set across an ``mx.eval``, so two
+# threads racing their first prefill could both observe UNPROVEN and the
+# winner could write PROVEN over the loser's FAILED.  The lock serializes the
+# proof; ``_record_pipeline_success`` refuses to leave FAILED regardless, so
+# FAILED is terminal even if a caller reaches it another way.  Re-entrant
+# because ``_prove_pipeline`` proves through ``qsa_prefill_direct``, which
+# calls ``_prove_first_dispatch``.
+_PIPELINE_LOCK = threading.RLock()
+
+_RECEIPT_WARNED = False
+
+
+def _dtype_key(dtype: mx.Dtype) -> str:
+    return str(dtype)
+
+
+def _dtype_proven(dtype: mx.Dtype) -> bool:
+    return _dtype_key(dtype) in _PIPELINE_PROVEN_DTYPES
+
+
+def _record_pipeline_failure() -> None:
+    """Retire the lane for the process.  FAILED is terminal."""
+
+    global _PIPELINE_STATE, _PIPELINE_PROVEN_DTYPES
+
+    _PIPELINE_STATE = _PIPELINE_FAILED
+    # Drop the dtype proofs too: one dead specialization retires the lane, and
+    # a stale PROVEN dtype would otherwise let a later dispatch skip its own
+    # proof.
+    _PIPELINE_PROVEN_DTYPES = frozenset()
+
+
+def _record_pipeline_success(dtype: mx.Dtype) -> None:
+    """Bank one dtype proof; never reopen a lane that already FAILED."""
+
+    global _PIPELINE_STATE, _PIPELINE_PROVEN_DTYPES
+
+    if _PIPELINE_STATE == _PIPELINE_FAILED:
+        return
+    _PIPELINE_PROVEN_DTYPES = _PIPELINE_PROVEN_DTYPES | {_dtype_key(dtype)}
+    if all(_dtype_key(known) in _PIPELINE_PROVEN_DTYPES for known in _SUPPORTED_DTYPES):
+        _PIPELINE_STATE = _PIPELINE_PROVEN
+
+
+def qsa_prefill_direct_build_info() -> dict[str, str]:
+    """Build receipts for the loaded extension (empty when not loaded).
+
+    The primitive links MLX's private C++ ABI, so ``mlx`` recording which
+    wheel the .so was compiled against is the difference between a clean
+    "rebuild me" and a mystery crash after ``pip install -U mlx``.
+    """
+
+    if _EXT is None:
+        return {}
+    return {
+        "built_against_mlx": str(getattr(_EXT, "BUILT_AGAINST_MLX", "unknown")),
+        "built_against_nanobind": str(
+            getattr(_EXT, "BUILT_AGAINST_NANOBIND", "unknown")
+        ),
+        "metal_library": str(getattr(_EXT, "METAL_LIBRARY", "unknown")),
+        "imported_mlx": str(getattr(mx, "__version__", "unknown")),
+    }
+
+
+def qsa_prefill_direct_import_error() -> BaseException | None:
+    """Why the native module is unavailable, if it is."""
+
+    return _IMPORT_ERROR
+
+
+def qsa_prefill_direct_module_ready() -> bool:
+    """Whether the native symbol is importable and ABI-compatible."""
+
+    return _EXT is not None and hasattr(_EXT, "qwen4_qsa_sparse_gqa_attention")
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    raw = (os.environ.get(name) or "").strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def qsa_prefill_direct_enabled() -> bool:
+    """Kill switch only.  Default on; the module gate is separate."""
+
+    return _env_flag("MTPLX_QSA_PREFILL_DIRECT", default=True)
+
+
+def _validate_enabled() -> bool:
+    return _env_flag("MTPLX_QSA_PREFILL_DIRECT_VALIDATE", default=False)
+
+
+def _build_receipt_mismatch() -> str | None:
+    """Compare the baked mlx receipt against the mlx actually imported.
+
+    The primitive links MLX's private C++ ABI and its Steel headers, so an
+    extension built against a different wheel is a crash waiting for the
+    first dispatch — a `.so` that imports, probes and lists every symbol, and
+    then mis-reads a struct. CMake bakes ``BUILT_AGAINST_MLX`` from the build
+    interpreter for exactly this comparison.
+    """
+
+    if _EXT is None:
+        return None
+    built = str(getattr(_EXT, "BUILT_AGAINST_MLX", "") or "").strip()
+    runtime = str(getattr(mx, "__version__", "") or "").strip()
+    if not built or built == "unknown":
+        return "the native QSA extension carries no BUILT_AGAINST_MLX receipt"
+    if not runtime:
+        return None
+    if built != runtime:
+        return (
+            f"the native QSA extension was built against mlx {built} but "
+            f"mlx {runtime} is imported"
+        )
+    return None
+
+
+def _lane_unavailable_reason() -> str | None:
+    """Why the lane cannot serve this process, ignoring per-call geometry.
+
+    Deliberately does NOT consult :func:`qsa_prefill_direct_ready`: that
+    function proves the pipeline through the preflight, which comes back
+    through here, and the cycle would be infinite.
+    """
+
+    global _RECEIPT_WARNED
+
+    if _PIPELINE_STATE == _PIPELINE_FAILED:
+        return (
+            "the direct lane was disabled after a failed Metal pipeline "
+            "proof in this process"
+        )
+    if not qsa_prefill_direct_module_ready():
+        return "the native QSA sparse-GQA extension is not loaded"
+    if not qsa_prefill_direct_enabled():
+        return "MTPLX_QSA_PREFILL_DIRECT is off"
+    mismatch = _build_receipt_mismatch()
+    if mismatch is not None:
+        if not _RECEIPT_WARNED:
+            _RECEIPT_WARNED = True
+            logger.warning(
+                "%s: %s; the direct prefill lane is disabled — rebuild the "
+                "extension in the venv that serves (see "
+                "native_extensions/qsa_kernels/README.md).",
+                __name__,
+                mismatch,
+            )
+        return mismatch
+    return None
+
+
+def _lane_eligible() -> bool:
+    """Symbol, kill switch, build receipt and process state — no proof."""
+
+    return _lane_unavailable_reason() is None
+
+
+def qsa_prefill_direct_ready() -> bool:
+    """Whether this consumer can serve at all on this process.
+
+    The producer auto-gate in ``qwen4_exp`` calls this: on M3 there is no NAX
+    flash consumer, so the large-prefill lane may only arm itself when THIS
+    kernel is loaded, probed, receipt-matched, not killed by env, and known
+    to have a runnable Metal pipeline.  A present-but-unproven metallib is
+    not readiness: symbol presence never proved that ``get_library`` or
+    ``get_kernel`` can resolve the packaged specializations, so a real loaded
+    extension is proved once, here, before the answer is True — and because
+    the native kernel name embeds the query dtype, EVERY packaged dtype
+    specialization is proved, not just the bfloat16 default.
+    """
+
+    if not _lane_eligible():
+        return False
+    if _PIPELINE_STATE == _PIPELINE_PROVEN:
+        return True
+    if _EXT is not None and _on_metal_device():
+        return _prove_all_pipelines()
+    # No real extension is loaded (unit tests stub the module gate) or MLX is
+    # not on a Metal GPU, where nothing can be proved and the device gate in
+    # qsa_prefill_lane_auto_supported refuses anyway.
+    return True
+
+
+def _on_metal_device() -> bool:
+    """Metal availability is insufficient when MLX currently targets CPU."""
+
+    try:
+        return mx.metal.is_available() and mx.default_device() == mx.gpu
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _last_dim_contiguous(array: mx.array) -> bool:
+    """Best-effort mirror of the C++ ``strides(-1) == 1`` check.
+
+    The MLX Python array exposes no stride API, so this cannot be decided
+    from Python for the views this lane consumes (a transposed Q and a
+    length-sliced KV cache — both unit-stride in the feature axis by
+    construction, and neither can be made contiguous here without copying the
+    whole cache).  Rank/shape are checked above; the authoritative check is
+    the C++ ``unsupported()``, which raises rather than mis-indexing.  If a
+    future MLX exposes strides, use them.
+    """
+
+    strides = getattr(array, "strides", None)
+    if strides is None:
+        return True
+    try:
+        return int(strides[-1]) == 1
+    except (IndexError, TypeError, ValueError):  # pragma: no cover - defensive
+        return True
+
+
+def qsa_prefill_direct_unsupported_reason(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_ids: mx.array,
+    block_valid: mx.array,
+    *,
+    pos_start: int,
+    total_tokens: int,
+    scale: float,
+    compress_ratio: int = _COMPRESS_RATIO,
+    block_topk: int = _TOP_K_BLOCKS,
+    key_tile: int = _KEY_TILE,
+    dimension_tile: int = _DIMENSION_TILE,
+) -> str | None:
+    """Return why this call cannot use the direct kernel, or ``None``.
+
+    Every clause here has a counterpart in the vendored C++ ``unsupported()``
+    (``native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.cpp``) or in the
+    MTPLX block contract the C++ cannot see (model ratio/top-k, the suffix
+    relation, the dense/sparse boundary).  Keeping them in lockstep is what
+    makes "supported" mean "will dispatch".
+    """
+
+    unavailable = _lane_unavailable_reason()
+    if unavailable is not None:
+        return unavailable
+    if not _on_metal_device():
+        return "the active MLX device is not an available Metal GPU"
+
+    arrays = (queries, keys, values, block_ids, block_valid)
+    if any(not isinstance(array, mx.array) for array in arrays):
+        return "all tensor inputs must be MLX arrays"
+    if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
+        return "Q, K, and V must be rank four"
+    if block_ids.ndim != 2 or block_valid.ndim != 2:
+        return "block ids and validity must be rank two"
+
+    batch, query_heads, rows, head_dim = (int(x) for x in queries.shape)
+    if (batch, query_heads, head_dim) != (_BATCH, _Q_HEADS, _HEAD_DIM):
+        return "Q must have production shape [1, 24, S, 256]"
+    if rows <= 0:
+        return "the prefill kernel requires at least one query row"
+
+    key_batch, kv_heads, key_len, key_dim = (int(x) for x in keys.shape)
+    if (key_batch, kv_heads, key_dim) != (_BATCH, _KV_HEADS, _HEAD_DIM):
+        return "K must have production shape [1, 2, kL, 256]"
+    if tuple(int(x) for x in values.shape) != tuple(int(x) for x in keys.shape):
+        return "V must have the same shape as K"
+
+    if queries.dtype not in _SUPPORTED_DTYPES:
+        return "Q must be float16 or bfloat16"
+    if keys.dtype != queries.dtype or values.dtype != queries.dtype:
+        return "Q, K, and V dtypes must match"
+    if block_ids.dtype != mx.int32 or block_valid.dtype != mx.bool_:
+        return "block ids must be int32 and validity must be bool"
+    if tuple(int(x) for x in block_ids.shape) != (rows, _TOP_K_BLOCKS):
+        return "block ids must have shape [S, 512]"
+    if tuple(int(x) for x in block_valid.shape) != (rows, _TOP_K_BLOCKS):
+        return "block validity must have shape [S, 512]"
+    if not (
+        _last_dim_contiguous(queries)
+        and _last_dim_contiguous(keys)
+        and _last_dim_contiguous(values)
+    ):
+        return "Q, K, and V must be contiguous in their last axis"
+
+    # The model's own QSA configuration. The C++ checks tensor shapes; it
+    # cannot see that the indexer was configured with a different block size
+    # or budget, and the four-token expansion is compiled into the kernel.
+    if int(compress_ratio) != _COMPRESS_RATIO:
+        return "the kernel expands exactly four-token blocks"
+    if int(block_topk) != _TOP_K_BLOCKS:
+        return "the kernel consumes exactly 512 selected blocks"
+    if int(key_tile) != _KEY_TILE or int(dimension_tile) != _DIMENSION_TILE:
+        return "only the packaged (key_tile, dimension_tile) == (64, 64) ships"
+
+    # Host-static scalars only: comparing a traced scalar here would
+    # synchronize the graph on every layer of every chunk.
+    if isinstance(pos_start, mx.array) or isinstance(total_tokens, mx.array):
+        return "pos_start and total_tokens must be host integers"
+    if isinstance(scale, mx.array):
+        return "scale must be a host float"
+    if isinstance(pos_start, bool) or isinstance(total_tokens, bool):
+        return "pos_start and total_tokens cannot be bool"
+    try:
+        pos_start_i = operator.index(pos_start)
+        total_tokens_i = operator.index(total_tokens)
+    except TypeError:
+        return "pos_start and total_tokens must be exact host integers"
+    if isinstance(scale, bool) or not isinstance(scale, (int, float)):
+        return "scale must be a numeric host scalar"
+    scale_f = float(scale)
+
+    if pos_start_i < 0 or total_tokens_i <= 0:
+        return "positions must describe a non-empty non-negative suffix"
+    if pos_start_i + rows != total_tokens_i:
+        return "Q must be the suffix ending exactly at total_tokens"
+    # The native ABI has no logical-K parameter: params.kL is k.shape(2).
+    # Passing the capacity BACKING would make kL mean capacity and hide a
+    # logical-frontier mistake, so this lane takes the logical views returned
+    # by update_and_fetch and insists they are exactly the live cache.
+    if key_len != total_tokens_i:
+        return "K/V must be the logical cache prefix with kL == total_tokens"
+    if total_tokens_i > _MAX_CONTEXT:
+        return "the logical token count exceeds the production context limit"
+    if total_tokens_i // _COMPRESS_RATIO <= _TOP_K_BLOCKS:
+        return "the context has not crossed the dense/sparse boundary"
+    if not math.isfinite(scale_f) or scale_f != _EXPECTED_SCALE:
+        return "scale must equal the production 1/sqrt(256) value"
+    return None
+
+
+def qsa_prefill_direct_supported(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_ids: mx.array,
+    block_valid: mx.array,
+    *,
+    pos_start: int,
+    total_tokens: int,
+    scale: float,
+    compress_ratio: int = _COMPRESS_RATIO,
+    block_topk: int = _TOP_K_BLOCKS,
+) -> bool:
+    """Whether the exact production-only direct-kernel contract is met."""
+
+    return (
+        qsa_prefill_direct_unsupported_reason(
+            queries,
+            keys,
+            values,
+            block_ids,
+            block_valid,
+            pos_start=pos_start,
+            total_tokens=total_tokens,
+            scale=scale,
+            compress_ratio=compress_ratio,
+            block_topk=block_topk,
+        )
+        is None
+    )
+
+
+def _prefix_contract_violation(
+    block_ids: mx.array,
+    block_valid: mx.array,
+    *,
+    pos_start: int,
+    compress_ratio: int,
+) -> str | None:
+    """Prove the valid-prefix invariant the native ABI cannot express.
+
+    Synchronizes.  Only the debug/qualification path calls this; the hot path
+    relies on the producer contract pinned by
+    ``tests/test_qsa_selector_prefix_contract.py``.
+    """
+
+    rows = int(block_ids.shape[0])
+    slots = int(block_ids.shape[1])
+    ratio = int(compress_ratio)
+    qpos = mx.arange(pos_start, pos_start + rows, dtype=mx.int32)
+    complete = (qpos + 1) // ratio  # blocks fully visible to each row
+
+    valid = block_valid
+    counts = valid.astype(mx.int32).sum(axis=-1)
+    prefix = mx.arange(slots, dtype=mx.int32)[None, :] < counts[:, None]
+    expected_counts = mx.minimum(complete, mx.array(slots, dtype=mx.int32))
+
+    pair_valid = mx.logical_and(valid[:, 1:], valid[:, :-1])
+    ascending = mx.logical_or(
+        mx.logical_not(pair_valid), block_ids[:, 1:] > block_ids[:, :-1]
+    )
+    in_range = mx.logical_or(
+        mx.logical_not(valid),
+        mx.logical_and(block_ids >= 0, block_ids < complete[:, None]),
+    )
+
+    checks = {
+        "block_valid is not a per-row prefix": mx.all(prefix == valid),
+        "valid count != min(512, complete blocks)": mx.all(
+            counts == expected_counts
+        ),
+        "valid block ids are not strictly ascending": mx.all(ascending),
+        "a valid block id is negative or not fully visible": mx.all(in_range),
+    }
+    mx.eval(list(checks.values()))
+    for message, ok in checks.items():
+        if not bool(ok.item()):
+            return message
+    return None
+
+
+def qsa_prefill_direct_topk_buffer(
+    block_ids: mx.array,
+    block_valid: mx.array,
+    *,
+    pos_start: int,
+    compress_ratio: int = _COMPRESS_RATIO,
+    validate: bool | None = None,
+) -> mx.array:
+    """Adapt MTPLX's ``[S,512] int32`` + ``[S,512] bool`` to the native ABI.
+
+    Returns a contiguous ``[1, 1, S, 512]`` uint32 buffer.  The cast is
+    explicit and the contiguity is explicit: a bare reshape could hand the
+    kernel a strided view, and a negative int32 id would become a huge
+    uint32.  (The kernel would still mask that id via ``candidate < kL``, but
+    "would be masked anyway" is not a contract.)
+    """
+
+    if block_ids.dtype != mx.int32:
+        raise ValueError("block ids must be int32")
+    if block_valid.dtype != mx.bool_:
+        raise ValueError("block validity must be bool")
+    if block_ids.ndim != 2 or tuple(block_valid.shape) != tuple(block_ids.shape):
+        raise ValueError("block ids and validity must be matching [S, 512]")
+    if int(block_ids.shape[1]) != _TOP_K_BLOCKS:
+        raise ValueError("block ids must have exactly 512 slots")
+
+    if validate is None:
+        validate = _validate_enabled()
+    if validate:
+        violation = _prefix_contract_violation(
+            block_ids,
+            block_valid,
+            pos_start=pos_start,
+            compress_ratio=compress_ratio,
+        )
+        if violation is not None:
+            raise ValueError(
+                "QSA direct kernel prefix contract violated: " + violation
+            )
+
+    return mx.contiguous(block_ids.astype(mx.uint32)[None, None])
+
+
+def qsa_prefill_direct(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    block_ids: mx.array,
+    block_valid: mx.array,
+    *,
+    pos_start: int,
+    total_tokens: int,
+    scale: float,
+    compress_ratio: int = _COMPRESS_RATIO,
+    block_topk: int = _TOP_K_BLOCKS,
+) -> mx.array:
+    """Compute sparse-plus-tail QSA prefill attention as one Metal dispatch.
+
+    ``queries`` is ``[1,24,S,256]``.  ``keys``/``values`` are the LOGICAL
+    cache views returned by ``update_and_fetch`` (``kL == total_tokens``), not
+    the capacity backings — the native ABI has no separate logical-K length.
+    Selection arrays are ``[S,512]`` per query row.  The output is
+    ``[1,24,S,256]`` in the Q/K/V dtype.
+
+    Unsupported calls raise.  There is no dense fallback here: once this
+    function dispatches, later Metal failures propagate to the caller.
+    """
+
+    reason = qsa_prefill_direct_unsupported_reason(
+        queries,
+        keys,
+        values,
+        block_ids,
+        block_valid,
+        pos_start=pos_start,
+        total_tokens=total_tokens,
+        scale=scale,
+        compress_ratio=compress_ratio,
+        block_topk=block_topk,
+    )
+    if reason is not None:
+        raise ValueError(f"unsupported QSA prefill direct call: {reason}")
+
+    selected = qsa_prefill_direct_topk_buffer(
+        block_ids,
+        block_valid,
+        pos_start=int(pos_start),
+        compress_ratio=int(compress_ratio),
+    )
+    out = _EXT.qwen4_qsa_sparse_gqa_attention(
+        queries,
+        keys,
+        values,
+        selected,
+        float(scale),
+        int(pos_start),
+        key_tile=_KEY_TILE,
+        dimension_tile=_DIMENSION_TILE,
+    )
+    return _prove_first_dispatch(out, dtype=queries.dtype)
+
+
+def _prove_first_dispatch(out: mx.array, *, dtype: mx.Dtype) -> mx.array:
+    """Force the first dispatch OF THIS DTYPE, then trust the kernel.
+
+    MLX is lazy, so a missing or stale metallib (``get_library`` /
+    ``get_kernel`` failures are eval-time) would otherwise surface at an
+    arbitrary later point in the layer stack.  Evaluating here makes it a
+    clean, attributable error AND retires the lane, so the next request
+    routes to gather instead of hitting the same wall.  This is not a
+    fallback: the error is re-raised, never swallowed.
+
+    Per dtype, because the native kernel name embeds it: a proved bfloat16
+    pipeline must not let the first float16 request skip its own proof and
+    ride to an unattributed failure deep in the layer stack.
+    """
+
+    if _PIPELINE_STATE == _PIPELINE_FAILED or _dtype_proven(dtype):
+        return out
+    with _PIPELINE_LOCK:
+        # Re-read under the lock: a racing caller may have proved or retired
+        # this dtype while we waited, and FAILED must stay terminal.
+        if _PIPELINE_STATE == _PIPELINE_FAILED or _dtype_proven(dtype):
+            return out
+        try:
+            mx.eval(out)
+        except Exception:
+            _record_pipeline_failure()
+            logger.warning(
+                "%s: the QSA direct kernel failed its first %s evaluation; "
+                "the lane is disabled for this process.",
+                __name__,
+                _dtype_key(dtype),
+            )
+            raise
+        _record_pipeline_success(dtype)
+    return out
+
+
+def qsa_prefill_direct_preflight(*, dtype: mx.Dtype | None = None) -> bool:
+    """Dispatch and evaluate one tiny real call per dtype; True when it works.
+
+    Symbol presence is not pipeline readiness.  Benchmark harnesses and the
+    server preflight call this once, before traffic, so a packaging mistake
+    (renamed/absent metallib, missing specialization) cannot be discovered
+    mid-request.  ``dtype=None`` proves every packaged specialization, which
+    is what a before-traffic preflight wants; pass one dtype to prove just
+    that pipeline.  A failure disables the lane process-wide.  Never call
+    this on the hot path: it synchronizes.
+    """
+
+    if not _lane_eligible() or not _on_metal_device():
+        return False
+    if dtype is None:
+        return _prove_all_pipelines()
+    return _prove_pipeline(dtype=dtype)
+
+
+def _prove_all_pipelines() -> bool:
+    """Prove every packaged dtype specialization; the readiness answer.
+
+    The Metal kernel name carries the query dtype, so the metallib can hold a
+    valid bfloat16 specialization and a missing or stale float16 one.  Any
+    failure retires the whole lane, so the first False is final.
+    """
+
+    for dtype in _SUPPORTED_DTYPES:
+        if not _prove_pipeline(dtype=dtype):
+            return False
+    return True
+
+
+def _prove_pipeline(*, dtype: mx.Dtype = mx.bfloat16) -> bool:
+    """The proof itself, for ONE dtype.  Sets the process state; never raises.
+
+    Consults ``_lane_eligible`` rather than ``qsa_prefill_direct_ready``,
+    which calls back into here.  Serialized so that two threads racing their
+    first prefill cannot both observe UNPROVEN and let a late success
+    overwrite the other's FAILED.
+    """
+
+    if _PIPELINE_STATE == _PIPELINE_FAILED:
+        return False
+    if _dtype_proven(dtype):
+        return True
+    with _PIPELINE_LOCK:
+        return _prove_pipeline_locked(dtype)
+
+
+def _prove_pipeline_locked(dtype: mx.Dtype) -> bool:
+    if _PIPELINE_STATE == _PIPELINE_FAILED:
+        return False
+    if _dtype_proven(dtype):
+        return True
+    rows = 8
+    # Smallest shape that still crosses the dense/sparse boundary the
+    # production gate requires (total // 4 > 512).
+    total = 2056
+    pos_start = total - rows
+    queries = mx.zeros((_BATCH, _Q_HEADS, rows, _HEAD_DIM), dtype=dtype)
+    keys = mx.zeros((_BATCH, _KV_HEADS, total, _HEAD_DIM), dtype=dtype)
+    values = mx.zeros((_BATCH, _KV_HEADS, total, _HEAD_DIM), dtype=dtype)
+    ids = mx.broadcast_to(
+        mx.arange(_TOP_K_BLOCKS, dtype=mx.int32)[None, :], (rows, _TOP_K_BLOCKS)
+    )
+    block_ids = mx.contiguous(ids)
+    block_valid = mx.ones((rows, _TOP_K_BLOCKS), dtype=mx.bool_)
+    try:
+        out = qsa_prefill_direct(
+            queries,
+            keys,
+            values,
+            block_ids,
+            block_valid,
+            pos_start=pos_start,
+            total_tokens=total,
+            scale=_EXPECTED_SCALE,
+        )
+        mx.eval(out)
+    except Exception as exc:
+        _record_pipeline_failure()
+        logger.warning(
+            "%s: QSA direct-kernel %s preflight failed; the lane is disabled "
+            "for this process: %s",
+            __name__,
+            _dtype_key(dtype),
+            exc,
+        )
+        return False
+    _record_pipeline_success(dtype)
+    return True

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1240,10 +1240,24 @@ def _compiled_qsa_indexer_enabled() -> bool:
 def qsa_prefill_lane_auto_supported() -> bool:
     """Device gate for the auto default: the lane's fast consumer must exist.
 
-    Mirrors the flash kernel's own eligibility (Metal GPU + Metal 4
-    TensorOps). Machines without it would ride the eager selector into the
-    dense-mask reconstruction — pure tax — so auto stays off there until the
-    portable gather tier carries its own receipts on that hardware class.
+    The producer only emits the ``("flash_prefill", ids, valid)`` tuple when
+    this returns True, so it must name EVERY fast consumer of that tuple.
+    Two exist:
+
+    * Metal 4 TensorOps (NAX) machines take ``qsa_prefill_flash`` (M4/M5).
+    * M3-class machines have no G17 tensor units and can never take that
+      kernel, but they can take the vendored Steel sparse-GQA kernel when it
+      is built and probed.
+
+    Machines with neither would ride the eager selector into the dense-mask
+    reconstruction — pure tax — so auto stays off there until the portable
+    gather tier carries its own receipts on that hardware class.
+
+    ``MTPLX_QSA_PREFILL=0`` remains the master kill switch above this, and
+    ``MTPLX_QSA_PREFILL_DIRECT=0`` (honored inside
+    ``qsa_prefill_direct_ready``) removes the direct consumer from this
+    answer, so killing the direct lane on an M3 also disarms the producer
+    instead of leaving it selecting for nobody.
     """
 
     try:
@@ -1255,7 +1269,11 @@ def qsa_prefill_lane_auto_supported() -> bool:
             qsa_indexer_select_nax_available,
         )
 
-        return bool(qsa_indexer_select_nax_available())
+        if bool(qsa_indexer_select_nax_available()):
+            return True
+        from mtplx.kernels.qsa_prefill_direct import qsa_prefill_direct_ready
+
+        return bool(qsa_prefill_direct_ready())
     except Exception:
         return False
 
@@ -1323,6 +1341,25 @@ def _qsa_prefill_flash_min_context() -> int:
         return 32768
 
 
+def _qsa_prefill_direct_min_context() -> int:
+    """Crossover for the vendored Steel sparse-GQA consumer (M3 lane).
+
+    Defaults to the flash consumer's 32768 so the two direct consumers share
+    one story until an operator turns the knob. oMLX measured +11.7% prefill
+    on M3 already at 16K; an M3 Ultra 256GB sequential A/B of this port
+    (2026-09-01) saw the 32k TTFT win with
+    ``MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT=2049``.
+    """
+
+    try:
+        return max(
+            2049,
+            int(os.environ.get("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT") or 32768),
+        )
+    except ValueError:
+        return 32768
+
+
 def _qsa_prefill_score_workspace_bytes() -> int:
     """Byte budget for per-head float32 logits plus the reduced score plane."""
 
@@ -1374,6 +1411,15 @@ def _qsa_prefill_flash_attention_enabled(rows: int, total_tokens: int) -> bool:
     )
 
 
+def _qsa_prefill_direct_attention_enabled(rows: int, total_tokens: int) -> bool:
+    """Whether the vendored Steel sparse-GQA consumer may serve this chunk."""
+
+    return (
+        _qsa_large_prefill_enabled(rows, total_tokens)
+        and int(total_tokens) - int(rows) >= _qsa_prefill_direct_min_context()
+    )
+
+
 _QSA_PREFILL_COUNTS: Dict[str, int] = {}
 _QSA_PREFILL_DEBUG_ARMED = False
 
@@ -1384,6 +1430,14 @@ def _qsa_prefill_count(lane: str) -> None:
 
     global _QSA_PREFILL_DEBUG_ARMED
     _QSA_PREFILL_COUNTS[lane] = _QSA_PREFILL_COUNTS.get(lane, 0) + 1
+    receipt = (os.environ.get("MTPLX_QSA_PREFILL_ENGAGEMENT_FILE") or "").strip()
+    if receipt:
+        try:
+            Path(receipt).write_text(
+                json.dumps(dict(_QSA_PREFILL_COUNTS), sort_keys=True) + "\n"
+            )
+        except OSError:
+            pass
     if not _QSA_PREFILL_DEBUG_ARMED:
         _QSA_PREFILL_DEBUG_ARMED = True
         raw = (os.environ.get("MTPLX_QSA_PREFILL_DEBUG") or "0").strip().lower()
@@ -1404,6 +1458,40 @@ def qsa_prefill_engagement() -> Dict[str, int]:
     """Snapshot of per-lane large-prefill engagement counters."""
 
     return dict(_QSA_PREFILL_COUNTS)
+
+
+def _qsa_prefill_dispatch_tier(
+    *,
+    flash_supported,
+    flash_call,
+    direct_supported,
+    direct_call,
+    gather_enabled: bool,
+    gather_call,
+):
+    """Pick the one consumer of the ``("flash_prefill", ids, valid)`` tuple.
+
+    Order is flash (M4/M5 MPP) -> direct (Steel, the M3 lane) -> gather
+    (portable) -> dense. Each predicate is called at most once and only
+    until one answers True. Returns the attention output, or ``None`` to
+    mean "no tier dispatched; rebuild the dense mask". There is no retry:
+    once a tier is entered its failure propagates.
+    """
+
+    if flash_supported():
+        out = flash_call()
+        _qsa_prefill_count("flash_kernel")
+        return out
+    if direct_supported():
+        out = direct_call()
+        _qsa_prefill_count("direct_kernel")
+        return out
+    if gather_enabled:
+        out = gather_call()
+        _qsa_prefill_count("gather_tier")
+        return out
+    _qsa_prefill_count("dense_fallback")
+    return None
 
 
 def _qsa_prefill_gather_enabled() -> bool:
@@ -3051,17 +3139,25 @@ class Attention(nn.Module):
             )
 
             _, block_ids, block_valid = sel_mask
-            if _qsa_prefill_flash_attention_enabled(S, T) and qsa_prefill_flash_supported(
-                q,
-                cache.kv.keys,
-                cache.kv.values,
-                block_ids,
-                block_valid,
-                pos_start=pos_start,
-                total_tokens=T,
-                scale=self.scale,
-            ):
-                out = qsa_prefill_flash(
+
+            def _qsa_flash_supported() -> bool:
+                return bool(
+                    _qsa_prefill_flash_attention_enabled(S, T)
+                ) and bool(
+                    qsa_prefill_flash_supported(
+                        q,
+                        cache.kv.keys,
+                        cache.kv.values,
+                        block_ids,
+                        block_valid,
+                        pos_start=pos_start,
+                        total_tokens=T,
+                        scale=self.scale,
+                    )
+                )
+
+            def _qsa_flash_call():
+                return qsa_prefill_flash(
                     q,
                     cache.kv.keys,
                     cache.kv.values,
@@ -3071,16 +3167,48 @@ class Attention(nn.Module):
                     total_tokens=T,
                     scale=self.scale,
                 )
-                _qsa_prefill_count("flash_kernel")
-                out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
-                return self.o_proj(out * mx.sigmoid(gate))
 
-            # Portable tier (MTPLX_QSA_PREFILL_GATHER): same compact block
-            # contract, bounded gathered attention on any Metal device — the
-            # universal lane for machines without Metal 4 TensorOps. Same
-            # visible set as the dense mask; only reduction order differs.
-            if _qsa_prefill_gather_enabled():
-                out = _qsa_prefill_gather_attention(
+            def _qsa_direct_supported() -> bool:
+                if not _qsa_prefill_direct_attention_enabled(S, T):
+                    return False
+                from mtplx.kernels.qsa_prefill_direct import (
+                    qsa_prefill_direct_supported,
+                )
+
+                return bool(
+                    qsa_prefill_direct_supported(
+                        q,
+                        k,
+                        v,
+                        block_ids,
+                        block_valid,
+                        pos_start=pos_start,
+                        total_tokens=T,
+                        scale=self.scale,
+                        compress_ratio=self.indexer.ratio,
+                        block_topk=self.indexer.block_topk,
+                    )
+                )
+
+            def _qsa_direct_call():
+                from mtplx.kernels.qsa_prefill_direct import qsa_prefill_direct
+
+                out = qsa_prefill_direct(
+                    q,
+                    k,
+                    v,
+                    block_ids,
+                    block_valid,
+                    pos_start=pos_start,
+                    total_tokens=T,
+                    scale=self.scale,
+                    compress_ratio=self.indexer.ratio,
+                    block_topk=self.indexer.block_topk,
+                )
+                return out
+
+            def _qsa_gather_call():
+                return _qsa_prefill_gather_attention(
                     q,
                     cache.kv.keys,
                     cache.kv.values,
@@ -3092,14 +3220,22 @@ class Attention(nn.Module):
                     scale=self.scale,
                     tile_rows=_qsa_prefill_gather_tile_rows(),
                 )
-                _qsa_prefill_count("gather_tier")
+
+            out = _qsa_prefill_dispatch_tier(
+                flash_supported=_qsa_flash_supported,
+                flash_call=_qsa_flash_call,
+                direct_supported=_qsa_direct_supported,
+                direct_call=_qsa_direct_call,
+                gather_enabled=_qsa_prefill_gather_enabled(),
+                gather_call=_qsa_gather_call,
+            )
+            if out is not None:
                 out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
                 return self.o_proj(out * mx.sigmoid(gate))
 
             # Static unsupported geometry falls back exactly.  Once the
             # supported kernel is dispatched, failures propagate instead of
             # being hidden behind a dense retry.
-            _qsa_prefill_count("dense_fallback")
             sel_mask = _qsa_blocks_to_dense_mask(
                 block_ids,
                 block_valid,

--- a/mtplx/profiles.py
+++ b/mtplx/profiles.py
@@ -322,6 +322,15 @@ MODEL_RUNTIME_ENV_OVERRIDE_KEYS = frozenset(
         "MTPLX_QSA_PREFILL_MIN_CONTEXT",
         "MTPLX_QSA_PREFILL_FLASH_MIN_CONTEXT",
         "MTPLX_QSA_PREFILL_SCORE_MB",
+        # Vendored Steel sparse-GQA consumer of the same block selections
+        # (native_extensions/qsa_kernels, oMLX PR #3244). Default on wherever
+        # the native module is built and ABI-probed; "0" kills only this
+        # consumer. MTPLX_QSA_PREFILL=0 still kills the whole lane. It is the
+        # only fast consumer M3-class GPUs can reach, so it also participates
+        # in the producer auto-gate.
+        "MTPLX_QSA_PREFILL_DIRECT",
+        "MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT",
+        "MTPLX_QSA_PREFILL_DIRECT_VALIDATE",
         # Portable gathered-attention tier for the flash_prefill contract:
         # the universal (non-NAX) consumer of the same block selections.
         "MTPLX_QSA_PREFILL_GATHER",

--- a/native_extensions/qsa_kernels/.gitignore
+++ b/native_extensions/qsa_kernels/.gitignore
@@ -1,0 +1,7 @@
+build/
+*.egg-info/
+mtplx_qsa_kernels/*.so
+mtplx_qsa_kernels/*.dylib
+mtplx_qsa_kernels/*.metallib
+mtplx_qsa_kernels/__pycache__/
+__pycache__/

--- a/native_extensions/qsa_kernels/CMakeLists.txt
+++ b/native_extensions/qsa_kernels/CMakeLists.txt
@@ -1,0 +1,104 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(mtplx_qsa_kernels LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# oMLX builds this kernel family against a 15.0 deployment target; keep the
+# C++ and Metal outputs on the same target so a metallib built here cannot
+# outrun the .so's minimum OS.
+if(CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET
+      "15.0"
+      CACHE STRING "" FORCE)
+endif()
+
+option(BUILD_SHARED_LIBS "Build extensions as a shared library" ON)
+
+# Pass BOTH hints from sys.executable at configure time (see setup.py):
+# CMake otherwise happily selects a framework Python outside the venv and
+# links the extension against the wrong interpreter.
+find_package(
+  Python 3.11
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+
+# Build receipts baked into the module. The primitive links MLX's private C++
+# ABI, so the wrapper must be able to prove which wheel it was built against.
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c
+          "import mlx.core as mx; print(mx.__version__)"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MTPLX_QSA_MLX_VERSION)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c
+          "import nanobind; print(nanobind.__version__)"
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MTPLX_QSA_NANOBIND_VERSION)
+
+set(MTPLX_QSA_METAL_LIBRARY "mtplx_qsa_kernels")
+
+add_library(mtplx_qsa_kernel_ops)
+target_sources(
+  mtplx_qsa_kernel_ops
+  PRIVATE ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_sparse_gqa.cpp)
+target_include_directories(mtplx_qsa_kernel_ops
+                           PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(mtplx_qsa_kernel_ops PUBLIC mlx)
+
+if(MLX_BUILD_METAL)
+  mlx_build_metallib(
+    TARGET
+    mtplx_qsa_kernels_metallib
+    TITLE
+    ${MTPLX_QSA_METAL_LIBRARY}
+    SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_sparse_gqa.metal
+    INCLUDE_DIRS
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${MLX_INCLUDE_DIRS}
+    OUTPUT_DIRECTORY
+    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+  add_dependencies(mtplx_qsa_kernel_ops mtplx_qsa_kernels_metallib)
+endif()
+
+nanobind_add_module(
+  _ext
+  NB_STATIC
+  STABLE_ABI
+  LTO
+  NOMINSIZE
+  NB_DOMAIN
+  mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)
+target_link_libraries(_ext PRIVATE mtplx_qsa_kernel_ops)
+target_compile_definitions(
+  _ext
+  PRIVATE MTPLX_QSA_BUILD_MLX_VERSION="${MTPLX_QSA_MLX_VERSION}"
+          MTPLX_QSA_BUILD_NANOBIND_VERSION="${MTPLX_QSA_NANOBIND_VERSION}"
+          MTPLX_QSA_METAL_LIBRARY="${MTPLX_QSA_METAL_LIBRARY}")
+
+if(BUILD_SHARED_LIBS)
+  # @loader_path resolves the sibling kernel_ops dylib. The second entry
+  # resolves the mlx wheel's libmlx.dylib from the installed layout
+  # (site-packages/mtplx_qsa_kernels -> site-packages -> mlx/lib); without it
+  # the only libmlx rpath is the link-time absolute path into the build env,
+  # which is dead after install.
+  target_link_options(_ext PRIVATE -Wl,-rpath,@loader_path
+                      -Wl,-rpath,@loader_path/../mlx/lib)
+endif()

--- a/native_extensions/qsa_kernels/README.md
+++ b/native_extensions/qsa_kernels/README.md
@@ -1,0 +1,79 @@
+# mtplx_qsa_kernels — Qwen4 QSA sparse-GQA Metal kernel
+
+Optional native extension behind `mtplx/kernels/qsa_prefill_direct.py`. It is
+the only fast QSA prefill consumer an M3-class GPU can reach: the existing
+`qsa_prefill_flash` kernel needs Metal 4 TensorOps (G17 / NAX), which M3 does
+not have.
+
+Vendored from oMLX PR #3244 at revision
+`dc312e6e905e03d21ef0c4a86289cbfa2cf857cc`. See
+`mtplx_qsa_kernels/NOTICE` for provenance, MTPLX modifications, and licenses.
+
+Nothing in MTPLX requires this module. Without it the import stays green and
+the direct lane reports unsupported.
+
+## Build (on the target machine, in the venv that will run MTPLX)
+
+This extension links MLX's **private C++ ABI** and compiles against the Steel
+Metal headers shipped in the mlx wheel. It is not portable between wheels.
+Build it in the same interpreter that serves.
+
+```sh
+# 1. Requirements: full Xcode (working `xcrun -sdk macosx metal`), CMake >= 3.27.
+xcrun -sdk macosx metal --version
+
+# 2. Exact ABI pins. nanobind MUST match the version the mlx wheel was built
+#    with; a mismatch imports cleanly and then rejects every mx.array.
+python -m pip install "nanobind==2.15.0"
+python -c "import mlx.core as mx; print('mlx', mx.__version__)"
+
+# 3. Build in place (puts _ext*.so and mtplx_qsa_kernels.metallib inside the
+#    mtplx_qsa_kernels/ package directory, where the wrapper finds them).
+cd native_extensions/qsa_kernels
+python setup.py build_ext --inplace
+
+# 4. Prove the artifact, not the symbol.
+python - <<'PY'
+import mtplx_qsa_kernels as ext
+print(ext.BUILT_AGAINST_MLX, ext.BUILT_AGAINST_NANOBIND, ext.METAL_LIBRARY)
+from mtplx.kernels.qsa_prefill_direct import (
+    qsa_prefill_direct_build_info, qsa_prefill_direct_preflight)
+print(qsa_prefill_direct_build_info())
+print("pipeline ok:", qsa_prefill_direct_preflight())
+PY
+```
+
+`otool -L mtplx_qsa_kernels/_ext*.so` must resolve `libmlx.dylib` to the mlx
+wheel in this venv, not to a build-tree absolute path.
+
+## Things that break it
+
+* **nanobind drift.** `nanobind>=2` at the MTPLX root is a floor, not a pin.
+  The exact version is what matters; `abi_probe` catches a mismatch at import
+  and disables the lane with one warning.
+* **mlx upgrade.** Any `pip install -U mlx`, even inside MTPLX's
+  `>=0.32.2,<0.33` runtime range, invalidates this build. The wrapper detects
+  it: `BUILT_AGAINST_MLX` is compared against the imported version at
+  readiness, and a mismatch warns once and disables the lane, so the symptom
+  is "the direct lane stopped engaging", not a crash. Rebuild here.
+  `pyproject.toml` pins the BUILD to `mlx==0.32.2` so a PEP 517 isolated
+  build cannot quietly pick a different 0.32.x than the serving venv holds.
+* **Metallib name or location.** The C++ resolves `mtplx_qsa_kernels` from the
+  directory of the loaded `.so`. Renaming or moving either one turns a symbol
+  that imports fine into an `mx.eval`-time pipeline failure. That is what
+  `qsa_prefill_direct_preflight()` exists to catch before traffic. A failed
+  proof — from the preflight or from the first real dispatch — retires the
+  lane for the whole process, so `qsa_prefill_direct_ready()` goes False, the
+  M3 producer auto-gate disarms, and traffic routes to the gather tier
+  instead of re-hitting the same wall every request.
+* **Retuning `WM`.** It is part of the compiled kernel name and its MMA
+  layout, and the M2/M3 threadgroup ceiling is 896 for some kernels, not 1024.
+  Both the Metal header and the C++ carry a `static_assert(WM * 32 <= 896)`.
+  It is not a Python tuning knob.
+
+## Scope
+
+Only `(BK, DC) = (64, 64)` is instantiated, for fp16 and bf16 — the
+specialization oMLX's production glue uses and the one that was measured on
+M3. The C++ `unsupported()` was narrowed to match, so the Python support
+check, the C++ check, and the packaged metallib all describe the same set.

--- a/native_extensions/qsa_kernels/bindings.cpp
+++ b/native_extensions/qsa_kernels/bindings.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal nanobind bindings for MTPLX's vendored Qwen4 QSA sparse-GQA
+// primitive. Scope is deliberately one kernel plus the ABI canary; the oMLX
+// bindings.cpp this is derived from exposes seven unrelated kernel families
+// that MTPLX does not vendor.
+
+#include <nanobind/nanobind.h>
+// StreamOrDevice is a std::variant over monostate/Stream/Device; without the
+// variant caster the "stream" keyword argument does not bind.
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/variant.h>
+
+#include "qwen4_qsa_sparse_gqa.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+#ifndef MTPLX_QSA_BUILD_MLX_VERSION
+#define MTPLX_QSA_BUILD_MLX_VERSION "unknown"
+#endif
+#ifndef MTPLX_QSA_BUILD_NANOBIND_VERSION
+#define MTPLX_QSA_BUILD_NANOBIND_VERSION "unknown"
+#endif
+#ifndef MTPLX_QSA_METAL_LIBRARY
+#define MTPLX_QSA_METAL_LIBRARY "mtplx_qsa_kernels"
+#endif
+
+NB_MODULE(_ext, m) {
+  m.doc() = "MTPLX Qwen4 QSA sparse-GQA Metal kernel (vendored from oMLX)";
+
+  // ABI canary: when the extension is built with a nanobind whose ABI tag
+  // differs from the one the mlx wheel was built with, the NB_DOMAIN is
+  // isolated and every mx.array argument is rejected with "incompatible
+  // function arguments" (oMLX issue #2139). The Python wrapper calls this
+  // probe once at import and disables the lane when it fails.
+  m.def(
+      "abi_probe",
+      [](const mlx::core::array &a) { return static_cast<int64_t>(a.size()); },
+      "a"_a);
+
+  // Build receipts. The primitive links MLX's private C++ ABI, so ANY wheel
+  // change needs a rebuild — which is why the native build pins mlx exactly.
+  // The Python wrapper compares BUILT_AGAINST_MLX against the imported
+  // mlx.core.__version__ during its readiness check: a mismatch warns once
+  // and disables the direct lane rather than dispatching a .so that will
+  // mis-read MLX's structs.
+  m.attr("BUILT_AGAINST_MLX") = MTPLX_QSA_BUILD_MLX_VERSION;
+  m.attr("BUILT_AGAINST_NANOBIND") = MTPLX_QSA_BUILD_NANOBIND_VERSION;
+  m.attr("METAL_LIBRARY") = MTPLX_QSA_METAL_LIBRARY;
+
+  m.def(
+      "qwen4_qsa_sparse_gqa_attention",
+      &mtplx::qsa_kernels::qwen4_qsa_sparse_gqa_attention,
+      "queries"_a,
+      "keys"_a,
+      "values"_a,
+      "selected_blocks"_a,
+      "scale"_a,
+      "q_offset"_a,
+      "key_tile"_a = 64,
+      "dimension_tile"_a = 64,
+      "stream"_a = nb::none());
+}

--- a/native_extensions/qsa_kernels/kernels/steel_qwen4_qsa_sparse_gqa.h
+++ b/native_extensions/qsa_kernels/kernels/steel_qwen4_qsa_sparse_gqa.h
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 OpenAI
+//
+// Vendored into MTPLX from oMLX (https://github.com/jundot/omlx), PR #3244,
+// revision dc312e6e905e03d21ef0c4a86289cbfa2cf857cc, file
+// omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_qwen4_qsa_sparse_gqa.h.
+// The kernel body is unmodified; MTPLX adds only the WM threadgroup
+// static_assert below (M2/M3 cap 896 threads for some kernels, issue #400).
+
+#pragma once
+
+#include "mlx/backend/metal/kernels/steel/attn/attn.h"
+#include "mlx/backend/metal/kernels/steel/attn/params.h"
+
+using namespace mlx::steel;
+
+struct Qwen4SparseMaxOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return metal::max(x, y);
+  }
+};
+
+struct Qwen4SparseSumOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x + y;
+  }
+};
+
+struct Qwen4SparseMulOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x * y;
+  }
+};
+
+struct Qwen4SparseExpSubOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return fast::exp2(x - y);
+  }
+};
+
+struct Qwen4SparseDivOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x / y;
+  }
+};
+
+// Exact Qwen4 QSA main attention over query-specific selected four-token
+// blocks.
+//
+// One threadgroup owns one (query row, KV head). Qwen's 12 query heads per
+// KV head are padded to one 16-row Steel MMA tile, letting both main GQA groups
+// reuse each randomly addressed K/V tile without materializing the enormous
+// [query, selected, kv-head, dim] gathered tensors. Invalid early-prefix
+// blocks are masked before online FP32 softmax. The
+// selected block list is chronological, and the zero-to-three causal tail is
+// generated in-kernel, so accumulation follows the checkpoint's dense-mask
+// token order without materializing an expanded 2,051-index tensor.
+// The 128-bit global K/V staging pattern is adapted from mlx-serve's MIT
+// ``msv_attn_p256`` kernel (Copyright 2026 David Dalcu); the query-specific
+// direct-index/GQA organization and Steel MMA implementation are oMLX-specific.
+// clang-format off
+template <
+    typename T,
+    int BK,
+    int DC,
+    int GQA,
+    int H_PAD,
+    int D,
+    int WM,
+    typename IndexT,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void
+qwen4_qsa_sparse_gqa_attention(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* V [[buffer(2)]],
+    const device IndexT* Topk [[buffer(3)]],
+    device T* O [[buffer(4)]],
+    const constant Qwen4QSASparseGQAParams* params [[buffer(5)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = BK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int kNWarps = WM;
+  constexpr int TQ = H_PAD / (kNWarps * kFragSize);
+  constexpr int TK = BK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int D_CHUNKS = D / DC;
+
+  // MTPLX addition (M3 Ultra target, issue #400): the launch is
+  // MTL::Size(32, WM, 1) and the kernel attribute is WM * 32. M2/M3 cap some
+  // kernels at 896 threads per threadgroup rather than 1024, so any future
+  // WM retune must re-open that question deliberately instead of silently
+  // producing an unlaunchable pipeline.
+  static_assert(WM * 32 <= 896,
+                "Threadgroup exceeds the M2/M3 896-thread ceiling.");
+  static_assert(GQA <= H_PAD, "Qwen GQA heads must fit the padded MMA tile.");
+  static_assert(TQ == 1, "Qwen sparse GQA expects one query-head tile.");
+  static_assert(H_PAD % (kNWarps * kFragSize) == 0,
+                "Padded query heads must divide evenly across simdgroups.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of eight.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of eight.");
+  static_assert(D % DC == 0, "Head dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+  const int q_pos = int(tid.x);
+  const int kv_head = int(tid.y);
+  const int b = int(tid.z);
+
+  threadgroup T Qs[H_PAD * LDQ];
+  threadgroup T KVs[(BK * LDV > DC * LDK) ? BK * LDV : DC * LDK];
+  threadgroup int selected[BK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, D_CHUNKS * TDC, MMAFragAcc> Otile;
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * simd_group_id;
+  const short Qs_offset = (tm + sm) * LDQ + sn;
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const int query_head_base = kv_head * GQA;
+  const device T *q_base = Q + size_t(b) * params->Q_strides[0] +
+                           size_t(query_head_base) * params->Q_strides[1] +
+                           size_t(q_pos) * params->Q_strides[2];
+  const device T *k_base = K + size_t(b) * params->K_strides[0] +
+                           size_t(kv_head) * params->K_strides[1];
+  const device T *v_base = V + size_t(b) * params->V_strides[0] +
+                           size_t(kv_head) * params->V_strides[1];
+  const device IndexT *topk_base = Topk + size_t(b) * params->Topk_strides[0] +
+                                   size_t(q_pos) * params->Topk_strides[2];
+
+  const int q_abs = params->q_offset + q_pos;
+  constexpr int kCompressRatio = 4;
+  constexpr int kTail = kCompressRatio - 1;
+  const int selected_tokens = params->topk * kCompressRatio + kTail;
+  const int complete_blocks = (q_abs + 1) / kCompressRatio;
+  const int valid_blocks = metal::min(params->topk, complete_blocks);
+  const int n_tiles = (selected_tokens + BK - 1) / BK;
+
+  for (int ktile = 0; ktile < n_tiles; ++ktile) {
+    const int topk_off = ktile * BK;
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int slot = topk_off + k;
+      int k_pos = -1;
+      if (slot < params->topk * kCompressRatio) {
+        const int block_slot = slot / kCompressRatio;
+        if (block_slot < valid_blocks) {
+          const IndexT raw_block = topk_base[block_slot];
+          const ulong candidate = ulong(raw_block) * ulong(kCompressRatio) +
+                                  ulong(slot % kCompressRatio);
+          if (candidate < ulong(params->kL) && candidate <= ulong(q_abs)) {
+            k_pos = int(candidate);
+          }
+        }
+      } else if (slot < selected_tokens) {
+        const int tail_offset = slot - params->topk * kCompressRatio;
+        const int candidate = complete_blocks * kCompressRatio + tail_offset;
+        if (candidate < params->kL && candidate <= q_abs) {
+          k_pos = candidate;
+        }
+      }
+      selected[k] = k_pos;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+      for (int elem = lane; elem < H_PAD * (DC / 8); elem += tgp_size) {
+        const int h = elem / (DC / 8);
+        const int d8 = elem - h * (DC / 8);
+        uint4 word = uint4(0);
+        if (h < GQA) {
+          word = *((const device uint4 *)(q_base +
+                                          size_t(h) * params->Q_strides[1] +
+                                          dbase) +
+                   d8);
+        }
+        *((threadgroup uint4 *)(Qs + h * LDQ) + d8) = word;
+      }
+      for (int elem = lane; elem < BK * (DC / 8); elem += tgp_size) {
+        const int k = elem / (DC / 8);
+        const int d8 = elem - k * (DC / 8);
+        const int k_pos = selected[k];
+        uint4 word = uint4(0);
+        if (k_pos >= 0) {
+          word = *((const device uint4 *)(k_base +
+                                          size_t(k_pos) * params->K_strides[2] +
+                                          dbase) +
+                   d8);
+        }
+        thread T *values = (thread T *)&word;
+        const int d = d8 * 8;
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < 8; ++e) {
+          KVs[k + (d + e) * LDK] = values[e];
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        Qtile.template load<T, 1, 1, LDQ, 1>(&Qs[Qs_offset + dd * kFragSize]);
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Stile)::kElemsPerTile; ++i) {
+      Stile.elems()[i] *= scale;
+    }
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      // Early first-chunk rows can have no complete block, so entire leading
+      // tiles are invalid before the causal tail in the final tile. True
+      // -INFINITY makes those tiles contribute exp2(-inf - finite_max) == 0;
+      // finite_min would incorrectly add one to the softmax denominator.
+      constexpr auto neg_inf = selem_t(-INFINITY);
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short e = 0; e < stile_t::MMAFrag_t::kElemCols; ++e) {
+            if (selected[col_pos + e] < 0) {
+              Stile.frag_at(i, j)[e] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+    Stile.template row_reduce<Qwen4SparseMaxOp>(new_max);
+    Stile.template row_bin_op<Qwen4SparseExpSubOp>(new_max);
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<Qwen4SparseSumOp>(sum_score_tmp);
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+    Otile.template row_bin_op<Qwen4SparseMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < D_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+      for (int elem = lane; elem < BK * (DC / 8); elem += tgp_size) {
+        const int k = elem / (DC / 8);
+        const int d8 = elem - k * (DC / 8);
+        const int k_pos = selected[k];
+        uint4 word = uint4(0);
+        if (k_pos >= 0) {
+          word = *((const device uint4 *)(v_base +
+                                          size_t(k_pos) * params->V_strides[2] +
+                                          dbase) +
+                   d8);
+        }
+        *((threadgroup uint4 *)(KVs + k * LDV) + d8) = word;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(Otile.frag_at(iq, vchunk * TDC + id),
+                            Stile.frag_at(iq, ik), Vtile.frag_at(0, 0),
+                            Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  Otile.template row_bin_op<Qwen4SparseDivOp>(sum_score);
+  device T *out = O + size_t(b) * params->O_strides[0] +
+                  size_t(query_head_base + tm + sm) * params->O_strides[1] +
+                  size_t(q_pos) * params->O_strides[2] + sn;
+  const short rows_left = short(GQA - (tm + sm));
+  if (rows_left > 0) {
+    Otile.template store_safe<T, 1, 1>(out, params->O_strides[1],
+                                       short2(D - sn, rows_left));
+  }
+}

--- a/native_extensions/qsa_kernels/mtplx_qsa_kernels/LICENSE.txt
+++ b/native_extensions/qsa_kernels/mtplx_qsa_kernels/LICENSE.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 oMLX contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/native_extensions/qsa_kernels/mtplx_qsa_kernels/MLX_LICENSE.txt
+++ b/native_extensions/qsa_kernels/mtplx_qsa_kernels/MLX_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2023 Apple Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/native_extensions/qsa_kernels/mtplx_qsa_kernels/MLX_SERVE_LICENSE.txt
+++ b/native_extensions/qsa_kernels/mtplx_qsa_kernels/MLX_SERVE_LICENSE.txt
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 David Dalcu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The MIT terms above cover mlx-serve's own code. This distribution also includes
+third-party software under its own licenses, including the Apache License 2.0,
+the BSD 3-Clause License, and further MIT-licensed components. Those licenses
+continue to apply to those portions.
+
+See NOTICE for the list and the required attributions, and LICENSE-APACHE-2.0
+for the text of the Apache License, Version 2.0.

--- a/native_extensions/qsa_kernels/mtplx_qsa_kernels/NOTICE
+++ b/native_extensions/qsa_kernels/mtplx_qsa_kernels/NOTICE
@@ -1,0 +1,45 @@
+mtplx_qsa_kernels
+=================
+
+This package contains the Qwen4 QSA sparse-GQA Metal attention kernel used by
+MTPLX's `mtplx/kernels/qsa_prefill_direct.py` lane.
+
+PROVENANCE
+
+  Upstream project : oMLX (https://github.com/jundot/omlx)
+  Upstream PR      : #3244 ("Qwen4 QSA direct sparse-GQA main attention")
+  Upstream revision: dc312e6e905e03d21ef0c4a86289cbfa2cf857cc
+  Upstream paths   : omlx/custom_kernels/glm_moe_dsa/csrc/
+                       qwen4_qsa_sparse_gqa.{h,cpp,metal}
+                       kernels/steel_qwen4_qsa_sparse_gqa.h
+                       bindings.cpp (abi_probe + one kernel binding only)
+                       CMakeLists.txt (trimmed to one target)
+
+  Licensed under the Apache License, Version 2.0. See LICENSE.txt.
+  Copyright (c) 2026 OpenAI (steel_qwen4_qsa_sparse_gqa.h).
+
+MTPLX MODIFICATIONS
+
+  * namespace omlx::glm_kernels -> mtplx::qsa_kernels;
+  * Metal library / metallib name "omlx_glm_kernels" -> "mtplx_qsa_kernels";
+  * primitive name OMLXQwen4QSASparseGQAAttention ->
+    MTPLXQwen4QSASparseGQAAttention;
+  * accepted (key_tile, dimension_tile) narrowed to the single packaged
+    specialization (64, 64), for both fp16 and bf16;
+  * only the (64, 64) kernels are instantiated in the .metal file;
+  * static_assert(WM * 32 <= 896) added for the M2/M3 threadgroup ceiling;
+  * bindings reduced to abi_probe, build receipts, and this one kernel.
+
+  The Metal include order in qwen4_qsa_sparse_gqa.metal is unchanged and is
+  load-bearing (Steel's attention header provides Limits).
+
+THIRD-PARTY NOTICES
+
+  MLX (https://github.com/ml-explore/mlx), MIT. The kernel includes MLX's
+  Steel MMA and attention headers from the installed mlx wheel.
+  See MLX_LICENSE.txt.
+
+  mlx-serve, MIT, Copyright 2026 David Dalcu. The 128-bit global K/V staging
+  pattern in steel_qwen4_qsa_sparse_gqa.h is adapted from mlx-serve's
+  `msv_attn_p256` kernel; the attribution comment is preserved verbatim in
+  that header. See MLX_SERVE_LICENSE.txt.

--- a/native_extensions/qsa_kernels/mtplx_qsa_kernels/__init__.py
+++ b/native_extensions/qsa_kernels/mtplx_qsa_kernels/__init__.py
@@ -1,0 +1,24 @@
+"""Native Qwen4 QSA sparse-GQA Metal kernel for MTPLX.
+
+Optional: MTPLX imports this package defensively. When the extension was
+never built the import fails and ``mtplx/kernels/qsa_prefill_direct.py``
+reports the lane unsupported without raising.
+
+See NOTICE for provenance (oMLX PR #3244) and the license set.
+"""
+
+from ._ext import (  # noqa: F401
+    BUILT_AGAINST_MLX,
+    BUILT_AGAINST_NANOBIND,
+    METAL_LIBRARY,
+    abi_probe,
+    qwen4_qsa_sparse_gqa_attention,
+)
+
+__all__ = [
+    "BUILT_AGAINST_MLX",
+    "BUILT_AGAINST_NANOBIND",
+    "METAL_LIBRARY",
+    "abi_probe",
+    "qwen4_qsa_sparse_gqa_attention",
+]

--- a/native_extensions/qsa_kernels/pyproject.toml
+++ b/native_extensions/qsa_kernels/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+# nanobind is pinned EXACTLY, not floated. mlx 0.32.2 was built with
+# nanobind 2.15.0 via FetchContent; an extension built with a different
+# nanobind ABI tag imports and lists every symbol but lands in an isolated
+# NB_DOMAIN, so every mx.array argument is rejected with "incompatible
+# function arguments" (oMLX issue #2139). The abi_probe canary catches that
+# at import, but the pin is what prevents it.
+#
+# mlx is pinned to ONE wheel for the same reason at the C++ level: this
+# extension links MLX's private Primitive ABI and its Steel Metal headers,
+# which carry no compatibility promise across patch releases. A range would
+# let a PEP 517 isolated build resolve a different 0.32.x than the serving
+# venv holds, producing a .so that imports, probes, and then mis-reads a
+# struct. Build it in the SAME venv that will run MTPLX and rebuild after
+# any mlx upgrade; the CMake-baked BUILT_AGAINST_MLX receipt is checked
+# against the imported mlx at readiness and disables the lane on a mismatch.
+requires = [
+  "setuptools>=42",
+  "cmake>=3.27",
+  "mlx==0.32.2",
+  "nanobind==2.15.0",
+]
+build-backend = "setuptools.build_meta"

--- a/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.cpp
+++ b/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Vendored into MTPLX from oMLX (https://github.com/jundot/omlx), PR #3244,
+// revision dc312e6e905e03d21ef0c4a86289cbfa2cf857cc.
+//
+// MTPLX changes, all deliberate and narrow:
+//   * namespace omlx::glm_kernels -> mtplx::qsa_kernels;
+//   * Metal library name "omlx_glm_kernels" -> "mtplx_qsa_kernels" (a
+//     same-process collision with a co-installed oMLX would otherwise pick
+//     whichever metallib loaded first);
+//   * primitive name OMLX... -> MTPLX...;
+//   * the accepted (key_tile, dimension_tile) set is narrowed to the single
+//     shipped specialization (64, 64) so this check matches both the
+//     packaged .metal instantiations and the Python support check exactly;
+//   * a WM threadgroup static_assert for the M2/M3 896-thread ceiling.
+
+#include "qwen4_qsa_sparse_gqa.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace mtplx::qsa_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+// Metal library base name. Must match the metallib produced by CMakeLists.txt
+// and installed next to _ext*.so; get_library resolves it from the loaded
+// binary's directory.
+constexpr const char *kMetalLibrary = "mtplx_qsa_kernels";
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void *>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get mtplx_qsa_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+bool last_dim_contiguous(const array &arr) { return arr.strides(-1) == 1; }
+
+struct Qwen4QSASparseGQAParams {
+  int B;
+  int q_heads;
+  int kv_heads;
+  int qL;
+  int kL;
+  int topk;
+  int gqa_factor;
+  int q_offset;
+
+  float scale;
+
+  int64_t Q_strides[3];
+  int64_t K_strides[3];
+  int64_t V_strides[3];
+  int64_t Topk_strides[3];
+  int64_t O_strides[3];
+};
+
+class Qwen4QSASparseGQAPrimitive : public Primitive {
+public:
+  Qwen4QSASparseGQAPrimitive(Stream stream, float scale, int q_offset,
+                             int key_tile, int dimension_tile)
+      : Primitive(stream), scale_(scale), q_offset_(q_offset),
+        key_tile_(key_tile), dimension_tile_(dimension_tile) {}
+
+  static bool unsupported(const array &q, const array &k, const array &v,
+                          const array &selected, float scale, int q_offset,
+                          int key_tile, int dimension_tile, Stream stream) {
+    if (stream.device == Device::cpu || q.dtype() != k.dtype() ||
+        q.dtype() != v.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 ||
+        selected.ndim() != 4 || selected.dtype() != uint32) {
+      return true;
+    }
+    if (!last_dim_contiguous(q) || !last_dim_contiguous(k) ||
+        !last_dim_contiguous(v) || !last_dim_contiguous(selected)) {
+      return true;
+    }
+    if (q.shape(0) != 1 || k.shape(0) != 1 || v.shape(0) != 1 ||
+        selected.shape(0) != 1 || q.shape(1) != 24 || k.shape(1) != 2 ||
+        v.shape(1) != 2 || q.shape(3) != 256 || k.shape(3) != 256 ||
+        v.shape(3) != 256 || k.shape(2) != v.shape(2) || q.shape(2) <= 0 ||
+        selected.shape(1) != 1 || selected.shape(2) != q.shape(2) ||
+        selected.shape(3) != 512) {
+      return true;
+    }
+    // MTPLX narrowing: only the packaged (BK, DC) = (64, 64) specialization.
+    if (key_tile != 64 || dimension_tile != 64) {
+      return true;
+    }
+    // Logical-view ABI: params.kL IS k.shape(2), so the caller must hand in
+    // the live cache prefix, not a capacity backing and not an interior
+    // window. Q is the SUFFIX ending exactly at the frontier, so equality —
+    // not <= — is the contract the Python wrapper enforces
+    // (key_len != total_tokens_i in qsa_prefill_direct.py). A shorter Q
+    // window would still launch here and silently attend the wrong rows.
+    if (q_offset < 0 || q_offset + q.shape(2) != k.shape(2)) {
+      return true;
+    }
+    // The one production scale: 1/sqrt(256) == 1/16, which is exactly
+    // representable in binary floating point, so this equality is safe and
+    // needs no tolerance. Any other value means the caller is not the QSA
+    // prefill lane this kernel was measured for.
+    if (scale != 0.0625f) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(const std::vector<array> & /* inputs */,
+                std::vector<array> & /* outputs */) override {
+    throw std::runtime_error("Qwen4QSASparseGQAPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(const std::vector<array> &inputs,
+                std::vector<array> &outputs) override {
+    auto &stream = this->stream();
+    auto &device = metal::device(stream.device);
+    const auto &q = inputs[0];
+    const auto &k = inputs[1];
+    const auto &v = inputs[2];
+    const auto &selected = inputs[3];
+    auto &out = outputs[0];
+
+    constexpr int gqa = 12;
+    constexpr int dim = 256;
+    constexpr int wm = 2;
+    constexpr int hpad = 16;
+    // Mirrors the in-kernel assert: the launch below is (32, wm, 1) threads.
+    static_assert(wm * 32 <= 896,
+                  "Threadgroup exceeds the M2/M3 896-thread ceiling.");
+
+    out.set_data(allocator::malloc(out.nbytes()));
+    Qwen4QSASparseGQAParams params{
+        /* int B = */ 1,
+        /* int q_heads = */ 24,
+        /* int kv_heads = */ 2,
+        /* int qL = */ q.shape(2),
+        /* int kL = */ k.shape(2),
+        /* int topk = */ selected.shape(3),
+        /* int gqa_factor = */ gqa,
+        /* int q_offset = */ q_offset_,
+        /* float scale = */ scale_,
+        /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
+        /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
+        /* int64_t V_strides[3] = */ {v.strides(0), v.strides(1), v.strides(2)},
+        /* int64_t Topk_strides[3] = */
+        {selected.strides(0), selected.strides(1), selected.strides(2)},
+        /* int64_t O_strides[3] = */
+        {out.strides(0), out.strides(1), out.strides(2)}};
+
+    std::string kernel_name;
+    concatenate(kernel_name, "qwen4_qsa_sparse_gqa_", type_to_name(q), "_bk",
+                key_tile_, "_dc", dimension_tile_, "_gqa", gqa, "_hp", hpad,
+                "_d", dim, "_wm", wm);
+
+    auto library = device.get_library(kMetalLibrary, current_binary_dir());
+    auto kernel = device.get_kernel(kernel_name, library);
+    auto &encoder = metal::get_command_encoder(stream);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(q, 0);
+    encoder.set_input_array(k, 1);
+    encoder.set_input_array(v, 2);
+    encoder.set_input_array(selected, 3);
+    encoder.set_output_array(out, 4);
+    encoder.set_bytes(params, 5);
+    encoder.dispatch_threadgroups(MTL::Size(q.shape(2), k.shape(1), 1),
+                                  MTL::Size(32, wm, 1));
+  }
+
+  DEFINE_NAME(MTPLXQwen4QSASparseGQAAttention)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive &other) const override {
+    const auto &rhs = static_cast<const Qwen4QSASparseGQAPrimitive &>(other);
+    return scale_ == rhs.scale_ && q_offset_ == rhs.q_offset_ &&
+           key_tile_ == rhs.key_tile_ && dimension_tile_ == rhs.dimension_tile_;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr, scale_, q_offset_, key_tile_,
+                           dimension_tile_);
+  }
+
+private:
+  float scale_;
+  int q_offset_;
+  int key_tile_;
+  int dimension_tile_;
+};
+
+} // namespace
+
+array qwen4_qsa_sparse_gqa_attention(const array &queries, const array &keys,
+                                     const array &values,
+                                     const array &selected_blocks, float scale,
+                                     int q_offset, int key_tile,
+                                     int dimension_tile, StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (Qwen4QSASparseGQAPrimitive::unsupported(
+          queries, keys, values, selected_blocks, scale, q_offset, key_tile,
+          dimension_tile, stream)) {
+    std::ostringstream msg;
+    msg << "[mtplx_qsa_kernels.qwen4_qsa_sparse_gqa_attention] expected "
+        << "q=[1,24,M,256], k/v=[1,2,K,256], uint32 selected blocks="
+        << "[1,1,M,512], q_offset>=0 with q_offset+M==K (the logical cache "
+        << "prefix, so Q is the suffix ending at the frontier), "
+        << "scale==0.0625, (BK,DC)==(64,64); got " << queries.shape() << ", "
+        << keys.shape() << ", " << values.shape() << ", "
+        << selected_blocks.shape() << ", q_offset=" << q_offset
+        << ", scale=" << scale << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  Shape out_shape{queries.shape(0), queries.shape(1), queries.shape(2),
+                  queries.shape(3)};
+  return array(std::move(out_shape), queries.dtype(),
+               std::make_shared<Qwen4QSASparseGQAPrimitive>(
+                   stream, scale, q_offset, key_tile, dimension_tile),
+               std::vector<array>{queries, keys, values, selected_blocks});
+}
+
+} // namespace mtplx::qsa_kernels

--- a/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.h
+++ b/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Vendored into MTPLX from oMLX (https://github.com/jundot/omlx), PR #3244,
+// revision dc312e6e905e03d21ef0c4a86289cbfa2cf857cc. The oMLX namespace
+// ``omlx::glm_kernels`` is renamed to ``mtplx::qsa_kernels`` and the tile
+// defaults are pinned to the one measured production specialization so a
+// co-installed oMLX cannot collide with this module's Metal library name.
+
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace mtplx::qsa_kernels {
+
+// Exact Qwen4 QSA main attention over query-specific selected four-token
+// blocks. ``selected_blocks`` is ``[1, 1, qL, 512]`` uint32 holding a
+// chronological VALID PREFIX of block ids; validity is positional, derived
+// in-kernel as ``min(512, (q_offset + row + 1) / 4)``. Callers own that
+// invariant (see mtplx/kernels/qsa_prefill_direct.py).
+mx::array qwen4_qsa_sparse_gqa_attention(
+    const mx::array &queries, const mx::array &keys, const mx::array &values,
+    const mx::array &selected_blocks, float scale, int q_offset,
+    int key_tile = 64, int dimension_tile = 64, mx::StreamOrDevice s = {});
+
+} // namespace mtplx::qsa_kernels

--- a/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.metal
+++ b/native_extensions/qsa_kernels/qwen4_qsa_sparse_gqa.metal
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Vendored into MTPLX from oMLX (https://github.com/jundot/omlx), PR #3244,
+// revision dc312e6e905e03d21ef0c4a86289cbfa2cf857cc.
+//
+// MTPLX ships only the one measured production specialization
+// (BK=64, DC=64) in fp16 and bf16. The oMLX file also instantiates
+// (128,32), (256,32) and (128,64); packaging kernels that no MTPLX caller
+// can request only widens the Metal-compilation surface that must be
+// qualified on the first M3 run.
+
+// Include order is load-bearing: Steel's attention header provides Limits
+// used by the specialized Qwen kernel. The params struct is defined here
+// (Metal has no access to the C++ translation unit) and MUST match the
+// layout in qwen4_qsa_sparse_gqa.cpp byte-for-byte.
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
+
+struct Qwen4QSASparseGQAParams {
+  int B;
+  int q_heads;
+  int kv_heads;
+  int qL;
+  int kL;
+  int topk;
+  int gqa_factor;
+  int q_offset;
+
+  float scale;
+
+  int64_t Q_strides[3];
+  int64_t K_strides[3];
+  int64_t V_strides[3];
+  int64_t Topk_strides[3];
+  int64_t O_strides[3];
+};
+
+#include "kernels/steel_qwen4_qsa_sparse_gqa.h"
+// clang-format on
+
+#define instantiate_qwen4_sparse_gqa(tname, dtype, bk, dc)                     \
+  instantiate_kernel("qwen4_qsa_sparse_gqa_" #tname "_bk" #bk "_dc" #dc        \
+                     "_gqa12_hp16_d256_wm2",                                   \
+                     qwen4_qsa_sparse_gqa_attention, dtype, bk, dc, 12, 16,    \
+                     256, 2, uint, float)
+
+instantiate_qwen4_sparse_gqa(float16, half, 64, 64);
+instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 64, 64);

--- a/native_extensions/qsa_kernels/setup.py
+++ b/native_extensions/qsa_kernels/setup.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+from setuptools import setup
+
+from mlx import extension
+
+
+if __name__ == "__main__":
+    # CMake can otherwise select a framework Python outside the venv; both
+    # hints are needed because find_package(Python ...) and any transitive
+    # find_package(Python3 ...) read different cache variables.
+    os.environ.setdefault("CMAKE_ARGS", "")
+    os.environ["CMAKE_ARGS"] = " ".join(
+        part
+        for part in (
+            os.environ["CMAKE_ARGS"],
+            f"-DPython_EXECUTABLE={sys.executable}",
+            f"-DPython3_EXECUTABLE={sys.executable}",
+        )
+        if part
+    )
+    setup(
+        name="mtplx_qsa_kernels",
+        version="0.0.1",
+        description=(
+            "Qwen4 QSA sparse-GQA Steel Metal kernel for MTPLX "
+            "(vendored from oMLX PR #3244, Apache-2.0)."
+        ),
+        ext_modules=[extension.CMakeExtension("mtplx_qsa_kernels._ext")],
+        cmdclass={"build_ext": extension.CMakeBuild},
+        packages=["mtplx_qsa_kernels"],
+        package_data={
+            "mtplx_qsa_kernels": [
+                "*.so",
+                "*.dylib",
+                "*.metallib",
+                "LICENSE.txt",
+                "NOTICE",
+                "MLX_LICENSE.txt",
+                "MLX_SERVE_LICENSE.txt",
+            ]
+        },
+        zip_safe=False,
+        python_requires=">=3.11",
+    )

--- a/tests/test_qsa_prefill_direct.py
+++ b/tests/test_qsa_prefill_direct.py
@@ -1,0 +1,797 @@
+"""Behavioural gates for the direct Steel QSA prefill consumer.
+
+None of these need the native ``.so``: the extension is stubbed, so they run
+on any machine and pin the parts that decide whether a real build is used
+correctly — availability, the ABI canary, the kill switch, the geometry
+gates, and the Topk adapter that drops ``block_valid`` at the native ABI
+boundary.
+
+The numeric parity tests belong on the Studio with a built extension; see
+IMPLEMENTATION_NOTES.md.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+import pytest
+
+import mtplx.kernels.qsa_prefill_direct as direct
+
+_ROWS = 8
+_TOTAL = 2056  # 2056 // 4 == 514 > 512: past the dense/sparse boundary
+_POS_START = _TOTAL - _ROWS
+_SCALE = 0.0625
+
+
+class _FakeExt:
+    """Stands in for mtplx_qsa_kernels._ext with the same call surface."""
+
+    # A real build bakes this from the build interpreter's wheel, and the
+    # wrapper disables the lane when it does not match the mlx that is
+    # imported. A healthy stub therefore has to claim the runtime version.
+    BUILT_AGAINST_MLX = mx.__version__
+    BUILT_AGAINST_NANOBIND = "2.15.0"
+    METAL_LIBRARY = "mtplx_qsa_kernels"
+
+    def __init__(self):
+        self.calls = []
+
+    def abi_probe(self, a):
+        return a.size
+
+    def qwen4_qsa_sparse_gqa_attention(
+        self, q, k, v, selected, scale, q_offset, key_tile=64, dimension_tile=64
+    ):
+        self.calls.append(
+            dict(
+                q_dtype=q.dtype,
+                selected_shape=tuple(selected.shape),
+                selected_dtype=selected.dtype,
+                scale=scale,
+                q_offset=q_offset,
+                key_tile=key_tile,
+                dimension_tile=dimension_tile,
+                k_len=int(k.shape[2]),
+            )
+        )
+        return mx.zeros(tuple(q.shape), dtype=q.dtype)
+
+
+def _inputs(dtype=mx.bfloat16, *, rows=_ROWS, total=_TOTAL):
+    q = mx.zeros((1, 24, rows, 256), dtype=dtype)
+    k = mx.zeros((1, 2, total, 256), dtype=dtype)
+    v = mx.zeros((1, 2, total, 256), dtype=dtype)
+    ids, valid = _selection(total - rows, rows)
+    return q, k, v, ids, valid
+
+
+def _selection(pos_start: int, rows: int):
+    """A valid-prefix selection exactly as the production selectors emit."""
+
+    ids = []
+    valid = []
+    for r in range(rows):
+        complete = (pos_start + r + 1) // 4
+        take = min(512, complete)
+        row = list(range(take)) + [0] * (512 - take)
+        ids.append(row)
+        valid.append([True] * take + [False] * (512 - take))
+    return mx.array(ids, dtype=mx.int32), mx.array(valid, dtype=mx.bool_)
+
+
+def _kwargs(**overrides):
+    base = dict(
+        pos_start=_POS_START,
+        total_tokens=_TOTAL,
+        scale=_SCALE,
+        compress_ratio=4,
+        block_topk=512,
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture()
+def ext(monkeypatch):
+    """Install the stub extension and pretend we are on a Metal GPU."""
+
+    fake = _FakeExt()
+    monkeypatch.setattr(direct, "_EXT", fake)
+    monkeypatch.setattr(direct, "_on_metal_device", lambda: True)
+    monkeypatch.setattr(direct, "_PIPELINE_STATE", direct._PIPELINE_UNPROVEN)
+    monkeypatch.setattr(direct, "_PIPELINE_PROVEN_DTYPES", frozenset())
+    monkeypatch.delenv("MTPLX_QSA_PREFILL_DIRECT", raising=False)
+    monkeypatch.delenv("MTPLX_QSA_PREFILL_DIRECT_VALIDATE", raising=False)
+    return fake
+
+
+# --------------------------------------------------------------------------
+# 1. Missing extension: import stays green, lane reports unsupported
+# --------------------------------------------------------------------------
+
+
+def test_import_without_extension_never_raises(monkeypatch):
+    monkeypatch.setattr(direct, "_EXT", None)
+    monkeypatch.setattr(direct, "_on_metal_device", lambda: True)
+    q, k, v, ids, valid = _inputs()
+
+    assert direct.qsa_prefill_direct_module_ready() is False
+    assert direct.qsa_prefill_direct_ready() is False
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is False
+    assert direct.qsa_prefill_direct_build_info() == {}
+    # And the producer auto-gate must not arm the lane for a consumer that
+    # does not exist.
+    assert direct.qsa_prefill_direct_ready() is False
+
+
+def test_unsupported_call_raises_instead_of_falling_back(monkeypatch):
+    monkeypatch.setattr(direct, "_EXT", None)
+    q, k, v, ids, valid = _inputs()
+    with pytest.raises(ValueError, match="not loaded"):
+        direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+
+
+# --------------------------------------------------------------------------
+# 2. ABI mismatch: one warning, lane disabled, no per-call TypeError storm
+# --------------------------------------------------------------------------
+
+
+def test_abi_mismatch_disables_the_lane_with_one_warning(caplog):
+    class _Mismatched(_FakeExt):
+        def abi_probe(self, a):
+            raise TypeError("incompatible function arguments")
+
+    with caplog.at_level(logging.WARNING, logger=direct.__name__):
+        ext, error = direct._verify_abi(_Mismatched(), None)
+
+    assert ext is None
+    assert isinstance(error, TypeError)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "nanobind" in warnings[0].getMessage()
+
+
+def test_extension_without_abi_probe_is_refused(caplog):
+    class _NoProbe:
+        pass
+
+    with caplog.at_level(logging.WARNING, logger=direct.__name__):
+        ext, _ = direct._verify_abi(_NoProbe(), None)
+    assert ext is None
+
+
+def test_healthy_extension_passes_the_probe():
+    fake = _FakeExt()
+    ext, error = direct._verify_abi(fake, None)
+    assert ext is fake and error is None
+
+
+# --------------------------------------------------------------------------
+# 3. Kill switch
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF"])
+def test_kill_switch_disables_only_this_consumer(ext, monkeypatch, value):
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT", value)
+    q, k, v, ids, valid = _inputs()
+
+    assert direct.qsa_prefill_direct_enabled() is False
+    assert direct.qsa_prefill_direct_ready() is False
+    # The module is still loaded — only the consumer is off.
+    assert direct.qsa_prefill_direct_module_ready() is True
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is False
+    with pytest.raises(ValueError, match="MTPLX_QSA_PREFILL_DIRECT is off"):
+        direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert ext.calls == []
+
+
+def test_default_is_on_when_the_module_is_ready(ext):
+    q, k, v, ids, valid = _inputs()
+    assert direct.qsa_prefill_direct_ready() is True
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is True
+
+
+# --------------------------------------------------------------------------
+# 4. Geometry gates: each violation individually fails closed
+# --------------------------------------------------------------------------
+
+
+def test_baseline_geometry_dispatches_once(ext):
+    q, k, v, ids, valid = _inputs()
+    out = direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert tuple(out.shape) == (1, 24, _ROWS, 256)
+    assert len(ext.calls) == 1
+    call = ext.calls[0]
+    assert call["selected_shape"] == (1, 1, _ROWS, 512)
+    assert call["selected_dtype"] == mx.uint32
+    assert call["q_offset"] == _POS_START
+    assert call["scale"] == _SCALE
+    assert (call["key_tile"], call["dimension_tile"]) == (64, 64)
+    # kL is the LOGICAL cache length, never the capacity backing.
+    assert call["k_len"] == _TOTAL
+
+
+def _violations():
+    """One malformed argument per case; everything else stays production."""
+
+    q, k, v, ids, valid = _inputs()
+    fp16_q = mx.zeros((1, 24, _ROWS, 256), dtype=mx.float16)
+    cases = {
+        "batch": dict(queries=mx.zeros((2, 24, _ROWS, 256), dtype=mx.bfloat16)),
+        "query_heads": dict(queries=mx.zeros((1, 16, _ROWS, 256), dtype=mx.bfloat16)),
+        "head_dim": dict(queries=mx.zeros((1, 24, _ROWS, 128), dtype=mx.bfloat16)),
+        "rank": dict(queries=mx.zeros((24, _ROWS, 256), dtype=mx.bfloat16)),
+        "kv_heads": dict(keys=mx.zeros((1, 4, _TOTAL, 256), dtype=mx.bfloat16)),
+        "kv_shape_mismatch": dict(
+            values=mx.zeros((1, 2, _TOTAL - 8, 256), dtype=mx.bfloat16)
+        ),
+        "dtype_fp32": dict(
+            queries=mx.zeros((1, 24, _ROWS, 256), dtype=mx.float32),
+            keys=mx.zeros((1, 2, _TOTAL, 256), dtype=mx.float32),
+            values=mx.zeros((1, 2, _TOTAL, 256), dtype=mx.float32),
+        ),
+        "dtype_mix": dict(queries=fp16_q),
+        "ids_dtype": dict(block_ids=ids.astype(mx.int64)),
+        "valid_dtype": dict(block_valid=valid.astype(mx.int32)),
+        "ids_width": dict(
+            block_ids=mx.zeros((_ROWS, 256), dtype=mx.int32),
+            block_valid=mx.zeros((_ROWS, 256), dtype=mx.bool_),
+        ),
+        "ratio": dict(compress_ratio=2),
+        "topk": dict(block_topk=256),
+        "scale": dict(scale=0.125),
+        "scale_traced": dict(scale=mx.array(0.0625)),
+        "pos_traced": dict(pos_start=mx.array(_POS_START)),
+        "non_suffix": dict(pos_start=_POS_START - 1),
+        # kL must equal the logical frontier: a capacity backing is refused.
+        "capacity_backing": dict(
+            keys=mx.zeros((1, 2, _TOTAL + 4096, 256), dtype=mx.bfloat16),
+            values=mx.zeros((1, 2, _TOTAL + 4096, 256), dtype=mx.bfloat16),
+        ),
+        "below_boundary": dict(
+            keys=mx.zeros((1, 2, 2048, 256), dtype=mx.bfloat16),
+            values=mx.zeros((1, 2, 2048, 256), dtype=mx.bfloat16),
+            pos_start=2048 - _ROWS,
+            total_tokens=2048,
+            block_ids=_selection(2048 - _ROWS, _ROWS)[0],
+            block_valid=_selection(2048 - _ROWS, _ROWS)[1],
+        ),
+        "negative_pos": dict(pos_start=-1),
+    }
+    base = dict(queries=q, keys=k, values=v, block_ids=ids, block_valid=valid)
+    for name, override in cases.items():
+        merged = dict(base)
+        kw = _kwargs()
+        for key, value in override.items():
+            if key in merged:
+                merged[key] = value
+            else:
+                kw[key] = value
+        yield name, merged, kw
+
+
+@pytest.mark.parametrize("name,args,kwargs", list(_violations()), ids=lambda x: x)
+def test_each_geometry_violation_fails_closed(ext, name, args, kwargs):
+    ordered = (
+        args["queries"],
+        args["keys"],
+        args["values"],
+        args["block_ids"],
+        args["block_valid"],
+    )
+    assert direct.qsa_prefill_direct_supported(*ordered, **kwargs) is False, name
+    with pytest.raises(ValueError):
+        direct.qsa_prefill_direct(*ordered, **kwargs)
+    assert ext.calls == [], "an unsupported call reached the native symbol"
+
+
+def test_cpu_device_fails_closed(monkeypatch):
+    monkeypatch.setattr(direct, "_EXT", _FakeExt())
+    monkeypatch.setattr(direct, "_on_metal_device", lambda: False)
+    q, k, v, ids, valid = _inputs()
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is False
+
+
+def test_float16_is_supported_alongside_bfloat16(ext):
+    q, k, v, ids, valid = _inputs(dtype=mx.float16)
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is True
+
+
+# --------------------------------------------------------------------------
+# Topk adapter: the seam where block_valid is dropped
+# --------------------------------------------------------------------------
+
+
+def test_topk_buffer_shape_dtype_and_values():
+    ids, valid = _selection(_POS_START, _ROWS)
+    buffer = direct.qsa_prefill_direct_topk_buffer(
+        ids, valid, pos_start=_POS_START, validate=True
+    )
+    mx.eval(buffer)
+    assert tuple(buffer.shape) == (1, 1, _ROWS, 512)
+    assert buffer.dtype == mx.uint32
+    assert bool(mx.array_equal(buffer[0, 0], ids.astype(mx.uint32)).item())
+
+
+@pytest.mark.parametrize("complete", [0, 1, 511, 512, 513])
+def test_topk_buffer_accepts_every_prefix_length(complete):
+    """Early rows (complete < 512), the exact boundary, and full rows."""
+
+    pos_start = complete * 4  # q_abs == pos_start -> complete blocks visible
+    ids, valid = _selection(pos_start, 1)
+    buffer = direct.qsa_prefill_direct_topk_buffer(
+        ids, valid, pos_start=pos_start, validate=True
+    )
+    mx.eval(buffer)
+    assert tuple(buffer.shape) == (1, 1, 1, 512)
+
+
+@pytest.mark.parametrize("tail", [0, 1, 2, 3])
+def test_topk_buffer_accepts_every_causal_tail_length(tail):
+    pos_start = 4096 + tail
+    ids, valid = _selection(pos_start, 4)
+    buffer = direct.qsa_prefill_direct_topk_buffer(
+        ids, valid, pos_start=pos_start, validate=True
+    )
+    mx.eval(buffer)
+    assert tuple(buffer.shape) == (1, 1, 4, 512)
+
+
+def _mutate(ids: mx.array, valid: mx.array, row, slot, *, id_=None, ok=None):
+    ids_list = ids.tolist()
+    valid_list = valid.tolist()
+    if id_ is not None:
+        ids_list[row][slot] = id_
+    if ok is not None:
+        valid_list[row][slot] = ok
+    return (
+        mx.array(ids_list, dtype=mx.int32),
+        mx.array(valid_list, dtype=mx.bool_),
+    )
+
+
+def test_validity_hole_is_rejected():
+    """The failure the native ABI cannot express: a false inside the prefix
+    means the kernel reads that slot anyway and ignores a later valid one."""
+
+    pos_start = 400  # 100 complete blocks: a short, easy-to-poke prefix
+    ids, valid = _selection(pos_start, 1)
+    ids, valid = _mutate(ids, valid, 0, 3, ok=False)
+    with pytest.raises(ValueError, match="prefix"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid, pos_start=pos_start, validate=True
+        )
+
+
+def test_unsorted_valid_ids_are_rejected():
+    pos_start = 400
+    ids, valid = _selection(pos_start, 1)
+    swapped = ids.tolist()
+    swapped[0][2], swapped[0][5] = swapped[0][5], swapped[0][2]
+    with pytest.raises(ValueError, match="ascending"):
+        direct.qsa_prefill_direct_topk_buffer(
+            mx.array(swapped, dtype=mx.int32),
+            valid,
+            pos_start=pos_start,
+            validate=True,
+        )
+
+
+def test_duplicate_valid_ids_are_rejected():
+    pos_start = 400
+    ids, valid = _selection(pos_start, 1)
+    ids, valid = _mutate(ids, valid, 0, 5, id_=4)  # equal to slot 4: not strict
+    with pytest.raises(ValueError, match="ascending"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid, pos_start=pos_start, validate=True
+        )
+
+
+def test_negative_valid_id_is_rejected():
+    pos_start = 400
+    ids, valid = _selection(pos_start, 1)
+    ids, valid = _mutate(ids, valid, 0, 0, id_=-1)
+    with pytest.raises(ValueError, match="negative"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid, pos_start=pos_start, validate=True
+        )
+
+
+def test_out_of_range_valid_id_is_rejected():
+    """An id at or past the row's complete-block count is not causally
+    visible; the kernel would mask it, but that is luck, not contract."""
+
+    pos_start = 400
+    ids, valid = _selection(pos_start, 1)
+    # Last valid slot, so the ascending check still passes and only the
+    # visibility clause can fire.
+    ids, valid = _mutate(ids, valid, 0, 99, id_=9999)
+    with pytest.raises(ValueError, match="visible"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid, pos_start=pos_start, validate=True
+        )
+
+
+def test_short_valid_count_is_rejected():
+    """valid_blocks is positional in the kernel: min(512, complete). A row
+    that selected fewer than it should would silently attend padding."""
+
+    pos_start = 400
+    ids, valid = _selection(pos_start, 1)
+    ids, valid = _mutate(ids, valid, 0, 99, ok=False)
+    with pytest.raises(ValueError, match="valid count"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid, pos_start=pos_start, validate=True
+        )
+
+
+def test_adapter_rejects_wrong_static_layout():
+    ids, valid = _selection(_POS_START, _ROWS)
+    with pytest.raises(ValueError, match="int32"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids.astype(mx.uint32), valid, pos_start=_POS_START
+        )
+    with pytest.raises(ValueError, match="bool"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids, valid.astype(mx.int32), pos_start=_POS_START
+        )
+    with pytest.raises(ValueError, match="512 slots"):
+        direct.qsa_prefill_direct_topk_buffer(
+            ids[:, :256], valid[:, :256], pos_start=_POS_START
+        )
+
+
+def test_hot_path_does_not_validate_by_default(ext, monkeypatch):
+    """Per-call validation synchronizes; the producer contract is pinned by
+    tests/test_qsa_selector_prefix_contract.py instead."""
+
+    calls = []
+    monkeypatch.setattr(
+        direct,
+        "_prefix_contract_violation",
+        lambda *a, **kw: calls.append(1) or None,
+    )
+    q, k, v, ids, valid = _inputs()
+    direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert calls == []
+
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT_VALIDATE", "1")
+    direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert calls == [1]
+
+
+# --------------------------------------------------------------------------
+# Pipeline proof
+# --------------------------------------------------------------------------
+
+
+def test_first_dispatch_is_evaluated_then_later_ones_are_not(ext, monkeypatch):
+    evals = []
+    real_eval = mx.eval
+    monkeypatch.setattr(mx, "eval", lambda *a, **kw: evals.append(a) or real_eval(*a, **kw))
+    q, k, v, ids, valid = _inputs()
+
+    direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert len(evals) == 1, "the first dispatch must prove the Metal pipeline"
+    direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert len(evals) == 1, "later dispatches must stay lazy"
+
+
+def test_build_info_reports_the_wheel_the_extension_was_built_against(ext):
+    info = direct.qsa_prefill_direct_build_info()
+    assert info["built_against_mlx"] == mx.__version__
+    assert info["built_against_nanobind"] == "2.15.0"
+    assert info["metal_library"] == "mtplx_qsa_kernels"
+    assert "imported_mlx" in info
+
+
+# --------------------------------------------------------------------------
+# Fail-closed process state: a failed proof and a bad build receipt both
+# retire the lane (Codex CHANGES_REQUIRED follow-up)
+# --------------------------------------------------------------------------
+
+
+def test_failed_preflight_disables_the_lane_for_the_process(ext, monkeypatch):
+    """Symbol presence is not pipeline readiness.
+
+    A present .so with a missing, stale, or wrongly named metallib fails
+    inside the Metal pipeline creation. Before this, the preflight returned
+    False and ``ready()`` still said True, so the M3 auto-gate armed a
+    producer for a consumer that could not run and every request re-hit the
+    same wall.
+    """
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("failed to create Metal pipeline state")
+
+    monkeypatch.setattr(ext, "qwen4_qsa_sparse_gqa_attention", _boom)
+
+    assert direct.qsa_prefill_direct_preflight() is False
+
+    monkeypatch.setattr(ext, "qwen4_qsa_sparse_gqa_attention", _FakeExt().qwen4_qsa_sparse_gqa_attention)
+    ext.calls.clear()
+
+    assert direct.qsa_prefill_direct_ready() is False
+    q, k, v, ids, valid = _inputs()
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is False
+    with pytest.raises(ValueError, match="failed Metal pipeline"):
+        direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+    assert ext.calls == [], "a retired lane must never reach the native symbol"
+    # And a second preflight stays refused rather than retrying per request.
+    assert direct.qsa_prefill_direct_preflight() is False
+
+
+def test_failed_preflight_disarms_the_m3_producer_auto_gate(ext, monkeypatch):
+    """The gate that decides whether the selector emits the block tuple at
+    all. With no NAX consumer, a dead direct lane must leave it off."""
+
+    import mtplx.kernels.qsa_indexer_select as select_module
+    import mtplx.models.qwen4_exp as qwen4_exp
+
+    monkeypatch.setattr(
+        select_module, "qsa_indexer_select_nax_available", lambda: False
+    )
+    monkeypatch.setattr(mx.metal, "is_available", lambda: True)
+    monkeypatch.setattr(mx, "default_device", lambda: mx.gpu)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("failed to create Metal pipeline state")
+
+    monkeypatch.setattr(ext, "qwen4_qsa_sparse_gqa_attention", _boom)
+    assert direct.qsa_prefill_direct_preflight() is False
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is False
+
+
+def test_failed_first_dispatch_eval_also_retires_the_lane(ext, monkeypatch):
+    """The proof can also fail on the first REAL request: get_library and
+    get_kernel failures are eval-time, not dispatch-time."""
+
+    real_eval = mx.eval
+
+    def _boom_eval(*args, **kwargs):
+        raise RuntimeError("failed to load metallib mtplx_qsa_kernels")
+
+    monkeypatch.setattr(mx, "eval", _boom_eval)
+    q, k, v, ids, valid = _inputs()
+    with pytest.raises(RuntimeError, match="metallib"):
+        direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+
+    monkeypatch.setattr(mx, "eval", real_eval)
+    assert direct.qsa_prefill_direct_ready() is False
+    assert direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs()) is False
+
+
+def test_a_proven_pipeline_is_only_proved_once(ext):
+    """ready() proves a real loaded extension the first time it is asked —
+    once per packaged dtype specialization, because the Metal kernel name
+    embeds the query dtype. Afterwards it is a pure state read, not a
+    dispatch per request."""
+
+    assert direct.qsa_prefill_direct_ready() is True
+    assert len(ext.calls) == len(direct._SUPPORTED_DTYPES)
+    assert {call["q_dtype"] for call in ext.calls} == set(direct._SUPPORTED_DTYPES)
+    assert direct.qsa_prefill_direct_ready() is True
+    assert len(ext.calls) == len(direct._SUPPORTED_DTYPES)
+
+
+def _dtype_gated_ext(ext, monkeypatch, *, broken):
+    """Let every dtype through except ``broken``, which fails pipeline
+    creation the way a metallib missing that specialization does."""
+
+    healthy = ext.qwen4_qsa_sparse_gqa_attention
+
+    def _gated(q, k, v, selected, scale, q_offset, key_tile=64, dimension_tile=64):
+        if q.dtype == broken:
+            raise RuntimeError(
+                "failed to create Metal pipeline state object for "
+                f"qwen4_qsa_sparse_gqa_{broken}_bk64_dc64"
+            )
+        return healthy(
+            q,
+            k,
+            v,
+            selected,
+            scale,
+            q_offset,
+            key_tile=key_tile,
+            dimension_tile=dimension_tile,
+        )
+
+    monkeypatch.setattr(ext, "qwen4_qsa_sparse_gqa_attention", _gated)
+
+
+def test_a_proved_bfloat16_pipeline_does_not_prove_float16(ext, monkeypatch):
+    """The native kernel name carries the query dtype
+    (``qwen4_qsa_sparse_gqa_<type>_bk64_dc64_...``), so a metallib can hold a
+    good bfloat16 specialization beside a missing or stale float16 one. One
+    global PROVEN flag would let that build report ready and supported and
+    then die on the first float16 request — with the first-dispatch proof
+    skipped, so it would not even retire the lane. This lane fails closed for
+    the whole process instead."""
+
+    _dtype_gated_ext(ext, monkeypatch, broken=mx.float16)
+
+    # bfloat16 alone proves cleanly...
+    assert direct.qsa_prefill_direct_preflight(dtype=mx.bfloat16) is True
+    assert direct._dtype_proven(mx.bfloat16) is True
+    # ...and does NOT carry float16, which fails its own proof.
+    assert direct.qsa_prefill_direct_preflight(dtype=mx.float16) is False
+
+    # Whole-lane fail-closed: neither dtype is ready, supported, or usable.
+    assert direct.qsa_prefill_direct_ready() is False
+    assert direct._PIPELINE_STATE == direct._PIPELINE_FAILED
+    for dtype in (mx.float16, mx.bfloat16):
+        q, k, v, ids, valid = _inputs(dtype=dtype)
+        assert (
+            direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs())
+            is False
+        ), dtype
+        with pytest.raises(ValueError, match="failed Metal pipeline"):
+            direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+
+
+def test_ready_refuses_when_only_one_packaged_dtype_can_load(ext, monkeypatch):
+    """ready() is the M3 producer auto-gate. It must prove every packaged
+    specialization itself, not just the bfloat16 default."""
+
+    _dtype_gated_ext(ext, monkeypatch, broken=mx.float16)
+
+    assert direct.qsa_prefill_direct_ready() is False
+    assert direct.qsa_prefill_direct_ready() is False, "and it stays refused"
+
+
+def test_failed_stays_terminal_when_a_later_proof_succeeds(ext, monkeypatch):
+    """The check-then-set race, made deterministic: FAILED is documented as
+    terminal, so a proof that lands after it must not write PROVEN over it
+    and reopen readiness."""
+
+    monkeypatch.setattr(direct, "_PIPELINE_STATE", direct._PIPELINE_FAILED)
+    monkeypatch.setattr(direct, "_PIPELINE_PROVEN_DTYPES", frozenset())
+
+    # The extension is perfectly healthy; the lane is retired anyway.
+    assert direct.qsa_prefill_direct_preflight() is False
+    assert direct.qsa_prefill_direct_preflight(dtype=mx.float16) is False
+    assert ext.calls == [], "a retired lane must never reach the native symbol"
+
+    # The racing writer: a proof that had already started before the failure
+    # and only now reports success.
+    direct._record_pipeline_success(mx.bfloat16)
+    direct._record_pipeline_success(mx.float16)
+
+    assert direct._PIPELINE_STATE == direct._PIPELINE_FAILED
+    assert direct._PIPELINE_PROVEN_DTYPES == frozenset()
+    assert direct.qsa_prefill_direct_ready() is False
+
+
+def test_concurrent_first_proofs_cannot_lose_a_failure(ext, monkeypatch):
+    """Extra, non-deterministic cover for the same invariant: many threads
+    race their first proof, one dtype cannot load, and the lane ends FAILED
+    no matter which thread finishes last."""
+
+    import threading
+
+    _dtype_gated_ext(ext, monkeypatch, broken=mx.float16)
+
+    barrier = threading.Barrier(8)
+    results: list[bool] = []
+    lock = threading.Lock()
+
+    def _worker(dtype):
+        barrier.wait()
+        ok = direct.qsa_prefill_direct_preflight(dtype=dtype)
+        with lock:
+            results.append(ok)
+
+    threads = [
+        threading.Thread(target=_worker, args=(mx.bfloat16 if i % 2 else mx.float16,))
+        for i in range(8)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 8
+    assert direct._PIPELINE_STATE == direct._PIPELINE_FAILED
+    assert direct.qsa_prefill_direct_ready() is False
+
+
+def test_mismatched_mlx_build_receipt_disables_the_lane(ext, monkeypatch, caplog):
+    """The extension links MLX's private C++ ABI. A .so built against a
+    different wheel imports, passes abi_probe, lists every symbol, and then
+    mis-reads a struct — so the receipt is a gate, not a note in a dict."""
+
+    monkeypatch.setattr(ext, "BUILT_AGAINST_MLX", "0.31.0", raising=False)
+    monkeypatch.setattr(direct, "_RECEIPT_WARNED", False)
+    q, k, v, ids, valid = _inputs()
+
+    with caplog.at_level(logging.WARNING, logger=direct.__name__):
+        assert direct.qsa_prefill_direct_ready() is False
+        assert direct.qsa_prefill_direct_ready() is False
+        assert (
+            direct.qsa_prefill_direct_supported(q, k, v, ids, valid, **_kwargs())
+            is False
+        )
+        with pytest.raises(ValueError, match="built against mlx 0.31.0"):
+            direct.qsa_prefill_direct(q, k, v, ids, valid, **_kwargs())
+
+    assert ext.calls == []
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, "one warning, not one per layer per token"
+    assert "0.31.0" in warnings[0].getMessage()
+    # The build info still reports both sides so the operator can see why.
+    info = direct.qsa_prefill_direct_build_info()
+    assert info["built_against_mlx"] == "0.31.0"
+    assert info["imported_mlx"] == mx.__version__
+
+
+def test_missing_build_receipt_is_refused(ext, monkeypatch):
+    """An extension with no receipt predates the check; it is not trusted."""
+
+    monkeypatch.delattr(type(ext), "BUILT_AGAINST_MLX", raising=False)
+    monkeypatch.setattr(direct, "_RECEIPT_WARNED", False)
+    assert direct.qsa_prefill_direct_ready() is False
+    assert ext.calls == []
+
+
+def test_matching_receipt_keeps_the_lane_open(ext):
+    assert direct.qsa_prefill_direct_build_info()["built_against_mlx"] == mx.__version__
+    assert direct.qsa_prefill_direct_ready() is True
+
+
+# --------------------------------------------------------------------------
+# Native boundary: the C++ unsupported() must refuse what Python refuses.
+# These need a built .so; they are the live half of
+# test_cpp_unsupported_enforces_the_logical_view_and_scale_contracts.
+# --------------------------------------------------------------------------
+
+_NO_EXTENSION = pytest.mark.skipif(
+    direct._EXT is None or not hasattr(direct._EXT, "qwen4_qsa_sparse_gqa_attention"),
+    reason="no built mtplx_qsa_kernels extension on this machine",
+)
+
+
+def _native_args(*, total=_TOTAL, rows=_ROWS, dtype=mx.bfloat16):
+    q = mx.zeros((1, 24, rows, 256), dtype=dtype)
+    k = mx.zeros((1, 2, total, 256), dtype=dtype)
+    v = mx.zeros((1, 2, total, 256), dtype=dtype)
+    selected = mx.zeros((1, 1, rows, 512), dtype=mx.uint32)
+    return q, k, v, selected
+
+
+@_NO_EXTENSION
+def test_native_symbol_rejects_a_q_window_that_is_not_the_suffix():
+    """params.kL IS k.shape(2). A shorter Q window would launch and attend
+    the wrong rows, so the ABI takes equality, not <=."""
+
+    q, k, v, selected = _native_args()
+    with pytest.raises(ValueError):
+        direct._EXT.qwen4_qsa_sparse_gqa_attention(
+            q,
+            k,
+            v,
+            selected,
+            _SCALE,
+            _POS_START - 1,  # q_offset + qL < kL
+            key_tile=64,
+            dimension_tile=64,
+        )
+
+
+@_NO_EXTENSION
+def test_native_symbol_rejects_a_non_production_scale():
+    q, k, v, selected = _native_args()
+    with pytest.raises(ValueError):
+        direct._EXT.qwen4_qsa_sparse_gqa_attention(
+            q,
+            k,
+            v,
+            selected,
+            0.125,  # not 1/sqrt(256)
+            _POS_START,
+            key_tile=64,
+            dimension_tile=64,
+        )

--- a/tests/test_qsa_prefill_direct_greedy.py
+++ b/tests/test_qsa_prefill_direct_greedy.py
@@ -1,0 +1,144 @@
+"""Greedy-token fixture for the direct Steel QSA prefill lane.
+
+Production geometry (24q / 2kv / D256, indexer budget 2048 / ratio 4) so
+the native kernel's support check can actually fire. One Attention layer +
+a tiny embed/lm_head, not the 125B checkpoint — that would dual-load next
+to live :8002.
+
+Protocol: warm 2049 tokens (below the sparse producer gate), then a 32-token
+prefill chunk whose earliest query is past the dense/sparse boundary, then
+8 greedy decode steps. Direct vs gather vs dense must emit the same token
+ids. Direct must show ``direct_kernel > 0`` and no gather/dense fallback.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+from mlx.utils import tree_map
+
+import mtplx.kernels.qsa_prefill_direct as direct
+import mtplx.models.qwen4_exp as qwen4_exp
+from mtplx.attention_context import attention_phase
+from mtplx.models.qwen4_exp import Attention, QSACache, TextArgs
+
+pytestmark = pytest.mark.skipif(
+    direct._EXT is None
+    or not hasattr(direct._EXT, "qwen4_qsa_sparse_gqa_attention"),
+    reason="no built mtplx_qsa_kernels extension on this machine",
+)
+
+_HIDDEN = 2560
+_VOCAB = 512
+_WARM = 2049
+_SPARSE = 32
+_GREEDY = 8
+_SCALE_SEED = 7
+
+
+def _prod_args() -> TextArgs:
+    return TextArgs(
+        hidden_size=_HIDDEN,
+        num_hidden_layers=1,
+        num_attention_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        vocab_size=_VOCAB,
+        indexer_n_heads=4,
+        indexer_kv_heads=1,
+        indexer_head_dim=128,
+        indexer_budget=2048,
+        indexer_compress_ratio=4,
+    )
+
+
+@pytest.fixture(scope="module")
+def native_lane():
+    assert direct.qsa_prefill_direct_preflight() is True
+    return True
+
+
+def _arm_env(monkeypatch, *, direct_on: bool, gather_on: bool) -> None:
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_ROWS", "8")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_FLASH_MIN_CONTEXT", "999999")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT", "1" if direct_on else "0")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_GATHER", "1" if gather_on else "0")
+    monkeypatch.delenv("MTPLX_QSA_FLASH", raising=False)
+
+
+def _run_arm(layer, embed, lm_head, prompt, *, phase_prefill="prefill"):
+    qwen4_exp._QSA_PREFILL_COUNTS.clear()
+    cache = QSACache(compress_ratio=layer.indexer.ratio)
+    warm, sparse = prompt[:, :_WARM], prompt[:, _WARM:]
+    with attention_phase(phase_prefill):
+        out = layer(embed(warm), cache)
+        mx.eval(out)
+        out = layer(embed(sparse), cache)
+        mx.eval(out)
+    tokens = []
+    last = int(mx.argmax(lm_head(out[:, -1, :]), axis=-1).item())
+    tokens.append(last)
+    with attention_phase("ar_decode"):
+        for _ in range(_GREEDY - 1):
+            step = mx.array([[last]], dtype=mx.int32)
+            hid = layer(embed(step), cache)
+            mx.eval(hid)
+            last = int(mx.argmax(lm_head(hid[:, -1, :]), axis=-1).item())
+            tokens.append(last)
+    return tokens, dict(qwen4_exp.qsa_prefill_engagement())
+
+
+def test_greedy_tokens_match_across_direct_gather_dense(native_lane, monkeypatch):
+    mx.set_default_device(mx.gpu)
+    mx.random.seed(_SCALE_SEED)
+    args = _prod_args()
+    layer = Attention(args)
+    embed = nn.Embedding(_VOCAB, _HIDDEN)
+    lm_head = nn.Linear(_HIDDEN, _VOCAB, bias=False)
+
+    def _bf16(module):
+        module.update(tree_map(lambda p: p.astype(mx.bfloat16), module.parameters()))
+
+    _bf16(layer)
+    _bf16(embed)
+    _bf16(lm_head)
+    mx.eval(layer.parameters(), embed.parameters(), lm_head.parameters())
+    assert layer.q_proj.weight.dtype == mx.bfloat16
+
+    mx.random.seed(_SCALE_SEED + 1)
+    prompt = mx.random.randint(0, _VOCAB, (1, _WARM + _SPARSE))
+
+    _arm_env(monkeypatch, direct_on=True, gather_on=False)
+    direct_toks, direct_eng = _run_arm(layer, embed, lm_head, prompt)
+
+    _arm_env(monkeypatch, direct_on=False, gather_on=True)
+    gather_toks, gather_eng = _run_arm(layer, embed, lm_head, prompt)
+
+    _arm_env(monkeypatch, direct_on=False, gather_on=False)
+    dense_toks, dense_eng = _run_arm(layer, embed, lm_head, prompt)
+
+    print("direct_tokens", direct_toks, "eng", direct_eng)
+    print("gather_tokens", gather_toks, "eng", gather_eng)
+    print("dense_tokens", dense_toks, "eng", dense_eng)
+
+    assert direct_eng.get("direct_kernel", 0) >= 1, direct_eng
+    assert direct_eng.get("gather_tier", 0) == 0, direct_eng
+    assert direct_eng.get("dense_fallback", 0) == 0, direct_eng
+    assert gather_eng.get("direct_kernel", 0) == 0, gather_eng
+    assert gather_eng.get("gather_tier", 0) >= 1, gather_eng
+    assert dense_eng.get("direct_kernel", 0) == 0, dense_eng
+    assert dense_eng.get("gather_tier", 0) == 0, dense_eng
+    assert dense_eng.get("dense_fallback", 0) >= 1, dense_eng
+
+    assert direct_toks == gather_toks == dense_toks, (
+        direct_toks,
+        gather_toks,
+        dense_toks,
+        direct_eng,
+        gather_eng,
+        dense_eng,
+    )

--- a/tests/test_qsa_prefill_direct_numeric.py
+++ b/tests/test_qsa_prefill_direct_numeric.py
@@ -1,0 +1,310 @@
+"""Studio numeric parity for the vendored Steel QSA prefill kernel.
+
+Requires a built ``mtplx_qsa_kernels`` extension. Skips everywhere else.
+
+Bounds are the upstream oMLX ones (Codex §6 / oMLX tests):
+normal long-prefix ``max_error <= 5e-3``; early-prefix ``<= 2e-2`` with the
+one-visible-token row bit-identical. Do not tighten without repeated M3
+results.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+import mtplx.kernels.qsa_prefill_direct as direct
+from mtplx.models.qwen4_exp import _qsa_prefill_gather_attention
+
+pytestmark = pytest.mark.skipif(
+    direct._EXT is None
+    or not hasattr(direct._EXT, "qwen4_qsa_sparse_gqa_attention"),
+    reason="no built mtplx_qsa_kernels extension on this machine",
+)
+
+_SCALE = 0.0625
+_RATIO = 4
+_TOPK = 512
+_NORMAL_BOUND = 5e-3
+_EARLY_BOUND = 2e-2
+
+
+def _selection(pos_start: int, rows: int):
+    """Chronological valid prefix, same contract as the production selectors."""
+
+    ids = []
+    valid = []
+    for r in range(rows):
+        complete = (pos_start + r + 1) // _RATIO
+        take = min(_TOPK, complete)
+        start = max(0, complete - take)
+        row = list(range(start, start + take)) + [0] * (_TOPK - take)
+        ids.append(row)
+        valid.append([True] * take + [False] * (_TOPK - take))
+    return mx.array(ids, dtype=mx.int32), mx.array(valid, dtype=mx.bool_)
+
+
+def _random_qkv(dtype, *, rows: int, total: int, seed: int):
+    mx.random.seed(seed)
+    q = mx.random.normal((1, 24, rows, 256)).astype(dtype)
+    k = mx.random.normal((1, 2, total, 256)).astype(dtype)
+    v = mx.random.normal((1, 2, total, 256)).astype(dtype)
+    return q, k, v
+
+
+@pytest.fixture(scope="module")
+def native_lane():
+    info = direct.qsa_prefill_direct_build_info()
+    assert info.get("built_against_mlx") == mx.__version__, info
+    assert info.get("metal_library") == "mtplx_qsa_kernels", info
+    assert direct.qsa_prefill_direct_preflight() is True, info
+    assert direct.qsa_prefill_direct_ready() is True
+    return info
+
+
+def _parity(dtype, *, total: int, rows: int, seed: int, bound: float):
+    pos_start = total - rows
+    q, k, v = _random_qkv(dtype, rows=rows, total=total, seed=seed)
+    ids, valid = _selection(pos_start, rows)
+    got = direct.qsa_prefill_direct(
+        q,
+        k,
+        v,
+        ids,
+        valid,
+        pos_start=pos_start,
+        total_tokens=total,
+        scale=_SCALE,
+        compress_ratio=_RATIO,
+        block_topk=_TOPK,
+    )
+    ref = _qsa_prefill_gather_attention(
+        q,
+        k,
+        v,
+        ids,
+        valid,
+        pos_start=pos_start,
+        total_tokens=total,
+        compress_ratio=_RATIO,
+        scale=_SCALE,
+        tile_rows=8,
+    )
+    mx.eval(got, ref)
+    diff = mx.abs(got.astype(mx.float32) - ref.astype(mx.float32))
+    max_err = float(mx.max(diff).item())
+    # Argmax over D=256 flips on near-ties inside the 5e-3 bound; report the
+    # match rate but do not use it as a gate (Codex: copy oMLX max_error, do
+    # not chase bitwise / 1-ULP equality).
+    got_am = mx.argmax(got.astype(mx.float32), axis=-1)
+    ref_am = mx.argmax(ref.astype(mx.float32), axis=-1)
+    match = float(mx.mean((got_am == ref_am).astype(mx.float32)).item())
+    return max_err, match, got, ref, ids, valid
+
+
+def test_build_receipt_matches_runtime_mlx(native_lane):
+    assert native_lane["built_against_mlx"] == mx.__version__
+    assert native_lane["imported_mlx"] == mx.__version__
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16], ids=["bf16", "fp16"])
+def test_long_prefix_parity_vs_gather(native_lane, dtype):
+    """Production suffix just past the dense/sparse boundary."""
+
+    max_err, argmax_match, *_ = _parity(
+        dtype, total=2056, rows=8, seed=121, bound=_NORMAL_BOUND
+    )
+    print(f"long_prefix {dtype} max_err={max_err:.6g} argmax_match={argmax_match:.4f}")
+    assert max_err <= _NORMAL_BOUND, (max_err, argmax_match)
+
+
+@pytest.mark.parametrize("remainder", [0, 1, 2, 3])
+def test_causal_tail_mod4_parity_vs_gather(native_lane, remainder):
+    """Last visible token ``T-1 ≡ remainder (mod 4)``."""
+
+    # 2053 % 4 == 1 → T-1 ≡ 0; then 2054, 2055, 2056 cover 1,2,3.
+    total = 2053 + remainder
+    assert (total - 1) % 4 == remainder
+    max_err, argmax_match, *_ = _parity(
+        mx.bfloat16, total=total, rows=8, seed=400 + remainder, bound=_NORMAL_BOUND
+    )
+    assert max_err <= _NORMAL_BOUND, (remainder, max_err, argmax_match)
+
+
+def test_chunk_start_straddles_a_block(native_lane):
+    """pos_start is not block-aligned."""
+
+    total, rows = 2062, 9
+    pos_start = total - rows
+    assert pos_start % 4 != 0
+    max_err, argmax_match, *_ = _parity(
+        mx.bfloat16, total=total, rows=rows, seed=77, bound=_NORMAL_BOUND
+    )
+    assert max_err <= _NORMAL_BOUND, (max_err, argmax_match, pos_start)
+
+
+def test_selected_block_set_matches_gather_expansion(native_lane):
+    """The ids the direct kernel consumes are the same set gather expands."""
+
+    total, rows = 2056, 8
+    pos_start = total - rows
+    ids, valid = _selection(pos_start, rows)
+    mx.eval(ids, valid)
+    for r in range(rows):
+        qpos = pos_start + r
+        complete = (qpos + 1) // _RATIO
+        take = min(_TOPK, complete)
+        row_ids = [int(x) for x in ids[r, :take].tolist()]
+        assert row_ids == list(range(complete - take, complete))
+        assert all(0 <= b < complete for b in row_ids)
+        assert len(set(row_ids)) == take
+
+
+def test_capacity_backing_is_rejected_by_the_wrapper(native_lane):
+    q, k, v = _random_qkv(mx.bfloat16, rows=8, total=2056, seed=9)
+    cap_k = mx.concatenate([k, mx.zeros((1, 2, 128, 256), dtype=k.dtype)], axis=2)
+    cap_v = mx.concatenate([v, mx.zeros((1, 2, 128, 256), dtype=v.dtype)], axis=2)
+    ids, valid = _selection(2048, 8)
+    assert (
+        direct.qsa_prefill_direct_supported(
+            q,
+            cap_k,
+            cap_v,
+            ids,
+            valid,
+            pos_start=2048,
+            total_tokens=2056,
+            scale=_SCALE,
+        )
+        is False
+    )
+
+
+def test_future_tokens_in_the_logical_cache_cannot_leak(native_lane):
+    """Row 0 of a first chunk sees one token. Poisoning the rest must not
+    change that row. Uses the native symbol because the Python wrapper
+    refuses T below the dense/sparse boundary."""
+
+    mx.random.seed(313)
+    rows = 33
+    q = mx.random.normal((1, 24, rows, 256)).astype(mx.bfloat16)
+    k = mx.random.normal((1, 2, rows, 256)).astype(mx.bfloat16)
+    v = mx.random.normal((1, 2, rows, 256)).astype(mx.bfloat16)
+    selected = mx.broadcast_to(
+        mx.arange(_TOPK, dtype=mx.uint32)[None, None, None, :],
+        (1, 1, rows, _TOPK),
+    )
+    clean = direct._EXT.qwen4_qsa_sparse_gqa_attention(
+        q, k, v, selected, _SCALE, 0, key_tile=64, dimension_tile=64
+    )
+    k_poison = mx.concatenate(
+        [k[:, :, :1, :], mx.ones_like(k[:, :, 1:, :]) * 1.0e4], axis=2
+    )
+    v_poison = mx.concatenate(
+        [v[:, :, :1, :], mx.ones_like(v[:, :, 1:, :]) * 1.0e4], axis=2
+    )
+    poisoned = direct._EXT.qwen4_qsa_sparse_gqa_attention(
+        q, k_poison, v_poison, selected, _SCALE, 0, key_tile=64, dimension_tile=64
+    )
+    mx.eval(clean, poisoned)
+    assert mx.array_equal(clean[:, :, :1, :], poisoned[:, :, :1, :]).item()
+
+
+def test_early_prefix_matches_gather_with_upstream_bound(native_lane):
+    """complete < 512 on every row. Native symbol + gather oracle.
+
+    First row is one visible token → bit-identical. Rest: max_error <= 2e-2.
+    """
+
+    mx.random.seed(313)
+    rows = 33
+    q = mx.random.normal((1, 24, rows, 256)).astype(mx.bfloat16)
+    k = mx.random.normal((1, 2, rows, 256)).astype(mx.bfloat16)
+    v = mx.random.normal((1, 2, rows, 256)).astype(mx.bfloat16)
+    ids, valid = _selection(0, rows)
+    native = direct._EXT.qwen4_qsa_sparse_gqa_attention(
+        q,
+        k,
+        v,
+        mx.contiguous(ids.astype(mx.uint32)[None, None]),
+        _SCALE,
+        0,
+        key_tile=64,
+        dimension_tile=64,
+    )
+    ref = _qsa_prefill_gather_attention(
+        q,
+        k,
+        v,
+        ids,
+        valid,
+        pos_start=0,
+        total_tokens=rows,
+        compress_ratio=_RATIO,
+        scale=_SCALE,
+        tile_rows=8,
+    )
+    mx.eval(native, ref)
+    assert mx.array_equal(native[:, :, :1, :], ref[:, :, :1, :]).item()
+    err = float(
+        mx.max(mx.abs(native.astype(mx.float32) - ref.astype(mx.float32))).item()
+    )
+    assert err <= _EARLY_BOUND, err
+
+
+def test_missing_metallib_fails_preflight_in_a_fresh_process(native_lane):
+    """FAILED is process-wide, so this drill cannot share the pytest process."""
+
+    ext_dir = Path(direct.__file__).resolve().parents[2] / "native_extensions" / "qsa_kernels"
+    metallibs = list((ext_dir / "mtplx_qsa_kernels").glob("*.metallib"))
+    assert metallibs, f"no metallib next to the extension in {ext_dir}"
+    metallib = metallibs[0]
+    child = r"""
+import os, sys, traceback
+sys.path.insert(0, os.environ["MTPLX_SRC"])
+# Hide the metallib before the extension's first eval.
+src = os.environ["METALLIB"]
+dst = src + ".hidden"
+os.rename(src, dst)
+try:
+    import mlx.core as mx  # noqa: F401
+    from mtplx.kernels.qsa_prefill_direct import (
+        qsa_prefill_direct_preflight,
+        qsa_prefill_direct_ready,
+    )
+    ok = qsa_prefill_direct_preflight()
+    ready = qsa_prefill_direct_ready()
+    print(f"preflight={ok} ready={ready}")
+    sys.exit(0 if (ok is False and ready is False) else 2)
+except Exception:
+    traceback.print_exc()
+    sys.exit(2)
+finally:
+    if os.path.exists(dst) and not os.path.exists(src):
+        os.rename(dst, src)
+"""
+    env = os.environ.copy()
+    src_root = str(Path(direct.__file__).resolve().parents[2])
+    env["MTPLX_SRC"] = src_root
+    env["METALLIB"] = str(metallib)
+    env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
+    hidden = Path(str(metallib) + ".hidden")
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", child],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    finally:
+        if hidden.is_file() and not metallib.is_file():
+            hidden.rename(metallib)
+    assert metallib.is_file(), "child must restore the metallib"
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "preflight=False ready=False" in proc.stdout

--- a/tests/test_qsa_prefill_direct_routing.py
+++ b/tests/test_qsa_prefill_direct_routing.py
@@ -1,0 +1,529 @@
+"""Producer/consumer routing gates for the direct Steel QSA prefill lane.
+
+The failure these exist to prevent is the quiet one: a native kernel that
+imports, probes, reports supported, and is never called, because the producer
+that emits its ``("flash_prefill", ids, valid)`` tuple was gated on Metal 4
+TensorOps that M3 does not have. That produces a perfect null A/B result at
+the cost of a machine-night.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import mtplx.models.qwen4_exp as qwen4_exp
+from mtplx.attention_context import attention_phase
+
+
+@pytest.fixture()
+def lanes(monkeypatch):
+    """Control both fast consumers' availability independently."""
+
+    state = {"nax": False, "direct": True, "metal": True}
+
+    import mlx.core as mx
+
+    import mtplx.kernels.qsa_indexer_select as select_module
+    import mtplx.kernels.qsa_prefill_direct as direct_module
+
+    monkeypatch.setattr(
+        select_module, "qsa_indexer_select_nax_available", lambda: state["nax"]
+    )
+    monkeypatch.setattr(
+        direct_module, "qsa_prefill_direct_module_ready", lambda: state["direct"]
+    )
+    monkeypatch.setattr(mx.metal, "is_available", lambda: state["metal"])
+    monkeypatch.setattr(mx, "default_device", lambda: mx.gpu)
+    monkeypatch.delenv("MTPLX_QSA_PREFILL", raising=False)
+    monkeypatch.delenv("MTPLX_QSA_PREFILL_DIRECT", raising=False)
+    return state
+
+
+def test_m3_arms_the_lane_on_native_readiness_alone(lanes):
+    """No NAX, native module ready: the producer must arm."""
+
+    lanes["nax"] = False
+    lanes["direct"] = True
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is True
+    assert qwen4_exp._qsa_prefill_enabled() is True
+
+
+def test_m4_m5_still_arm_on_nax_without_the_native_module(lanes):
+    lanes["nax"] = True
+    lanes["direct"] = False
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is True
+
+
+def test_machine_with_neither_consumer_stays_off(lanes):
+    """Otherwise the eager selector pays for a dense-mask reconstruction."""
+
+    lanes["nax"] = False
+    lanes["direct"] = False
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is False
+    assert qwen4_exp._qsa_prefill_enabled() is False
+
+
+def test_cpu_or_no_metal_never_arms(lanes):
+    lanes["nax"] = True
+    lanes["direct"] = True
+    lanes["metal"] = False
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is False
+
+
+def test_killing_the_direct_consumer_also_disarms_the_m3_producer(
+    lanes, monkeypatch
+):
+    """Selecting blocks for a consumer that has been switched off is pure
+    tax; the gate must follow the kill switch."""
+
+    lanes["nax"] = False
+    lanes["direct"] = True
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT", "0")
+    assert qwen4_exp.qsa_prefill_lane_auto_supported() is False
+    assert qwen4_exp._qsa_prefill_enabled() is False
+
+
+def test_master_kill_switch_outranks_native_readiness(lanes, monkeypatch):
+    lanes["nax"] = False
+    lanes["direct"] = True
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "0")
+    assert qwen4_exp._qsa_prefill_enabled() is False
+
+
+def test_explicit_master_on_arms_without_either_consumer(lanes, monkeypatch):
+    lanes["nax"] = False
+    lanes["direct"] = False
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    assert qwen4_exp._qsa_prefill_enabled() is True
+
+
+def test_direct_consumer_crossover_is_independent_of_the_flash_one(
+    lanes, monkeypatch
+):
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_ROWS", "2")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_FLASH_MIN_CONTEXT", "65536")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT", "2049")
+
+    rows, total = 64, 4096
+    with attention_phase("prefill"):
+        assert qwen4_exp._qsa_large_prefill_enabled(rows, total) is True
+        assert qwen4_exp._qsa_prefill_flash_attention_enabled(rows, total) is False
+        assert qwen4_exp._qsa_prefill_direct_attention_enabled(rows, total) is True
+
+
+def test_direct_consumer_respects_the_master_row_and_phase_gates(
+    lanes, monkeypatch
+):
+    """MTP verify rows and decode must never reach this lane."""
+
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_ROWS", "32")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT", "2049")
+
+    with attention_phase("prefill"):
+        assert qwen4_exp._qsa_prefill_direct_attention_enabled(8, 4096) is False
+        assert qwen4_exp._qsa_prefill_direct_attention_enabled(64, 4096) is True
+        # Chunk gated on its EARLIEST query, not its final T.
+        assert qwen4_exp._qsa_prefill_direct_attention_enabled(64, 2100) is False
+    with attention_phase("decode"):
+        assert qwen4_exp._qsa_prefill_direct_attention_enabled(64, 4096) is False
+
+
+def test_counters_distinguish_all_four_tiers():
+    """The A/B receipt has to be able to say WHICH consumer ran.
+
+    A source check, kept as a cheap extra: the behavioural proof that each
+    tier bumps its own counter is the dispatch group at the bottom of this
+    file.  The counters live in the tier chooser that Attention.__call__
+    hands its four thunks to.
+    """
+
+    import ast
+    from pathlib import Path
+
+    path = Path(qwen4_exp.__file__)
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    chooser = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_qsa_prefill_dispatch_tier"
+    )
+    source = ast.get_source_segment(text, chooser) or ""
+    for lane in ("flash_kernel", "direct_kernel", "gather_tier", "dense_fallback"):
+        assert f'_qsa_prefill_count("{lane}")' in source
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Attention"
+    )
+    call = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__call__"
+    )
+    assert "_qsa_prefill_dispatch_tier(" in (ast.get_source_segment(text, call) or "")
+
+
+def test_engagement_snapshot_reports_the_direct_lane():
+    qwen4_exp._qsa_prefill_count("direct_kernel")
+    assert qwen4_exp.qsa_prefill_engagement().get("direct_kernel", 0) >= 1
+
+
+# --------------------------------------------------------------------------
+# Tier dispatch: which consumer actually ran (Codex CHANGES_REQUIRED
+# follow-up).  The gate tests above prove the producer arms; these prove the
+# consumer choice, by driving the extracted chooser with callable fakes
+# instead of reading the source.
+# --------------------------------------------------------------------------
+
+
+class _Tiers:
+    """Records which tier bodies ran, and in which order."""
+
+    def __init__(self, *, flash=False, direct=False, gather=True):
+        import mlx.core as mx
+
+        self.calls: list[str] = []
+        self._flash = flash
+        self._direct = direct
+        self.gather_enabled = gather
+        self._out = mx.zeros((1, 24, 4, 256), dtype=mx.bfloat16)
+
+    def _make(self, name):
+        def run():
+            self.calls.append(name)
+            return self._out
+
+        return run
+
+    def _pred(self, name, answer):
+        def ask():
+            self.calls.append(f"{name}?")
+            return answer
+
+        return ask
+
+    def kwargs(self):
+        return dict(
+            flash_supported=self._pred("flash", self._flash),
+            flash_call=self._make("flash"),
+            direct_supported=self._pred("direct", self._direct),
+            direct_call=self._make("direct"),
+            gather_enabled=self.gather_enabled,
+            gather_call=self._make("gather"),
+        )
+
+
+def _dispatch(tiers):
+    """Run the chooser and return (output, engagement delta)."""
+
+    before = qwen4_exp.qsa_prefill_engagement()
+    out = qwen4_exp._qsa_prefill_dispatch_tier(**tiers.kwargs())
+    after = qwen4_exp.qsa_prefill_engagement()
+    delta = {
+        lane: after.get(lane, 0) - before.get(lane, 0)
+        for lane in set(before) | set(after)
+        if after.get(lane, 0) != before.get(lane, 0)
+    }
+    return out, delta
+
+
+def test_m3_dispatch_runs_only_the_direct_kernel():
+    """No NAX flash consumer, direct ready: the direct body runs, nothing
+    below it does, and the receipt says direct_kernel."""
+
+    tiers = _Tiers(flash=False, direct=True, gather=True)
+    out, delta = _dispatch(tiers)
+
+    assert out is not None
+    assert [c for c in tiers.calls if not c.endswith("?")] == ["direct"]
+    assert delta == {"direct_kernel": 1}
+
+
+def test_m4_m5_dispatch_prefers_flash_even_when_direct_is_ready():
+    """M4/M5 must not have their answer changed by whether someone built the
+    extension: the MPP kernel keeps first refusal."""
+
+    tiers = _Tiers(flash=True, direct=True, gather=True)
+    out, delta = _dispatch(tiers)
+
+    assert [c for c in tiers.calls if not c.endswith("?")] == ["flash"]
+    assert "direct?" not in tiers.calls, "the direct predicate must not even run"
+    assert delta == {"flash_kernel": 1}
+    assert out is not None
+
+
+def test_missing_or_killed_direct_module_routes_to_gather():
+    tiers = _Tiers(flash=False, direct=False, gather=True)
+    out, delta = _dispatch(tiers)
+
+    assert [c for c in tiers.calls if not c.endswith("?")] == ["gather"]
+    assert delta == {"gather_tier": 1}
+    assert out is not None
+
+
+def test_gather_off_routes_to_the_dense_mask():
+    """The chooser returns None to mean "rebuild the dense mask"; no tier
+    body may have run."""
+
+    tiers = _Tiers(flash=False, direct=False, gather=False)
+    out, delta = _dispatch(tiers)
+
+    assert out is None
+    assert [c for c in tiers.calls if not c.endswith("?")] == []
+    assert delta == {"dense_fallback": 1}
+
+
+def test_no_lower_tier_runs_after_a_successful_direct_dispatch():
+    """The failure this port cannot survive: a lane that dispatched and then
+    quietly let a lower tier produce the numbers."""
+
+    tiers = _Tiers(flash=False, direct=True, gather=True)
+    _dispatch(tiers)
+
+    assert "gather" not in tiers.calls
+    assert tiers.calls.count("direct") == 1
+
+
+def test_a_dispatched_tier_failure_is_not_retried_lower():
+    """Fail-closed before dispatch, fail-loud after."""
+
+    import mlx.core as mx
+
+    tiers = _Tiers(flash=False, direct=True, gather=True)
+    kwargs = tiers.kwargs()
+
+    def _boom():
+        tiers.calls.append("direct")
+        raise RuntimeError("failed to load metallib mtplx_qsa_kernels")
+
+    kwargs["direct_call"] = _boom
+    with pytest.raises(RuntimeError, match="metallib"):
+        qwen4_exp._qsa_prefill_dispatch_tier(**kwargs)
+    assert "gather" not in tiers.calls
+    assert mx is not None
+
+
+# --------------------------------------------------------------------------
+# The same choice driven through the REAL support predicates, so the tier
+# order is proved against the production contracts and not only fakes.
+# --------------------------------------------------------------------------
+
+
+_ROWS = 64
+_TOTAL = 4096  # 4096 // 4 == 1024 > 512: past the dense/sparse boundary
+_SCALE = 0.0625
+
+
+class _FakeDirectExt:
+    BUILT_AGAINST_NANOBIND = "2.15.0"
+    METAL_LIBRARY = "mtplx_qsa_kernels"
+
+    def __init__(self):
+        import mlx.core as mx
+
+        self.BUILT_AGAINST_MLX = mx.__version__
+        self.calls = 0
+
+    def abi_probe(self, a):
+        return a.size
+
+    def qwen4_qsa_sparse_gqa_attention(self, q, k, v, selected, *args, **kwargs):
+        import mlx.core as mx
+
+        self.calls += 1
+        return mx.zeros(tuple(q.shape), dtype=q.dtype)
+
+
+@pytest.fixture()
+def production_call(monkeypatch):
+    """Production geometry plus a stubbed native extension."""
+
+    import mlx.core as mx
+
+    import mtplx.kernels.qsa_prefill_direct as direct_module
+
+    fake = _FakeDirectExt()
+    monkeypatch.setattr(direct_module, "_EXT", fake)
+    monkeypatch.setattr(direct_module, "_on_metal_device", lambda: True)
+    monkeypatch.setattr(
+        direct_module, "_PIPELINE_STATE", direct_module._PIPELINE_UNPROVEN
+    )
+    monkeypatch.setattr(direct_module, "_PIPELINE_PROVEN_DTYPES", frozenset())
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_ROWS", "2")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT", "2049")
+    monkeypatch.delenv("MTPLX_QSA_PREFILL_DIRECT", raising=False)
+
+    pos_start = _TOTAL - _ROWS
+    ids = mx.broadcast_to(
+        mx.arange(512, dtype=mx.int32)[None, :], (_ROWS, 512)
+    )
+    tensors = dict(
+        q=mx.zeros((1, 24, _ROWS, 256), dtype=mx.bfloat16),
+        k=mx.zeros((1, 2, _TOTAL, 256), dtype=mx.bfloat16),
+        v=mx.zeros((1, 2, _TOTAL, 256), dtype=mx.bfloat16),
+        block_ids=mx.contiguous(ids),
+        block_valid=mx.ones((_ROWS, 512), dtype=mx.bool_),
+        pos_start=pos_start,
+    )
+    return fake, tensors
+
+
+def _real_predicates(tensors, *, gather: bool):
+    """The exact predicates Attention.__call__ hands the chooser."""
+
+    from mtplx.kernels.qsa_prefill_direct import (
+        qsa_prefill_direct,
+        qsa_prefill_direct_supported,
+    )
+    from mtplx.kernels.qsa_prefill_flash import qsa_prefill_flash_supported
+
+    q = tensors["q"]
+    k = tensors["k"]
+    v = tensors["v"]
+    ids = tensors["block_ids"]
+    valid = tensors["block_valid"]
+    pos_start = tensors["pos_start"]
+    ran: list[str] = []
+
+    def flash_supported():
+        return bool(
+            qwen4_exp._qsa_prefill_flash_attention_enabled(_ROWS, _TOTAL)
+        ) and bool(
+            qsa_prefill_flash_supported(
+                q,
+                k,
+                v,
+                ids,
+                valid,
+                pos_start=pos_start,
+                total_tokens=_TOTAL,
+                scale=_SCALE,
+            )
+        )
+
+    def direct_supported():
+        if not qwen4_exp._qsa_prefill_direct_attention_enabled(_ROWS, _TOTAL):
+            return False
+        return bool(
+            qsa_prefill_direct_supported(
+                q,
+                k,
+                v,
+                ids,
+                valid,
+                pos_start=pos_start,
+                total_tokens=_TOTAL,
+                scale=_SCALE,
+            )
+        )
+
+    def direct_call():
+        ran.append("direct")
+        return qsa_prefill_direct(
+            q,
+            k,
+            v,
+            ids,
+            valid,
+            pos_start=pos_start,
+            total_tokens=_TOTAL,
+            scale=_SCALE,
+        )
+
+    def flash_call():  # pragma: no cover - only reached if NAX exists here
+        ran.append("flash")
+        return q
+
+    def gather_call():
+        ran.append("gather")
+        return q
+
+    return ran, dict(
+        flash_supported=flash_supported,
+        flash_call=flash_call,
+        direct_supported=direct_supported,
+        direct_call=direct_call,
+        gather_enabled=gather,
+        gather_call=gather_call,
+    )
+
+
+def test_real_predicates_route_a_production_call_to_the_direct_kernel(
+    production_call, monkeypatch
+):
+    """End to end through the real support checks: on a machine with no NAX
+    flash kernel, the loaded direct module takes the call and nothing
+    below it is asked."""
+
+    fake, tensors = production_call
+    with attention_phase("prefill"):
+        ran, kwargs = _real_predicates(tensors, gather=True)
+        assert kwargs["flash_supported"]() is False, "no NAX consumer here"
+        before = qwen4_exp.qsa_prefill_engagement().get("direct_kernel", 0)
+        out = qwen4_exp._qsa_prefill_dispatch_tier(**kwargs)
+        after = qwen4_exp.qsa_prefill_engagement().get("direct_kernel", 0)
+
+    assert out is not None
+    assert ran == ["direct"]
+    assert fake.calls == 1
+    assert after - before == 1
+
+
+def test_real_predicates_fall_to_gather_when_the_direct_lane_is_killed(
+    production_call, monkeypatch
+):
+    fake, tensors = production_call
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT", "0")
+    with attention_phase("prefill"):
+        ran, kwargs = _real_predicates(tensors, gather=True)
+        assert kwargs["direct_supported"]() is False
+        out = qwen4_exp._qsa_prefill_dispatch_tier(**kwargs)
+
+    assert ran == ["gather"]
+    assert fake.calls == 0
+    assert out is not None
+
+
+def test_real_predicates_fall_to_dense_when_gather_is_also_off(
+    production_call, monkeypatch
+):
+    fake, tensors = production_call
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_DIRECT", "0")
+    with attention_phase("prefill"):
+        ran, kwargs = _real_predicates(tensors, gather=False)
+        out = qwen4_exp._qsa_prefill_dispatch_tier(**kwargs)
+
+    assert out is None
+    assert ran == []
+    assert fake.calls == 0
+
+
+def test_real_predicates_refuse_the_direct_lane_after_a_failed_proof(
+    production_call, monkeypatch
+):
+    """The blocker: a failed pipeline proof must move the call to gather
+    instead of re-dispatching a kernel that cannot run."""
+
+    import mtplx.kernels.qsa_prefill_direct as direct_module
+
+    fake, tensors = production_call
+    monkeypatch.setattr(
+        direct_module, "_PIPELINE_STATE", direct_module._PIPELINE_FAILED
+    )
+    monkeypatch.setattr(direct_module, "_PIPELINE_PROVEN_DTYPES", frozenset())
+    with attention_phase("prefill"):
+        ran, kwargs = _real_predicates(tensors, gather=True)
+        assert kwargs["direct_supported"]() is False
+        out = qwen4_exp._qsa_prefill_dispatch_tier(**kwargs)
+
+    assert ran == ["gather"]
+    assert fake.calls == 0
+    assert out is not None

--- a/tests/test_qsa_prefill_direct_static.py
+++ b/tests/test_qsa_prefill_direct_static.py
@@ -1,0 +1,519 @@
+"""MLX-free structural gates for the vendored Steel QSA prefill consumer.
+
+These run anywhere — no MLX, no Metal, no built extension — because the
+things they pin are the ones that are expensive to discover late: the tier
+order inside ``Attention.__call__``, the producer auto-gate that decides
+whether the lane arms at all on M3, the env registration, the vendored
+provenance and licenses, and the two renames (Metal library, namespace) that
+keep a co-installed oMLX from colliding with this module.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_PATH = ROOT / "mtplx" / "models" / "qwen4_exp.py"
+WRAPPER_PATH = ROOT / "mtplx" / "kernels" / "qsa_prefill_direct.py"
+PROFILES_PATH = ROOT / "mtplx" / "profiles.py"
+EXT_DIR = ROOT / "native_extensions" / "qsa_kernels"
+PKG_DIR = EXT_DIR / "mtplx_qsa_kernels"
+
+MODEL_TEXT = MODEL_PATH.read_text(encoding="utf-8")
+MODEL_TREE = ast.parse(MODEL_TEXT, filename=str(MODEL_PATH))
+WRAPPER_TEXT = WRAPPER_PATH.read_text(encoding="utf-8")
+
+# The oMLX tree this port was taken from. Recorded here as well as in the
+# NOTICE files so a later "which upstream commit is this?" is one grep.
+OMLX_REVISION = "dc312e6e905e03d21ef0c4a86289cbfa2cf857cc"
+
+
+def _class_method_source(class_name: str, method_name: str) -> str:
+    cls = next(
+        node
+        for node in MODEL_TREE.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    source = ast.get_source_segment(MODEL_TEXT, method)
+    assert source is not None
+    return source
+
+
+def _function_source(name: str) -> str:
+    node = next(
+        item
+        for item in MODEL_TREE.body
+        if isinstance(item, ast.FunctionDef) and item.name == name
+    )
+    source = ast.get_source_segment(MODEL_TEXT, node)
+    assert source is not None
+    return source
+
+
+def test_attention_dispatch_order_is_flash_direct_gather_dense():
+    """The one ordering the whole port depends on.
+
+    MPP flash keeps first refusal (M4/M5 regression-free), the direct Steel
+    kernel takes the seam M3 can actually reach, and both sit above the
+    portable gather tier and the dense-mask reconstruction.
+    """
+
+    source = _class_method_source("Attention", "__call__")
+    flash = source.index("qsa_prefill_flash(")
+    direct = source.index("qsa_prefill_direct(")
+    gather = source.index("_qsa_prefill_gather_attention(")
+    dense = source.index("_qsa_blocks_to_dense_mask(")
+    assert flash < direct < gather < dense
+
+
+def test_direct_branch_is_independent_of_the_mpp_branch():
+    """The direct tier must not import or probe the MPP kernel to run.
+
+    If the direct support check were nested inside the MPP branch, M3 — where
+    the MPP check is always False — would never reach it.
+    """
+
+    source = _class_method_source("Attention", "__call__")
+    start = source.index("qsa_prefill_direct_supported(")
+    branch = source[source.index("_qsa_prefill_direct_attention_enabled(") : start]
+    assert "qsa_prefill_flash_supported" not in branch
+    assert "qsa_indexer_select_nax_available" not in branch
+
+
+def test_direct_branch_passes_logical_cache_views_not_capacity_backing():
+    """params.kL is k.shape(2); it must describe the live cache, not spare
+    capacity. The MPP branch deliberately takes cache.kv.keys and carries a
+    separate total_tokens contract; this ABI has no logical-K parameter."""
+
+    source = _class_method_source("Attention", "__call__")
+    call_start = source.index("out = qsa_prefill_direct(")
+    call = source[call_start : source.index("def _qsa_gather_call")]
+    assert "cache.kv.keys" not in call
+    assert "cache.kv.values" not in call
+    positional = [line.strip() for line in call.splitlines()]
+    assert "k," in positional
+    assert "v," in positional
+
+
+def test_direct_lane_has_its_own_engagement_counter():
+    """A/B law: no benchmark number without proof the arm's code ran.
+
+    The counters live in the extracted tier chooser, which is also what
+    tests/test_qsa_prefill_direct_routing.py drives with callable fakes.
+    """
+
+    source = _function_source("_qsa_prefill_dispatch_tier")
+    assert '_qsa_prefill_count("direct_kernel")' in source
+    assert "direct_call()" in source
+
+
+def test_producer_auto_gate_can_arm_without_nax():
+    """The blocking wiring bug both reviewers flagged.
+
+    Without this, the direct kernel is dead code with a green import: the
+    ("flash_prefill", ...) tuple it consumes is only produced when the auto
+    gate passes, and the gate used to be NAX-only.
+    """
+
+    node = next(
+        item
+        for item in MODEL_TREE.body
+        if isinstance(item, ast.FunctionDef)
+        and item.name == "qsa_prefill_lane_auto_supported"
+    )
+    # Compare executable statements, not prose: the docstring names both
+    # consumers and would decide the ordering assertion below.
+    body = "\n".join(
+        ast.get_source_segment(MODEL_TEXT, stmt) or ""
+        for stmt in node.body
+        if not (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant))
+    )
+    assert "qsa_indexer_select_nax_available()" in body
+    assert "qsa_prefill_direct_ready" in body
+    # NAX first: an M4/M5 machine must not have its answer changed by whether
+    # someone happened to build this extension.
+    assert body.index("qsa_indexer_select_nax_available()") < body.index(
+        "qsa_prefill_direct_ready"
+    )
+
+
+def test_master_kill_switch_still_outranks_the_direct_lane():
+    enabled = _function_source("_qsa_prefill_enabled")
+    assert 'raw in {"0", "false", "no", "off"}' in enabled
+    assert "qsa_prefill_lane_auto_supported()" in enabled
+
+
+def test_direct_tier_has_its_own_context_crossover():
+    source = _function_source("_qsa_prefill_direct_attention_enabled")
+    assert "_qsa_large_prefill_enabled(rows, total_tokens)" in source
+    assert (
+        "int(total_tokens) - int(rows) >= _qsa_prefill_direct_min_context()" in source
+    )
+    floor = _function_source("_qsa_prefill_direct_min_context")
+    assert 'os.environ.get("MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT") or 32768' in floor
+
+
+def test_direct_knobs_are_registered_for_operator_overrides():
+    profiles = PROFILES_PATH.read_text(encoding="utf-8")
+    for key in (
+        "MTPLX_QSA_PREFILL_DIRECT",
+        "MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT",
+        "MTPLX_QSA_PREFILL_DIRECT_VALIDATE",
+    ):
+        assert f'"{key}"' in profiles
+
+
+def test_wrapper_pins_the_measured_production_tiles():
+    """oMLX's fast.py defaults are (128, 32); its production glue uses
+    (64, 64), which is what was measured on M3 and what MTPLX packages."""
+
+    assert "_KEY_TILE = 64" in WRAPPER_TEXT
+    assert "_DIMENSION_TILE = 64" in WRAPPER_TEXT
+    assert "key_tile=_KEY_TILE" in WRAPPER_TEXT
+    assert "dimension_tile=_DIMENSION_TILE" in WRAPPER_TEXT
+
+
+def test_wrapper_support_check_mirrors_the_cpp_unsupported_clauses():
+    """Python "supported" must mean "will dispatch"; a gap either wastes the
+    fast path or turns a static mismatch into a runtime throw."""
+
+    for clause in (
+        "queries.ndim != 4",
+        "_SUPPORTED_DTYPES",
+        "keys.dtype != queries.dtype",
+        "(_BATCH, _Q_HEADS, _HEAD_DIM)",
+        "(_BATCH, _KV_HEADS, _HEAD_DIM)",
+        "_last_dim_contiguous",
+        "pos_start_i < 0",
+        "key_len != total_tokens_i",
+        "int(key_tile) != _KEY_TILE or int(dimension_tile) != _DIMENSION_TILE",
+        "int(compress_ratio) != _COMPRESS_RATIO",
+        "int(block_topk) != _TOP_K_BLOCKS",
+        "scale_f != _EXPECTED_SCALE",
+        "total_tokens_i // _COMPRESS_RATIO <= _TOP_K_BLOCKS",
+    ):
+        assert clause in WRAPPER_TEXT, clause
+
+
+def test_wrapper_converts_topk_explicitly_and_contiguously():
+    """A bare reshape+cast would hand the kernel a strided view, and a
+    negative int32 id would become a huge uint32."""
+
+    assert "mx.contiguous(block_ids.astype(mx.uint32)[None, None])" in WRAPPER_TEXT
+
+
+def test_wrapper_proves_the_metal_pipeline_on_first_dispatch():
+    """abi_probe proves the nanobind casters; only an eval proves the
+    metallib and the kernel specialization exist."""
+
+    assert "_PIPELINE_PROVEN" in WRAPPER_TEXT
+    assert "mx.eval(out)" in WRAPPER_TEXT
+    assert "def qsa_prefill_direct_preflight" in WRAPPER_TEXT
+
+
+def test_wrapper_never_falls_back_to_dense_after_dispatch():
+    """Fail-closed before dispatch, fail-loud after. A silent retry would
+    make an A/B arm report the fallback's numbers as the kernel's."""
+
+    tree = ast.parse(WRAPPER_TEXT, filename=str(WRAPPER_PATH))
+    direct = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "qsa_prefill_direct"
+    )
+    assert not any(isinstance(node, ast.Try) for node in ast.walk(direct))
+
+
+# --------------------------------------------------------------------------
+# Vendored native module
+# --------------------------------------------------------------------------
+
+
+def test_only_the_qwen4_sparse_gqa_primitive_was_vendored():
+    """oMLX's csrc carries seven kernel families; MTPLX takes one. Anything
+    else is build, symbol, and packaging risk for no benefit here."""
+
+    sources = sorted(p.name for p in EXT_DIR.glob("*.cpp"))
+    assert sources == ["bindings.cpp", "qwen4_qsa_sparse_gqa.cpp"]
+    metal = sorted(p.name for p in EXT_DIR.glob("*.metal"))
+    assert metal == ["qwen4_qsa_sparse_gqa.metal"]
+    headers = sorted(p.name for p in (EXT_DIR / "kernels").glob("*.h"))
+    assert headers == ["steel_qwen4_qsa_sparse_gqa.h"]
+
+
+def test_library_and_namespace_were_renamed_away_from_omlx():
+    """A co-installed oMLX must not be able to satisfy get_library() for this
+    module, and vice versa."""
+
+    raw = (EXT_DIR / "qwen4_qsa_sparse_gqa.cpp").read_text(encoding="utf-8")
+    # The provenance comment block legitimately names the old strings; only
+    # the code must be free of them.
+    cpp = "\n".join(
+        line for line in raw.splitlines() if not line.lstrip().startswith("//")
+    )
+    assert 'kMetalLibrary = "mtplx_qsa_kernels"' in cpp
+    assert "omlx_glm_kernels" not in cpp
+    assert "namespace mtplx::qsa_kernels" in cpp
+    assert "namespace omlx" not in cpp
+    assert "DEFINE_NAME(MTPLXQwen4QSASparseGQAAttention)" in cpp
+
+    cmake_raw = (EXT_DIR / "CMakeLists.txt").read_text(encoding="utf-8")
+    cmake = "\n".join(
+        line for line in cmake_raw.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert 'MTPLX_QSA_METAL_LIBRARY "mtplx_qsa_kernels"' in cmake
+    assert "omlx" not in cmake.lower()
+
+
+def test_metal_include_order_is_preserved():
+    """Upstream says the order is load-bearing: Steel's attention header
+    provides Limits for the specialized kernel."""
+
+    metal = (EXT_DIR / "qwen4_qsa_sparse_gqa.metal").read_text(encoding="utf-8")
+    utils = metal.index("mlx/backend/metal/kernels/utils.h")
+    steel = metal.index("steel/attn/kernels/steel_attention.h")
+    params = metal.index("struct Qwen4QSASparseGQAParams")
+    kernel = metal.index("kernels/steel_qwen4_qsa_sparse_gqa.h")
+    assert utils < steel < params < kernel
+    assert "clang-format off" in metal
+    cpp = (EXT_DIR / "qwen4_qsa_sparse_gqa.cpp").read_text(encoding="utf-8")
+    for field in (
+        "int q_offset",
+        "float scale",
+        "int64_t Q_strides[3]",
+        "int64_t O_strides[3]",
+    ):
+        assert field in metal
+        assert field in cpp
+
+
+def test_only_the_packaged_specialization_is_instantiated():
+    metal = (EXT_DIR / "qwen4_qsa_sparse_gqa.metal").read_text(encoding="utf-8")
+    instantiations = [
+        line for line in metal.splitlines() if line.startswith("instantiate_")
+    ]
+    assert instantiations == [
+        "instantiate_qwen4_sparse_gqa(float16, half, 64, 64);",
+        "instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 64, 64);",
+    ]
+
+
+def test_threadgroup_ceiling_is_asserted_at_compile_time():
+    """Issue #400: M2/M3 cap some kernels at 896 threads, not 1024. WM is
+    fixed at 2 (64 threads) — a future retune must re-open this deliberately
+    rather than produce an unlaunchable pipeline."""
+
+    header = (EXT_DIR / "kernels" / "steel_qwen4_qsa_sparse_gqa.h").read_text(
+        encoding="utf-8"
+    )
+    cpp = (EXT_DIR / "qwen4_qsa_sparse_gqa.cpp").read_text(encoding="utf-8")
+    assert "static_assert(WM * 32 <= 896" in header
+    assert "static_assert(wm * 32 <= 896" in cpp
+    assert "constexpr int wm = 2;" in cpp
+    # WM must not become a Python tuning knob: it is part of the compiled
+    # kernel name and its MMA layout.
+    assert "WM" not in WRAPPER_TEXT
+    assert "warp" not in WRAPPER_TEXT.lower()
+
+
+def test_native_build_pins_the_exact_nanobind_abi_and_mlx_domain():
+    pyproject = (EXT_DIR / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"nanobind==2.15.0"' in pyproject
+    # Exactly one wheel: a range lets a PEP 517 isolated build resolve a
+    # different 0.32.x than the serving venv holds, and this extension
+    # links MLX's private C++ ABI.
+    assert '"mlx==0.32.2"' in pyproject
+    cmake = (EXT_DIR / "CMakeLists.txt").read_text(encoding="utf-8")
+    assert "NB_DOMAIN\n  mlx" in cmake
+    # sys.executable must win over any framework Python CMake might find.
+    setup = (EXT_DIR / "setup.py").read_text(encoding="utf-8")
+    assert "Python_EXECUTABLE={sys.executable}" in setup
+    assert "Python3_EXECUTABLE={sys.executable}" in setup
+
+
+def test_extension_is_optional_and_packages_its_artifacts():
+    setup = (EXT_DIR / "setup.py").read_text(encoding="utf-8")
+    for artifact in ("*.so", "*.dylib", "*.metallib", "LICENSE.txt", "NOTICE"):
+        assert f'"{artifact}"' in setup
+    # A missing extension degrades; it never raises at import.
+    assert "except Exception as exc:" in WRAPPER_TEXT
+    assert "return None, _detach(exc)" in WRAPPER_TEXT
+
+
+def test_licenses_and_provenance_are_recorded():
+    for name in (
+        "LICENSE.txt",
+        "NOTICE",
+        "MLX_LICENSE.txt",
+        "MLX_SERVE_LICENSE.txt",
+    ):
+        assert (PKG_DIR / name).is_file(), name
+    notice = (PKG_DIR / "NOTICE").read_text(encoding="utf-8")
+    assert OMLX_REVISION in notice
+    assert "Apache License" in (PKG_DIR / "LICENSE.txt").read_text(encoding="utf-8")
+    # mlx-serve's MIT staging attribution must survive verbatim in the header.
+    steel = (EXT_DIR / "kernels" / "steel_qwen4_qsa_sparse_gqa.h").read_text(
+        encoding="utf-8"
+    )
+    assert "mlx-serve's MIT" in steel
+    assert "David Dalcu" in steel
+    assert "SPDX-License-Identifier: Apache-2.0" in steel
+
+    root_notice = (ROOT / "NOTICE").read_text(encoding="utf-8")
+    assert OMLX_REVISION in root_notice
+    assert "native_extensions/qsa_kernels" in root_notice
+
+
+def test_every_vendored_source_carries_the_spdx_tag():
+    for path in list(EXT_DIR.glob("*.cpp")) + list(EXT_DIR.glob("*.h")) + list(
+        EXT_DIR.glob("*.metal")
+    ) + list((EXT_DIR / "kernels").glob("*.h")):
+        head = path.read_text(encoding="utf-8")[:200]
+        assert "SPDX-License-Identifier: Apache-2.0" in head, path.name
+
+
+# --------------------------------------------------------------------------
+# Contract parity and fail-closed state (Codex CHANGES_REQUIRED follow-up)
+# --------------------------------------------------------------------------
+
+
+def _wrapper_function_source(name: str) -> str:
+    tree = ast.parse(WRAPPER_TEXT, filename=str(WRAPPER_PATH))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef) and item.name == name
+    )
+    source = ast.get_source_segment(WRAPPER_TEXT, node)
+    assert source is not None
+    return source
+
+
+def _wrapper_function_body(name: str) -> str:
+    """Executable statements only: prose legitimately names what the code
+    must not call."""
+
+    tree = ast.parse(WRAPPER_TEXT, filename=str(WRAPPER_PATH))
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef) and item.name == name
+    )
+    return "\n".join(
+        ast.get_source_segment(WRAPPER_TEXT, stmt) or ""
+        for stmt in node.body
+        if not (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant))
+    )
+
+
+def test_cpp_unsupported_enforces_the_logical_view_and_scale_contracts():
+    """The native boundary must refuse what the Python wrapper refuses.
+
+    This machine has no built ``.so``, so the parity that matters here is
+    the source contract: a caller that reaches the symbol directly, or a
+    later wrapper edit that drops a clause, must still hit ``std::
+    invalid_argument`` instead of a kernel reading the wrong rows.
+    """
+
+    cpp = (EXT_DIR / "qwen4_qsa_sparse_gqa.cpp").read_text(encoding="utf-8")
+    # Equality, not <=: params.kL IS k.shape(2), so Q is the suffix ending
+    # exactly at the logical frontier (Python: key_len != total_tokens_i).
+    assert "q_offset + q.shape(2) != k.shape(2)" in cpp
+    assert "q_offset + q.shape(2) > k.shape(2)" not in cpp
+    # The one production scale. 1/sqrt(256) == 1/16 is exactly representable,
+    # so the equality needs no tolerance (Python: scale_f != _EXPECTED_SCALE).
+    assert "scale != 0.0625f" in cpp
+    # scale has to reach unsupported() to be checked there.
+    assert "const array &selected, float scale, int q_offset" in cpp
+    message = cpp[cpp.index("std::ostringstream msg;") :]
+    assert "q_offset+M==K" in message
+    assert "scale==0.0625" in message
+
+
+def test_tier_chooser_orders_flash_direct_gather_dense():
+    """The extracted chooser is what the routing tests drive; its order is
+    the port's whole contract."""
+
+    source = _function_source("_qsa_prefill_dispatch_tier")
+    order = [
+        source.index("flash_supported()"),
+        source.index("direct_supported()"),
+        source.index("if gather_enabled:"),
+        source.index('_qsa_prefill_count("dense_fallback")'),
+    ]
+    assert order == sorted(order)
+    for lane in ("flash_kernel", "direct_kernel", "gather_tier", "dense_fallback"):
+        assert f'_qsa_prefill_count("{lane}")' in source
+
+
+def test_readiness_enforces_the_mlx_build_receipt():
+    """A .so built against a different mlx imports, probes, lists every
+    symbol, and then mis-reads MLX's private structs."""
+
+    assert "def _build_receipt_mismatch" in WRAPPER_TEXT
+    mismatch = _wrapper_function_source("_build_receipt_mismatch")
+    assert 'getattr(_EXT, "BUILT_AGAINST_MLX"' in mismatch
+    assert 'getattr(mx, "__version__"' in mismatch
+    assert "built != runtime" in mismatch
+    reason = _wrapper_function_source("_lane_unavailable_reason")
+    assert "_build_receipt_mismatch()" in reason
+    assert "logger.warning" in reason
+
+
+def test_a_failed_pipeline_proof_disables_the_lane_process_wide():
+    """Symbol presence is not readiness, and a failed proof is terminal:
+    otherwise the M3 auto-gate arms a producer for a consumer that cannot
+    run, every request re-hits the same wall, and the fallback never
+    engages."""
+
+    assert "_PIPELINE_FAILED" in WRAPPER_TEXT
+    assert "_PIPELINE_UNPROVEN" in WRAPPER_TEXT
+    reason = _wrapper_function_source("_lane_unavailable_reason")
+    assert "_PIPELINE_STATE == _PIPELINE_FAILED" in reason
+    # The per-call support check answers from the same state, so a failed
+    # proof also makes qsa_prefill_direct() raise instead of dispatching.
+    assert "_lane_unavailable_reason()" in _wrapper_function_source(
+        "qsa_prefill_direct_unsupported_reason"
+    )
+    ready = _wrapper_function_source("qsa_prefill_direct_ready")
+    assert "_lane_eligible()" in ready
+    # No recursion: the proof consults the eligibility helper, never ready().
+    for name in ("_lane_unavailable_reason", "_prove_pipeline"):
+        assert "qsa_prefill_direct_ready" not in _wrapper_function_body(name)
+    preflight = _wrapper_function_body("qsa_prefill_direct_preflight")
+    assert "_lane_eligible()" in preflight
+    assert "qsa_prefill_direct_ready" not in preflight
+
+
+def test_the_pipeline_proof_is_tracked_per_query_dtype():
+    """The Metal kernel name embeds the query dtype, so one bfloat16 proof
+    never licenses the float16 specialization."""
+
+    assert "_PIPELINE_PROVEN_DTYPES" in WRAPPER_TEXT
+    ready = _wrapper_function_body("qsa_prefill_direct_ready")
+    assert "_prove_all_pipelines()" in ready
+    prove_all = _wrapper_function_body("_prove_all_pipelines")
+    assert "_SUPPORTED_DTYPES" in prove_all
+    # The first-dispatch proof takes the dtype it is proving, so a float16
+    # first call cannot ride a bfloat16 PROVEN flag.
+    assert "def _prove_first_dispatch(out: mx.array, *, dtype: mx.Dtype)" in WRAPPER_TEXT
+    assert "_prove_first_dispatch(out, dtype=queries.dtype)" in WRAPPER_TEXT
+
+
+def test_failed_is_terminal_and_the_first_proof_is_serialized():
+    """Check-then-set across an mx.eval: without a lock two callers both see
+    UNPROVEN and a late success can overwrite FAILED."""
+
+    assert "import threading" in WRAPPER_TEXT
+    assert "_PIPELINE_LOCK = threading.RLock()" in WRAPPER_TEXT
+    for name in ("_prove_pipeline", "_prove_first_dispatch"):
+        assert "with _PIPELINE_LOCK:" in _wrapper_function_body(name), name
+    success = _wrapper_function_body("_record_pipeline_success")
+    assert "if _PIPELINE_STATE == _PIPELINE_FAILED:" in success
+    assert "return" in success

--- a/tests/test_qsa_selector_prefix_contract.py
+++ b/tests/test_qsa_selector_prefix_contract.py
@@ -1,0 +1,204 @@
+"""The invariant that licenses the direct kernel to ignore ``block_valid``.
+
+MTPLX's public block contract tolerates arbitrary validity holes; the
+vendored Steel kernel cannot represent them. It takes only uint32 ids and
+derives validity POSITIONALLY: it reads exactly the first
+``min(512, (q_abs + 1) // ratio)`` slots of each row. So the producers must
+emit a chronological VALID PREFIX — ascending, causally visible ids in
+``[0, valid_count)`` and padding after.
+
+Both production selectors do. This module proves it against the real
+selectors rather than against a restatement of the rule, because a future
+selector variant that emitted a hole inside the prefix would make the direct
+kernel attend block 0 exactly where the MPP and gather tiers mask it — a fast,
+plausible, wrong answer.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from mtplx.attention_context import attention_phase
+from mtplx.models.qwen4_exp import QSACache, QSAIndexer, TextArgs
+
+pytestmark = pytest.mark.skipif(
+    not mx.metal.is_available() or mx.default_device() != mx.gpu,
+    reason="the QSA selectors require the Metal GPU",
+)
+
+_RATIO = 4
+_BUDGET = 32  # block_topk == budget // ratio == 8
+_PRIMED = 2176  # comfortably past the 2049 minimum crossover floor
+
+
+def _args() -> TextArgs:
+    return TextArgs(
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        partial_rotary_factor=0.5,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=_BUDGET,
+        indexer_compress_ratio=_RATIO,
+    )
+
+
+@pytest.fixture()
+def indexer() -> QSAIndexer:
+    mx.random.seed(20260901)
+    module = QSAIndexer(_args())
+    module.q_layernorm.weight = module.q_layernorm.weight.astype(mx.float16)
+    module.k_layernorm.weight = module.k_layernorm.weight.astype(mx.float16)
+    mx.eval(module.parameters())
+    return module
+
+
+def _rows(module: QSAIndexer, rows: int, seed: int):
+    mx.random.seed(seed)
+    hidden_size = int(module.index_qk_proj.weight.shape[1])
+    qk_width = (module.n_heads + module.kv_heads) * module.head_dim
+    hidden = (mx.random.normal((1, rows, hidden_size)) * 0.2).astype(mx.float16)
+    qk_rows = (mx.random.normal((1, rows, qk_width)) * 0.2).astype(mx.float16)
+    mx.eval(hidden, qk_rows)
+    return hidden, qk_rows
+
+
+def _lane_env(monkeypatch) -> None:
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "1")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_ROWS", "2")
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setenv("MTPLX_FUSED_QSA_INDEXER", "0")
+    monkeypatch.setenv("MTPLX_COMPILED_QSA_INDEXER", "0")
+    monkeypatch.setenv("MTPLX_QSA_MTP_PRECOMPUTE", "0")
+
+
+def _select(module: QSAIndexer, monkeypatch, *, rows: int, force_eager: bool):
+    """Drive the real producer and return its (block_ids, block_valid)."""
+
+    _lane_env(monkeypatch)
+    if force_eager:
+        monkeypatch.setattr(
+            QSAIndexer, "_prefill_selector_supported", lambda *a, **kw: False
+        )
+    cache = QSACache(module.ratio)
+    hidden, qk_rows = _rows(module, _PRIMED, seed=5)
+    with attention_phase("prefill"):
+        module(hidden, 0, cache, qk_rows=qk_rows)
+        leaves = [f for f in (cache.raw_keys, cache.pooled) if f is not None]
+        mx.eval(*leaves)
+        cache.kv.offset = _PRIMED
+
+        hidden, qk_rows = _rows(module, rows, seed=9)
+        out = module(hidden, _PRIMED, cache, qk_rows=qk_rows)
+    return out
+
+
+def _assert_prefix_contract(block_ids, block_valid, *, pos_start: int) -> None:
+    """Exactly the rule the kernel assumes, checked on the host."""
+
+    mx.eval(block_ids, block_valid)
+    ids = block_ids.tolist()
+    valid = block_valid.tolist()
+    slots = len(ids[0])
+    for row, (row_ids, row_valid) in enumerate(zip(ids, valid)):
+        q_abs = pos_start + row
+        complete = (q_abs + 1) // _RATIO
+        expected = min(slots, complete)
+
+        count = sum(1 for ok in row_valid if ok)
+        assert count == expected, f"row {row}: valid count {count} != {expected}"
+        assert row_valid[:count] == [True] * count, f"row {row}: hole in prefix"
+        assert row_valid[count:] == [False] * (slots - count), (
+            f"row {row}: validity after the prefix"
+        )
+
+        selected = row_ids[:count]
+        assert selected == sorted(selected), f"row {row}: ids not ascending"
+        assert len(set(selected)) == count, f"row {row}: duplicate id"
+        assert all(0 <= b < complete for b in selected), (
+            f"row {row}: id outside the causally complete range"
+        )
+
+
+@pytest.mark.parametrize("rows", [64, 96])
+def test_eager_selector_emits_a_valid_prefix(indexer, monkeypatch, rows):
+    out = _select(indexer, monkeypatch, rows=rows, force_eager=True)
+    assert isinstance(out, tuple) and out[0] == "flash_prefill"
+    _assert_prefix_contract(out[1], out[2], pos_start=_PRIMED)
+
+
+def test_metal_selector_emits_a_valid_prefix(indexer, monkeypatch):
+    """Skips where the Metal prefill selector's own support check refuses;
+    the eager oracle above still pins the contract on that hardware."""
+
+    out = _select(indexer, monkeypatch, rows=64, force_eager=False)
+    assert isinstance(out, tuple) and out[0] == "flash_prefill"
+    _assert_prefix_contract(out[1], out[2], pos_start=_PRIMED)
+
+
+def test_both_selectors_agree_on_the_prefix_shape(indexer, monkeypatch):
+    """The direct kernel reads slots positionally, so the two producers must
+    not disagree about HOW MANY slots are live, even if they tie-break the
+    selected set differently."""
+
+    eager = _select(indexer, monkeypatch, rows=64, force_eager=True)
+    metal = _select(indexer, monkeypatch, rows=64, force_eager=False)
+    mx.eval(eager[2], metal[2])
+    assert bool(mx.array_equal(eager[2], metal[2]).item())
+
+
+def test_below_budget_context_never_emits_the_block_tuple(indexer, monkeypatch):
+    """Where the kernel's ``complete < topk`` branch would matter, MTPLX
+    does not route here at all: the indexer's dense-skip returns None
+    because the visible prefix already fits the budget (dense == sparse).
+
+    That is why the short-prefix arithmetic is covered at the adapter level
+    (tests/test_qsa_prefill_direct.py) rather than end to end — it is a
+    defensive branch of the vendored kernel, not a production regime.
+    """
+
+    _lane_env(monkeypatch)
+    tokens = indexer.block_topk * _RATIO  # exactly at the dense/sparse edge
+    cache = QSACache(indexer.ratio)
+    hidden, qk_rows = _rows(indexer, tokens, seed=5)
+    with attention_phase("prefill"):
+        indexer(hidden, 0, cache, qk_rows=qk_rows)
+        mx.eval(*[f for f in (cache.raw_keys, cache.pooled) if f is not None])
+        cache.kv.offset = tokens
+        hidden, qk_rows = _rows(indexer, 4, seed=3)
+        out = indexer(hidden, tokens, cache, qk_rows=qk_rows)
+
+    # Either the dense-skip (None) or a plain dense mask — never the compact
+    # block tuple the direct kernel consumes.
+    assert not (isinstance(out, tuple) and out and out[0] == "flash_prefill")
+
+
+def test_production_regime_prefixes_are_always_full(indexer, monkeypatch):
+    """The kernel's valid_blocks = min(topk, complete) must match the
+    producer's fill; past the crossover that always resolves to topk."""
+
+    _lane_env(monkeypatch)
+    monkeypatch.setenv("MTPLX_QSA_PREFILL_MIN_CONTEXT", "2049")
+    monkeypatch.setattr(
+        QSAIndexer, "_prefill_selector_supported", lambda *a, **kw: False
+    )
+    cache = QSACache(indexer.ratio)
+    hidden, qk_rows = _rows(indexer, _PRIMED, seed=5)
+    with attention_phase("prefill"):
+        indexer(hidden, 0, cache, qk_rows=qk_rows)
+        mx.eval(*[f for f in (cache.raw_keys, cache.pooled) if f is not None])
+        cache.kv.offset = _PRIMED
+        hidden, qk_rows = _rows(indexer, 64, seed=3)
+        out = indexer(hidden, _PRIMED, cache, qk_rows=qk_rows)
+
+    assert isinstance(out, tuple) and out[0] == "flash_prefill"
+    counts = out[2].astype(mx.int32).sum(axis=-1)
+    mx.eval(counts)
+    # Every row here is far past the budget, so every prefix is full: this is
+    # the regime production actually serves.
+    assert set(counts.tolist()) == {indexer.block_topk}


### PR DESCRIPTION
## Why

MTPLX's QSA large-prefill producer currently auto-enables only when the NAX flash kernel exists (M4/M5). M3 has no G17 tensor units, so that gate stays off and M3 either stays dense or pays the portable gather tier.

oMLX [PR #3244](https://github.com/jundot/omlx/pull/3244) already has a Steel sparse-GQA Metal kernel for the exact Flash-Next geometry (24q / 2kv / D256, 512 four-token blocks). This ports that kernel into MTPLX as an optional native extension and puts it in the existing `flash_prefill` consumer chain: **flash → direct → gather → dense**.

M4/M5 behavior is unchanged (flash still wins first). M3 can take the Steel kernel when the `.so` is built and proven. Missing or mismatched native code fails closed; it does not silently fall through after dispatch.

## What

- Vendor only the Qwen4 sparse-GQA primitive under `native_extensions/qsa_kernels/` (Apache-2.0, oMLX rev `dc312e6e905e03d21ef0c4a86289cbfa2cf857cc`). Library renamed `mtplx_qsa_kernels`. WM=2 (64 threads) with `static_assert` against the M2/M3 896-thread cap (#400).
- Optional Python wrapper `mtplx/kernels/qsa_prefill_direct.py`: nanobind `==2.15.0`, `NB_DOMAIN mlx`, `BUILT_AGAINST_MLX` vs runtime mlx, pipeline proof per fp16/bf16, kill switch `MTPLX_QSA_PREFILL_DIRECT`.
- Producer auto-gate: `qsa_prefill_lane_auto_supported()` is true on NAX **or** a ready direct module.
- Logical K/V only (`kL == T`). Chronological valid-prefix Topk adapter. Packaged specialization is `(key_tile, dimension_tile) = (64, 64)` only.
- `MTPLX_QSA_PREFILL_ENGAGEMENT_FILE` writes counters during a live serve so an A/B can prove `direct_kernel > 0` without relying on process-exit.

Default crossover stays 32768 (same story as flash). Operators who want the 16k/32k M3 win set `MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT=2049` (and the matching producer min-context).

## Measurements

**Hardware:** Mac Studio M3 Ultra, 80-core GPU, 256 GB unified, fan default (not a controlled-fan run; not a product headline).  
**Model:** `Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed` rev `29ba90f`, served as `mtplx-flash-next-optimized-speed`.  
**Baseline:** MTPLX PR #391 restack @ `4359de8` (already live on this box).  
**Sampler:** temperature 1.0, top_p 0.95, top_k 20, thinking off, streaming.  
**Date:** 2026-09-01.  
**Kernel env:** `MTPLX_QSA_PREFILL=1`, `MTPLX_QSA_PREFILL_DIRECT=1`, `MTPLX_QSA_PREFILL_GATHER=0`, `MTPLX_QSA_PREFILL_MIN_CONTEXT=2049`, `MTPLX_QSA_PREFILL_DIRECT_MIN_CONTEXT=2049`.  
**Engagement:** `direct_kernel=1911`, `metal_selector=1911`, gather_tier=0.

| Cell | PR391 | This port | Change |
|---|---|---|---|
| decode-short (256 tok) | 99.0 tok/s | 100.3 tok/s | +1.3% |
| 16k TTFT | 17.79 s | 16.96 s | −4.7% |
| 16k prefill | 832 tok/s | 873 tok/s | +4.9% |
| 32k TTFT | 40.69 s | 34.32 s | **−15.6%** |
| 32k prefill | 726 tok/s | 873 tok/s | +20% |
| agent-code decode | 76.6 tok/s | 74.8 tok/s | −2.4% |

Numeric vs the gather oracle (oMLX bounds): bf16 max abs err 0.00146, fp16 0.00018 (bound 5e-3). Greedy tokens through a production-geometry Attention layer were identical across direct / gather / dense.

This port is the **attention consumer only**. oMLX's larger prefill numbers also include native indexer scores and fp32 top-k, which are not in this PR.

## Tests

`tests/test_qsa_prefill_direct_static.py` is mlx-free and passes on this tree. Wrapper / routing / selector-prefix tests need mlx; numeric and greedy skip unless the native `.so` is built.

Build the extension in the serving venv:

```
pip install "nanobind==2.15.0" "mlx==0.32.2"
cd native_extensions/qsa_kernels
python setup.py build_ext --inplace
```

See `native_extensions/qsa_kernels/README.md`.

## Related

- oMLX https://github.com/jundot/omlx/pull/3244 (source kernel)
- MTPLX https://github.com/youssofal/MTPLX/pull/391 (restack we measured against; this PR is against main and does not depend on it)
