### PR TITLE
fix(app): preserve scrollable height in long chat drafts

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Chat/Primitives/ComposerInputTextView.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Chat/Primitives/ComposerInputTextView.swift
@@ -142,7 +142,9 @@ struct ComposerInputTextView: NSViewRepresentable {
             width: visibleWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
-        let targetHeight = max(measuredHeight, minHeight)
+        // The document must remain taller than the viewport for long drafts.
+        // Height is measured below; synchronizing the width must not collapse it.
+        let targetHeight = max(textView.frame.height, minHeight)
         if abs(textView.frame.width - visibleWidth) > 0.5
             || abs(textView.frame.height - targetHeight) > 0.5 {
             textView.frame = NSRect(
@@ -160,16 +162,17 @@ struct ComposerInputTextView: NSViewRepresentable {
         layoutManager.ensureLayout(for: textContainer)
         let usedHeight = layoutManager.usedRect(for: textContainer).height
         let contentHeight = usedHeight + textView.textContainerInset.height * 2
-        let clampedHeight = min(max(contentHeight, minHeight), maxHeight)
+        let documentHeight = max(contentHeight, minHeight)
+        let clampedHeight = min(documentHeight, maxHeight)
         let visibleWidth = max(
             textView.enclosingScrollView?.contentSize.width ?? textView.bounds.width,
             1
         )
         if abs(textView.frame.width - visibleWidth) > 0.5
-            || abs(textView.frame.height - clampedHeight) > 0.5 {
+            || abs(textView.frame.height - documentHeight) > 0.5 {
             textView.frame = NSRect(
                 origin: .zero,
-                size: NSSize(width: visibleWidth, height: clampedHeight)
+                size: NSSize(width: visibleWidth, height: documentHeight)
             )
         }
         if abs(measuredHeight - clampedHeight) > 0.5 {

--- a/apps/MTPLXApp/Tests/MTPLXAppHostTests/ComposerReturnToSendTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppHostTests/ComposerReturnToSendTests.swift
@@ -82,4 +82,31 @@ final class ComposerReturnToSendTests: XCTestCase {
             "submit must read the committed view string, not the stale binding"
         )
     }
+    @MainActor
+    func testLongComposerKeepsFullDocumentHeight() throws {
+        let box = Box()
+        let (host, textView) = try mountComposer(box: box)
+        defer { _ = host }
+        textView.string = (1...20).map { "line \($0)" }.joined(separator: "\n")
+        textView.setSelectedRange(NSRange(location: textView.string.utf16.count, length: 0))
+        textView.delegate?.textDidChange?(Notification(name: NSText.didChangeNotification, object: textView))
+
+        let layoutManager = try XCTUnwrap(textView.layoutManager)
+        let container = try XCTUnwrap(textView.textContainer)
+        layoutManager.ensureLayout(for: container)
+        let contentHeight = layoutManager.usedRect(for: container).height
+            + textView.textContainerInset.height * 2
+        XCTAssertGreaterThan(contentHeight, 160)
+        XCTAssertGreaterThanOrEqual(textView.frame.height, contentHeight)
+        let scrollView = try XCTUnwrap(textView.enclosingScrollView)
+        XCTAssertTrue(scrollView.hasVerticalScroller)
+        textView.scrollRangeToVisible(textView.selectedRange())
+        XCTAssertGreaterThan(scrollView.contentView.bounds.origin.y, 0)
+
+        textView.string = "short draft"
+        textView.delegate?.textDidChange?(Notification(name: NSText.didChangeNotification, object: textView))
+        XCTAssertLessThanOrEqual(textView.frame.height, 160)
+        XCTAssertFalse(scrollView.hasVerticalScroller)
+    }
+
 }


### PR DESCRIPTION
## Summary

Long chat drafts clamp the NSTextView document itself to the composer's maximum visible height. Once the text exceeds that height, the scroll view cannot reach the remaining lines, which makes continued typing disappear above or below the visible area.

Keep the document at its full measured content height and clamp only the height reported to SwiftUI. Width synchronization preserves the document height instead of shrinking it back to the viewport size. Shortening the draft still shrinks the document and hides the scroller.

Adds a composer regression covering overflowing content, scrolling to the insertion point, and shrinking back to a short draft.

Fixes #424.

## Validation

- `python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py -q`: passed (one skipped).
- `python -m build`: passed.
- `scripts/fresh_venv_smoke.sh`: passed.
- Isolated AppKit proof using the actual composer source and text-sync helper: before the fix, 360-point content had a 160-point document and failed the height assertion; after the fix, the document measured 360 points, the final insertion point scrolled into view, and a short draft shrank the document and hid the scroller.
- `swift test --package-path apps/MTPLXApp --filter ComposerReturnToSendTests` was attempted but cannot build on this Command Line Tools installation: the existing SwiftData models require the unavailable `SwiftDataMacros` plugin. The new package test therefore still needs a full-Xcode run.

Manual check: enter more than ten lines with Shift+Enter in Chat, continue typing at the end, then replace the draft with one short line. The insertion point should remain reachable and the composer should shrink again.
