### PR TITLE
Add optional aria2c download acceleration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install -U pip
       - run: python -m pip install -e ".[dev,server]"
-      - run: python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py tests/test_server_openai.py tests/test_openai_bridge.py tests/test_thermal.py tests/test_cache_state.py
+      - run: python -m pytest tests/test_no_mlx_imports.py tests/test_public_cli.py tests/test_runtime_kpis.py tests/test_server_openai.py tests/test_openai_bridge.py tests/test_thermal.py tests/test_cache_state.py tests/test_aria2_downloader.py
       - run: python -m compileall -q mtplx tests

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,6 +15,16 @@ Homebrew is the recommended macOS path. Python-only installs can use PyPI:
 python3 -m pip install -U mtplx
 ```
 
+For faster parallel model downloads, install aria2 and let `pull` select it automatically:
+
+```bash
+brew install aria2
+mtplx pull Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed
+```
+
+Use `--download-backend aria2` to require aria2c, or `--download-backend python` to force the built-in downloader.
+Hugging Face credentials are passed to aria2c through standard input and are never placed in the process arguments.
+
 The GitHub release wheel remains available for reproducible installs:
 
 ```bash

--- a/mtplx/aria2_downloader.py
+++ b/mtplx/aria2_downloader.py
@@ -1,0 +1,309 @@
+"""Small, dependency-free aria2c runner for Hugging Face downloads."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import secrets
+import socket
+import subprocess
+import tempfile
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class Aria2DownloadError(RuntimeError):
+    """Raised when aria2c cannot complete a requested transfer."""
+
+
+@dataclass(frozen=True)
+class Aria2Download:
+    """One aria2 download and the metadata needed to verify it."""
+
+    url: str
+    output: Path
+    headers: tuple[str, ...] = ()
+    expected_size: int | None = None
+    sha256: str | None = None
+    display_name: str | None = None
+
+
+Aria2ProgressCallback = Callable[[int, float, str | None], None]
+
+
+def _single_line(value: str, *, label: str) -> str:
+    if "\n" in value or "\r" in value:
+        raise Aria2DownloadError(f"aria2 {label} must fit on one line")
+    return value
+
+
+def _build_input(
+    downloads: Iterable[Aria2Download],
+    gids: dict[Path, str],
+) -> str:
+    lines: list[str] = []
+    for download in downloads:
+        url = _single_line(download.url, label="URL")
+        output = download.output.resolve()
+        directory = _single_line(str(output.parent), label="destination")
+        filename = _single_line(output.name, label="filename")
+        lines.extend(
+            [
+                url,
+                f"  gid={gids[download.output]}",
+                f"  dir={directory}",
+                f"  out={filename}",
+                "  continue=true",
+                "  auto-file-renaming=false",
+                "  allow-overwrite=false",
+            ]
+        )
+        if download.sha256:
+            checksum = _single_line(download.sha256, label="checksum")
+            lines.append(f"  checksum=sha-256={checksum}")
+        for header in download.headers:
+            lines.append(f"  header={_single_line(header, label='header')}")
+    return "\n".join(lines) + "\n"
+
+
+def _reserve_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _command(
+    executable: str,
+    *,
+    rpc_port: int,
+    rpc_secret: str,
+    connections: int,
+    concurrent_downloads: int,
+) -> list[str]:
+    return [
+        executable,
+        "--input-file=-",
+        "--enable-rpc=true",
+        "--rpc-listen-all=false",
+        f"--rpc-listen-port={rpc_port}",
+        f"--rpc-secret={rpc_secret}",
+        f"--max-concurrent-downloads={max(1, concurrent_downloads)}",
+        f"--max-connection-per-server={max(1, connections)}",
+        f"--split={max(1, connections)}",
+        "--min-split-size=1M",
+        "--file-allocation=none",
+        "--max-tries=5",
+        "--retry-wait=2",
+        "--connect-timeout=30",
+        "--timeout=60",
+        "--summary-interval=0",
+        "--console-log-level=warn",
+        "--download-result=hide",
+    ]
+
+
+def _rpc_call(
+    *,
+    port: int,
+    secret: str,
+    method: str,
+    params: list[object],
+    timeout: float = 0.5,
+) -> object:
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": "mtplx",
+            "method": f"aria2.{method}",
+            "params": [f"token:{secret}", *params],
+        }
+    )
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+    try:
+        connection.request(
+            "POST",
+            "/jsonrpc",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        body = json.loads(response.read().decode("utf-8"))
+    finally:
+        connection.close()
+    if response.status != 200 or "error" in body:
+        detail = body.get("error", {}).get("message", f"HTTP {response.status}")
+        raise Aria2DownloadError(f"aria2 RPC failed: {detail}")
+    return body.get("result")
+
+
+def _status_bytes(
+    *,
+    port: int,
+    secret: str,
+    gids: dict[Path, str],
+    downloads: list[Aria2Download],
+    initial_sizes: dict[Path, int],
+) -> tuple[int, float, str | None, bool, str | None, int]:
+    completed = 0
+    rate = 0.0
+    active_name: str | None = None
+    fastest = -1.0
+    terminal = 0
+    seen = 0
+    errors: list[str] = []
+    by_output = {download.output: download for download in downloads}
+    for output, gid in gids.items():
+        try:
+            result = _rpc_call(
+                port=port,
+                secret=secret,
+                method="tellStatus",
+                params=[
+                    gid,
+                    [
+                        "status",
+                        "completedLength",
+                        "downloadSpeed",
+                        "errorCode",
+                        "errorMessage",
+                    ],
+                ],
+            )
+        except (Aria2DownloadError, OSError, ValueError):
+            completed += initial_sizes.get(output, 0)
+            continue
+        if not isinstance(result, dict):
+            completed += initial_sizes.get(output, 0)
+            continue
+        seen += 1
+        item_completed = max(
+            initial_sizes.get(output, 0),
+            int(result.get("completedLength") or 0),
+        )
+        item_rate = float(result.get("downloadSpeed") or 0)
+        completed += item_completed
+        rate += item_rate
+        status = result.get("status")
+        if status in {"complete", "error", "removed"}:
+            terminal += 1
+        if status in {"error", "removed"}:
+            message = result.get("errorMessage") or result.get("errorCode") or status
+            errors.append(f"{by_output[output].display_name or output.name}: {message}")
+        if status == "active" and item_rate > fastest:
+            fastest = item_rate
+            active_name = by_output[output].display_name
+    all_terminal = seen == len(gids) and terminal == len(gids)
+    return completed, rate, active_name, all_terminal, "; ".join(errors) or None, seen
+
+
+def run_aria2_downloads(
+    downloads: Iterable[Aria2Download],
+    *,
+    executable: str,
+    progress_callback: Aria2ProgressCallback | None = None,
+    progress_interval_s: float = 0.4,
+    connections: int = 16,
+    concurrent_downloads: int = 4,
+) -> None:
+    """Run one aria2c process and report byte-accurate aggregate progress."""
+
+    jobs = list(downloads)
+    if not jobs:
+        return
+    for job in jobs:
+        job.output.parent.mkdir(parents=True, exist_ok=True)
+    gids = {job.output: secrets.token_hex(8) for job in jobs}
+    initial_sizes = {
+        job.output: job.output.stat().st_size if job.output.is_file() else 0
+        for job in jobs
+    }
+    rpc_port = _reserve_loopback_port()
+    rpc_secret = secrets.token_urlsafe(24)
+    argv = _command(
+        executable,
+        rpc_port=rpc_port,
+        rpc_secret=rpc_secret,
+        connections=connections,
+        concurrent_downloads=concurrent_downloads,
+    )
+    job_input = _build_input(jobs, gids)
+
+    with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as error_log:
+        process = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=error_log,
+            text=True,
+        )
+        try:
+            assert process.stdin is not None
+            process.stdin.write(job_input)
+            process.stdin.close()
+            interval = max(0.1, float(progress_interval_s))
+            next_progress = time.monotonic() + interval
+            status_started_at = time.monotonic()
+            download_error: str | None = None
+            while process.poll() is None:
+                now = time.monotonic()
+                if now >= next_progress:
+                    (
+                        completed,
+                        rate,
+                        active_name,
+                        all_terminal,
+                        status_error,
+                        seen,
+                    ) = _status_bytes(
+                        port=rpc_port,
+                        secret=rpc_secret,
+                        gids=gids,
+                        downloads=jobs,
+                        initial_sizes=initial_sizes,
+                    )
+                    if progress_callback is not None:
+                        progress_callback(completed, rate, active_name)
+                    if all_terminal:
+                        download_error = status_error
+                        _rpc_call(
+                            port=rpc_port,
+                            secret=rpc_secret,
+                            method="shutdown",
+                            params=[],
+                        )
+                        break
+                    if seen == 0 and now - status_started_at >= 5.0:
+                        download_error = "aria2c did not register any download jobs"
+                        _rpc_call(
+                            port=rpc_port,
+                            secret=rpc_secret,
+                            method="shutdown",
+                            params=[],
+                        )
+                        break
+                    next_progress = now + interval
+                time.sleep(min(0.1, interval))
+            return_code = process.wait(timeout=5)
+        except BaseException:
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
+            raise
+
+        if return_code != 0 or download_error:
+            error_log.seek(0)
+            detail = error_log.read()[-4096:].strip()
+            for job in jobs:
+                for header in job.headers:
+                    detail = detail.replace(header, "<redacted header>")
+            reasons = [reason for reason in (download_error, detail) if reason]
+            suffix = f": {'; '.join(reasons)}" if reasons else ""
+            raise Aria2DownloadError(f"aria2c exited with status {return_code}{suffix}")
+
+    if progress_callback is not None:
+        completed = sum(
+            job.output.stat().st_size if job.output.is_file() else 0 for job in jobs
+        )
+        progress_callback(completed, 0.0, None)

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -3348,6 +3348,12 @@ def build_parser() -> argparse.ArgumentParser:
     pull_p.add_argument("--cache-dir")
     pull_p.add_argument("--revision")
     pull_p.add_argument(
+        "--download-backend",
+        choices=("auto", "python", "aria2"),
+        default="auto",
+        help="Download engine. auto uses aria2c when installed.",
+    )
+    pull_p.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON"
     )
     pull_p.add_argument(

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -5710,13 +5710,15 @@ def cmd_pull_public(args: Any) -> int:
         )
         progress_interval_s = 0.4
     try:
-        result = pull_model(
-            args.model,
-            cache_dir=args.cache_dir,
-            revision=args.revision,
-            progress_callback=callback,
-            progress_interval_s=progress_interval_s,
-        )
+        pull_kwargs = {
+            "cache_dir": args.cache_dir,
+            "revision": args.revision,
+            "progress_callback": callback,
+            "progress_interval_s": progress_interval_s,
+        }
+        if hasattr(args, "download_backend"):
+            pull_kwargs["download_backend"] = args.download_backend
+        result = pull_model(args.model, **pull_kwargs)
     except KeyboardInterrupt:
         finalize()
         if progress_json:

--- a/mtplx/hf_loader.py
+++ b/mtplx/hf_loader.py
@@ -1121,6 +1121,144 @@ def _download_repo_file(
     )
 
 
+def _resolve_download_backend(requested: str) -> tuple[str, str | None]:
+    backend = requested.strip().lower()
+    if backend not in {"auto", "python", "aria2"}:
+        raise ValueError(
+            "download backend must be one of: auto, python, aria2"
+        )
+    aria2c = shutil.which("aria2c")
+    if backend == "python":
+        return "python", None
+    if aria2c:
+        return "aria2", aria2c
+    if backend == "aria2":
+        raise RuntimeError(
+            "aria2 download backend requested, but aria2c is not installed. "
+            "Install it with `brew install aria2` or use --download-backend python."
+        )
+    return "python", None
+
+
+def _download_repo_files_with_aria2(
+    repo_files: list[RepoFile],
+    *,
+    executable: str,
+    repo_id: str,
+    revision: str | None,
+    destination: Path,
+    hf_hub_url: Callable[..., str],
+    build_hf_headers: Callable[..., dict[str, str]],
+    token: str | bool | None,
+    callback: DownloadProgressCallback | None,
+    total_bytes: int | None,
+    started_at: float,
+    progress_interval_s: float,
+    last_emit_at: float,
+    last_emit_size: int,
+) -> tuple[float, int]:
+    from mtplx.aria2_downloader import Aria2Download, run_aria2_downloads
+
+    headers = tuple(
+        f"{name}: {value}" for name, value in build_hf_headers(token=token).items()
+    )
+    downloads: list[Aria2Download] = []
+    settled_bytes = 0
+    for repo_file in repo_files:
+        target = _safe_destination_for_repo_file(destination, repo_file)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        expected_size = repo_file.size_bytes
+        if expected_size is not None and target.exists() and target.stat().st_size == expected_size:
+            settled_bytes += expected_size
+            continue
+        if expected_size is None and target.exists() and target.stat().st_size > 0:
+            settled_bytes += target.stat().st_size
+            continue
+
+        partial = target.with_name(target.name + ".incomplete")
+        if target.exists():
+            target.unlink()
+        if (
+            expected_size is not None
+            and partial.exists()
+            and partial.stat().st_size > expected_size
+        ):
+            partial.unlink()
+        downloads.append(
+            Aria2Download(
+                url=hf_hub_url(
+                    repo_id=repo_id,
+                    filename=repo_file.path,
+                    revision=revision,
+                ),
+                output=partial,
+                headers=headers,
+                expected_size=expected_size,
+                sha256=repo_file.sha256,
+                display_name=repo_file.path,
+            )
+        )
+
+    def report(completed: int, rate_bps: float, file_path: str | None) -> None:
+        nonlocal last_emit_at, last_emit_size
+        now = time.monotonic()
+        current_size = settled_bytes + completed
+        interval = max(0.001, now - last_emit_at)
+        reported_size = min(current_size, total_bytes) if total_bytes else current_size
+        _emit_download_progress(
+            callback,
+            {
+                "event": "progress",
+                "repo_id": repo_id,
+                "path": str(destination),
+                "file": file_path,
+                "size_bytes": reported_size,
+                "total_bytes": total_bytes,
+                "delta_bytes": current_size - last_emit_size,
+                "rate_bps": max(0.0, rate_bps),
+                "elapsed_s": now - started_at,
+                "interval_s": interval,
+                "stalled_s": 0,
+                "message": "Downloading model files with aria2c",
+            },
+        )
+        last_emit_at = now
+        last_emit_size = current_size
+
+    run_aria2_downloads(
+        downloads,
+        executable=executable,
+        progress_callback=report if callback is not None else None,
+        progress_interval_s=progress_interval_s,
+    )
+    for download in downloads:
+        partial = download.output
+        if not partial.is_file():
+            raise RuntimeError(
+                f"aria2c did not produce a completed file for {download.display_name}"
+            )
+        if (
+            download.expected_size is not None
+            and partial.stat().st_size != download.expected_size
+        ):
+            raise RuntimeError(
+                f"incomplete download for {download.display_name}: expected "
+                f"{download.expected_size} bytes, got {partial.stat().st_size}"
+            )
+        target = partial.with_name(partial.name.removesuffix(".incomplete"))
+        partial.replace(target)
+    return _emit_current_download_size(
+        callback,
+        repo_id=repo_id,
+        destination=destination,
+        total_bytes=total_bytes,
+        started_at=started_at,
+        last_emit_at=last_emit_at,
+        last_emit_size=last_emit_size,
+        measure=lambda: manifest_bytes_on_disk(destination, repo_files),
+    )
+
+
 def _download_snapshot_with_structured_progress(
     *,
     repo_id: str,
@@ -1128,6 +1266,8 @@ def _download_snapshot_with_structured_progress(
     destination: Path,
     progress_callback: DownloadProgressCallback | None,
     progress_interval_s: float,
+    download_backend: str = "python",
+    aria2c_path: str | None = None,
 ) -> tuple[Path, int | None]:
     HfApi, hf_hub_url, get_session, build_hf_headers, hf_raise_for_status = _hub_runtime()
     try:
@@ -1173,6 +1313,30 @@ def _download_snapshot_with_structured_progress(
     started_at = time.monotonic()
     last_emit_at = started_at
     last_emit_size = measure()
+    if download_backend == "aria2":
+        if not aria2c_path:
+            raise RuntimeError("aria2 download backend has no aria2c executable")
+        try:
+            _download_repo_files_with_aria2(
+                repo_files,
+                executable=aria2c_path,
+                repo_id=repo_id,
+                revision=revision,
+                destination=destination,
+                hf_hub_url=hf_hub_url,
+                build_hf_headers=build_hf_headers,
+                token=token,
+                callback=progress_callback,
+                total_bytes=total_bytes,
+                started_at=started_at,
+                progress_interval_s=max(0.1, progress_interval_s),
+                last_emit_at=last_emit_at,
+                last_emit_size=last_emit_size,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(_classify_pull_error(exc, repo_id)) from exc
+        return destination, total_bytes
+
     for repo_file in repo_files:
         try:
             last_emit_at, last_emit_size = _download_repo_file(
@@ -1295,6 +1459,7 @@ def pull_model(
     progress_interval_s: float = 10.0,
     force_sync: bool = False,
     destination: Path | None = None,
+    download_backend: str = "python",
 ) -> dict[str, Any]:
     repo_id = repo_id_from_model_ref(model_ref)
     if repo_id is None:
@@ -1381,6 +1546,7 @@ def pull_model(
         )
     else:
         reused_existing = False
+        selected_backend, aria2c_path = _resolve_download_backend(download_backend)
         # Pin the whole download to one resolved commit so every file comes
         # from the same snapshot even if the repo is pushed to mid-download.
         _resolve_remote_snapshot()
@@ -1442,13 +1608,15 @@ def pull_model(
             else contextlib.nullcontext()
         )
         with progress_suppression:
-            if progress_callback is not None:
+            if progress_callback is not None or selected_backend == "aria2":
                 resolved, total_bytes_from_download = _download_snapshot_with_structured_progress(
                     repo_id=repo_id,
                     revision=download_revision,
                     destination=destination,
                     progress_callback=progress_callback,
                     progress_interval_s=progress_interval_s,
+                    download_backend=selected_backend,
+                    aria2c_path=aria2c_path,
                 )
                 if total_bytes_from_download:
                     total_bytes = total_bytes_from_download

--- a/tests/test_aria2_downloader.py
+++ b/tests/test_aria2_downloader.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from mtplx import hf_loader
+from mtplx.aria2_downloader import (
+    Aria2Download,
+    Aria2DownloadError,
+    _build_input,
+    _command,
+    run_aria2_downloads,
+)
+from mtplx.cli import build_parser
+
+
+def test_aria2_job_input_carries_resume_checksum_and_secret_header(tmp_path: Path):
+    output = tmp_path / "weights.safetensors.incomplete"
+    download = Aria2Download(
+        url="https://huggingface.co/org/repo/resolve/commit/weights.safetensors",
+        output=output,
+        headers=("authorization: Bearer hf_secret",),
+        sha256="a" * 64,
+    )
+
+    payload = _build_input([download], {output: "0123456789abcdef"})
+    argv = _command(
+        "/opt/homebrew/bin/aria2c",
+        rpc_port=12345,
+        rpc_secret="rpc-secret",
+        connections=16,
+        concurrent_downloads=4,
+    )
+
+    assert "continue=true" in payload
+    assert "checksum=sha-256=" + "a" * 64 in payload
+    assert "header=authorization: Bearer hf_secret" in payload
+    assert "weights.safetensors.incomplete" in payload
+    assert all("hf_secret" not in argument for argument in argv)
+
+
+def test_aria2_job_input_rejects_header_newlines(tmp_path: Path):
+    output = tmp_path / "weights.incomplete"
+    download = Aria2Download(
+        url="https://example.invalid/weights",
+        output=output,
+        headers=("authorization: safe\nX-Injected: unsafe",),
+    )
+
+    with pytest.raises(Aria2DownloadError, match="header must fit on one line"):
+        _build_input([download], {output: "0123456789abcdef"})
+
+
+@pytest.mark.parametrize(
+    ("requested", "found", "expected"),
+    [
+        ("python", "/opt/homebrew/bin/aria2c", ("python", None)),
+        ("auto", None, ("python", None)),
+        (
+            "auto",
+            "/opt/homebrew/bin/aria2c",
+            ("aria2", "/opt/homebrew/bin/aria2c"),
+        ),
+        (
+            "aria2",
+            "/opt/homebrew/bin/aria2c",
+            ("aria2", "/opt/homebrew/bin/aria2c"),
+        ),
+    ],
+)
+def test_resolve_download_backend(monkeypatch, requested, found, expected):
+    monkeypatch.setattr(hf_loader.shutil, "which", lambda _name: found)
+
+    assert hf_loader._resolve_download_backend(requested) == expected
+
+
+def test_resolve_download_backend_requires_installed_aria2(monkeypatch):
+    monkeypatch.setattr(hf_loader.shutil, "which", lambda _name: None)
+
+    with pytest.raises(RuntimeError, match="aria2c is not installed"):
+        hf_loader._resolve_download_backend("aria2")
+
+
+def test_aria2_backend_lands_verified_partials_and_emits_progress(
+    monkeypatch, tmp_path: Path
+):
+    content = b"parallel weights"
+    sha256 = hashlib.sha256(content).hexdigest()
+    repo_file = hf_loader.RepoFile(
+        path="weights/model.safetensors",
+        size_bytes=len(content),
+        sha256=sha256,
+    )
+    destination = tmp_path / "model"
+    destination.mkdir()
+    events: list[dict] = []
+    captured: dict[str, object] = {}
+
+    def fake_run(downloads, **kwargs):
+        jobs = list(downloads)
+        captured["jobs"] = jobs
+        captured["kwargs"] = kwargs
+        for job in jobs:
+            job.output.parent.mkdir(parents=True, exist_ok=True)
+            job.output.write_bytes(content)
+        kwargs["progress_callback"](len(content), 4096.0, repo_file.path)
+
+    monkeypatch.setattr(
+        "mtplx.aria2_downloader.run_aria2_downloads",
+        fake_run,
+    )
+
+    hf_loader._download_repo_files_with_aria2(
+        [repo_file],
+        executable="/opt/homebrew/bin/aria2c",
+        repo_id="org/repo",
+        revision="commit",
+        destination=destination,
+        hf_hub_url=lambda **_kwargs: "https://example.invalid/weights",
+        build_hf_headers=lambda token=None: {
+            "authorization": f"Bearer {token}",
+        },
+        token="hf_secret",
+        callback=events.append,
+        total_bytes=len(content),
+        started_at=time.monotonic(),
+        progress_interval_s=0.1,
+        last_emit_at=time.monotonic(),
+        last_emit_size=0,
+    )
+
+    jobs = captured["jobs"]
+    assert isinstance(jobs, list)
+    assert jobs[0].sha256 == sha256
+    assert jobs[0].headers == ("authorization: Bearer hf_secret",)
+    assert (destination / repo_file.path).read_bytes() == content
+    assert not (destination / f"{repo_file.path}.incomplete").exists()
+    assert any(event["event"] == "progress" for event in events)
+
+
+def test_pull_parser_accepts_aria2_backend():
+    args = build_parser().parse_args(
+        ["pull", "org/repo", "--download-backend", "aria2"]
+    )
+
+    assert args.download_backend == "aria2"
+
+
+@pytest.mark.skipif(shutil.which("aria2c") is None, reason="aria2c is not installed")
+def test_aria2_runner_resumes_against_range_server(tmp_path: Path):
+    content = bytes(range(256)) * 8192
+    range_requests: list[str] = []
+
+    class RangeHandler(BaseHTTPRequestHandler):
+        def do_HEAD(self):
+            self._send(include_body=False)
+
+        def do_GET(self):
+            self._send(include_body=True)
+
+        def _send(self, *, include_body: bool):
+            start = 0
+            end = len(content) - 1
+            requested = self.headers.get("Range")
+            if requested:
+                range_requests.append(requested)
+                match = re.fullmatch(r"bytes=(\d+)-(\d*)", requested)
+                assert match is not None
+                start = int(match.group(1))
+                if match.group(2):
+                    end = min(end, int(match.group(2)))
+                if start >= len(content):
+                    self.send_response(416)
+                    self.send_header("Content-Range", f"bytes */{len(content)}")
+                    self.end_headers()
+                    return
+                self.send_response(206)
+                self.send_header("Content-Range", f"bytes {start}-{end}/{len(content)}")
+            else:
+                self.send_response(200)
+            body = content[start : end + 1]
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if include_body:
+                self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RangeHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    output = tmp_path / "weights.incomplete"
+    output.write_bytes(content[: 512 * 1024])
+    progress: list[tuple[int, float, str | None]] = []
+    try:
+        run_aria2_downloads(
+            [
+                Aria2Download(
+                    url=f"http://127.0.0.1:{server.server_port}/weights",
+                    output=output,
+                    expected_size=len(content),
+                    sha256=hashlib.sha256(content).hexdigest(),
+                    display_name="weights",
+                )
+            ],
+            executable=shutil.which("aria2c") or "aria2c",
+            progress_callback=lambda *event: progress.append(event),
+            progress_interval_s=0.1,
+            connections=4,
+            concurrent_downloads=1,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert output.read_bytes() == content
+    assert range_requests
+    assert progress[-1][0] == len(content)

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -8314,12 +8314,19 @@ def test_pull_progress_json_emits_ndjson_events(tmp_path, monkeypatch, capsys):
     import mtplx.hf_loader as hf_loader
 
     def fake_pull_model(
-        model, *, cache_dir, revision, progress_callback, progress_interval_s
+        model,
+        *,
+        cache_dir,
+        revision,
+        progress_callback,
+        progress_interval_s,
+        download_backend,
     ):
         assert model == "mtplx/example"
         assert cache_dir == str(tmp_path)
         assert revision is None
         assert progress_interval_s == 0.4
+        assert download_backend == "auto"
         progress_callback(
             {
                 "event": "start",


### PR DESCRIPTION
## Summary

- add an optional aria2c backend for parallel Hugging Face model pulls
- resume existing .incomplete files with 16 segmented connections and four concurrent files
- report accurate structured progress through aria2 JSON-RPC instead of sparse-file size
- verify Hugging Face SHA-256 checksums before atomic rename
- keep Hugging Face credentials off process arguments and fall back to Python when aria2c is unavailable

## Usage

Install aria2 with Homebrew, then use the default auto selection or pass --download-backend aria2 to require it. Pass --download-backend python to retain the built-in path.

## Verification

- repository CI test set plus aria2, Hugging Face loader, and artifact suites
- real loopback aria2 resume from a 512 KiB partial with final SHA-256 verification
- Python bytecode compilation

Closes #451