### PR TITLE
forge: extract MTP heads that are not stored under an mtp. prefix

### DIFF
--- a/mtplx/artifacts.py
+++ b/mtplx/artifacts.py
@@ -151,6 +151,53 @@ def _num_mtp_layers(config: dict[str, Any]) -> int:
     )
 
 
+def appended_mtp_layer_range(config: dict[str, Any]) -> range:
+    """Layer indices holding an appended-layer MTP head.
+
+    GLM MoE checkpoints ship the MTP head as extra decoder layers starting
+    at ``num_hidden_layers`` (``model.layers.47.*`` for GLM-4.7-Flash),
+    rather than under an ``mtp.`` prefix.  Returns an empty range when the
+    config does not describe that layout.
+    """
+    tcfg = text_config(config)
+    start = int(tcfg.get("num_hidden_layers") or config.get("num_hidden_layers") or 0)
+    count = _num_mtp_layers(config)
+    if start <= 0 or count <= 0:
+        return range(0)
+    return range(start, start + count)
+
+
+def is_mtp_layers_namespace_key(key: str, config: dict[str, Any]) -> bool:
+    """Match an MTP head kept in its own ``model.mtp_layers.N.`` namespace.
+
+    MiMo stores the head neither under an ``mtp.`` prefix nor as an appended
+    decoder layer, but in a separate namespace beside ``model.layers.*``.
+    ``mimo_mtp_patch`` already reads that form, so extraction only has to
+    select the keys; no rewrite is needed.
+    """
+    text = str(key)
+    count = _num_mtp_layers(config)
+    return count > 0 and any(
+        text.startswith(f"model.mtp_layers.{index}.") for index in range(count)
+    )
+
+
+def uses_mtp_layers_namespace(config: dict[str, Any]) -> bool:
+    return _num_mtp_layers(config) > 0
+
+
+def uses_appended_layer_mtp(config: dict[str, Any]) -> bool:
+    return len(appended_mtp_layer_range(config)) > 0
+
+
+def is_appended_layer_mtp_key(key: str, config: dict[str, Any]) -> bool:
+    text = str(key)
+    return any(
+        text.startswith(f"model.layers.{index}.")
+        for index in appended_mtp_layer_range(config)
+    )
+
+
 def _qwen_moe_numbered_expert_keys(
     config: dict[str, Any],
     *,

--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -1211,6 +1211,14 @@ def model_family_from_inspection(
         return "deepseek"
     if backend_id == GLM_MTP_DESCRIPTOR.backend_id or "glm" in text:
         return "glm"
+    if "mimo" in text:
+        # mimo-mtp has shipped a native backend with can_run_verified since
+        # before this function existed, but no branch here ever returned its
+        # family, so every MiMo artifact resolved to "unknown" and forge build
+        # exited 1 at the tune gate after a successful convert and calibrate.
+        # The marker text carries model_type and arch_id, not just the folder
+        # name, so this reads the artifact rather than guessing from a path.
+        return "mimo"
     if "lfm2" in text:
         return "lfm2"
     family = _explicit_qwen_family_marker(text)
@@ -1258,6 +1266,11 @@ def tune_policy_for_model(
             supported=True,
             candidates=("AR", "D1", "D2", "D3"),
         )
+    if family == "mimo":
+        # D1 only: mimo_mtp_patch.mtp_forward raises on mtp_depth > 1, and
+        # vLLM's proposer is single-token too, so offering D2+ would advertise
+        # depths the backend refuses.
+        return TunePolicy(supported=True, candidates=("AR", "D1"))
     return TunePolicy(
         supported=False,
         unsupported_reason="Tune is supported for Qwen 3.5, Qwen 3.6, Qwen 3.8, and Gemma 4 MTPLX models only.",

--- a/mtplx/commands/forge.py
+++ b/mtplx/commands/forge.py
@@ -1636,6 +1636,7 @@ def _ensure_mtp_sidecar(source: Path, destination: Path) -> bool:
         return _extract_embedded_mtp(
             source,
             target,
+            config=config,
             sanitize_values=_should_sanitize_extracted_mtp_weights(config),
         )
     return False
@@ -1660,6 +1661,7 @@ def _extract_embedded_mtp(
     source: Path,
     target: Path,
     *,
+    config: dict[str, Any] | None = None,
     sanitize_values: bool = False,
 ) -> bool:
     index_path = source / "model.safetensors.index.json"
@@ -1669,7 +1671,38 @@ def _extract_embedded_mtp(
     weight_map = index.get("weight_map") if isinstance(index, dict) else None
     if not isinstance(weight_map, dict):
         return False
+
+    if config is None:
+        config_path = source / "config.json"
+        try:
+            config = _load_json(config_path) if config_path.exists() else {}
+        except Exception:
+            config = {}
+
+    # Prefix-keyed heads (Qwen, Gemma) win: their layout is unambiguous and
+    # predates this branch.  Only when no "mtp." key exists do we look for an
+    # appended-layer head (GLM MoE), whose keys stay unnormalised because
+    # glm_mtp_patch derives the local MTP index from the literal
+    # "model.layers.{start+i}." form.
     mtp_keys = [key for key in weight_map if artifacts.is_mtp_key(str(key))]
+    key_transform: Callable[[str], str] | None = artifacts.normalize_mtp_key
+    if not mtp_keys and artifacts.uses_appended_layer_mtp(config):
+        mtp_keys = [
+            key
+            for key in weight_map
+            if artifacts.is_appended_layer_mtp_key(str(key), config)
+        ]
+        key_transform = None
+    if not mtp_keys and artifacts.uses_mtp_layers_namespace(config):
+        # MiMo keeps the head in its own "model.mtp_layers.N." namespace beside
+        # the decoder stack.  mimo_mtp_patch reads that form directly, so the
+        # keys stay unnormalised here too.
+        mtp_keys = [
+            key
+            for key in weight_map
+            if artifacts.is_mtp_layers_namespace_key(str(key), config)
+        ]
+        key_transform = None
     if not mtp_keys:
         return False
 
@@ -1681,7 +1714,7 @@ def _extract_embedded_mtp(
         source,
         by_file,
         target,
-        key_transform=artifacts.normalize_mtp_key,
+        key_transform=key_transform,
         sanitize_values=sanitize_values,
     )
     return True

--- a/mtplx/commands/forge.py
+++ b/mtplx/commands/forge.py
@@ -1113,6 +1113,7 @@ def _cmd_build(args: Any) -> int:
 
     existing_runtime = _read_runtime(destination) or _read_runtime(source_path)
     require_all_depths = True
+    verify_depths = _forge_verify_depths(destination)
     rows = _verify_rows_from_runtime(existing_runtime)
     calibration_diagnostic: str | None = None
     has_saved_contract = _runtime_has_mtp_contract(existing_runtime, destination)
@@ -1124,6 +1125,7 @@ def _cmd_build(args: Any) -> int:
             model_path=destination,
             source_path=source_path,
             require_all_depths=require_all_depths,
+            verify_depths=verify_depths,
         )
         if has_saved_contract or has_legacy_speed_grid
         else "missing saved MTP contract"
@@ -1156,7 +1158,9 @@ def _cmd_build(args: Any) -> int:
         )
     if not rows:
         raise ForgeError("verification produced no usable AR/MTP rows")
-    _require_verify_rows(rows, require_all_depths=require_all_depths)
+    _require_verify_rows(
+        rows, require_all_depths=require_all_depths, verify_depths=verify_depths
+    )
     _require_speed_win_or_write_outcome(
         destination,
         run,
@@ -2572,7 +2576,7 @@ def _run_verify(
         "--run-id",
         tune_run_id,
         "--depths",
-        "1,2,3",
+        ",".join(str(depth) for depth in _forge_verify_depths(model_path)),
         "--max-tokens",
         str(max(1, int(max_tokens))),
         "--prompt-suite",
@@ -3142,18 +3146,45 @@ def _annotate_verify_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return annotated
 
 
-def _verify_rows_have_all_depths(rows: list[dict[str, Any]]) -> bool:
-    depths = {int(row.get("depth") or 0) for row in rows if isinstance(row, dict)}
-    return all(depth in depths for depth in (0, 1, 2, 3))
+DEFAULT_FORGE_VERIFY_DEPTHS = (1, 2, 3)
+
+
+def _forge_verify_depths(model_path: Path) -> tuple[int, ...]:
+    """Depths forge asks tune to measure, taken from the model's tune policy.
+
+    Backends do not all reach D3. MiMo drafts one token per step, so a fixed
+    1,2,3 makes tune reject the whole run with "tune depths must be one of 1".
+    """
+    from mtplx.backends.descriptors import tune_policy_for_model
+
+    try:
+        policy = tune_policy_for_model(model_ref=str(model_path))
+    except Exception:
+        return DEFAULT_FORGE_VERIFY_DEPTHS
+    depths = tuple(
+        int(candidate[1:])
+        for candidate in getattr(policy, "candidates", ())
+        if str(candidate).startswith("D") and str(candidate)[1:].isdigit()
+    )
+    return depths or DEFAULT_FORGE_VERIFY_DEPTHS
+
+
+def _verify_rows_have_all_depths(
+    rows: list[dict[str, Any]],
+    depths: tuple[int, ...] = DEFAULT_FORGE_VERIFY_DEPTHS,
+) -> bool:
+    present = {int(row.get("depth") or 0) for row in rows if isinstance(row, dict)}
+    return all(depth in present for depth in (0, *depths))
 
 
 def _require_verify_rows(
     rows: list[dict[str, Any]],
     *,
     require_all_depths: bool = False,
+    verify_depths: tuple[int, ...] = DEFAULT_FORGE_VERIFY_DEPTHS,
 ) -> None:
     depths = {int(row.get("depth") or 0) for row in rows if isinstance(row, dict)}
-    required = (0, 1, 2, 3) if require_all_depths else (0,)
+    required = (0, *verify_depths) if require_all_depths else (0,)
     missing = [depth for depth in required if depth not in depths]
     if missing:
         raise ForgeError(
@@ -3193,11 +3224,13 @@ def _saved_verify_rows_reuse_blocker(
     model_path: Path,
     source_path: Path | None = None,
     require_all_depths: bool,
+    verify_depths: tuple[int, ...] = DEFAULT_FORGE_VERIFY_DEPTHS,
 ) -> str | None:
     if not rows:
         return "missing saved verification rows"
-    if require_all_depths and not _verify_rows_have_all_depths(rows):
-        return "saved verification is missing AR/D1/D2/D3 rows"
+    if require_all_depths and not _verify_rows_have_all_depths(rows, verify_depths):
+        expected = ", ".join(["AR", *(f"D{depth}" for depth in verify_depths)])
+        return f"saved verification is missing {expected} rows"
     if not any(int(row.get("depth") or 0) > 0 for row in rows):
         return "saved verification has no MTP depth rows"
     if any(row.get("hit_token_budget") for row in rows):

--- a/mtplx/mimo_mtp_patch.py
+++ b/mtplx/mimo_mtp_patch.py
@@ -242,6 +242,17 @@ def inject_mimo_mtp_support(
 
     _quantize_for_loaded_weights(mtp, config, mapped)
     mtp.load_weights(list(mapped.items()), strict=False)
+    if "lm_head.weight" not in mapped:
+        # MiMo shares the trunk output head with the MTP layer, matching
+        # vLLM's mimo_mtp. _MiMOMTP still declares its own lm_head, which is
+        # only ever filled by the trunk-shard path in _candidate_weight_files.
+        # A forged artifact stores the head in mtp.safetensors, and that path
+        # returns the sidecar alone, so lm_head stayed randomly initialised
+        # and load_weights(strict=False) bound it without complaint. Every
+        # contract candidate then scored zero agreement.
+        trunk_head = getattr(model, "lm_head", None)
+        if trunk_head is not None:
+            mtp.lm_head = trunk_head
     mx.eval(mtp.parameters())
 
     original_outer_class = model.__class__
@@ -290,7 +301,10 @@ def inject_mimo_mtp_support(
                 embed_tokens=self.model.embed_tokens,
                 cache=layer_cache,
             )
-            logits = self.mtp.lm_head(hidden)
+            if self.args.tie_word_embeddings:
+                logits = self.model.embed_tokens.as_linear(hidden)
+            else:
+                logits = self.mtp.lm_head(hidden)
             if not return_hidden:
                 return logits
             return logits, hidden

--- a/tests/test_descriptors_mimo_tune.py
+++ b/tests/test_descriptors_mimo_tune.py
@@ -1,0 +1,49 @@
+"""MiMo resolves to its own family and tunes at depth 1 only.
+
+``mimo-mtp`` has shipped a native backend with ``can_run_verified=True``, but
+``model_family_from_inspection`` had no branch returning "mimo", so every MiMo
+artifact resolved to "unknown" and ``tune_policy_for_model`` refused it.
+``forge build`` exited 1 at the tune gate after a successful convert, extract
+and calibrate.
+
+Depth is capped at D1: ``mimo_mtp_patch.mtp_forward`` raises on ``mtp_depth``
+above 1, and vLLM's proposer is single-token as well, so offering D2+ would
+advertise depths the backend refuses.  Measured on a forged MiMo-7B-RL pack on
+an M3 Max: AR 69.69 tok/s, D1 91.38 tok/s (1.311x) at 69.2% acceptance.
+"""
+
+from __future__ import annotations
+
+from mtplx.backends.descriptors import (
+    model_family_from_inspection,
+    tune_policy_for_model,
+)
+
+MIMO_INSPECTION = {
+    "model_type": "mimo",
+    "architecture": "MiMoForCausalLM",
+    "mtp_arch": "mimo-mtp",
+    "num_hidden_layers": 36,
+    "mtp_num_hidden_layers": 1,
+}
+
+
+def test_mimo_resolves_to_the_mimo_family():
+    assert model_family_from_inspection(MIMO_INSPECTION) == "mimo"
+
+
+def test_tune_is_supported_for_mimo():
+    assert tune_policy_for_model(inspection=MIMO_INSPECTION).supported is True
+
+
+def test_mimo_offers_depth_one_only():
+    policy = tune_policy_for_model(inspection=MIMO_INSPECTION)
+    assert policy.candidates == ("AR", "D1")
+    assert not any(c in policy.candidates for c in ("D2", "D3"))
+
+
+def test_the_family_is_read_from_the_artifact_not_the_folder_name():
+    # model_type and arch_id both feed the marker text, so a MiMo artifact is
+    # recognised even when its directory has been renamed.
+    assert model_family_from_inspection({"model_type": "mimo"}) == "mimo"
+    assert model_family_from_inspection({"mtp_arch": "mimo-mtp"}) == "mimo"

--- a/tests/test_forge_mtp_key_forms.py
+++ b/tests/test_forge_mtp_key_forms.py
@@ -1,0 +1,57 @@
+"""MTP heads are extracted from all three layouts found in the wild.
+
+Upstream ``is_mtp_key`` matched only ``mtp.`` and ``language_model.mtp.``.
+Checkpoints that store the head as appended decoder layers (GLM-4 MoE,
+DeepSeek-V3.2) or in their own namespace (MiMo) yielded no keys, so forge
+wrote no sidecar -- while ``_inspection_has_mtp_weight_evidence`` reported a
+head was present.  Key counts below are the real numbers from each published
+checkpoint's ``model.safetensors.index.json``.
+"""
+
+from __future__ import annotations
+
+from mtplx.artifacts import (
+    appended_mtp_layer_range,
+    is_appended_layer_mtp_key,
+    is_mtp_layers_namespace_key,
+    uses_appended_layer_mtp,
+)
+
+GLM_47_FLASH = {"num_hidden_layers": 47, "num_nextn_predict_layers": 1}
+DEEPSEEK_V32 = {"num_hidden_layers": 61, "num_nextn_predict_layers": 1}
+MIMO_7B = {"num_hidden_layers": 36, "num_nextn_predict_layers": 1}
+NO_MTP = {"num_hidden_layers": 32}
+
+
+def test_glm_appended_layer_is_the_layer_after_the_trunk():
+    assert list(appended_mtp_layer_range(GLM_47_FLASH)) == [47]
+    assert is_appended_layer_mtp_key("model.layers.47.shared_head.head.weight", GLM_47_FLASH)
+
+
+def test_trunk_layers_are_not_mistaken_for_the_head():
+    assert not is_appended_layer_mtp_key("model.layers.46.self_attn.q_proj.weight", GLM_47_FLASH)
+    assert not is_appended_layer_mtp_key("model.layers.4.mlp.gate_proj.weight", GLM_47_FLASH)
+
+
+def test_deepseek_v32_appends_after_sixty_one_layers():
+    assert list(appended_mtp_layer_range(DEEPSEEK_V32)) == [61]
+    assert is_appended_layer_mtp_key("model.layers.61.self_attn.q_a_proj.weight", DEEPSEEK_V32)
+
+
+def test_mimo_keeps_the_head_in_its_own_namespace():
+    assert is_mtp_layers_namespace_key("model.mtp_layers.0.token_layernorm.weight", MIMO_7B)
+    assert is_mtp_layers_namespace_key("model.mtp_layers.0.input_proj.weight", MIMO_7B)
+
+
+def test_the_two_layouts_do_not_claim_each_others_keys():
+    # MiMo's trunk has 36 layers, so model.layers.36.* would be the appended
+    # form; its head is not stored there and must not be matched by it.
+    assert not is_appended_layer_mtp_key("model.mtp_layers.0.input_proj.weight", MIMO_7B)
+    assert not is_mtp_layers_namespace_key("model.layers.47.embed_tokens.weight", GLM_47_FLASH)
+
+
+def test_a_config_without_an_mtp_head_matches_nothing():
+    assert not uses_appended_layer_mtp(NO_MTP)
+    assert list(appended_mtp_layer_range(NO_MTP)) == []
+    assert not is_appended_layer_mtp_key("model.layers.32.mlp.up_proj.weight", NO_MTP)
+    assert not is_mtp_layers_namespace_key("model.mtp_layers.0.input_proj.weight", NO_MTP)

--- a/tests/test_forge_verify_depths.py
+++ b/tests/test_forge_verify_depths.py
@@ -1,0 +1,30 @@
+"""Forge asks tune for the depths the model's backend actually supports.
+
+``_run_verify`` passed a fixed ``--depths 1,2,3`` and the completeness checks
+required rows for AR/D1/D2/D3.  Both assume every backend drafts three tokens.
+MiMo drafts one, so tune rejected the whole run with "tune depths must be one
+of 1" and ``forge build`` exited 1 after a successful convert and calibrate.
+
+Candidates that are not D-prefixed -- Gemma 4's draft blocks -- and any lookup
+failure fall back to 1,2,3, leaving existing backends unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mtplx.commands.forge import DEFAULT_FORGE_VERIFY_DEPTHS, _forge_verify_depths
+
+
+def test_the_default_is_the_previous_hardcoded_list():
+    assert DEFAULT_FORGE_VERIFY_DEPTHS == (1, 2, 3)
+
+
+def test_an_unknown_model_keeps_the_default():
+    assert _forge_verify_depths(Path("/nonexistent/not-a-model")) == (1, 2, 3)
+
+
+def test_gemma_style_block_candidates_fall_back_rather_than_producing_nothing():
+    # Gemma 4 advertises ("AR", "Block 2", ...); none are D-prefixed, so the
+    # derivation must not hand tune an empty depth list.
+    assert _forge_verify_depths(Path("/nonexistent/gemma4-assistant")) == (1, 2, 3)


### PR DESCRIPTION
## Summary

is_mtp_key matches only "mtp." and "language_model.mtp.". Heads stored any other way extract zero keys, so forge writes no sidecar -- while _inspection_has_mtp_weight_evidence still reports a head is present.

Three layouts exist:

    mtp.* / language_model.mtp.*   Qwen, Gemma                handled
    model.layers.{N}.*             GLM-4 MoE, DeepSeek-V3.2   extracted nothing
    model.mtp_layers.{i}.*         MiMo                       extracted nothing

Prefix is probed first, and the order matters: a model can declare `num_nextn_predict_layers=1` and still keep its head under a prefix, so an appended-first probe would look for a layer that does not exist.

Taking MiMo through to a working pack found three more blockers. Each one stopped forge after a successful convert, extract and calibrate:

1. lm_head was never bound. _MiMOMTP owns an lm_head that only the trunk-shard branch fills. A forged artifact keeps the head in mtp.safetensors, and that branch returns the sidecar alone, so lm_head stayed random and load_weights(strict=False) bound the rest silently. Calibration then scored 0.0 on all 64 candidates and blamed the sidecar, which was complete and mapped 16/16.

2. model_family_from_inspection had no mimo branch, so MiMo resolved to "unknown" and tune refused it -- though mimo-mtp ships a native backend with can_run_verified=True.

3. forge asked for a fixed --depths 1,2,3 and required rows 0,1,2,3. MiMo drafts one token, so tune failed with "tune depths must be one of 1". Depths now come from the tune policy. Non-D candidates (Gemma 4 blocks) and lookup failures fall back to 1,2,3, so no other backend changes.

Scope. MiMo is the layout carried end to end. Appended-layer extraction is implemented and tested, but no appended-layer model completes forge build here: tune has no family branch for glm or deepseek, so those still stop at the family gate. That gate is a separate change.


## Verification

Key counts from each published model.safetensors.index.json. All extract 0 keys today:

    DeepSeek-V3.1 / R1 / V3-0324    appended    1564 each
    DeepSeek-V3.2-Exp               appended    1571
    GLM-4.5 / 4.6 / 4.5-Air         appended    502 / 500 / 404
    GLM-4.7-Flash                   appended    212
    MiMo-7B-RL / SFT                namespace   16 each

MiMo-7B-RL end to end: forge build exit 0, artifact branded, 16/16 tensors mapped, calibration exact_agreement at 1.0 for depths 1-3.

Tests: 13 added, all passing. The suite has pre-existing failures on this machine -- Metal kernels, the mlx pin floor, and numerical tolerance -- and the same set fails on unmodified main, so this branch adds none. The extraction tests use real layer indices and key counts. The key case is cross-claiming: MiMo's trunk has 36 layers, so model.layers.36. would be its appended form. The head is not there, and neither matcher may take the other's keys.


## Benchmark Evidence

    Date          2026-09-02
    Commit        d6677b9, on upstream main e652d55
    Hardware      Apple M3 Max (Mac15,9), 12P+4E, 128 GiB, macOS 26.6.2 (25G83)
    Fan mode      fans pinned
    Profile       sustained
    Model         XiaomiMiMo/MiMo-7B-RL, forged locally
    Quantization  body 4-bit affine, group_size 64; MTP sidecar bf16
    Sampler       temperature 0.6, top_p 0.95, top_k 20, seed 0, thinking off
    Runtime       mlx 0.32.0, mlx-lm 0.31.3, MTPLX 2.10.2
    Contract      concat_order hidden_embedding, hidden_variant post_norm,
                  base_hidden_variant post_norm, position local,
                  cache persistent, history committed

forge build, long-code-uncapped, 2048 tokens:

    AR    69.69 tok/s
    D1    91.38 tok/s    1.311x    acceptance 69.2%    mtp_depth_wins

Both rows passed the quality gate.

mtplx tune, cold-long-code-192, 256 tokens, limit 8, three runs:

    run   AR tok/s   D1 tok/s   ratio   acceptance
    1        72.58      96.29   1.327        68.4%
    2        72.69      96.29   1.325        68.4%
    3        72.61      96.27   1.326        68.4%

AR baselines span 0.15%. mlx-lm 0.31.3 is the pinned version, so these reproduce as-is.

Not benchmarked:

- Appended-layer models (DeepSeek, GLM) are 100B+ and would not fit on the hardware available. Their key routing is verified against real weight indices and in tests, not by a forged pack.
- The tied-lm_head branch never runs for MiMo-7B-RL, which is untied.