### PR TITLE
server+session bank: the admission shed asks the live sessions for reuse and walks the bank before letting a request die (#447)

### DIFF
--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -17435,6 +17435,18 @@ def _prefill_admission_min_miss_tokens() -> int:
         return 4096
 
 
+def _prefill_admission_live_prefix_enabled() -> bool:
+    return os.environ.get(
+        "MTPLX_PREFILL_ADMISSION_LIVE_PREFIX", "1"
+    ).strip().lower() not in {"0", "off", "false", "no"}
+
+
+def _prefill_admission_chain_shed_enabled() -> bool:
+    return os.environ.get(
+        "MTPLX_PREFILL_ADMISSION_CHAIN_SHED", "1"
+    ).strip().lower() not in {"0", "off", "false", "no"}
+
+
 # Same line as _allocator_pressure_level's WARNING edge: at >=97% of the
 # Metal limit the next growth step swaps.
 _PREFILL_ADMISSION_PRESSURE_FRACTION = 0.97
@@ -17555,6 +17567,56 @@ def _prefill_admission_shed(
                 if block_tokens > reused_tokens:
                     reused_tokens = block_tokens
                     reused_mode = "block_prefix"
+        # The bank is not the only holder of reusable state: the engine's
+        # live sessions serve a committed prefix directly (that is what a
+        # warm turn's cached_tokens reads), and a live frontier can be
+        # unbanked — a refused snapshot (retokenized-history mismatch)
+        # banks nothing while the live KV still serves. Estimating from
+        # the bank alone read a warm 212k-token session as a full miss,
+        # cleared its snapshots as "superseded", and every client retry
+        # was then a 211,807-token cold miss that could never be admitted
+        # until a server restart (#447).
+        if _prefill_admission_live_prefix_enabled():
+            sessions = getattr(state, "sessions", None)
+            live_tokens = 0
+            if sessions is not None:
+                # Ask the same ladder session resolution asks (exact, then
+                # pending-postcommit near prefix, then best common prefix),
+                # with the non-exact answers rewound to the block floor the
+                # bank estimate above uses — the reuse a request achieves
+                # is never more optimistic than resolution's own match.
+                try:
+                    exact_fn = getattr(sessions, "longest_prefix_session", None)
+                    live = exact_fn(prompt_ids) if callable(exact_fn) else None
+                    if live is not None:
+                        live_tokens = len(
+                            getattr(live, "committed_token_ids", ()) or ()
+                        )
+                    if live_tokens <= 0:
+                        near_fn = getattr(
+                            sessions, "pending_near_prefix_session", None
+                        )
+                        if callable(near_fn):
+                            near, matched = near_fn(prompt_ids)
+                            if near is not None:
+                                live_tokens = _block_restorable_prefix_tokens(
+                                    int(matched)
+                                )
+                    if live_tokens <= 0:
+                        common_fn = getattr(
+                            sessions, "best_common_prefix_session", None
+                        )
+                        if callable(common_fn):
+                            shared, matched = common_fn(prompt_ids)
+                            if shared is not None:
+                                live_tokens = _block_restorable_prefix_tokens(
+                                    int(matched)
+                                )
+                except Exception:
+                    live_tokens = 0
+            if live_tokens > reused_tokens:
+                reused_tokens = int(live_tokens)
+                reused_mode = "live_session"
         miss_tokens = max(0, prompt_tokens - reused_tokens)
         if miss_tokens < _prefill_admission_min_miss_tokens():
             return None
@@ -17601,6 +17663,38 @@ def _prefill_admission_shed(
                             protect_active=True,
                         )
                     )
+                # Escalation between the protected LRU pass and giving up
+                # (#447): a deep session's sibling snapshots — forked
+                # generations of the same conversation that no put()-time
+                # supersede collapses — are active-protected above, so a
+                # 12.6 GiB bank served a 7 GiB deficit with zero evictions
+                # and the request died on the sustained-pressure 507. Walk
+                # those chain prefixes (never a session's terminal entry,
+                # never the entry this prompt restores from; the SSD cold
+                # tier keeps every eviction restorable) before letting the
+                # prefill start into a projection that crosses the line.
+                if _prefill_admission_chain_shed_enabled():
+                    bank_bytes_now = int(session_bank.total_nbytes)
+                    remaining = deficit - max(
+                        0, bank_bytes_before - bank_bytes_now
+                    )
+                    chain_fn = getattr(
+                        session_bank, "shrink_for_admission", None
+                    )
+                    if (
+                        remaining > 0
+                        and bank_bytes_now > 0
+                        and callable(chain_fn)
+                    ):
+                        chain_evicted, terminal_evicted = chain_fn(
+                            max(0, bank_bytes_now - remaining),
+                            protect_tokens=prompt_ids,
+                            reason="prefill_admission_chain",
+                        )
+                        receipt["chain_entries_evicted"] = int(chain_evicted)
+                        receipt["terminal_entries_evicted"] = int(
+                            terminal_evicted
+                        )
                 receipt["bank_bytes_after"] = int(session_bank.total_nbytes)
             except Exception as exc:
                 receipt["bank_error"] = repr(exc)

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -2759,6 +2759,111 @@ class SessionBank:
             evicted += 1
         return evicted
 
+    def shrink_for_admission(
+        self,
+        target_bytes: int,
+        *,
+        protect_tokens: list[int] | tuple[int, ...] | None = None,
+        reason: str = "prefill_admission_chain",
+    ) -> tuple[int, int]:
+        """Escalating eviction for the admission shed (#447).
+
+        Runs only when the pre-prefill projection says the request in front
+        of us is likely to die on the sustained-pressure abort, after the
+        superseded clear and the ``protect_active`` LRU pass both came up
+        short: a deep session's sibling snapshots — forked generations of
+        the same conversation whose retokenized histories diverge, so
+        ``_supersede_contained_prefixes`` never collapses them — are all
+        active-protected there. A 12.6 GiB bank served a 7 GiB deficit
+        with zero evictions and the request 507'd.
+
+        Phase 1 walks non-terminal entries (any session keeps its highest
+        ``prefix_len`` entry — the one the protected-terminal order guards).
+        Phase 2, only if the deficit stands, takes remaining entries in the
+        take-anything order of real memory pressure (active sessions last).
+        Both phases spare the entry the imminent prompt restores from
+        (``protect_tokens``), and every eviction is RAM-only: the SSD cold
+        tier still restores a walked entry, so the worst case is a disk
+        read on some session's next turn, not this request's abort.
+        Returns ``(non_terminal_evicted, terminal_evicted)``.
+        """
+        target = max(0, int(target_bytes))
+        protected_keys: set[tuple[int, ...]] = set()
+        if protect_tokens:
+            tokens = tuple(int(token) for token in protect_tokens)
+            best_key = None
+            best_common = 0
+            for key, entry in self._entries.items():
+                common = common_prefix_len(tokens, entry.token_ids)
+                if common > best_common:
+                    best_common = common
+                    best_key = key
+            if best_key is not None:
+                protected_keys.add(best_key)
+
+        def _walk(candidates_fn, order_key) -> int:
+            evicted = 0
+            while self._entries and self.total_nbytes > target:
+                candidates = candidates_fn()
+                if not candidates:
+                    break
+                victim = min(candidates, key=order_key)
+                before = len(self._entries)
+                self._evict_entry(victim, reason=reason)
+                if len(self._entries) >= before:
+                    break
+                evicted += 1
+            return evicted
+
+        def _evictable(entry) -> bool:
+            # Entries holding a live cache reference are the live session's
+            # own arrays (the same bar _supersede_contained_prefixes sets);
+            # walking one frees nothing and costs the running session its
+            # state. Measured: the first decode after such an eviction ran
+            # at 15 tok/s against 63 stock.
+            return entry.cache_ref is None and not entry.live_ref_only
+
+        def _non_terminal_candidates():
+            terminal: dict[str, int] = {}
+            for entry in self._entries.values():
+                lineage = entry.session_id or ""
+                if entry.prefix_len > terminal.get(lineage, -1):
+                    terminal[lineage] = entry.prefix_len
+            return [
+                entry
+                for key, entry in self._entries.items()
+                if key not in protected_keys
+                and _evictable(entry)
+                and entry.prefix_len < terminal.get(entry.session_id or "", -1)
+            ]
+
+        non_terminal = _walk(
+            _non_terminal_candidates,
+            lambda entry: (
+                entry.last_access_s,
+                -entry.nbytes,
+                entry.created_at_s,
+            ),
+        )
+        if self.total_nbytes <= target:
+            return non_terminal, 0
+
+        active = self._active_session_ids()
+        terminal_evicted = _walk(
+            lambda: [
+                entry
+                for key, entry in self._entries.items()
+                if key not in protected_keys and _evictable(entry)
+            ],
+            lambda entry: (
+                entry.session_id in active,
+                entry.last_access_s,
+                -entry.nbytes,
+                entry.created_at_s,
+            ),
+        )
+        return non_terminal, terminal_evicted
+
     def _evict_entry(self, entry: SessionBankEntry, *, reason: str) -> None:
         entry.eviction_reason = reason
         if self._entries.pop(entry.token_ids, None) is None:

--- a/tests/test_prefill_admission_shed.py
+++ b/tests/test_prefill_admission_shed.py
@@ -327,3 +327,281 @@ class TestBlockPrefixRestorableEntries:
         assert receipt is not None
         assert receipt["reusable_prefix_tokens"] == 0
         assert bank.cleared_sessions == ["gate"]
+
+
+class _LiveSession:
+    def __init__(self, committed):
+        self.committed_token_ids = tuple(int(t) for t in committed)
+
+
+def _state_with_live(committed, *, near=None, common=None):
+    """Fake EngineSessionManager exposing the resolution ladder: exact
+    containment, then (near, matched) / (common, matched) tuples."""
+    state = _state()
+    live = _LiveSession(committed)
+
+    def longest_prefix_session(token_ids):
+        tokens = tuple(int(t) for t in token_ids)
+        prefix = live.committed_token_ids
+        if prefix and len(prefix) <= len(tokens) and tokens[: len(prefix)] == prefix:
+            return live
+        return None
+
+    state.sessions = SimpleNamespace(
+        longest_prefix_session=longest_prefix_session,
+        pending_near_prefix_session=lambda token_ids: near or (None, 0),
+        best_common_prefix_session=lambda token_ids: common or (None, 0),
+    )
+    return state
+
+
+class TestLiveSessionPrefix:
+    """#447, receipt 2: a warm 212k session whose newest turns were never
+    banked (snapshot commits refused on retokenized-history mismatch) read
+    as a full miss, was cleared as "superseded", and every client retry was
+    a 211,807-token cold miss. The engine's live sessions are the state the
+    request actually reuses; the shed must ask them too."""
+
+    def test_live_prefix_under_the_miss_floor_leaves_the_guard_inert(
+        self, monkeypatch
+    ):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:97_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        assert _shed(state, prompt, bank, "warm") is None
+        assert bank.cleared_sessions == []
+        assert entry in bank.entries
+
+    def test_live_prefix_pins_instead_of_clearing(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:60_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        assert receipt["reusable_prefix_tokens"] == 60_000
+        assert receipt["miss_tokens"] == 40_000
+        assert bank.cleared_sessions == []
+        assert "warm" in bank.touched
+
+    def test_live_prefix_yields_to_the_export(self, monkeypatch):
+        monkeypatch.setenv("MTPLX_PREFILL_ADMISSION_LIVE_PREFIX", "0")
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:60_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+        assert bank.cleared_sessions == ["warm"]
+
+    def test_state_without_sessions_keeps_the_bank_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(_state(), prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+        assert bank.cleared_sessions == ["warm"]
+
+
+class _ChainBank(_Bank):
+    """Active-protecting bank: shrink_to_bytes honors protect_active the way
+    the real bank does (touched sessions are the active set), and the chain
+    walk keeps each session's longest entry plus the protect_tokens match."""
+
+    def __init__(self, entries):
+        super().__init__(entries)
+        self.chain_calls: list[tuple[int, str]] = []
+
+    def shrink_to_bytes(self, target_bytes, *, reason="", protect_active=False):
+        self.shrink_calls.append((int(target_bytes), reason, protect_active))
+        evicted = 0
+        active = set(self.touched)
+        while self.entries and self.total_nbytes > int(target_bytes):
+            candidates = [
+                e
+                for e in self.entries
+                if not (protect_active and e.session_id in active)
+            ]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            evicted += 1
+        return evicted
+
+    def shrink_for_admission(self, target_bytes, *, protect_tokens=None, reason=""):
+        self.chain_calls.append((int(target_bytes), reason))
+        protected = set()
+        if protect_tokens:
+            tokens = tuple(int(t) for t in protect_tokens)
+            best, best_common = None, 0
+            for e in self.entries:
+                common = 0
+                for left, right in zip(tokens, e.token_ids):
+                    if left != right:
+                        break
+                    common += 1
+                if common > best_common:
+                    best, best_common = e, common
+            if best is not None:
+                protected.add(id(best))
+        non_terminal = 0
+        while self.entries and self.total_nbytes > int(target_bytes):
+            terminal = {}
+            for e in self.entries:
+                key = e.session_id or ""
+                terminal[key] = max(terminal.get(key, -1), len(e.token_ids))
+            candidates = [
+                e
+                for e in self.entries
+                if id(e) not in protected
+                and len(e.token_ids) < terminal.get(e.session_id or "", -1)
+            ]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            non_terminal += 1
+        terminals = 0
+        while self.entries and self.total_nbytes > int(target_bytes):
+            candidates = [e for e in self.entries if id(e) not in protected]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            terminals += 1
+        return non_terminal, terminals
+
+
+class TestChainPrefixEscalation:
+    """#447, receipt 1: 12.6 GiB of a deep session's own sibling snapshots
+    were active-protected, the LRU pass evicted nothing, and a warm turn
+    with a 23k miss died on the sustained-pressure 507."""
+
+    def _fixture(self):
+        prompt = list(range(100_000))
+        exact = _Entry(prompt[:50_000], "deep", 2 * GIB)
+        terminal = _Entry(prompt[:49_000] + list(range(700_000, 711_000)), "deep", 3 * GIB)
+        sibling = _Entry(prompt[:30_000] + list(range(800_000, 800_400)), "deep", 6 * GIB)
+        return prompt, exact, terminal, sibling
+
+    def test_sibling_snapshots_are_walked_when_lru_is_protected(
+        self, monkeypatch
+    ):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _ChainBank([exact, terminal, sibling])
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert receipt["reusable_prefix_tokens"] == 50_000
+        assert receipt["lru_entries_evicted"] == 0
+        assert receipt["chain_entries_evicted"] == 1
+        assert receipt["terminal_entries_evicted"] == 0
+        assert sibling not in bank.entries
+        assert exact in bank.entries
+        assert terminal in bank.entries
+        assert receipt["bank_bytes_after"] == 5 * GIB
+
+    def test_chain_walk_yields_to_the_export(self, monkeypatch):
+        monkeypatch.setenv("MTPLX_PREFILL_ADMISSION_CHAIN_SHED", "0")
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _ChainBank([exact, terminal, sibling])
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert "chain_entries_evicted" not in receipt
+        assert bank.chain_calls == []
+        assert sibling in bank.entries
+
+    def test_bank_without_the_method_is_tolerated(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _Bank([exact, terminal, sibling])
+        bank.shrink_to_bytes = lambda *a, **k: 0
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert "chain_entries_evicted" not in receipt
+
+
+class TestLiveSessionLadder:
+    """The resolution ladder: a mutated history (retokenized turns, the
+    #446 fork shape) misses exact containment but is still served by the
+    pending-near-prefix and best-common lookups; the shed's estimate must
+    follow the same ladder or it reads a warm engine as a full miss."""
+
+    def test_pending_near_prefix_serves_the_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live((), near=(_LiveSession(prompt[:60_000]), 60_000))
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        expected = srv._block_restorable_prefix_tokens(60_000)
+        assert receipt["reusable_prefix_tokens"] == expected
+        assert bank.cleared_sessions == []
+
+    def test_best_common_serves_the_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live((), common=(_LiveSession(prompt[:60_000]), 60_000))
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        assert receipt["reusable_prefix_tokens"] == srv._block_restorable_prefix_tokens(60_000)
+
+    def test_exact_wins_over_the_tolerant_rungs(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(
+            prompt[:60_000], common=(_LiveSession(prompt[:10_000]), 10_000)
+        )
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_tokens"] == 60_000
+
+    def test_ladder_exceptions_never_cost_the_request(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state()
+
+        def boom(token_ids):
+            raise RuntimeError("probe blew up")
+
+        state.sessions = SimpleNamespace(
+            longest_prefix_session=boom,
+            pending_near_prefix_session=boom,
+            best_common_prefix_session=boom,
+        )
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+
+
+class TestTerminalPhase:
+    """Phase 2 (#447): when non-terminal walking cannot cover the deficit
+    (every fork is its own session's terminal — the post-#446 shape), the
+    walk takes remaining entries rather than letting the request die, but
+    never the entry the imminent prompt restores from."""
+
+    def test_other_terminals_fall_when_siblings_are_not_enough(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        exact = _Entry(prompt[:50_000], "deep", 2 * GIB)
+        fork = _Entry(prompt[:20_000] + list(range(900_000, 950_000)), "fork-session", 6 * GIB)
+        bank = _ChainBank([exact, fork])
+        bank.touched.append("fork-session")  # recently active: LRU pass skips it
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert receipt["chain_entries_evicted"] == 0
+        assert receipt["terminal_entries_evicted"] == 1
+        assert fork not in bank.entries
+        assert exact in bank.entries

--- a/tests/test_session_bank_chain_shed.py
+++ b/tests/test_session_bank_chain_shed.py
@@ -1,0 +1,129 @@
+"""#447: SessionBank.shrink_for_admission — escalating eviction for the
+admission shed. Phase 1 walks non-terminal chain entries (every session
+keeps its highest-prefix entry); phase 2, only if the deficit stands,
+takes remaining entries in take-anything order with active sessions last.
+Both phases spare the entry the imminent prompt restores from.
+
+Pure host tests -- synthetic entries, ``cache=[]`` plus ``nbytes_override``,
+no MLX, no model, no Metal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from mtplx.session_bank import SessionBank
+
+
+RUNTIME = SimpleNamespace(model_path=Path("models/example"), mtp_enabled=True)
+
+
+def _bank(**kwargs) -> SessionBank:
+    defaults = dict(max_entries=16, max_bytes=10_000, per_session_max_bytes=10_000)
+    defaults.update(kwargs)
+    return SessionBank(**defaults)
+
+
+def _put(bank: SessionBank, tokens, *, session_id: str, nbytes: int):
+    return bank.put(
+        runtime=RUNTIME,
+        token_ids=list(tokens),
+        cache=[],
+        logits=None,
+        hidden=None,
+        session_id=session_id,
+        nbytes_override=nbytes,
+    )
+
+
+def _keys(bank: SessionBank):
+    return set(bank._entries.keys())
+
+
+def test_phase_one_evicts_the_sibling_and_stops():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)      # sibling fork
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)  # terminal of a
+    _put(bank, (7, 7, 7), session_id="b", nbytes=50)         # terminal of b
+    assert bank.shrink_for_admission(150) == (1, 0)
+    assert _keys(bank) == {(1, 2, 3, 4, 5), (7, 7, 7)}
+
+
+def test_phase_two_takes_terminals_when_siblings_are_not_enough():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    _put(bank, (7, 7, 7), session_id="b", nbytes=50)
+    non_terminal, terminal = bank.shrink_for_admission(
+        0, protect_tokens=(1, 2, 3, 4, 5, 6)
+    )
+    assert non_terminal == 1
+    assert terminal == 1
+    # The imminent prompt's restore source survives both phases.
+    assert _keys(bank) == {(1, 2, 3, 4, 5)}
+
+
+def test_protect_tokens_shields_the_restore_source():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    non_terminal, terminal = bank.shrink_for_admission(
+        0, protect_tokens=(1, 2, 9, 9, 10)
+    )
+    # The shorter fork is what this prompt restores from: phase 1 skips it,
+    # phase 2 takes the session's terminal instead.
+    assert (non_terminal, terminal) == (0, 1)
+    assert _keys(bank) == {(1, 2, 9, 9)}
+
+
+def test_phase_two_takes_active_sessions_last():
+    import time
+
+    bank = _bank()
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    _put(bank, (7, 7), session_id="b", nbytes=100)
+    # put() stamps the active pin for both; age b out of the TTL so only
+    # a is active when phase 2 orders its victims.
+    bank._session_last_active["b"] = time.monotonic() - 100_000
+    non_terminal, terminal = bank.shrink_for_admission(100)
+    assert (non_terminal, terminal) == (0, 1)
+    assert _keys(bank) == {(1, 2, 3)}
+
+
+def test_lru_order_among_siblings():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)            # oldest sibling
+    _put(bank, (1, 8, 8), session_id="a", nbytes=60)         # newer sibling
+    _put(bank, (1, 2, 3, 4, 5, 6), session_id="a", nbytes=100)
+    assert bank.shrink_for_admission(160) == (1, 0)
+    assert (1, 9) not in _keys(bank)
+    assert (1, 8, 8) in _keys(bank)
+
+
+def test_target_already_met_is_a_no_op():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    assert bank.shrink_for_admission(1_000) == (0, 0)
+    assert len(bank._entries) == 2
+
+
+def test_eviction_reason_is_recorded():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    bank.shrink_for_admission(100, reason="prefill_admission_chain")
+    assert bank.eviction_log[-1]["reason"] == "prefill_admission_chain"
+
+
+def test_live_referenced_entries_are_never_victims():
+    bank = _bank()
+    fork = _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    # The fork's arrays are the live session's own state (a live-ref lease):
+    # walking it frees nothing and costs the running session its state.
+    fork.cache_ref = object()
+    assert bank.shrink_for_admission(0) == (0, 1)
+    assert (1, 2, 9, 9) in _keys(bank)
+    assert (1, 2, 3, 4, 5) not in _keys(bank)


### PR DESCRIPTION
## Summary

Fixes the two admission-shed defects from #447, each behind an explicit-export kill switch and with its receipt extended:

1. **The reuse estimate now asks the live sessions, not just the bank** (`MTPLX_PREFILL_ADMISSION_LIVE_PREFIX`). The engine's live sessions serve a committed prefix directly — that is what `cached_tokens` reads on every warm turn — and a live frontier can be unbanked (a refused snapshot on retokenized-history mismatch banks nothing while the live KV still serves). Estimating from the bank alone read a warm 212k session as a full miss, cleared its snapshots as "superseded", and every retry was then a 211,807-token cold miss until a server restart. The shed now walks the same ladder session resolution walks (`longest_prefix_session` → `pending_near_prefix_session` → `best_common_prefix_session`, tolerant answers rewound to the block floor the bank estimate already uses) and reports `reusable_prefix_mode: "live_session"`.

2. **When the projection crosses the line, the shed escalates through the bank instead of letting the request die** (`MTPLX_PREFILL_ADMISSION_CHAIN_SHED`). New `SessionBank.shrink_for_admission`: phase 1 walks non-terminal chain entries (every session keeps its highest-prefix entry — the one the protected-terminal order guards); phase 2, only if the deficit stands, takes remaining entries in the take-anything order real memory pressure uses (active sessions last). Both phases spare the entry the imminent prompt restores from and never touch a live-referenced entry (the same bar `_supersede_contained_prefixes` sets). Evictions are RAM-only — the SSD cold tier still restores a walked entry, so the worst case is a disk read on some session's next turn, not this request's abort. `shrink_to_bytes` and its dynamic-ceiling / macOS-pressure callers are unchanged. The receipt gains `chain_entries_evicted` and `terminal_entries_evicted`.

## Verification

- `tests/test_prefill_admission_shed.py`: all pre-existing tests unchanged and passing; new cases for the live ladder (inert under the miss floor, pin-instead-of-clear, exact beats tolerant rungs, exceptions never cost the request, export yields), and for the escalation (siblings walked when LRU is protected, terminals only in phase 2, export yields, banks without the method tolerated).
- New `tests/test_session_bank_chain_shed.py`: phase ordering, protect_tokens shielding, live-ref entries never victims, active-last ordering in phase 2, LRU among siblings, reasons recorded.
- Full run: the admission + session-bank suites (incl. `test_session_bank_restore_aliasing.py`, `test_session_bank_snapshot_settle.py`, `test_session_bank_protected_terminal.py`), plus the CONTRIBUTING trio (`test_no_mlx_imports.py`, `test_public_cli.py`, `test_runtime_kpis.py`), `python -m build`, and `scripts/fresh_venv_smoke.sh` — all green.
- `scripts/agent_session_gate.py --context-tokens 40000` against a serving daemon: `pass: true, failures: []` on this branch (and on stock 2.11.1 for the baseline).

**Incident replay (the #447 receipt-1 scenario)** — 115k incremental session, cross-session vision call 0.5 s after the deep turn, then the next warm turn, M5 Max 128 GB, Optimized-Speed pack, SSD session cache on:

- stock 2.11.1: next turn **HTTP 507** (`reusable exact 114,880, miss 23,086, projected 107.0 G > threshold 100.0 G, bank 12.6 GiB resident, lru_entries_evicted: 0, cache_cleared`), then `allocation_failure_shed`.
- this branch: next turn **completes in 33 s, `cached=114,941`** — receipt: `reusable_prefix_mode: exact 114,941, chain_entries_evicted: 0, terminal_entries_evicted: 2, bank 8.35 → 4.35 GiB`. Reproduced twice (33.0 s / 33.5 s).

**Estimate A/B (receipt-2 shape)** — incremental session with snapshots too large to bank (`MTPLX_SESSION_BANK_MAX_BYTES=256MiB`) under a reduced `MTPLX_MEMORY_LIMIT_BYTES`: on the same turn, stock's shed read `reusable_prefix_tokens: 0, mode: none` while the completed turn itself reported `cached=37,963`; this branch read `mode: live_session, reusable 38,188`.

## Benchmark Evidence

No decode or prefill path is touched; the guard runs pre-prefill only, and with no shed firing the code is inert (verified: zero guard events in the parity runs below).

- Hardware: MacBook Pro M5 Max, 128 GB. Model: `Youssofal--Qwen3.8-Flash-Next-MTPLX-Optimized-Speed` (trunk 4-bit dynamic + 8-bit attention). Sampler: temp 0.3 / top-p 0.9 / top-k 40, reasoning high, MTP depth 3, draft temp 0.3, turbo profile, context window 262144, 700-token code answers. Fans: system default (no fan control). Date: 2026-09-04. Baseline: brew 2.11.1 (`dd4031a`); branch: this PR.
- Short context (23k prompt, one round each, zero guard events both arms): decode 65.3 vs 67.1 tok/s median, prefill 883 vs 976 tok/s — within this workload's run-to-run spread.
- Deep context (5 × 23k incremental to ~115k, full-cache decode, 120 s settle before each arm, rotated order, 5 branch / 6 stock samples across three sessions): medians ~64 vs ~64 tok/s. Both arms occasionally show a single ~16 tok/s generation at ~115k during an allocator-deferral window (observed on stock and branch alike; pre-existing, unrelated to this change).

Harness scripts and full serve logs available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
