### PR TITLE
Fix SSD prefix restores hydrating full long snapshots

### DIFF
--- a/mtplx/cache_bank/codec.py
+++ b/mtplx/cache_bank/codec.py
@@ -59,6 +59,12 @@ class DecodedPayload:
     # v3: (token_count, recurrent-only CacheSnapshot, hidden_last|None)
     gdn_boundaries: tuple = ()
     has_recurrent: bool = False
+    # When a cold prefix restore decodes only the attention-KV blocks that
+    # precede a safe boundary, these fields describe the materialized prefix
+    # lengths.  The SessionBank keeps the entry's original token identity;
+    # these are strictly the lengths represented by the decoded snapshots.
+    cache_snapshot_prefix_len: int | None = None
+    mtp_history_snapshot_prefix_len: int | None = None
 
 
 class ColdEncodeInterrupted(RuntimeError):
@@ -329,6 +335,100 @@ def decode_payload(
     return decoded
 
 
+def decode_payload_prefix(
+    spec: dict[str, Any],
+    read_tensor: Callable[[str], bytes],
+    *,
+    cache_prefix_len: int,
+    mtp_history_prefix_len: int | None = None,
+    boundary_prefix_len: int | None = None,
+) -> DecodedPayload:
+    """Decode only the SSD payload needed for a sub-prefix restore.
+
+    The cold tier stores attention tensors in fixed token blocks.  A normal
+    ``decode_payload`` reconstructs every block in a long snapshot, even when
+    a divergent follow-up can restore only a short recurrent-safe boundary.
+    This variant reads only the attention blocks through that boundary and,
+    when needed, the single matching recurrent boundary.  Non-trimmable top
+    level states are deliberately skipped: the boundary snapshot owns those
+    states and will overwrite them during restore.
+    """
+
+    cache_prefix_len = max(0, int(cache_prefix_len))
+    mtp_prefix_len = (
+        None
+        if mtp_history_prefix_len is None
+        else max(0, int(mtp_history_prefix_len))
+    )
+    selected_boundary = _gdn_boundary_spec_at_or_below(
+        spec, boundary_prefix_len
+    )
+    boundary_states = (
+        selected_boundary.get("states") if selected_boundary is not None else None
+    )
+    cache_spec = spec["cache_snapshot"]
+    cache_snapshot = CacheSnapshot(
+        states=_decode_cache_states_prefix(
+            cache_spec["states"],
+            boundary_states,
+            read_tensor,
+            prefix_len=cache_prefix_len,
+        ),
+        # Restoring a partial tensor state must not reinstate the original
+        # full-prefix offset.  Real attention cache state setters derive the
+        # offset from the truncated tensors; recurrent meta is restored from
+        # the selected boundary below.
+        meta_states=_none_tree_like(cache_spec["meta_states"]),
+    )
+    mtp_spec = spec.get("mtp_history_snapshot")
+    mtp_history_snapshot = None
+    if mtp_spec is not None:
+        mtp_history_snapshot = CacheSnapshot(
+            states=_decode_tree_prefix(
+                mtp_spec["states"],
+                read_tensor,
+                prefix_len=mtp_prefix_len,
+            ),
+            meta_states=_none_tree_like(mtp_spec["meta_states"]),
+        )
+    boundaries = ()
+    if selected_boundary is not None:
+        boundaries = (
+            (
+                int(selected_boundary["tokens"]),
+                CacheSnapshot(
+                    states=tuple(
+                        decode_tree(item, read_tensor)
+                        for item in _spec_items(selected_boundary["states"])
+                    ),
+                    meta_states=tuple(
+                        decode_tree(item, read_tensor)
+                        for item in _spec_items(selected_boundary["meta_states"])
+                    ),
+                ),
+                decode_tree(
+                    selected_boundary.get("hidden_last") or {"kind": "none"},
+                    read_tensor,
+                ),
+            ),
+        )
+    decoded = DecodedPayload(
+        cache_snapshot=cache_snapshot,
+        # These are small final-token tensors and remain useful to callers
+        # that reject the partial candidate before it reaches the boundary
+        # restore.  They are not the source of the multi-GB hydration.
+        logits=decode_tree(spec["logits"], read_tensor),
+        hidden=decode_tree(spec["hidden"], read_tensor),
+        mtp_history_snapshot=mtp_history_snapshot,
+        gdn_boundaries=boundaries,
+        has_recurrent=bool(spec.get("has_recurrent", False)),
+        cache_snapshot_prefix_len=cache_prefix_len,
+        mtp_history_snapshot_prefix_len=mtp_prefix_len,
+    )
+    _eval_decoded_arrays(decoded)
+    return decoded
+
+
 def _eval_decoded_arrays(decoded: DecodedPayload) -> None:
     """Single batched evaluation of every decoded array (vs per-tensor eval)."""
     arrays: list[Any] = []
@@ -392,6 +492,104 @@ def decode_gdn_boundaries(
     return boundaries
 
 
+def _gdn_boundary_spec_at_or_below(
+    spec: dict[str, Any], prefix_len: int | None
+) -> dict[str, Any] | None:
+    if prefix_len is None:
+        return None
+    limit = int(prefix_len)
+    best: dict[str, Any] | None = None
+    for record in spec.get("gdn_boundaries") or []:
+        try:
+            tokens = int(record.get("tokens", 0))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if 0 < tokens <= limit and (best is None or tokens > int(best["tokens"])):
+            best = record
+    return best
+
+
+def _spec_items(spec: Any) -> list[Any]:
+    if not isinstance(spec, dict) or spec.get("kind") not in {"tuple", "list"}:
+        raise ValueError("expected tuple/list cache-state payload spec")
+    return list(spec.get("items") or [])
+
+
+def _none_tree_like(spec: Any) -> Any:
+    """Return a shape-compatible tree whose leaves are ``None``.
+
+    CacheSnapshot's outer state/meta tuples are positional.  Keeping that
+    shape lets ``restore_cache`` skip every original full-prefix meta state.
+    """
+
+    kind = spec.get("kind") if isinstance(spec, dict) else None
+    if kind == "tuple":
+        return tuple(_none_tree_like(item) for item in spec.get("items") or [])
+    if kind == "list":
+        return [_none_tree_like(item) for item in spec.get("items") or []]
+    return None
+
+
+def _decode_cache_states_prefix(
+    states_spec: Any,
+    boundary_states_spec: Any,
+    read_tensor: Callable[[str], bytes],
+    *,
+    prefix_len: int,
+) -> Any:
+    states = _spec_items(states_spec)
+    boundary_states = (
+        _spec_items(boundary_states_spec)
+        if boundary_states_spec is not None
+        else [None] * len(states)
+    )
+    if len(states) != len(boundary_states):
+        raise ValueError("SSD boundary cache-state shape mismatch")
+    decoded = []
+    for state_spec, boundary_spec in zip(states, boundary_states):
+        # A non-None boundary state identifies a recurrent/non-trimmable
+        # cache entry.  Its state comes from the selected boundary; loading
+        # the full final snapshot here is both unnecessary and expensive.
+        if isinstance(boundary_spec, dict) and boundary_spec.get("kind") != "none":
+            decoded.append(None)
+        else:
+            decoded.append(
+                _decode_tree_prefix(state_spec, read_tensor, prefix_len=prefix_len)
+            )
+    kind = states_spec.get("kind") if isinstance(states_spec, dict) else None
+    return tuple(decoded) if kind == "tuple" else decoded
+
+
+def _decode_tree_prefix(
+    spec: Any,
+    read_tensor: Callable[[str], bytes],
+    *,
+    prefix_len: int | None,
+) -> Any:
+    kind = spec.get("kind") if isinstance(spec, dict) else None
+    if kind == "tuple":
+        return tuple(
+            _decode_tree_prefix(item, read_tensor, prefix_len=prefix_len)
+            for item in spec.get("items") or []
+        )
+    if kind == "list":
+        return [
+            _decode_tree_prefix(item, read_tensor, prefix_len=prefix_len)
+            for item in spec.get("items") or []
+        ]
+    if kind == "dict":
+        return {
+            _decode_tree_prefix(key, read_tensor, prefix_len=prefix_len):
+            _decode_tree_prefix(value, read_tensor, prefix_len=prefix_len)
+            for key, value in spec.get("items") or []
+        }
+    if kind == "tensor_blocks":
+        return _decode_tensor_blocks(
+            spec, read_tensor, prefix_len=prefix_len
+        )
+    return decode_tree(spec, read_tensor)
+
+
 def _decode_tensor(spec: dict[str, Any], read_tensor: Callable[[str], bytes]) -> Any:
     dtype = str(spec["dtype"])
     shape = tuple(int(dim) for dim in spec.get("shape") or [])
@@ -409,14 +607,35 @@ def _decode_tensor(spec: dict[str, Any], read_tensor: Callable[[str], bytes]) ->
     return arr
 
 
-def _decode_tensor_blocks(spec: dict[str, Any], read_tensor: Callable[[str], bytes]) -> Any:
+def _decode_tensor_blocks(
+    spec: dict[str, Any],
+    read_tensor: Callable[[str], bytes],
+    *,
+    prefix_len: int | None = None,
+) -> Any:
     axis = int(spec.get("axis", 2))
-    chunks = [_decode_tensor({**block, "dtype": spec["dtype"]}, read_tensor) for block in spec.get("blocks", [])]
+    limit = None if prefix_len is None else max(0, int(prefix_len))
+    blocks = list(spec.get("blocks", []))
+    if limit is not None:
+        blocks = [block for block in blocks if int(block.get("start", 0)) < limit]
+    chunks = [
+        _decode_tensor({**block, "dtype": spec["dtype"]}, read_tensor)
+        for block in blocks
+    ]
     if not chunks:
         shape = tuple(int(dim) for dim in spec.get("shape") or [])
+        if limit is not None and axis < len(shape):
+            shape = (*shape[:axis], min(limit, shape[axis]), *shape[axis + 1 :])
         return mx.zeros(shape)
     arr = mx.concatenate(chunks, axis=axis)
     shape = tuple(int(dim) for dim in spec.get("shape") or [])
+    if limit is not None and axis < len(shape):
+        size = min(limit, shape[axis])
+        if int(arr.shape[axis]) > size:
+            slices = [slice(None)] * int(arr.ndim)
+            slices[axis] = slice(0, size)
+            arr = arr[tuple(slices)]
+        shape = (*shape[:axis], size, *shape[axis + 1 :])
     if shape:
         arr = arr.reshape(shape)
     return arr

--- a/mtplx/cache_bank/codec.py
+++ b/mtplx/cache_bank/codec.py
@@ -340,6 +340,7 @@ def decode_payload_prefix(
     read_tensor: Callable[[str], bytes],
     *,
     cache_prefix_len: int,
+    mtp_history_prefix_len: int | None = None,
     boundary_prefix_len: int | None = None,
 ) -> DecodedPayload:
     """Decode only the SSD payload needed for a sub-prefix restore.
@@ -354,6 +355,11 @@ def decode_payload_prefix(
     """
 
     cache_prefix_len = max(0, int(cache_prefix_len))
+    mtp_prefix_len = (
+        None
+        if mtp_history_prefix_len is None
+        else max(0, int(mtp_history_prefix_len))
+    )
     selected_boundary = _gdn_boundary_spec_at_or_below(
         spec, boundary_prefix_len
     )
@@ -377,15 +383,22 @@ def decode_payload_prefix(
     mtp_spec = spec.get("mtp_history_snapshot")
     mtp_history_snapshot = None
     if mtp_spec is not None:
-        # MTP history is shifted relative to the target cache (it is built
-        # from prompt_ids[1:]) and can also be a trailing-window cache.  Its
-        # physical rows therefore cannot be addressed by the target-prefix
-        # token number.  Keep the complete snapshot and let SessionBank apply
-        # its existing delta trim after restore.
-        mtp_history_snapshot = CacheSnapshot(
-            states=tuple(decode_tree(mtp_spec["states"], read_tensor)),
-            meta_states=tuple(decode_tree(mtp_spec["meta_states"], read_tensor)),
-        )
+        if mtp_prefix_len is None:
+            mtp_history_snapshot = CacheSnapshot(
+                states=tuple(decode_tree(mtp_spec["states"], read_tensor)),
+                meta_states=tuple(
+                    decode_tree(mtp_spec["meta_states"], read_tensor)
+                ),
+            )
+        else:
+            mtp_history_snapshot = CacheSnapshot(
+                states=_decode_tree_prefix(
+                    mtp_spec["states"],
+                    read_tensor,
+                    prefix_len=mtp_prefix_len,
+                ),
+                meta_states=_none_tree_like(mtp_spec["meta_states"]),
+            )
     boundaries = ()
     if selected_boundary is not None:
         boundaries = (
@@ -418,7 +431,7 @@ def decode_payload_prefix(
         gdn_boundaries=boundaries,
         has_recurrent=bool(spec.get("has_recurrent", False)),
         cache_snapshot_prefix_len=cache_prefix_len,
-        mtp_history_snapshot_prefix_len=None,
+        mtp_history_snapshot_prefix_len=mtp_prefix_len,
     )
     _eval_decoded_arrays(decoded)
     return decoded
@@ -505,6 +518,10 @@ def _gdn_boundary_spec_at_or_below(
 
 
 def payload_supports_prefix_decode(spec: dict[str, Any]) -> bool:
+    return snapshot_supports_prefix_decode(spec.get("cache_snapshot"))
+
+
+def snapshot_supports_prefix_decode(snapshot_spec: Any) -> bool:
     """Whether the target-cache representation can be safely block-sliced.
 
     Most attention caches derive their offset from the restored K/V tensors.
@@ -515,7 +532,7 @@ def payload_supports_prefix_decode(spec: dict[str, Any]) -> bool:
     """
 
     try:
-        meta_items = _spec_items(spec["cache_snapshot"]["meta_states"])
+        meta_items = _spec_items(snapshot_spec["meta_states"])
     except (KeyError, ValueError, TypeError):
         return False
     for meta_spec in meta_items:

--- a/mtplx/cache_bank/codec.py
+++ b/mtplx/cache_bank/codec.py
@@ -340,7 +340,6 @@ def decode_payload_prefix(
     read_tensor: Callable[[str], bytes],
     *,
     cache_prefix_len: int,
-    mtp_history_prefix_len: int | None = None,
     boundary_prefix_len: int | None = None,
 ) -> DecodedPayload:
     """Decode only the SSD payload needed for a sub-prefix restore.
@@ -355,11 +354,6 @@ def decode_payload_prefix(
     """
 
     cache_prefix_len = max(0, int(cache_prefix_len))
-    mtp_prefix_len = (
-        None
-        if mtp_history_prefix_len is None
-        else max(0, int(mtp_history_prefix_len))
-    )
     selected_boundary = _gdn_boundary_spec_at_or_below(
         spec, boundary_prefix_len
     )
@@ -383,13 +377,14 @@ def decode_payload_prefix(
     mtp_spec = spec.get("mtp_history_snapshot")
     mtp_history_snapshot = None
     if mtp_spec is not None:
+        # MTP history is shifted relative to the target cache (it is built
+        # from prompt_ids[1:]) and can also be a trailing-window cache.  Its
+        # physical rows therefore cannot be addressed by the target-prefix
+        # token number.  Keep the complete snapshot and let SessionBank apply
+        # its existing delta trim after restore.
         mtp_history_snapshot = CacheSnapshot(
-            states=_decode_tree_prefix(
-                mtp_spec["states"],
-                read_tensor,
-                prefix_len=mtp_prefix_len,
-            ),
-            meta_states=_none_tree_like(mtp_spec["meta_states"]),
+            states=tuple(decode_tree(mtp_spec["states"], read_tensor)),
+            meta_states=tuple(decode_tree(mtp_spec["meta_states"], read_tensor)),
         )
     boundaries = ()
     if selected_boundary is not None:
@@ -423,7 +418,7 @@ def decode_payload_prefix(
         gdn_boundaries=boundaries,
         has_recurrent=bool(spec.get("has_recurrent", False)),
         cache_snapshot_prefix_len=cache_prefix_len,
-        mtp_history_snapshot_prefix_len=mtp_prefix_len,
+        mtp_history_snapshot_prefix_len=None,
     )
     _eval_decoded_arrays(decoded)
     return decoded
@@ -507,6 +502,54 @@ def _gdn_boundary_spec_at_or_below(
         if 0 < tokens <= limit and (best is None or tokens > int(best["tokens"])):
             best = record
     return best
+
+
+def payload_supports_prefix_decode(spec: dict[str, Any]) -> bool:
+    """Whether the target-cache representation can be safely block-sliced.
+
+    Most attention caches derive their offset from the restored K/V tensors.
+    A few cache layouts instead require coupled, model-specific metadata (or
+    physically rotate their backing rows).  Reconstructing only their first
+    tensor blocks is not equivalent to a trim, so those entries retain the
+    established full-decode restore path.
+    """
+
+    try:
+        meta_items = _spec_items(spec["cache_snapshot"]["meta_states"])
+    except (KeyError, ValueError, TypeError):
+        return False
+    for meta_spec in meta_items:
+        values = _flat_string_sequence(meta_spec)
+        if values is None:
+            continue
+        # DeepSeek-V4's five fields include rolling-window and compressor
+        # counters which must stay coupled to its compressed tensor state.
+        if values and values[0] == "mtplx-deepseek-v4-cache-v1":
+            return False
+        # Gemma's rotating cache carries (keep, max_size, offset, write_idx).
+        # The persisted tensor order is ring-buffer order once full, so a
+        # token-prefix slice cannot faithfully reconstruct it.
+        if len(values) == 4 and all(_is_decimal_string(value) for value in values):
+            return False
+    return True
+
+
+def _flat_string_sequence(spec: Any) -> tuple[str, ...] | None:
+    kind = spec.get("kind") if isinstance(spec, dict) else None
+    if kind == "none":
+        return ()
+    if kind not in {"tuple", "list"}:
+        return None
+    values: list[str] = []
+    for item in spec.get("items") or []:
+        if not isinstance(item, dict) or item.get("kind") != "str":
+            return None
+        values.append(str(item.get("value", "")))
+    return tuple(values)
+
+
+def _is_decimal_string(value: str) -> bool:
+    return value.lstrip("-").isdigit()
 
 
 def _spec_items(spec: Any) -> list[Any]:

--- a/mtplx/cache_bank/cold_tier.py
+++ b/mtplx/cache_bank/cold_tier.py
@@ -25,6 +25,7 @@ from .codec import (
     build_payload_spec,
     decode_gdn_boundaries,
     decode_payload,
+    decode_payload_prefix,
     encode_payload,
 )
 
@@ -143,6 +144,11 @@ class ColdRestoreRecord:
     has_recurrent: bool = False
     # Lazy loader for boundaries skipped at exact-restore time (callable -> tuple).
     gdn_boundary_loader: Any = None
+    # Prefix lengths represented by the hydrated snapshots.  A cold
+    # sub-prefix restore retains the entry's full token identity, while its
+    # decoded KV only covers the boundary it will actually serve.
+    cache_snapshot_prefix_len: int | None = None
+    mtp_history_snapshot_prefix_len: int | None = None
 
 
 @dataclass(frozen=True)
@@ -271,6 +277,27 @@ def block_aligned_prefix_len(matched_tokens: int, *, block_size: int) -> int:
     block = max(1, int(block_size))
     matched = max(0, int(matched_tokens))
     return (matched // block) * block
+
+
+def _payload_boundary_at_or_below(
+    payload_spec: dict[str, Any], prefix_len: int
+) -> int | None:
+    """Return the newest persisted recurrent boundary at or below ``prefix_len``.
+
+    This deliberately inspects JSON metadata only.  The matching boundary's
+    tensors are decoded later by ``decode_payload_prefix``; no large blob is
+    read merely to choose a safe restore point.
+    """
+
+    best: int | None = None
+    for record in payload_spec.get("gdn_boundaries") or []:
+        try:
+            tokens = int(record.get("tokens", 0))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if 0 < tokens <= int(prefix_len) and (best is None or tokens > best):
+            best = tokens
+    return best
 
 
 def chain_block_hashes(
@@ -1006,6 +1033,7 @@ class SessionBankColdTier:
                 started_s=started,
                 require_exact_prefix=False,
                 include_gdn_boundaries=True,
+                prefix_restore_tokens=int(best[1]),
             )
             if record is None:
                 return None
@@ -1921,6 +1949,7 @@ class SessionBankColdTier:
         started_s: float,
         require_exact_prefix: bool = True,
         include_gdn_boundaries: bool = False,
+        prefix_restore_tokens: int | None = None,
     ) -> ColdRestoreRecord | None:
         metadata = dict(row)
         token_ids = tuple(int(token) for token in json.loads(str(metadata["token_ids_json"])))
@@ -1954,14 +1983,50 @@ class SessionBankColdTier:
                 raise FileNotFoundError(str(path))
             return path.read_bytes()
 
-        # Exact-prefix restores never rewind below the stored boundary, so the
-        # (MB-scale x boundary-count) interior snapshots are decoded only for
-        # partial restores — keeps exact restart-warm on the fast path.
-        decoded = decode_payload(
-            payload["payload_spec"],
-            read_tensor,
-            include_gdn_boundaries=include_gdn_boundaries,
+        payload_spec = payload["payload_spec"]
+        partial_restore = (
+            prefix_restore_tokens is not None
+            and not require_exact_prefix
+            and int(prefix_restore_tokens) > 0
         )
+        if partial_restore:
+            requested_prefix = int(prefix_restore_tokens)
+            has_recurrent = bool(payload_spec.get("has_recurrent", False))
+            boundary_prefix = _payload_boundary_at_or_below(
+                payload_spec, requested_prefix
+            )
+            # Recurrent state is only valid at a captured boundary.  Do not
+            # fall back to hydrating the final multi-GB snapshot just to learn
+            # that SessionBank must reject this candidate later.
+            if has_recurrent and boundary_prefix is None:
+                self._set_last_miss("ssd_prefix_boundary_missing")
+                return None
+            restore_point = (
+                int(boundary_prefix)
+                if boundary_prefix is not None
+                else requested_prefix
+            )
+            # Non-boundary restores re-forward token N-1 for fresh logits;
+            # boundary restores resume directly at N.  MTP history always
+            # lands at the true restore boundary.
+            cache_prefix_len = (
+                restore_point if boundary_prefix is not None else restore_point - 1
+            )
+            decoded = decode_payload_prefix(
+                payload_spec,
+                read_tensor,
+                cache_prefix_len=max(0, cache_prefix_len),
+                mtp_history_prefix_len=restore_point,
+                boundary_prefix_len=boundary_prefix,
+            )
+        else:
+            # Exact-prefix restores never rewind below the stored boundary, so
+            # the interior snapshots are decoded lazily as before.
+            decoded = decode_payload(
+                payload_spec,
+                read_tensor,
+                include_gdn_boundaries=include_gdn_boundaries,
+            )
         restore_s = time.perf_counter() - started_s
         self._inc("restore_hits")
         with self._stats_lock:
@@ -1976,10 +2041,9 @@ class SessionBankColdTier:
         )
         metadata["capabilities"] = json.loads(str(metadata.get("capabilities_json") or "[]"))
         metadata["block_hashes"] = json.loads(str(metadata.get("block_hashes_json") or "[]"))
-        payload_spec = payload["payload_spec"]
         boundary_loader = (
             None
-            if include_gdn_boundaries
+            if include_gdn_boundaries or partial_restore
             else (lambda: decode_gdn_boundaries(payload_spec, read_tensor))
         )
         return ColdRestoreRecord(
@@ -1995,6 +2059,10 @@ class SessionBankColdTier:
             gdn_boundaries=tuple(decoded.gdn_boundaries or ()),
             has_recurrent=bool(decoded.has_recurrent),
             gdn_boundary_loader=boundary_loader,
+            cache_snapshot_prefix_len=decoded.cache_snapshot_prefix_len,
+            mtp_history_snapshot_prefix_len=(
+                decoded.mtp_history_snapshot_prefix_len
+            ),
         )
 
     def _candidate_rows(

--- a/mtplx/cache_bank/cold_tier.py
+++ b/mtplx/cache_bank/cold_tier.py
@@ -28,6 +28,7 @@ from .codec import (
     decode_payload_prefix,
     encode_payload,
     payload_supports_prefix_decode,
+    snapshot_supports_prefix_decode,
 )
 
 
@@ -2024,10 +2025,26 @@ class SessionBankColdTier:
                     if boundary_prefix is not None
                     else restore_point - 1
                 )
+                mtp_history_prefix_len = None
+                mtp_spec = payload_spec.get("mtp_history_snapshot")
+                # A committed MTP cache holds prompt_ids[1:], so its useful
+                # prefix is exactly one token shorter than the target-cache
+                # boundary.  This is the 0.28 GiB tail of the user's observed
+                # restore: leave windowed or coupled layouts on the legacy
+                # full-decode-and-trim path, but never hydrate a long
+                # committed-history snapshot merely to trim it immediately.
+                if (
+                    mtp_spec is not None
+                    and str(metadata.get("mtp_history_policy") or "").lower()
+                    == "committed"
+                    and snapshot_supports_prefix_decode(mtp_spec)
+                ):
+                    mtp_history_prefix_len = max(0, restore_point - 1)
                 decoded = decode_payload_prefix(
                     payload_spec,
                     read_tensor,
                     cache_prefix_len=max(0, cache_prefix_len),
+                    mtp_history_prefix_len=mtp_history_prefix_len,
                     boundary_prefix_len=boundary_prefix,
                 )
         else:

--- a/mtplx/cache_bank/cold_tier.py
+++ b/mtplx/cache_bank/cold_tier.py
@@ -27,6 +27,7 @@ from .codec import (
     decode_payload,
     decode_payload_prefix,
     encode_payload,
+    payload_supports_prefix_decode,
 )
 
 
@@ -1995,30 +1996,40 @@ class SessionBankColdTier:
             boundary_prefix = _payload_boundary_at_or_below(
                 payload_spec, requested_prefix
             )
-            # Recurrent state is only valid at a captured boundary.  Do not
-            # fall back to hydrating the final multi-GB snapshot just to learn
-            # that SessionBank must reject this candidate later.
-            if has_recurrent and boundary_prefix is None:
-                self._set_last_miss("ssd_prefix_boundary_missing")
-                return None
-            restore_point = (
-                int(boundary_prefix)
-                if boundary_prefix is not None
-                else requested_prefix
-            )
-            # Non-boundary restores re-forward token N-1 for fresh logits;
-            # boundary restores resume directly at N.  MTP history always
-            # lands at the true restore boundary.
-            cache_prefix_len = (
-                restore_point if boundary_prefix is not None else restore_point - 1
-            )
-            decoded = decode_payload_prefix(
-                payload_spec,
-                read_tensor,
-                cache_prefix_len=max(0, cache_prefix_len),
-                mtp_history_prefix_len=restore_point,
-                boundary_prefix_len=boundary_prefix,
-            )
+            # Preserve the established tiny-gap behavior for hybrid entries
+            # without an interior capture.  SessionBank decides whether that
+            # full snapshot can serve the requested match; rejecting it here
+            # would turn tokenizer-boundary drift into an avoidable cold
+            # prefill.  Likewise, cache types whose metadata couples rolling
+            # state to their tensors must use the exact decoder plus trim.
+            if (
+                (has_recurrent and boundary_prefix is None)
+                or not payload_supports_prefix_decode(payload_spec)
+            ):
+                decoded = decode_payload(
+                    payload_spec,
+                    read_tensor,
+                    include_gdn_boundaries=include_gdn_boundaries,
+                )
+            else:
+                restore_point = (
+                    int(boundary_prefix)
+                    if boundary_prefix is not None
+                    else requested_prefix
+                )
+                # Non-boundary restores re-forward token N-1 for fresh
+                # logits; boundary restores resume directly at N.
+                cache_prefix_len = (
+                    restore_point
+                    if boundary_prefix is not None
+                    else restore_point - 1
+                )
+                decoded = decode_payload_prefix(
+                    payload_spec,
+                    read_tensor,
+                    cache_prefix_len=max(0, cache_prefix_len),
+                    boundary_prefix_len=boundary_prefix,
+                )
         else:
             # Exact-prefix restores never rewind below the stored boundary, so
             # the interior snapshots are decoded lazily as before.

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -433,6 +433,12 @@ class SessionBankEntry:
     # kvcache-v2: SSD-restored entries defer boundary decode (exact restores
     # never need them); the loader fills gdn_boundaries on first partial use.
     gdn_boundary_loader: Any = None
+    # SSD block-prefix restores may hydrate only the cache state required for
+    # the boundary they will serve.  ``prefix_len`` remains the full token
+    # identity used for candidate matching; these fields describe the actual
+    # materialized state spans.
+    cache_snapshot_prefix_len: int | None = None
+    mtp_history_snapshot_prefix_len: int | None = None
 
     @property
     def prefix_len(self) -> int:
@@ -1486,6 +1492,17 @@ class SessionBank:
             draft_head_identity=metadata.get("draft_head_identity"),
             policy_fingerprint=metadata.get("policy_fingerprint"),
             mtp_history_snapshot=_clone_tree(record.mtp_history_snapshot),
+            cache_snapshot_prefix_len=(
+                int(record.cache_snapshot_prefix_len)
+                if getattr(record, "cache_snapshot_prefix_len", None) is not None
+                else None
+            ),
+            mtp_history_snapshot_prefix_len=(
+                int(record.mtp_history_snapshot_prefix_len)
+                if getattr(record, "mtp_history_snapshot_prefix_len", None)
+                is not None
+                else None
+            ),
             snapshot_epoch=int(metadata.get("snapshot_epoch") or len(record.token_ids)),
             mtp_snapshot_epoch=(
                 int(metadata["mtp_snapshot_epoch"])
@@ -1726,17 +1743,48 @@ class SessionBank:
                     )
                     return None
 
+        # A cold block-prefix candidate can represent the long entry's token
+        # identity while only hydrating KV blocks through the safe restore
+        # point.  Never ask restore_cache to trim bytes that were purposely
+        # not read from SSD; a malformed partial record fails closed.
+        cache_snapshot_prefix_len = int(
+            getattr(entry, "cache_snapshot_prefix_len", None)
+            or entry.prefix_len
+        )
+        mtp_snapshot_prefix_len = int(
+            getattr(entry, "mtp_history_snapshot_prefix_len", None)
+            or entry.prefix_len
+        )
+        required_cache_prefix_len = (
+            restore_point if boundary_snapshot is not None else restore_point - 1
+        )
+        if cache_snapshot_prefix_len < required_cache_prefix_len:
+            self.last_miss_reason = CacheMissReason.NO_SNAPSHOT_COVERAGE.value
+            return None
+        if (
+            entry.mtp_history_snapshot is not None
+            and mtp_snapshot_prefix_len < restore_point
+        ):
+            self.last_miss_reason = CacheMissReason.NO_SNAPSHOT_COVERAGE.value
+            return None
+
         actual_restore_mode = "clone"
-        mtp_history_trim_tokens = max(0, int(entry.prefix_len) - restore_point)
+        mtp_history_trim_tokens = max(0, mtp_snapshot_prefix_len - restore_point)
         # Boundary restores land the KV at the full boundary (no seed forward
         # will run — it would advance recurrent state past the captured
         # boundary a second time). Non-boundary restores keep the seed-forward
         # slot semantics.
-        trim_to_target = (
-            (lambda c: _trim_cache_ref_to_tokens(c, restore_point))
-            if boundary_snapshot is not None
-            else (lambda c: _trim_cache_ref_to_prefix(c, restore_point))
-        )
+        if cache_snapshot_prefix_len == required_cache_prefix_len:
+            # The cold decoder supplied precisely the state this consumer
+            # needs.  Calling the legacy trim here would remove valid KV rows
+            # (or demand an absent long tail) after a partial hydration.
+            trim_to_target = lambda _cache: True
+        else:
+            trim_to_target = (
+                (lambda c: _trim_cache_ref_to_tokens(c, restore_point))
+                if boundary_snapshot is not None
+                else (lambda c: _trim_cache_ref_to_prefix(c, restore_point))
+            )
         # Passive-probe maintenance splits: CPU-side perf_counter spans only,
         # written into the caller-owned served_out dict (request-local, same
         # non-shared contract as put's timing_out). No evaluation points are

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -1751,9 +1751,13 @@ class SessionBank:
             getattr(entry, "cache_snapshot_prefix_len", None)
             or entry.prefix_len
         )
-        mtp_snapshot_prefix_len = int(
-            getattr(entry, "mtp_history_snapshot_prefix_len", None)
-            or entry.prefix_len
+        mtp_prefix_recorded = getattr(
+            entry, "mtp_history_snapshot_prefix_len", None
+        )
+        mtp_snapshot_prefix_len = (
+            int(mtp_prefix_recorded)
+            if mtp_prefix_recorded is not None
+            else int(entry.prefix_len)
         )
         required_cache_prefix_len = (
             restore_point if boundary_snapshot is not None else restore_point - 1
@@ -1763,13 +1767,19 @@ class SessionBank:
             return None
         if (
             entry.mtp_history_snapshot is not None
-            and mtp_snapshot_prefix_len < restore_point
+            and mtp_snapshot_prefix_len < max(0, restore_point - 1)
         ):
             self.last_miss_reason = CacheMissReason.NO_SNAPSHOT_COVERAGE.value
             return None
 
         actual_restore_mode = "clone"
-        mtp_history_trim_tokens = max(0, mtp_snapshot_prefix_len - restore_point)
+        # Committed MTP history is built from prompt_ids[1:], so a boundary at
+        # N retains N-1 history rows.  Legacy full snapshots retain the
+        # nominal entry prefix length and therefore preserve the established
+        # delta-trim behavior; prefix-decoded entries record their true span.
+        mtp_history_trim_tokens = max(
+            0, mtp_snapshot_prefix_len - max(0, restore_point - 1)
+        )
         # Boundary restores land the KV at the full boundary (no seed forward
         # will run — it would advance recurrent state past the captured
         # boundary a second time). Non-boundary restores keep the seed-forward

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -1828,7 +1828,18 @@ class SessionBank:
             # Overwrite recurrent (non-trimmable) states with the interior
             # boundary capture; trimmable entries are None in these snapshots.
             _overwrite_started = time.perf_counter()
-            restore_cache(cache, boundary_snapshot, restore_meta_state=False)
+            restore_cache(
+                cache,
+                boundary_snapshot,
+                # Prefix-decoded cold entries intentionally omitted the
+                # full-entry meta state.  Their recurrent metadata must come
+                # from the selected boundary together with its state.  A
+                # custom factory only changes how the target cache is made;
+                # it must not suppress this boundary-specific metadata.
+                restore_meta_state=(
+                    getattr(entry, "cache_snapshot_prefix_len", None) is not None
+                ),
+            )
             if _mnt is not None:
                 _mnt["recurrent_overwrite_s"] = (
                     time.perf_counter() - _overwrite_started

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -1773,13 +1773,20 @@ class SessionBank:
             return None
 
         actual_restore_mode = "clone"
-        # Committed MTP history is built from prompt_ids[1:], so a boundary at
-        # N retains N-1 history rows.  Legacy full snapshots retain the
-        # nominal entry prefix length and therefore preserve the established
-        # delta-trim behavior; prefix-decoded entries record their true span.
-        mtp_history_trim_tokens = max(
-            0, mtp_snapshot_prefix_len - max(0, restore_point - 1)
-        )
+        if mtp_prefix_recorded is None:
+            # Legacy full and live-reference snapshots are trimmed by the
+            # prompt-prefix gap.  Their physical MTP offset may be windowed,
+            # so it cannot be treated as an absolute token position.
+            mtp_history_trim_tokens = max(
+                0, int(entry.prefix_len) - restore_point
+            )
+        else:
+            # Prefix-decoded committed MTP history records its physical span.
+            # It is built from prompt_ids[1:], so a boundary at N retains N-1
+            # history rows and needs no further trim when decoded to that size.
+            mtp_history_trim_tokens = max(
+                0, mtp_snapshot_prefix_len - max(0, restore_point - 1)
+            )
         # Boundary restores land the KV at the full boundary (no seed forward
         # will run — it would advance recurrent state past the captured
         # boundary a second time). Non-boundary restores keep the seed-forward
@@ -1788,7 +1795,8 @@ class SessionBank:
             # The cold decoder supplied precisely the state this consumer
             # needs.  Calling the legacy trim here would remove valid KV rows
             # (or demand an absent long tail) after a partial hydration.
-            trim_to_target = lambda _cache: True
+            def trim_to_target(_cache: list[Any]) -> bool:
+                return True
         else:
             trim_to_target = (
                 (lambda c: _trim_cache_ref_to_tokens(c, restore_point))

--- a/tests/test_cache_bank.py
+++ b/tests/test_cache_bank.py
@@ -170,8 +170,8 @@ def test_cache_bank_codec_prefix_decode_reads_only_needed_kv_blocks():
     assert not later_blocks.intersection(reads)
 
 
-def test_cache_bank_codec_prefix_decode_keeps_full_mtp_history_for_trim():
-    """MTP history is shifted, so it must use the existing delta-trim path."""
+def test_cache_bank_codec_prefix_decode_reads_only_needed_mtp_history():
+    """Committed MTP history is shifted by one target token."""
 
     snapshot = CacheSnapshot(
         states=(mx.zeros((1, 1, 1024, 2), dtype=mx.float16),),
@@ -193,12 +193,13 @@ def test_cache_bank_codec_prefix_decode_keeps_full_mtp_history_for_trim():
         encoded.spec,
         encoded.tensors.__getitem__,
         cache_prefix_len=256,
+        mtp_history_prefix_len=255,
     )
 
     assert decoded.cache_snapshot.states[0].shape == (1, 1, 256, 2)
-    assert decoded.mtp_history_snapshot_prefix_len is None
+    assert decoded.mtp_history_snapshot_prefix_len == 255
     assert decoded.mtp_history_snapshot is not None
-    assert decoded.mtp_history_snapshot.states[0].shape == (1, 1, 1024, 2)
+    assert decoded.mtp_history_snapshot.states[0].shape == (1, 1, 255, 2)
 
 
 def test_cache_bank_codec_rejects_prefix_decode_for_coupled_cache_metadata():
@@ -1043,7 +1044,12 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
             hidden=None,
             session_id="hybrid-session",
             template_hash="template-a",
+            mtp_history_policy="committed",
             policy_fingerprint="policy-a",
+            mtp_history_snapshot=CacheSnapshot(
+                states=(AttentionStub(1199).state,),
+                meta_states=(None,),
+            ),
             snapshot_epoch=1200,
             gdn_boundaries=[(1024, boundary_state, hidden_last)],
         )
@@ -1072,6 +1078,10 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
         assert restored_k.shape == (1, 1, 1024, 2)
         assert restored_v.shape == (1, 1, 1024, 2)
         assert ssd_entry.cache_snapshot.states[1] is None
+        assert ssd_entry.mtp_history_snapshot_prefix_len == 1023
+        assert ssd_entry.mtp_history_snapshot is not None
+        assert ssd_entry.mtp_history_snapshot.states[0][0].shape == (1, 1, 1023, 2)
+        assert ssd_entry.mtp_history_snapshot.states[0][1].shape == (1, 1, 1023, 2)
         restored_hidden = ssd_entry.gdn_boundaries[0][2]
         assert restored_hidden is not None
         assert float(mx.max(mx.abs(restored_hidden - hidden_last)).item()) == 0.0
@@ -1085,14 +1095,18 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
             # factory.  Boundary metadata must still replace this cache's
             # initial recurrent metadata.
             cache_factory=lambda: [AttentionStub(0), RecurrentStub()],
+            mtp_cache_factory=lambda: [AttentionStub(0)],
         )
         assert restored is not None
-        cache, _mtp, mode, restore_point, boundary_hidden = restored
+        cache, mtp_cache, mode, restore_point, boundary_hidden = restored
         assert restore_point == 1024
         assert boundary_hidden is not None
         attention, recurrent = cache
         assert attention.state[0].shape == (1, 1, 1024, 2)
         assert attention.state[1].shape == (1, 1, 1024, 2)
+        assert mtp_cache is not None
+        assert mtp_cache[0].state[0].shape == (1, 1, 1023, 2)
+        assert mtp_cache[0].state[1].shape == (1, 1, 1023, 2)
         assert float(mx.max(mx.abs(recurrent.state[0] - mx.full((2, 2), 7.0))).item()) == 0.0
         assert recurrent.meta_state == ("boundary_recurrent_state",)
     finally:

--- a/tests/test_cache_bank.py
+++ b/tests/test_cache_bank.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import mlx.core as mx
 
 from mtplx.cache_bank import SessionBankColdTier
-from mtplx.cache_bank.codec import decode_payload, encode_payload
+from mtplx.cache_bank.codec import (
+    decode_payload,
+    decode_payload_prefix,
+    encode_payload,
+)
 from mtplx.cache_state import CacheSnapshot
 from mtplx.session_bank import SessionBank
 
@@ -112,6 +116,57 @@ def test_cache_bank_codec_chunks_large_sequence_tensors():
     assert len(state_spec["blocks"]) == 2
     decoded = decode_payload(encoded.spec, encoded.tensors.__getitem__)
     assert decoded.cache_snapshot.states[0][0].shape == (1, 1, 512, 2)
+
+
+def test_cache_bank_codec_prefix_decode_reads_only_needed_kv_blocks():
+    """A boundary restore must not hydrate the long snapshot tail.
+
+    This is the regression behind a short foreground request waiting on a
+    multi-GB SSD entry: only KV through the chosen boundary and that boundary's
+    recurrent state may be read.
+    """
+
+    snapshot = CacheSnapshot(
+        states=(
+            mx.zeros((1, 1, 1024, 2), dtype=mx.float16),
+            mx.full((1, 4), 9.0, dtype=mx.float16),
+        ),
+        meta_states=(None, None),
+    )
+    boundary = CacheSnapshot(
+        states=(None, mx.full((1, 4), 7.0, dtype=mx.float16)),
+        meta_states=(None, None),
+    )
+    encoded = encode_payload(
+        cache_snapshot=snapshot,
+        logits=None,
+        hidden=None,
+        mtp_history_snapshot=None,
+        gdn_boundaries=[(256, boundary, None)],
+        has_recurrent=True,
+        block_size=256,
+    )
+    reads: list[str] = []
+
+    def read_tensor(name: str) -> bytes:
+        reads.append(name)
+        return encoded.tensors[name]
+
+    decoded = decode_payload_prefix(
+        encoded.spec,
+        read_tensor,
+        cache_prefix_len=256,
+        boundary_prefix_len=256,
+    )
+    state_spec = encoded.spec["cache_snapshot"]["states"]["items"][0]
+    later_blocks = {block["name"] for block in state_spec["blocks"][1:]}
+
+    assert decoded.cache_snapshot_prefix_len == 256
+    assert decoded.cache_snapshot.states[0].shape == (1, 1, 256, 2)
+    assert decoded.cache_snapshot.states[1] is None
+    assert decoded.gdn_boundaries[0][0] == 256
+    assert decoded.gdn_boundaries[0][1].states[1].tolist() == [[7.0] * 4]
+    assert not later_blocks.intersection(reads)
 
 
 def test_session_bank_cold_tier_write_only_writes_but_does_not_restore(tmp_path):
@@ -856,15 +911,28 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
             def replace_state(self, value):
                 self.state = list(value)
 
+        class AttentionStub:
+            """Tiny trimmable KV stand-in with an on-disk block tail."""
+
+            def __init__(self, tokens: int):
+                self.state = (
+                    mx.full((1, 1, tokens, 2), 5.0, dtype=mx.float16),
+                    mx.full((1, 1, tokens, 2), 6.0, dtype=mx.float16),
+                )
+                self.meta_state = None
+
+            def is_trimmable(self):
+                return True
+
         boundary_state = CacheSnapshot(
-            states=(mx.full((2, 2), 7.0),),
-            meta_states=(None,),
+            states=(None, mx.full((2, 2), 7.0)),
+            meta_states=(None, None),
         )
         hidden_last = mx.full((1, 1, 4), 3.0)
         entry = bank.put(
             runtime=runtime,
             token_ids=list(range(1200)),
-            cache=[RecurrentStub()],
+            cache=[AttentionStub(1200), RecurrentStub()],
             logits=mx.zeros((1, 4)),
             hidden=None,
             session_id="hybrid-session",
@@ -893,6 +961,11 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
         assert getattr(ssd_entry, "cache_source") == "ssd"
         assert ssd_entry.has_recurrent is True
         assert [b for b, _, _ in ssd_entry.gdn_boundaries] == [1024]
+        assert ssd_entry.cache_snapshot_prefix_len == 1024
+        restored_k, restored_v = ssd_entry.cache_snapshot.states[0]
+        assert restored_k.shape == (1, 1, 1024, 2)
+        assert restored_v.shape == (1, 1, 1024, 2)
+        assert ssd_entry.cache_snapshot.states[1] is None
         restored_hidden = ssd_entry.gdn_boundaries[0][2]
         assert restored_hidden is not None
         assert float(mx.max(mx.abs(restored_hidden - hidden_last)).item()) == 0.0
@@ -902,13 +975,15 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
             ssd_entry,
             int(matched),
             mode="clone",
-            cache_factory=lambda: [RecurrentStub()],
+            cache_factory=lambda: [AttentionStub(0), RecurrentStub()],
         )
         assert restored is not None
         cache, _mtp, mode, restore_point, boundary_hidden = restored
         assert restore_point == 1024
         assert boundary_hidden is not None
-        recurrent = cache[0]
+        attention, recurrent = cache
+        assert attention.state[0].shape == (1, 1, 1024, 2)
+        assert attention.state[1].shape == (1, 1, 1024, 2)
         assert float(mx.max(mx.abs(recurrent.state[0] - mx.full((2, 2), 7.0))).item()) == 0.0
     finally:
         cold.close()

--- a/tests/test_cache_bank.py
+++ b/tests/test_cache_bank.py
@@ -11,6 +11,7 @@ from mtplx.cache_bank.codec import (
     decode_payload,
     decode_payload_prefix,
     encode_payload,
+    payload_supports_prefix_decode,
 )
 from mtplx.cache_state import CacheSnapshot
 from mtplx.session_bank import SessionBank
@@ -167,6 +168,111 @@ def test_cache_bank_codec_prefix_decode_reads_only_needed_kv_blocks():
     assert decoded.gdn_boundaries[0][0] == 256
     assert decoded.gdn_boundaries[0][1].states[1].tolist() == [[7.0] * 4]
     assert not later_blocks.intersection(reads)
+
+
+def test_cache_bank_codec_prefix_decode_keeps_full_mtp_history_for_trim():
+    """MTP history is shifted, so it must use the existing delta-trim path."""
+
+    snapshot = CacheSnapshot(
+        states=(mx.zeros((1, 1, 1024, 2), dtype=mx.float16),),
+        meta_states=(None,),
+    )
+    mtp_snapshot = CacheSnapshot(
+        states=(mx.full((1, 1, 1024, 2), 3.0, dtype=mx.float16),),
+        meta_states=(None,),
+    )
+    encoded = encode_payload(
+        cache_snapshot=snapshot,
+        logits=None,
+        hidden=None,
+        mtp_history_snapshot=mtp_snapshot,
+        block_size=256,
+    )
+
+    decoded = decode_payload_prefix(
+        encoded.spec,
+        encoded.tensors.__getitem__,
+        cache_prefix_len=256,
+    )
+
+    assert decoded.cache_snapshot.states[0].shape == (1, 1, 256, 2)
+    assert decoded.mtp_history_snapshot_prefix_len is None
+    assert decoded.mtp_history_snapshot is not None
+    assert decoded.mtp_history_snapshot.states[0].shape == (1, 1, 1024, 2)
+
+
+def test_cache_bank_codec_rejects_prefix_decode_for_coupled_cache_metadata():
+    """Ring/compressor cache metadata cannot be reconstructed by KV slicing."""
+
+    snapshot = CacheSnapshot(
+        states=(mx.zeros((1, 1, 1024, 2), dtype=mx.float16),),
+        meta_states=(("mtplx-deepseek-v4-cache-v1", "1024", "0", "8", "2"),),
+    )
+    encoded = encode_payload(
+        cache_snapshot=snapshot,
+        logits=None,
+        hidden=None,
+        mtp_history_snapshot=None,
+        block_size=256,
+    )
+
+    assert payload_supports_prefix_decode(encoded.spec) is False
+
+
+def test_cold_tier_keeps_tiny_recurrent_prefix_without_boundary(tmp_path, monkeypatch):
+    """Tiny tokenizer-drift restores retain the pre-prefix-decode behavior."""
+
+    monkeypatch.setenv("MTPLX_SESSION_BLOCK_PREFIX_RESTORE", "1")
+    cold = SessionBankColdTier(
+        base_dir=tmp_path / "session-bank",
+        mode="on",
+        min_prefix_tokens=2,
+    )
+
+    class RecurrentStub:
+        def __init__(self):
+            self.state = [mx.ones((2, 2)), None]
+            self.meta_state = ("owned_recurrent_state", "persistent_eval")
+
+        def is_trimmable(self):
+            return False
+
+    try:
+        runtime = FakeRuntime()
+        bank = SessionBank(cold_tier=cold)
+        entry = bank.put(
+            runtime=runtime,
+            token_ids=list(range(41)),
+            cache=[RecurrentStub()],
+            logits=mx.zeros((1, 4)),
+            hidden=None,
+            template_hash="template-a",
+            policy_fingerprint="policy-a",
+            snapshot_epoch=41,
+            gdn_boundaries=[],
+        )
+        assert entry is not None
+        assert entry.has_recurrent is True
+        assert cold.flush(timeout_s=5.0) is True
+        bank.clear()
+
+        candidates = bank.near_prefix_candidates(
+            list(range(40)) + [99_001],
+            max_token_gap=8,
+            min_matched_tokens=4,
+            block_size=8,
+            block_min_matched_tokens=8,
+            model_path=str(runtime.model_path),
+            mtp_enabled=runtime.mtp_enabled,
+            template_hash="template-a",
+            policy_fingerprint="policy-a",
+        )
+
+        assert candidates
+        assert candidates[0][1] == 40
+        assert getattr(candidates[0][0], "cache_source") == "ssd"
+    finally:
+        cold.close()
 
 
 def test_session_bank_cold_tier_write_only_writes_but_does_not_restore(tmp_path):
@@ -926,7 +1032,7 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
 
         boundary_state = CacheSnapshot(
             states=(None, mx.full((2, 2), 7.0)),
-            meta_states=(None, None),
+            meta_states=(None, ("boundary_recurrent_state",)),
         )
         hidden_last = mx.full((1, 1, 4), 3.0)
         entry = bank.put(
@@ -975,6 +1081,9 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
             ssd_entry,
             int(matched),
             mode="clone",
+            # The foreground near-prefix path supplies a target-specific
+            # factory.  Boundary metadata must still replace this cache's
+            # initial recurrent metadata.
             cache_factory=lambda: [AttentionStub(0), RecurrentStub()],
         )
         assert restored is not None
@@ -985,6 +1094,7 @@ def test_cold_tier_v3_roundtrips_gdn_boundaries_and_boundary_restores(tmp_path, 
         assert attention.state[0].shape == (1, 1, 1024, 2)
         assert attention.state[1].shape == (1, 1, 1024, 2)
         assert float(mx.max(mx.abs(recurrent.state[0] - mx.full((2, 2), 7.0))).item()) == 0.0
+        assert recurrent.meta_state == ("boundary_recurrent_state",)
     finally:
         cold.close()
 


### PR DESCRIPTION
## Summary

- Decode only the KV blocks required through the selected prefix/GDN boundary for SSD cold prefix restores.
- Slice committed MTP history to the boundary-aligned `N - 1` prefix instead of hydrating and immediately trimming its full tail.
- Preserve the legacy full-decode path for tiny hybrid gaps without a boundary and cache layouts with coupled/ring metadata.
- Carry the materialized snapshot spans into SessionBank so restore does not trim data that was deliberately never read.

## Validation

- Added codec and end-to-end cold-tier regressions covering partial KV, GDN boundary state, committed MTP history, and boundary metadata restoration.
- `63 passed, 1 deselected` across the related cache-bank/cold-tier test set; syntax and F/E9 static checks pass.
- Replayed a persisted 74,308-token Qwen entry locally at its 2,048-token GDN boundary: 2,281 blobs / 0.277 GiB were decoded in 0.314 s, instead of hydrating the multi-GiB entry.