### PR TITLE
fix(telemetry): expose finish_stop_origin in public stats and request log

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -14643,6 +14643,10 @@ def _metrics_envelope(
             stats.get("repetition_stop_trimmed_tokens") or 0
         ),
         "repetition_stop_raw_tokens": int(stats.get("repetition_stop_raw_tokens") or 0),
+        # #414: which speculative branch emitted the stop token. Null on
+        # length/aborted finishes — stamped unconditionally here because
+        # the JSONL is the forensics surface the release note names.
+        "finish_stop_origin": stats.get("finish_stop_origin"),
         "loop_guard": dict(stats.get("loop_guard") or {}),
         "thinking_guard": dict(stats.get("thinking_guard") or {}),
         "lock_wait_time_s": lock_wait_time_s,
@@ -18227,6 +18231,13 @@ def _public_mtplx_stats(generated: dict[str, Any]) -> dict[str, Any]:
         reason = stats.get("repetition_stop_reason")
         if reason is not None:
             public["repetition_stop_reason"] = str(reason)
+    # #414 telemetry: same quiet-envelope rule. finish_stop_origin is None
+    # on every length/aborted finish, so it joins the envelope only when a
+    # stop actually named its commit path — without this the origin exists
+    # on GenerationStats but never reaches the SSE payload.
+    stop_origin = stats.get("finish_stop_origin")
+    if stop_origin is not None:
+        public["finish_stop_origin"] = str(stop_origin)
     # Draft-sampler truth keys (same quiet-envelope idiom): stamped only
     # when the resolution ran, so AR responses — which carry no draft
     # telemetry at all — and legacy envelopes stay byte-stable.

--- a/tests/test_finish_stop_origin.py
+++ b/tests/test_finish_stop_origin.py
@@ -113,3 +113,36 @@ class TestBatchedLoopWiring:
         src = inspect.getsource(gen)
         cut = src.index('if finish_reason != "stop":')
         assert "stop_origin = None" in src[cut : cut + 120]
+
+
+def test_stats_origin_reaches_public_surfaces():
+    """#414 followup: the origin reached GenerationStats but neither the SSE
+    mtplx_stats payload nor the request-log JSONL row, so the release note's
+    "diagnosable from request logs alone" promise was unreadable without a
+    local patch."""
+    from mtplx.server.openai import _metrics_envelope, _public_mtplx_stats
+
+    stats = {"finish_stop_origin": "residual_correction"}
+    # SSE mtplx_stats: quiet-envelope rule — present when a stop named its
+    # commit path, absent on length finishes (None in to_dict()).
+    assert (
+        _public_mtplx_stats({"stats": stats})["finish_stop_origin"]
+        == "residual_correction"
+    )
+    # Request-log JSONL row: nullable like repetition_stop_reason.
+    envelope = _metrics_envelope(
+        stats=stats,
+        prompt_tokens=512,
+        completion_tokens=37,
+        request_elapsed_s=0.5,
+        token_times=[10.0],
+        request_started_s=9.5,
+        lock_wait_time_s=0.0,
+        session_id=None,
+        session_cache_hit=False,
+        cache_miss_reason=None,
+        session_restore_mode="cold",
+        mtp_depth=3,
+        generation_limits={},
+    )
+    assert envelope["finish_stop_origin"] == "residual_correction"


### PR DESCRIPTION
## Summary

- `finish_stop_origin` (added in 2.10.2 for #414) was stamped on `GenerationStats` at every commit site of the batched loop, but never copied out: `_public_mtplx_stats` only copies `PUBLIC_MTPLX_STATS_KEYS` entries, and the request-log `_metrics_envelope` built its row without the field
- so neither the final SSE `mtplx_stats` payload nor the request-log JSONL named the stop's commit path, and adjudicating a #414-style report still needed a local patch — the exact thing the field was added to avoid (the release note said "diagnosable from request logs alone")
- exposure follows the two existing idioms:
  - `_public_mtplx_stats`: quiet-envelope stamp beside `repetition_stop_triggered` — present only when a stop actually named a path, so length finishes (`None` in `to_dict()`) keep quiet envelopes byte-stable for existing clients
  - `_metrics_envelope`: nullable stamp beside `repetition_stop_reason` — the JSONL row always carries it (null when nothing fired)

No decoding-path change: `generation.py` is untouched.

## Verification

- before, on current `main`: `python -m pytest tests/test_finish_stop_origin.py` — the new surface test fails (`KeyError: 'finish_stop_origin'`); the field exists on `GenerationStats` but `_public_mtplx_stats({"stats": {...}})` and `_metrics_envelope(...)` both omit it
- after: `python -m pytest tests/test_finish_stop_origin.py` — 11 passed
- envelope safety: `python -m pytest tests/test_request_observability_golden.py tests/test_response_envelope_parity.py tests/test_dashboard_endpoints.py tests/test_context_copy_stats.py tests/test_api_benchmark_contracts.py` — all pass, golden matrix untouched (quiet envelopes stay byte-stable)
- CONTRIBUTING check set: `python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py tests/test_server_openai.py` — 415 passed
- `python -m compileall -q mtplx tests` — clean
- greedy depth-parity re-check with the in-tree tiny qwen4_exp fixture (`scripts/qwen4exp_mtp_tiny_smoke` builders, depth 1/2/3 vs AR): token-identical on the patched tree, so the speculative commit path is unaffected

Fixes #414 (the diagnostic half: the D2/D3 output divergence itself is expected under temperature=1.0 — different depths consume RNG draws at different rates — but with this the origin is now readable from the stock wheel's SSE payload and request logs, which is what rerunning the repro needs)
