### PR TITLE
tune: let Qwen 3.8 Flash-Next (qwen4_exp) be measured

### DIFF
--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -1250,6 +1250,14 @@ def tune_policy_for_model(
         return GEMMA4_ASSISTANT_DESCRIPTOR.tune_policy
     if family == "step":
         return STEP3P5_MTP_DESCRIPTOR.tune_policy
+    if family == "qwen4_exp":
+        # Qwen 3.8 Flash-Next: backend qwen4_exp, can_run_verified=True, packs
+        # record mtp_depth_max 3. The allowlist stopped at qwen3_8, so tune
+        # called the model unsupported.
+        return TunePolicy(
+            supported=True,
+            candidates=("AR", "D1", "D2", "D3"),
+        )
     return TunePolicy(
         supported=False,
         unsupported_reason="Tune is supported for Qwen 3.5, Qwen 3.6, Qwen 3.8, and Gemma 4 MTPLX models only.",

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2250,6 +2250,18 @@ def _exact_paged_env_from_args(args: Any) -> dict[str, str]:
     return exact_paged_attention_env(**_exactness_profile_kwargs(args))
 
 
+
+def _model_config_is_qwen4_exp(model: str) -> bool:
+    """Mirror of the server's qwen4_exp predicate: read the pack config."""
+    try:
+        with open(Path(str(model)) / "config.json", "rb") as fh:
+            cfg = json.load(fh)
+    except Exception:
+        return False
+    mt = str(cfg.get("model_type") or "").lower()
+    tmt = str((cfg.get("text_config") or {}).get("model_type") or "").lower()
+    return "qwen4_exp" in (mt, tmt) or "qwen4_exp_text" in (mt, tmt)
+
 def _depth_sweep_native60(
     *,
     model: str,
@@ -2276,6 +2288,7 @@ def _depth_sweep_native60(
 ) -> dict[str, Any]:
     from mtplx.benchmarks.runners.mtp_depth_sweep import run_mtp_depth_sweep
 
+    _family_batched = _model_config_is_qwen4_exp(model)
     previous = apply_profile_env("performance-cold")
     if runtime_env:
         os.environ.update({key: str(value) for key, value in runtime_env.items()})
@@ -2313,9 +2326,15 @@ def _depth_sweep_native60(
             mtp_cache_policy=mtp_cache_policy,
             mtp_history_policy=mtp_history_policy,
             min_speculative_depth=1,
-            verify_strategy="capture_commit",
+            # qwen4_exp cannot run the qwen3-next structure verify lanes: their
+            # capture stack introspects the qwen3-next DecoderLayer layout
+            # (input_layernorm et al.) and raises on Flash-Next hyper-connection
+            # layers. The family's repair-free lane wraps the batched verify
+            # (MTPLX_FAMILY_CAPTURE_COMMIT), so batched is the base strategy
+            # there -- the same coercion the server applies at boot.
+            verify_strategy="batched" if _family_batched else "capture_commit",
             draft_core=str(draft_core or "stock"),
-            verify_core="linear-gdn-from-conv-tape",
+            verify_core="stock" if _family_batched else "linear-gdn-from-conv-tape",
             draft_lm_head_bits=int(draft_lm_head["bits"]),
             draft_lm_head_group_size=int(draft_lm_head["group_size"]),
             draft_lm_head_mode=str(draft_lm_head["mode"]),

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -11595,7 +11595,13 @@ def generate_mtpk(
 
         before_verify = None
         if a3b_target_prefix_route is None:
-            if _skip_verify_snapshot():
+            # The family capture lane commits by replaying the GDN recurrences
+            # from the pre-verify snapshot (commit_verified_window), so it needs
+            # that snapshot regardless of MTPLX_SKIP_VERIFY_SNAPSHOT -- the same
+            # rule the block round applies above. The lazy snapshot is
+            # zero-copy, so honouring the skip here only removes the commit's
+            # input and forces the rollback + re-forward fallback.
+            if _skip_verify_snapshot() and not family_capture_commit_active:
                 event["snapshot"] = "skipped_capture_commit_required"
             else:
                 started = time.perf_counter()

--- a/tests/test_descriptors_qwen4_exp_tune.py
+++ b/tests/test_descriptors_qwen4_exp_tune.py
@@ -1,0 +1,42 @@
+"""Tune is enabled for the Qwen 3.8 Flash-Next family (qwen4_exp).
+
+qwen4-next ships backend qwen4_exp with can_run_verified=True and the forged
+packs record mtp_depth_max 3, yet the family never reached tune: the allowlist
+stopped at qwen3_8, so `mtplx tune` reported the model unsupported and no
+depth could be measured or chosen for the geometry that 2.11 made its headline
+decode lane.
+"""
+
+from __future__ import annotations
+
+from mtplx.backends.descriptors import (
+    model_family_from_inspection,
+    tune_policy_for_model,
+)
+
+FLASH_NEXT_INSPECTION = {
+    "model_type": "qwen4_exp_text",
+    "architecture": "Qwen4ExpForConditionalGeneration",
+    "mtp_arch": "qwen4-next",
+    "num_hidden_layers": 48,
+    "mtp_num_hidden_layers": 1,
+}
+
+
+def test_flash_next_resolves_to_the_qwen4_exp_family():
+    assert model_family_from_inspection(FLASH_NEXT_INSPECTION) == "qwen4_exp"
+
+
+def test_tune_is_supported_for_flash_next():
+    assert tune_policy_for_model(inspection=FLASH_NEXT_INSPECTION).supported is True
+
+
+def test_flash_next_offers_depths_one_to_three():
+    policy = tune_policy_for_model(inspection=FLASH_NEXT_INSPECTION)
+    assert policy.candidates == ("AR", "D1", "D2", "D3")
+
+
+def test_the_family_does_not_ride_the_dense_qwen3_8_contract():
+    # Flash-Next carries "3.8" in its public name; it must resolve to its own
+    # family, not the dense-27B qwen3_8 behaviour contract.
+    assert model_family_from_inspection({"model_type": "qwen4_exp_text"}) != "qwen3_8"

--- a/tests/test_tune_qwen4_exp_verify_strategy.py
+++ b/tests/test_tune_qwen4_exp_verify_strategy.py
@@ -1,0 +1,41 @@
+"""The tune candidate runner reads the pack config to pick the verify lane.
+
+_depth_sweep_native60 hardcoded verify_strategy="capture_commit" and the
+linear-gdn-from-conv-tape capture backend for every candidate. Those are
+qwen3-next structure lanes: their capture stack introspects the qwen3-next
+DecoderLayer layout (input_layernorm et al.) and raises AttributeError on
+Flash-Next hyper-connection layers. The server already coerces qwen4_exp to
+'batched' at boot; the candidate runner now applies the same predicate.
+"""
+
+from __future__ import annotations
+
+import json
+
+from mtplx.commands.public import _model_config_is_qwen4_exp
+
+
+def _write(tmp_path, config):
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    return str(tmp_path)
+
+
+def test_flash_next_pack_is_recognised_from_its_text_config(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen4_exp", "text_config": {"model_type": "qwen4_exp_text"}})
+    assert _model_config_is_qwen4_exp(path) is True
+
+
+def test_top_level_model_type_alone_is_enough(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen4_exp_text"})
+    assert _model_config_is_qwen4_exp(path) is True
+
+
+def test_dense_qwen3_5_pack_keeps_the_capture_commit_lane(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen3_5", "text_config": {"model_type": "qwen3_5_text"}})
+    assert _model_config_is_qwen4_exp(path) is False
+
+
+def test_missing_or_unreadable_config_is_not_flash_next(tmp_path):
+    assert _model_config_is_qwen4_exp(str(tmp_path)) is False
+    (tmp_path / "config.json").write_text("{not json")
+    assert _model_config_is_qwen4_exp(str(tmp_path)) is False


### PR DESCRIPTION
## Summary

`mtplx tune` does not support Qwen 3.8 Flash-Next, and forge knows it: _verify_rows_lane routes qwen4_exp packs to the family-serve lane, which boots `mtplx serve` and records two smoke rows (AR, and whatever depth the family's adaptive policy lands on) because serve is the only path that applies the family contract. That is why the shipped pack carries AR and D3 only, with no per-position acceptance and no D1/D2. This change gives tune the same contract so it becomes an instrument for the family too: a full depth sweep, acceptance by position, and the same paired protocol every other family gets.

Three things stood between tune and that, each a place where it diverged from what the server already does for this family. First, tune_policy_for_model has no qwen4_exp branch, so tune reports "supported for Qwen 3.5, Qwen 3.6, Qwen 3.8, and Gemma 4 only" although the backend is qwen4_exp with can_run_verified=True and the packs record mtp_depth_max 3. Then, with the branch in:

1. _depth_sweep_native60 hardcodes verify_strategy="capture_commit" and the linear-gdn-from-conv-tape capture backend. Those are qwen3-next structure lanes; their capture stack introspects the qwen3-next DecoderLayer layout and raises AttributeError ('DecoderLayer' has no attribute 'input_layernorm') on Flash-Next hyper-connection layers. The server's _coerce_family_verify_strategy turns those lanes into 'batched' for qwen4_exp because the family's repair-free commit wraps the batched verify. The runner now applies the same predicate, read from the pack config.

2. The family commit (commit_verified_window) replays the GDN recurrences from the pre-verify snapshot, so it needs that snapshot regardless of MTPLX_SKIP_VERIFY_SNAPSHOT. The block round already takes it unconditionally; the plain verify path honoured the skip and fell to "capture commit failed after MTPLX_SKIP_VERIFY_SNAPSHOT=1". An operator export of 0 survives apply_profile_env but the runner re-applies profile.env_dict() through a raw os.environ.update, and the flag is not in EXTERNAL_RUNTIME_ENV_KEYS. The plain path now applies the block round's rule.

Scope. Serve also applies a qwen4_exp family env block (MTPLX_FAMILY_CAPTURE_COMMIT, the fixed-M4 verifier, NAX_VERIFY off, the fused GDN/HC kernels). Tune's candidate children still do not receive it; the numbers below were taken with that block exported by the harness. Applying it on the tune path is a follow-up.


## Verification

Blocker chain reproduced at each step on the pack below: allowlist rejection; AttributeError on input_layernorm with the allowlist alone; KeyError 'conv_states' when a capture-commit lane is forced; RuntimeError on the skipped snapshot with the batched lane; then a clean sweep with the snapshot rule.

Forcing the wrong commit path by hand is the failure mode to watch for: it ran D3 at 0.80x with acceptance 0.214 on a corrupted recurrent state while the quality gate still passed. The result below has monotone per-position acceptance in the 0.9s and passes the quality gate on every row.

Tests: 8 added (qwen4_exp tune policy; the pack-config lane predicate, including the unreadable-config path). Related suites pass with no failures on the branch cut from main.


## Benchmark Evidence

    Date          2026-09-04
    Commit        7e81194, on upstream main dd4031a
    Hardware      Apple M3 Max (Mac15,9), 128 GiB, macOS 26.6.2 (25G83)
    Fan mode      fans pinned
    Profile       turbo, plus the server's qwen4_exp family env block (38 keys via _server_runtime_env_overrides)
    Model         Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed (qwen4_exp_text, 48 layers, 512 experts, mtp_depth_max 3)
    Sampler       temperature 1.0, top_p 0.95, top_k 20, seed 0, thinking disabled
    Runtime       mlx 0.32.0, mlx-lm 0.31.3, MTPLX 2.11.1
    Tokens        192 per prompt, limit 4, suite cold-long-code-192

mtplx tune, depths 1-3, two runs:

    run 1  AR 36.27   D1 45.30 (1.249x)   D2 58.42 (1.611x)   D3 73.60 (2.029x)
    run 2  AR 36.28   D1 45.26 (1.248x)   D2 58.73 (1.619x)   D3 73.88 (2.037x)
    acceptance     D1 0.939   D2 0.932/0.898   D3 0.961/0.922/0.882   (identical in both runs)

Winner D3 in both runs; quality gate passed on every row; AR drift between runs 0.03%. D3 reproduces the pack's own recorded 73.47 tok/s within 0.2%, so the tuner now measures the lane the server was already running.

Not benchmarked:

- Without the family env block the same pack runs AR at ~30.7 tok/s with ~42 GB of compressed memory on this machine. That is the tune-path gap noted under Scope, not a property of the fix.
- Other qwen4_exp packs (8-bit, FP16) were not run.
- forge's lane routing is unchanged: qwen4_exp packs still verify through family-serve. Switching forge to the tune lane for this family is a separate decision, and it should wait until the family env block reaches the tune path (see Scope).