### PR TITLE
fix(openai): accept OpenAI's off-ish reasoning_effort values

### DIFF
--- a/mtplx/reasoning_effort.py
+++ b/mtplx/reasoning_effort.py
@@ -12,6 +12,11 @@ level. That is how 2.7.0 shipped with Qwen 3.8's ``xhigh`` bouncing back to
 ``medium``: the request path knew the level, the live-settings coercer did
 not, and because that POST is all-or-nothing the app's whole settings payload
 was rejected.
+
+``_OPENAI_EFFORT_ALIASES`` widens only what arrives over the wire. The CLI
+gates ``--reasoning-effort`` on ``REASONING_EFFORT_CHOICES`` through argparse
+``choices`` and ``mtplx config set`` compares against the same tuple, so an
+alias never reaches either; the canonical vocabulary is unchanged.
 """
 
 from __future__ import annotations
@@ -25,11 +30,24 @@ REASONING_EFFORT_LEVELS = ("low", "medium", "high", "xhigh")
 REASONING_EFFORT_AUTO = "auto"
 REASONING_EFFORT_CHOICES = (REASONING_EFFORT_AUTO, *REASONING_EFFORT_LEVELS)
 
+# OpenAI's off-ish effort values, which clients hardcode and give the user no
+# way to change: Cherry Studio's translate pane sends one of these on every
+# request and has no effort picker, so the whole pane 400s against MTPLX.
+# None of them can mean "no reasoning" here -- that is `reasoning: off` or
+# chat_template_kwargs.enable_thinking -- and this field can only answer with
+# a level, so they resolve to the lowest one rather than rejecting the
+# request. Junk values still raise.
+_OPENAI_EFFORT_ALIASES = {
+    alias: REASONING_EFFORT_LEVELS[0]
+    for alias in ("minimal", "none", "off", "disable", "disabled")
+}
+
 
 def normalize_reasoning_effort(
     value: Any, *, default: str = REASONING_EFFORT_AUTO
 ) -> str:
     effort = str(value or default).strip().lower()
+    effort = _OPENAI_EFFORT_ALIASES.get(effort, effort)
     if effort not in REASONING_EFFORT_CHOICES:
         raise ValueError(
             "reasoning_effort must be one of: " + ", ".join(REASONING_EFFORT_CHOICES)

--- a/tests/test_qwen38_family.py
+++ b/tests/test_qwen38_family.py
@@ -662,6 +662,29 @@ def test_normalize_reasoning_effort_accepts_xhigh() -> None:
         srv._normalize_reasoning_effort("ultra")
 
 
+def test_normalize_reasoning_effort_maps_openai_off_values() -> None:
+    """OpenAI's off-ish effort values resolve instead of 400-ing the request.
+
+    Clients hardcode them and do not expose a picker: Cherry Studio's
+    translate pane sends one on every call, so the whole pane failed against
+    a server whose vocabulary starts at `low`. None of them can mean "no
+    reasoning" here -- that is `reasoning: off` or
+    chat_template_kwargs.enable_thinking -- so the lowest level is the
+    closest answer this field can give.
+    """
+
+    from mtplx.reasoning_effort import REASONING_EFFORT_LEVELS
+    from mtplx.server import openai as srv
+
+    lowest = REASONING_EFFORT_LEVELS[0]
+    for alias in ("minimal", "none", "off", "disable", "disabled", "NONE", " none "):
+        assert srv._normalize_reasoning_effort(alias) == lowest, alias
+    for level in REASONING_EFFORT_CHOICES:
+        assert srv._normalize_reasoning_effort(level) == level, level
+    with pytest.raises(ValueError):
+        srv._normalize_reasoning_effort("banana")
+
+
 def test_reasoning_effort_vocabulary_covers_every_family() -> None:
     """No family may advertise a level the writing surfaces would reject.
 


### PR DESCRIPTION
## Summary

A client that hardcodes OpenAI's `reasoning_effort: "minimal"` or `"none"` gets a 400 out of the chat request path. Cherry Studio's translate pane sends one on every call and exposes no effort picker, so the entire pane is unusable against MTPLX — reproduced against 2.11.0:

```
$ curl -s localhost:8080/v1/chat/completions -H 'Content-Type: application/json' \
    -d '{"model":"...","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"none"}'
{"message": "reasoning_effort must be one of: auto, low, medium, high, xhigh",
 "type": "invalid_request_error", ...}
```

This maps `minimal`/`none`/`off`/`disable`/`disabled` onto the lowest level in `normalize_reasoning_effort`, the one place the request path and the live-settings POST share.

None of those values can mean "no reasoning" on this server — that is `reasoning: off` or `chat_template_kwargs.enable_thinking` — and `reasoning_effort` can only answer with a level, so the lowest one is the closest available answer rather than a rejected request. Deliberately **not** wired to reasoning-off, because a client asking for an effort level should not have thinking silently disabled underneath it.

Scope is narrow by construction:

- `REASONING_EFFORT_CHOICES` is untouched, so every family's `effort_levels` contract and the app's picker are unchanged.
- Junk values still raise (`"banana"` → 400).
- The aliases only widen what arrives over the wire: `--reasoning-effort` is gated by argparse `choices=REASONING_EFFORT_CHOICES` and `mtplx config set` compares against the same tuple, so an alias cannot reach either surface.

I left CHANGELOG.md alone since entries there look maintainer-written at release time; happy to add one in whatever wording you prefer.

## Verification

macOS 15.6 (arm64), Python 3.12.13, this branch installed with `-e ".[dev,server]"`.

```
python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py \
                 tests/test_runtime_kpis.py tests/test_qwen38_family.py \
                 tests/test_openai_bridge.py
453 passed

python -m build              -> mtplx-2.10.2-py3-none-any.whl
scripts/fresh_venv_smoke.sh  -> passed no-MLX CLI survival checks
scripts/check_ai_attribution.py --range upstream/main..HEAD -> clean
```

New test `test_normalize_reasoning_effort_maps_openai_off_values` covers the five aliases plus case and whitespace variants, asserts every canonical choice still round-trips, and asserts junk still raises.

End to end on a live server (Qwen3.8-27B-UD-Q4_K_XL, one M5 Pro, `--profile turbo --reasoning on --reasoning-effort xhigh`): `minimal`, `none`, `off`, `disable` all return 200 after the change and `banana` still returns 400.

## Benchmark Evidence

No runtime performance change: the added lookup is one dict `get` on the request-validation path, before generation.
