### PR TITLE
Fix long-context recovery, verifier capacity, and Flash-Next tuning

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Services/MTPLXRuntimeBootstrapper.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Services/MTPLXRuntimeBootstrapper.swift
@@ -112,10 +112,11 @@ public struct MTPLXRuntimeBootstrapper: Sendable {
         guard isAppManagedRuntime(installedExecutable) else {
             return true
         }
-        guard let bundled = try? Self.wheelFingerprint(
-            of: URL(fileURLWithPath: wheelPath)
-        ) else {
-            return true
+        guard let selected = try? selectedBundledRuntimeWheel(
+            fallback: URL(fileURLWithPath: wheelPath),
+            python: runtimeDir.appendingPathComponent("bin/python")
+        ), let bundled = try? Self.wheelFingerprint(of: selected) else {
+            return false
         }
         return bundled == Self.recordedWheelFingerprint(runtimeDir: runtimeDir)
     }
@@ -267,7 +268,11 @@ public struct MTPLXRuntimeBootstrapper: Sendable {
         let runtimeDir = URL(
             fileURLWithPath: MTPLXCommandBuilder.appRuntimeDirectory(environment: environment)
         )
-        let fingerprint = try? Self.wheelFingerprint(of: URL(fileURLWithPath: wheelPath))
+        guard let selected = try? selectedBundledRuntimeWheel(
+            fallback: URL(fileURLWithPath: wheelPath),
+            python: runtimeDir.appendingPathComponent("bin/python")
+        ) else { return false }
+        let fingerprint = try? Self.wheelFingerprint(of: selected)
         let recheckRequested = FileManager.default.fileExists(
             atPath: Self.importRecheckRequestURL(environment: environment).path
         )
@@ -446,7 +451,34 @@ public struct MTPLXRuntimeBootstrapper: Sendable {
         return env
     }
 
-    private func installBundledRuntime(wheel: URL, rebuildFromScratch: Bool = false) throws -> URL {
+    func selectedBundledRuntimeWheel(fallback: URL, python: URL) throws -> URL {
+        let resources = fallback.deletingLastPathComponent()
+        let native = resources.appendingPathComponent("Native", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: native.path) else { return fallback }
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: native, includingPropertiesForKeys: nil
+        )
+        guard contents.contains(where: { $0.pathExtension == "whl" }) else {
+            return fallback
+        }
+        // Run against the actual venv, so pip's tags cover its Python ABI,
+        // CPU and macOS version. Unsupported cells retain the pure wheel.
+        let output = try run(
+            executable: python,
+            arguments: ["-I", "-B", resources.appendingPathComponent("select_runtime_wheel.py").path,
+                        fallback.path, native.path],
+            displayCommand: "Selecting compatible bundled MTPLX runtime"
+        )
+        let selected = URL(fileURLWithPath: output.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard FileManager.default.fileExists(atPath: selected.path) else {
+            throw MTPLXRuntimeBootstrapperError.runtimeStillMissing(
+                output: "Compatible bundled runtime was not found: \(output)"
+            )
+        }
+        return selected
+    }
+
+    private func installBundledRuntime(wheel fallback: URL, rebuildFromScratch: Bool = false) throws -> URL {
         let runtimeDir = URL(fileURLWithPath: MTPLXCommandBuilder.appRuntimeDirectory(environment: environment))
         try FileManager.default.createDirectory(
             at: runtimeDir.deletingLastPathComponent(),
@@ -464,6 +496,7 @@ public struct MTPLXRuntimeBootstrapper: Sendable {
             arguments: ["-m", "pip", "install", "-U", "pip"],
             displayCommand: "runtime python -m pip install -U pip"
         )
+        let wheel = try selectedBundledRuntimeWheel(fallback: fallback, python: venvPython)
         _ = try run(
             executable: venvPython,
             arguments: ["-m", "pip", "install", "-U", "\(wheel.path)[server]"],

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/MTPLXAppCoreTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/MTPLXAppCoreTests.swift
@@ -10230,6 +10230,30 @@ final class MTPLXAppCoreTests: XCTestCase {
         )
     }
 
+    func testNativeWheelSelectionOwnsTheManagedRuntimeFingerprint() throws {
+        let fixture = try makeRuntimeFixture(wheelContents: "pure-wheel")
+        let nativeDir = fixture.home.appendingPathComponent("Native")
+        try FileManager.default.createDirectory(at: nativeDir, withIntermediateDirectories: true)
+        let native = nativeDir.appendingPathComponent("mtplx-1.0.0-cp314-cp314-macosx_15_0_arm64.whl")
+        try Data("native-wheel".utf8).write(to: native)
+        let python = fixture.runtimeDir.appendingPathComponent("bin/python")
+        try Data("#!/bin/sh\nprintf '%s\\n' '\(native.path)'\n".utf8).write(to: python)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: python.path)
+        let bootstrapper = MTPLXRuntimeBootstrapper(environment: fixture.environment)
+        MTPLXRuntimeBootstrapper.recordWheelFingerprint(for: fixture.wheel, runtimeDir: fixture.runtimeDir)
+        XCTAssertFalse(bootstrapper.installedRuntimeMatchesBundledWheel(
+            installedExecutable: fixture.managedExecutable
+        ), "An OS upgrade that enables the native artifact must refresh a pure installation")
+        MTPLXRuntimeBootstrapper.recordWheelFingerprint(for: native, runtimeDir: fixture.runtimeDir)
+        XCTAssertTrue(bootstrapper.installedRuntimeMatchesBundledWheel(
+            installedExecutable: fixture.managedExecutable
+        ))
+        try Data("#!/bin/sh\nexit 1\n".utf8).write(to: python)
+        XCTAssertFalse(bootstrapper.installedRuntimeMatchesBundledWheel(
+            installedExecutable: fixture.managedExecutable
+        ), "A failed selector must not silently bless an unknown installed artifact")
+    }
+
     func testSameVersionWheelRebuildForcesVenvRefresh() throws {
         let fixture = try makeRuntimeFixture(wheelContents: "wheel-A")
         MTPLXRuntimeBootstrapper.recordWheelFingerprint(

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/RuntimeBundledArtifactTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/RuntimeBundledArtifactTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import MTPLXAppCore
+
+/// Opt-in release-artifact check using the actual installer, without app UI.
+/// The caller supplies an isolated HOME and built wheel/Python resources.
+final class RuntimeBundledArtifactTests: XCTestCase {
+    func testFreshArtifactInstallAndReuse() throws {
+        let inputs = ProcessInfo.processInfo.environment
+        guard let wheel = inputs["MTPLX_QA_WHEEL"],
+              let python = inputs["MTPLX_QA_PYTHON"],
+              let home = inputs["MTPLX_QA_HOME"] else {
+            throw XCTSkip("Set MTPLX_QA_WHEEL, MTPLX_QA_PYTHON and an isolated MTPLX_QA_HOME")
+        }
+        let environment = [
+            "HOME": home,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "MTPLX_BUNDLED_RUNTIME_WHEEL": wheel,
+            "MTPLX_APP_BUNDLED_PYTHON": python,
+        ]
+        let bootstrapper = MTPLXRuntimeBootstrapper(environment: environment)
+        let installed = try bootstrapper.installOrUpdate()
+        let runtime = installed.deletingLastPathComponent().deletingLastPathComponent()
+        XCTAssertTrue(installed.path.hasPrefix(home + "/"))
+        let selected = try bootstrapper.selectedBundledRuntimeWheel(
+            fallback: URL(fileURLWithPath: wheel),
+            python: runtime.appendingPathComponent("bin/python")
+        )
+        if let expected = inputs["MTPLX_QA_EXPECT_WHEEL"] {
+            XCTAssertEqual(selected.lastPathComponent, expected)
+        }
+        XCTAssertEqual(
+            MTPLXRuntimeBootstrapper.recordedWheelFingerprint(runtimeDir: runtime),
+            try MTPLXRuntimeBootstrapper.wheelFingerprint(of: selected)
+        )
+        XCTAssertTrue(bootstrapper.runtimeImportHealthAccepted(installedExecutable: installed))
+        let before = try FileManager.default.attributesOfItem(atPath: installed.path)[.modificationDate] as? Date
+        XCTAssertEqual(try bootstrapper.installOrUpdate(), installed)
+        let after = try FileManager.default.attributesOfItem(atPath: installed.path)[.modificationDate] as? Date
+        XCTAssertEqual(before, after, "A healthy matching artifact should be reused")
+        let receipt: [String: String] = [
+            "installed": installed.path,
+            "selectedWheel": selected.path,
+            "wheelSHA256": try MTPLXRuntimeBootstrapper.wheelFingerprint(of: selected),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: receipt, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: home).appendingPathComponent("artifact-install-receipt.json"))
+    }
+}

--- a/apps/MTPLXApp/script/build_and_run.sh
+++ b/apps/MTPLXApp/script/build_and_run.sh
@@ -25,6 +25,7 @@ ICNS_SOURCE="$ROOT/Resources/AppIcon.icns"
 THERMALFORGE_SOURCE="${MTPLX_THERMALFORGE_BINARY:-$HOME/.mtplx/bin/thermalforge}"
 REQUIRE_THERMALFORGE_RESOURCE="${MTPLX_REQUIRE_THERMALFORGE_RESOURCE:-0}"
 RUNTIME_WHEEL_SOURCE="${MTPLX_RUNTIME_WHEEL:-}"
+NATIVE_RUNTIME_WHEEL_SOURCE="${MTPLX_NATIVE_RUNTIME_WHEEL:-}"
 REQUIRE_RUNTIME_WHEEL_RESOURCE="${MTPLX_REQUIRE_RUNTIME_WHEEL_RESOURCE:-0}"
 BUNDLED_PYTHON_DIR="${MTPLX_BUNDLED_PYTHON_DIR:-}"
 REQUIRE_BUNDLED_PYTHON_RESOURCE="${MTPLX_REQUIRE_BUNDLED_PYTHON_RESOURCE:-0}"
@@ -327,6 +328,17 @@ elif [[ "$REQUIRE_RUNTIME_WHEEL_RESOURCE" == "1" ]]; then
   echo "error: runtime wheel resource missing at $RUNTIME_WHEEL_SOURCE" >&2
   echo "set MTPLX_RUNTIME_WHEEL to the mtplx release wheel before building the release app" >&2
   exit 1
+fi
+if [[ -n "$NATIVE_RUNTIME_WHEEL_SOURCE" ]]; then
+  if [[ ! -f "$NATIVE_RUNTIME_WHEEL_SOURCE" || ! -f "$RUNTIME_WHEEL_SOURCE" ]]; then
+    echo "error: native runtime requires both native and pure fallback wheels" >&2
+    exit 1
+  fi
+  mkdir -p "$BUNDLE_DIR/Contents/Resources/Runtime/Native"
+  /usr/bin/ditto --norsrc "$NATIVE_RUNTIME_WHEEL_SOURCE" \
+    "$BUNDLE_DIR/Contents/Resources/Runtime/Native/$(basename "$NATIVE_RUNTIME_WHEEL_SOURCE")"
+  /usr/bin/ditto --norsrc "$REPO_ROOT/scripts/select_runtime_wheel.py" \
+    "$BUNDLE_DIR/Contents/Resources/Runtime/select_runtime_wheel.py"
 fi
 # Bundled Python interpreter (python-build-standalone install_only_stripped
 # tree). With it in Contents/Resources/PythonRuntime, the app can build its

--- a/docs/diagnostics/agent-session-traces.md
+++ b/docs/diagnostics/agent-session-traces.md
@@ -1,0 +1,57 @@
+# Diagnose an agent session
+
+Use the engine's request receipts, flight recorder and the actual client history together. A successful request is not proof that a coding task finished correctly: run the generated artifact and exercise follow-up edits.
+
+## Capture an isolated run
+
+Give each baseline and candidate its own runtime, port and SSD-cache directory. Keep model files and native sampler settings identical. Record the commit, imported package path, model revision, memory limits and hardware. Verify thermal conditions before performance measurements; run one model at a time and wait for its memory to drain before switching versions.
+
+```sh
+mtplx serve --model /path/to/model --port 8211 \
+  --ssd-session-cache-dir /path/to/run/ssd-bank \
+  --request-log-jsonl /path/to/run/requests.jsonl \
+  --flight-recorder /path/to/run/flight.jsonl
+```
+
+Point OpenCode or Pi at that port using the normal MTPLX integration. Let coding tasks stop naturally. Preserve both the client transcript and the generated project. To capture exact encoded token IDs for a local reproduction, set `MTPLX_REQUEST_CAPTURE_DIR` before starting the server. Captures contain prompt content; keep them local unless you intend to share that content.
+
+## Open the joined view
+
+```sh
+mtplx trace report SESSION_ID --port 8211 \
+  --db /path/to/opencode.db \
+  --request-log /path/to/run/requests.jsonl \
+  --flight-log /path/to/run/flight.jsonl \
+  --out /path/to/run/report.html
+
+mtplx trace report --pi-session /path/to/pi-session.jsonl \
+  --request-log /path/to/run/requests.jsonl \
+  --flight-log /path/to/run/flight.jsonl \
+  --out /path/to/run/report.html
+```
+
+The report includes cache reuse, TTFT, decode curves, draft-position acceptance, tools, a request selector, an interval scrubber, and exportable evidence JSON. `mtplx trace request REQUEST_ID --json` exposes the same counters for scripts; use the same explicit log paths. Rotation files are read oldest first.
+
+Identity matters. Flight events join to receipts by exact server request ID. Updated Pi integration supplies the preceding transcript entry ID; a unique matching receipt links directly to its response. OpenCode supplies the user-turn ID, which can contain several engine/tool steps. Older transcripts and ambiguous retries still require time/token matching, and are labelled accordingly. Unmatched receipts are retained in the evidence export. Pi readers follow the active branch rather than counting abandoned history as completed work.
+
+## Decide whether MTP pays
+
+Measure AR on the same model, hardware, context and workload. Pass that measured rate using `--ar-tok-s`; the tool never substitutes the CLI's historical 40 TPS default.
+
+Let `G` be tokens actually delivered, `N` completed speculative rounds, `T` full decode wall time and `t_AR` seconds per AR token. The observed speedup is:
+
+`speedup = (G / T) * t_AR`
+
+MTP helps when `T/N < (G/N) * t_AR`. Include drafting, verification, commit/repair, host overhead and stalls in the full cycle; verify time alone is insufficient.
+
+For fixed depth `D`, away from start/end boundaries and copy routes, aggregate acceptance `q = accepted draft tokens / all proposed draft tokens` gives approximately `G/N = 1 + D*q`. Thus `q_break_even = (cycle_time/t_AR - 1) / D`. At D3, acceptance of 20%, 30%, 40% and 50% buys approximately 1.6, 1.9, 2.2 and 2.5 tokens per round. Each is worthwhile only when its measured round costs less than that many AR steps.
+
+Conditional per-position acceptance is different: expected output is `1 + p1 + p1*p2 + p1*p2*p3`. Do not multiply the already-unconditional per-depth receipt rates again. Mixed depths and context-copy routes invalidate the fixed-depth shortcut; use actual delivered tokens and total time.
+
+## Interpret gaps and memory
+
+Flight samples are progress-driven at approximately one-second intervals. Missing samples are missing observations, not fabricated zero-throughput intervals. Counter resets produce unknown deltas. Some recorded GPU timing spans overlap; summing them does not necessarily recover exclusive wall time.
+
+Allocator active bytes, free allocator-cache bytes, bank logical bytes, process RSS and physical system pressure measure different things. Shared cache references must not be counted twice. Releasing a logical bank entry is not proof that physical memory was freed: re-read allocator counters. `cache_cleared` records the allocator cache, not deletion of the useful prompt prefix.
+
+Test anonymous clients both with and without reasoning history, multiple distinct conversations, SSD partial restores, long outputs, edited prefixes, cancellation/retry and normal background apps. Keep the historical baseline and candidate evidence; never infer cross-chip speedups from an M5 fallback run.

--- a/docs/diagnostics/agent-session-traces.md
+++ b/docs/diagnostics/agent-session-traces.md
@@ -42,6 +42,8 @@ Let `G` be tokens actually delivered, `N` completed speculative rounds, `T` full
 
 `speedup = (G / T) * t_AR`
 
+The acceptance threshold holds the recorded cycle cost fixed. Re-measure when context, hardware, route or acceptance changes: rejected drafts also change repair cost.
+
 MTP helps when `T/N < (G/N) * t_AR`. Include drafting, verification, commit/repair, host overhead and stalls in the full cycle; verify time alone is insufficient.
 
 For fixed depth `D`, away from start/end boundaries and copy routes, aggregate acceptance `q = accepted draft tokens / all proposed draft tokens` gives approximately `G/N = 1 + D*q`. Thus `q_break_even = (cycle_time/t_AR - 1) / D`. At D3, acceptance of 20%, 30%, 40% and 50% buys approximately 1.6, 1.9, 2.2 and 2.5 tokens per round. Each is worthwhile only when its measured round costs less than that many AR steps.
@@ -55,3 +57,13 @@ Flight samples are progress-driven at approximately one-second intervals. Missin
 Allocator active bytes, free allocator-cache bytes, bank logical bytes, process RSS and physical system pressure measure different things. Shared cache references must not be counted twice. Releasing a logical bank entry is not proof that physical memory was freed: re-read allocator counters. `cache_cleared` records the allocator cache, not deletion of the useful prompt prefix.
 
 Test anonymous clients both with and without reasoning history, multiple distinct conversations, SSD partial restores, long outputs, edited prefixes, cancellation/retry and normal background apps. Keep the historical baseline and candidate evidence; never infer cross-chip speedups from an M5 fallback run.
+
+## Repeat the same request at AR, D1, D2 and D3
+
+```sh
+python scripts/mtp_cost_probe.py request.json \
+  --request-log /path/to/run/requests.jsonl --out /path/to/new/probe \
+  --base-url http://127.0.0.1:8211 --repeats 2
+```
+
+Supply a normal chat-completion request JSON with the actual coding task and native sampler. This tool reverses depth order on alternate rounds, verifies actual fan ramp before each request, checks that the server honored the mode/depth, retains full timestamped streams and exact receipts, and computes economics against measured AR. It introduces no output or reasoning cap. Tool calls are recorded as model output; use the real client to execute and validate a whole task.

--- a/docs/diagnostics/agent-session-traces.md
+++ b/docs/diagnostics/agent-session-traces.md
@@ -60,6 +60,13 @@ Test anonymous clients both with and without reasoning history, multiple distinc
 
 ## Repeat the same request at AR, D1, D2 and D3
 
+`mtplx tune` measures its selected calibration suite. Its effective per-case
+budget is the smaller of `--max-tokens` and the suite's `max_tokens`; the
+bundled warm-coding case uses 512. Raw rows record `prompt_tokens` and
+`token_budget`. To test a larger calibration window, supply a custom suite
+with that budget and raise the command's bound. Use the uncapped request
+replay below and real clients to evaluate long coding sessions.
+
 ```sh
 python scripts/mtp_cost_probe.py request.json \
   --request-log /path/to/run/requests.jsonl --out /path/to/new/probe \

--- a/docs/diagnostics/agent-session-traces.md
+++ b/docs/diagnostics/agent-session-traces.md
@@ -67,3 +67,7 @@ python scripts/mtp_cost_probe.py request.json \
 ```
 
 Supply a normal chat-completion request JSON with the actual coding task and native sampler. This tool reverses depth order on alternate rounds, verifies actual fan ramp before each request, checks that the server honored the mode/depth, retains full timestamped streams and exact receipts, and computes economics against measured AR. It introduces no output or reasoning cap. Tool calls are recorded as model output; use the real client to execute and validate a whole task.
+
+For a candidate replay, `--seed-map seeds.json` accepts the baseline's resolved seeds keyed by run label, for example `{"r1-d0": 123, "r1-d3": 456}`. Exact request captures record the resolved seed in `outcome.resolved_seed`. Preserve the request hash and every sampler setting alongside the seeds. Matching seeds reduce one source of variation; different speculative routes can still consume randomness differently.
+
+A repetition-guard stop can arrive with client `finish_reason: "stop"`. The probe retains that sample but exits unsuccessfully and excludes its throughput from MTP economics. A guard pass is not a code-quality pass: run the produced code, its assertions and the actual client follow-up before accepting a performance result.

--- a/mtplx/adaptive.py
+++ b/mtplx/adaptive.py
@@ -207,6 +207,12 @@ class ExpectedValueDepthPolicy:
         self._cycles_observed += 1
         for index in range(attempted_depth):
             self._attempt_counts[index] += 1
+            # These estimates are multiplied in should_continue_after_draft,
+            # so each is conditional on all earlier drafts being accepted.
+            # Positions beyond the first rejection were never tested; marking
+            # them rejected would count that earlier failure repeatedly.
+            if index > accepted_depths:
+                continue
             accepted = 1.0 if accepted_depths > index else 0.0
             self._accept_ewma[index] = (
                 (1.0 - self.ewma_alpha) * self._accept_ewma[index]
@@ -214,6 +220,7 @@ class ExpectedValueDepthPolicy:
             )
         return {
             "kind": "expected_value",
+            "acceptance_definition": "conditional_on_previous_positions",
             "attempted_depth": attempted_depth,
             "accepted_depths": accepted_depths,
             "next_depth": self.current_depth,

--- a/mtplx/attention_split.py
+++ b/mtplx/attention_split.py
@@ -403,14 +403,15 @@ def _install_split_attention_hook(attn: Any) -> bool:
                 # M<=32 windows (QL<=5 at GQA 6): 0.917 vs 1.015 ms/layer at 72.7k, 0.257 vs
                 # 0.306 at 16k. Variant A covers the wider windows (QL 6-10). Both bail to
                 # the scalar routes on any contract miss.
-                output = sdpa_nax_flash_dsplit(
-                    queries=queries,
-                    keys=cache.keys,
-                    values=cache.values,
-                    offset=cache.offset,
-                    scale=self.scale,
-                )
-                if output is None:
+                if not lane_disabled("nax_flash_dsplit_sdpa"):
+                    output = sdpa_nax_flash_dsplit(
+                        queries=queries,
+                        keys=cache.keys,
+                        values=cache.values,
+                        offset=cache.offset,
+                        scale=self.scale,
+                    )
+                if output is None and not lane_disabled("nax_flash_sdpa"):
                     output = sdpa_nax_flash(
                         queries=queries,
                         keys=cache.keys,
@@ -441,7 +442,11 @@ def _install_split_attention_hook(attn: Any) -> bool:
             # kernel for q_len >= 6 — the M-curve regime where the scalar
             # kernels pay (Battery A + spot receipts: QL9 +34%/+45% at
             # 71k/128k). Bails fall through to the scalar routes unchanged.
-            elif _env_enabled("MTPLX_NAX_TILE_ROUTE") and int(queries.shape[2]) >= 6:
+            elif (
+                _env_enabled("MTPLX_NAX_TILE_ROUTE")
+                and int(queries.shape[2]) >= 6
+                and not lane_disabled("nax_tile_sdpa")
+            ):
                 from .kernels.sdpa_nax_tile import sdpa_nax_tile
 
                 output = sdpa_nax_tile(

--- a/mtplx/backends/descriptors.py
+++ b/mtplx/backends/descriptors.py
@@ -1250,6 +1250,14 @@ def tune_policy_for_model(
         return GEMMA4_ASSISTANT_DESCRIPTOR.tune_policy
     if family == "step":
         return STEP3P5_MTP_DESCRIPTOR.tune_policy
+    if family == "qwen4_exp":
+        # Qwen 3.8 Flash-Next: backend qwen4_exp, can_run_verified=True, packs
+        # record mtp_depth_max 3. The allowlist stopped at qwen3_8, so tune
+        # called the model unsupported.
+        return TunePolicy(
+            supported=True,
+            candidates=("AR", "D1", "D2", "D3"),
+        )
     return TunePolicy(
         supported=False,
         unsupported_reason="Tune is supported for Qwen 3.5, Qwen 3.6, Qwen 3.8, and Gemma 4 MTPLX models only.",

--- a/mtplx/benchmarks/runners/mtp_depth_sweep.py
+++ b/mtplx/benchmarks/runners/mtp_depth_sweep.py
@@ -254,6 +254,7 @@ def run_mtp_depth_sweep(
             ar_rows.append(
                 {
                     "prompt_id": case.id,
+                    "prompt_tokens": len(ids),
                     "category": case.category,
                     "generation_started_at": generation_started_at,
                     "generation_ended_at": generation_ended_at,
@@ -346,6 +347,7 @@ def run_mtp_depth_sweep(
             rows.append(
                 {
                     "prompt_id": case.id,
+                    "prompt_tokens": len(ids),
                     "category": case.category,
                     "prompt_sha256": case.prompt_sha256,
                     "generation_started_at": generation_started_at,

--- a/mtplx/benchmarks/runners/mtp_depth_sweep.py
+++ b/mtplx/benchmarks/runners/mtp_depth_sweep.py
@@ -34,6 +34,13 @@ def _rate_by_depth(accepted: list[int], drafted: list[int]) -> list[float | None
     return [(a / d if d else None) for a, d in zip(accepted, drafted)]
 
 
+def _accepted_drafts_per_cycle(accepted: int, drafted_by_depth: list[int]) -> float | None:
+    # The first proposal counts draft cycles even when event recording is off.
+    # Verification calls also include copy/bonus forwards, so use proposals.
+    cycles = int(drafted_by_depth[0]) if drafted_by_depth else 0
+    return accepted / cycles if cycles else None
+
+
 def _token_budget(max_tokens: int, case_max_tokens: int) -> int:
     return min(int(max_tokens), int(case_max_tokens))
 
@@ -392,8 +399,10 @@ def run_mtp_depth_sweep(
                         out.stats.accepted_by_depth,
                         out.stats.drafted_by_depth,
                     ),
-                    "mean_accepted_drafts_per_cycle": (
-                        out.stats.accepted_drafts / max(1, len(out.stats.events))
+                    "draft_cycles": (out.stats.drafted_by_depth[0]
+                                     if out.stats.drafted_by_depth else 0),
+                    "mean_accepted_drafts_per_cycle": _accepted_drafts_per_cycle(
+                        out.stats.accepted_drafts, out.stats.drafted_by_depth
                     ),
                     "acceptance_rate": (
                         out.stats.accepted_drafts / out.stats.drafted_tokens

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -3069,6 +3069,11 @@ def build_parser() -> argparse.ArgumentParser:
         )
         p.add_argument("--json", action="store_true", help="machine-readable output")
 
+        p.add_argument("--request-log", help="explicit request JSONL, including its rotation files")
+        p.add_argument("--flight-log", help="explicit flight JSONL, including its rotation files")
+        p.add_argument("--pi-session", help="Pi session JSONL instead of the OpenCode database")
+        p.add_argument("--ar-tok-s", type=float, help="measured AR decode TPS for the same hardware, model and workload; never a default estimate")
+
     trace_sessions_p = trace_sub.add_parser(
         "sessions", help="List recent OpenCode sessions with server-request matches"
     )

--- a/mtplx/cli.py
+++ b/mtplx/cli.py
@@ -2913,7 +2913,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Comma-separated MTP depths or Gemma draft blocks to compare against AR",
     )
-    tune_p.add_argument("--max-tokens", type=int, default=512)
+    tune_p.add_argument("--max-tokens", type=int, default=512,
+                        help="Per-case upper bound; the prompt suite's token budget also applies")
     tune_p.add_argument("--limit", type=int, default=1)
     tune_p.add_argument("--seed", type=int, default=0)
     tune_p.add_argument("--run-id")

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -442,11 +442,37 @@ def _runtime_env_with_model_contract_overrides(
     runtime_env: dict[str, str],
     inspection: dict[str, Any],
     profile: Any,
+    *,
+    model: str | None = None,
 ) -> dict[str, str]:
-    return runtime_env_with_contract_overrides(
+    resolved = runtime_env_with_contract_overrides(
         runtime_env,
         _profile_scoped_model_runtime_contract(inspection, profile),
     )
+    if model is not None and _model_config_is_qwen4_exp(model):
+        from mtplx.profiles import (
+            MODEL_RUNTIME_ENV_OVERRIDE_KEYS,
+            PROFILE_ENV_USER_OVERRIDE_KEYS,
+        )
+        from mtplx.server.openai import (
+            _server_runtime_env_overrides,
+            load_runtime_contract,
+        )
+
+        # Resolve before applying any profile: profile defaults must not look
+        # like operator exports to the serve contract's hardware/pack gates.
+        # Keep the same precedence as serve: explicit runtime env, then the
+        # family overrides (which remove operator-owned lane keys themselves).
+        for key in MODEL_RUNTIME_ENV_OVERRIDE_KEYS | PROFILE_ENV_USER_OVERRIDE_KEYS:
+            value = os.environ.get(key)
+            if value is not None and value.strip():
+                resolved[key] = value
+        contract, _ = load_runtime_contract(model)
+        resolved.update(_server_runtime_env_overrides(
+            SimpleNamespace(model=model, generation_mode="mtp", verify_strategy="batched"),
+            contract.runtime_env_overrides if contract is not None else {},
+        ))
+    return resolved
 
 
 def _bench_run_console_summary(envelope: dict[str, Any]) -> dict[str, Any]:
@@ -2291,6 +2317,8 @@ def _depth_sweep_native60(
     _family_batched = _model_config_is_qwen4_exp(model)
     previous = apply_profile_env("performance-cold")
     if runtime_env:
+        for key in runtime_env:
+            previous.setdefault(key, os.environ.get(key))
         os.environ.update({key: str(value) for key, value in runtime_env.items()})
     draft_lm_head = draft_lm_head or {
         "bits": 4,
@@ -2301,11 +2329,11 @@ def _depth_sweep_native60(
     # the model in-process; pin the serve-path Metal allocator caps first.
     from mtplx.server.openai import apply_memory_caps_preflight
 
-    memory_preflight = apply_memory_caps_preflight(
-        entry="bench.depth_sweep",
-        model=str(model),
-    )
     try:
+        memory_preflight = apply_memory_caps_preflight(
+            entry="bench.depth_sweep",
+            model=str(model),
+        )
         result = run_mtp_depth_sweep(
             model,
             prompt_suite,
@@ -3820,6 +3848,7 @@ def _cmd_tune_candidate(args: Any) -> int:
             profile.env_dict(),
             inspection,
             profile,
+            model=runtime_model,
         )
     )
     draft_lm_head = _model_draft_lm_head_spec(inspection, profile)
@@ -6111,6 +6140,7 @@ def _cmd_bench_run(args: Any) -> int:
         runtime_env,
         inspection,
         selected_profile,
+        model=runtime_model,
     )
     draft_lm_head = _model_draft_lm_head_spec(inspection, selected_profile)
     draft_sampler = _model_draft_sampler_spec(inspection, selected_profile)

--- a/mtplx/commands/public.py
+++ b/mtplx/commands/public.py
@@ -2250,6 +2250,18 @@ def _exact_paged_env_from_args(args: Any) -> dict[str, str]:
     return exact_paged_attention_env(**_exactness_profile_kwargs(args))
 
 
+
+def _model_config_is_qwen4_exp(model: str) -> bool:
+    """Mirror of the server's qwen4_exp predicate: read the pack config."""
+    try:
+        with open(Path(str(model)) / "config.json", "rb") as fh:
+            cfg = json.load(fh)
+    except Exception:
+        return False
+    mt = str(cfg.get("model_type") or "").lower()
+    tmt = str((cfg.get("text_config") or {}).get("model_type") or "").lower()
+    return "qwen4_exp" in (mt, tmt) or "qwen4_exp_text" in (mt, tmt)
+
 def _depth_sweep_native60(
     *,
     model: str,
@@ -2276,6 +2288,7 @@ def _depth_sweep_native60(
 ) -> dict[str, Any]:
     from mtplx.benchmarks.runners.mtp_depth_sweep import run_mtp_depth_sweep
 
+    _family_batched = _model_config_is_qwen4_exp(model)
     previous = apply_profile_env("performance-cold")
     if runtime_env:
         os.environ.update({key: str(value) for key, value in runtime_env.items()})
@@ -2313,9 +2326,15 @@ def _depth_sweep_native60(
             mtp_cache_policy=mtp_cache_policy,
             mtp_history_policy=mtp_history_policy,
             min_speculative_depth=1,
-            verify_strategy="capture_commit",
+            # qwen4_exp cannot run the qwen3-next structure verify lanes: their
+            # capture stack introspects the qwen3-next DecoderLayer layout
+            # (input_layernorm et al.) and raises on Flash-Next hyper-connection
+            # layers. The family's repair-free lane wraps the batched verify
+            # (MTPLX_FAMILY_CAPTURE_COMMIT), so batched is the base strategy
+            # there -- the same coercion the server applies at boot.
+            verify_strategy="batched" if _family_batched else "capture_commit",
             draft_core=str(draft_core or "stock"),
-            verify_core="linear-gdn-from-conv-tape",
+            verify_core="stock" if _family_batched else "linear-gdn-from-conv-tape",
             draft_lm_head_bits=int(draft_lm_head["bits"]),
             draft_lm_head_group_size=int(draft_lm_head["group_size"]),
             draft_lm_head_mode=str(draft_lm_head["mode"]),

--- a/mtplx/commands/trace.py
+++ b/mtplx/commands/trace.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
-import glob
 import json
 import os
 import re
@@ -25,8 +24,9 @@ import sqlite3
 import sys
 import time
 import urllib.request
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 LOGS_DIR = Path(os.path.expanduser("~/.mtplx/logs"))
 METRICS_DIR = Path(os.path.expanduser("~/.mtplx/metrics"))
@@ -43,7 +43,7 @@ _SPARK = "▁▂▃▄▅▆▇█"
 def _fmt_clock(ts: float | None) -> str:
     if not ts:
         return "-"
-    return _dt.datetime.fromtimestamp(ts).strftime("%m-%d %H:%M:%S")
+    return _dt.datetime.fromtimestamp(ts, tz=_dt.UTC).astimezone().strftime("%m-%d %H:%M:%S")
 
 
 def _fmt_dur(seconds: float | None) -> str:
@@ -126,25 +126,31 @@ def _load_jsonl(path: Path) -> list[dict]:
     return records
 
 
-def _load_receipts(port: int, since_s: float | None = None) -> list[dict]:
-    records = _load_jsonl(LOGS_DIR / f"request-log-{port}.jsonl")
+def _load_receipts(port: int, since_s: float | None = None, *, path: str | None = None) -> list[dict]:
+    records = _load_rotated(Path(path).expanduser() if path else LOGS_DIR / f"request-log-{port}.jsonl")
     if since_s is not None:
         records = [r for r in records if float(r.get("logged_at_s") or 0) >= since_s]
     return records
 
 
-def _load_flight(port: int, since_s: float | None = None) -> list[dict]:
+def _load_rotated(path: Path) -> list[dict]:
+    generations = []
+    for candidate in path.parent.glob(path.name + ".*"):
+        suffix = candidate.name.rsplit(".", 1)[-1]
+        if suffix.isdigit():
+            generations.append((int(suffix), candidate))
+    return [row for _, part in sorted(generations, reverse=True)
+            for row in _load_jsonl(part)] + _load_jsonl(path)
+
+
+def _source_port(args: argparse.Namespace) -> int | None:
+    return (args.port or 0) if getattr(args, "request_log", None) else _detect_port(args.port)
+
+
+def _load_flight(port: int, since_s: float | None = None, *, path: str | None = None) -> list[dict]:
     """Flight events oldest-first across the rotation cascade
     (flight-<port>.jsonl.N .. .1, then the live file)."""
-    events: list[dict] = []
-    generations: list[tuple[int, Path]] = []
-    for path in METRICS_DIR.glob(f"flight-{port}.jsonl.*"):
-        suffix = path.name.rsplit(".", 1)[-1]
-        if suffix.isdigit():
-            generations.append((int(suffix), path))
-    for _, path in sorted(generations, reverse=True):
-        events.extend(_load_jsonl(path))
-    events.extend(_load_jsonl(METRICS_DIR / f"flight-{port}.jsonl"))
+    events = _load_rotated(Path(path).expanduser() if path else METRICS_DIR / f"flight-{port}.jsonl")
     if since_s is not None:
         events = [e for e in events if float(e.get("ts") or 0) >= since_s]
     return events
@@ -242,6 +248,14 @@ def _match_receipt(message: dict, receipts: list[dict], used: set[int]) -> dict 
     """Best receipt for an assistant message: exact session ids narrow the pool,
     then nearest logged_at_s to the message completion, with a token cross-foot
     tiebreak (completion_tokens ~ output+reasoning) for historical fuzzy joins."""
+    parent_entry = message.get("_parent_entry_id")
+    if parent_entry:
+        exact = [(i, r) for i, r in enumerate(receipts) if i not in used
+                 and r.get("request_client_entry_id") == parent_entry]
+        # Retries may share a leaf. Do not claim an exact join when ambiguous.
+        if len(exact) == 1:
+            used.add(exact[0][0])
+            return exact[0][1]
     msg_time = message.get("time") or {}
     completed_s = (msg_time.get("completed") or 0) / 1000.0
     created_s = (msg_time.get("created") or 0) / 1000.0
@@ -252,6 +266,9 @@ def _match_receipt(message: dict, receipts: list[dict], used: set[int]) -> dict 
     best, best_score = None, None
     for idx, receipt in enumerate(receipts):
         if idx in used:
+            continue
+        turn = receipt.get("request_client_turn_id")
+        if turn and message.get("parentID") and turn != message["parentID"]:
             continue
         logged = float(receipt.get("logged_at_s") or 0)
         anchor = completed_s or (created_s + float(receipt.get("request_elapsed_s") or 0))
@@ -275,10 +292,13 @@ def _match_receipt(message: dict, receipts: list[dict], used: set[int]) -> dict 
 
 
 def _join_session(
-    conn: sqlite3.Connection, session_id: str, receipts: list[dict], flight: list[dict]
+    conn: sqlite3.Connection | None, session_id: str, receipts: list[dict], flight: list[dict],
+    *, session: dict | None = None, messages: list[dict] | None = None,
 ) -> dict:
-    session = _opencode_session_row(conn, session_id) or {"id": session_id}
-    messages = _opencode_messages(conn, session_id)
+    if session is None:
+        session = _opencode_session_row(conn, session_id) or {"id": session_id}
+    if messages is None:
+        messages = _opencode_messages(conn, session_id)
     scoped = [r for r in receipts if r.get("session_id") == session_id]
     pool = scoped or receipts
     flight_rids = _flight_by_rid(flight)
@@ -301,10 +321,35 @@ def _join_session(
                 "turn": turn_no,
                 "message": message,
                 "receipt": receipt,
+                "join": ("exact Pi parent entry" if receipt and message.get("_parent_entry_id")
+                         and receipt.get("request_client_entry_id") == message["_parent_entry_id"]
+                         else "exact client turn; request by time/tokens" if receipt and receipt.get("request_client_turn_id")
+                         else "session/time/tokens"),
                 "flight": flight_rids.get(rid, []) if rid else [],
             }
         )
-    return {"session": session, "turns": turns, "receipt_pool_scoped": bool(scoped)}
+    return {"session": session, "turns": turns, "receipt_pool_scoped": bool(scoped),
+            "join_mode": "exact session; requests matched by time and tokens" if scoped else "time+token fallback",
+            "unmatched_receipts": [r for i, r in enumerate(pool) if i not in used]}
+
+
+def _load_joined(args: argparse.Namespace, receipts: list[dict], flight: list[dict]):
+    pi_path = getattr(args, "pi_session", None)
+    if pi_path:
+        from .trace_clients import load_pi_session
+
+        session, messages = load_pi_session(Path(pi_path).expanduser())
+        if not session.get("id"):
+            raise ValueError("Pi transcript has no session identity")
+        return None, _join_session(None, session["id"], receipts, flight,
+                                   session=session, messages=messages)
+    conn = _opencode_connect(Path(args.db))
+    if conn is None:
+        raise ValueError(f"OpenCode database not found: {args.db}")
+    session_id = _resolve_session_arg(conn, args.session)
+    if not session_id:
+        raise ValueError("no OpenCode sessions found")
+    return conn, _join_session(conn, session_id, receipts, flight)
 
 
 # ---------------------------------------------------------------------------
@@ -417,8 +462,8 @@ def _cmd_sessions(args: argparse.Namespace) -> int:
     if conn is None:
         print(f"opencode db not found: {args.db}", file=sys.stderr)
         return 1
-    port = _detect_port(args.port)
-    receipts = _load_receipts(port) if port else []
+    port = _source_port(args)
+    receipts = _load_receipts(port, path=getattr(args, "request_log", None)) if port is not None else []
     sessions = _opencode_sessions(conn, limit=args.limit)
     by_session: dict[str, int] = {}
     for receipt in receipts:
@@ -507,21 +552,18 @@ def _turn_row(turn: dict) -> dict:
 
 
 def _cmd_session(args: argparse.Namespace) -> int:
-    conn = _opencode_connect(Path(args.db))
-    if conn is None:
-        print(f"opencode db not found: {args.db}", file=sys.stderr)
-        return 1
-    session_id = _resolve_session_arg(conn, args.session)
-    if not session_id:
-        print("no opencode sessions found", file=sys.stderr)
-        return 1
-    port = _detect_port(args.port)
+    port = _source_port(args)
     if port is None:
         print("no request logs found under ~/.mtplx/logs", file=sys.stderr)
         return 1
-    receipts = _load_receipts(port)
-    flight = _load_flight(port)
-    joined = _join_session(conn, session_id, receipts, flight)
+    receipts = _load_receipts(port, path=getattr(args, "request_log", None))
+    flight = _load_flight(port, path=getattr(args, "flight_log", None))
+    try:
+        _conn, joined = _load_joined(args, receipts, flight)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    session_id = joined["session"]["id"]
     rows = [_turn_row(t) for t in joined["turns"] if t["kind"] == "assistant"]
     flags = _detect_pathologies(joined["turns"])
 
@@ -537,7 +579,7 @@ def _cmd_session(args: argparse.Namespace) -> int:
         "directory": joined["session"].get("directory"),
         "port": port,
         "turns": len(rows),
-        "join_mode": "exact session_id" if joined["receipt_pool_scoped"] else "time+token fallback",
+        "join_mode": joined["join_mode"],
         "warm_cache_reuse": round(reuse, 4) if reuse is not None else None,
         "total_completion_tokens": sum(r["completion_tokens"] or 0 for r in rows),
         "total_client_reasoning_tokens": sum(r["client_reasoning_tokens"] or 0 for r in rows),
@@ -631,11 +673,11 @@ _RECEIPT_GROUPS: list[tuple[str, list[str]]] = [
 
 
 def _cmd_request(args: argparse.Namespace) -> int:
-    port = _detect_port(args.port)
+    port = _source_port(args)
     if port is None:
         print("no request logs found under ~/.mtplx/logs", file=sys.stderr)
         return 1
-    receipts = _load_receipts(port)
+    receipts = _load_receipts(port, path=getattr(args, "request_log", None))
     if not receipts:
         print(f"no receipts for port {port}", file=sys.stderr)
         return 1
@@ -656,10 +698,13 @@ def _cmd_request(args: argparse.Namespace) -> int:
         return 1
 
     rid = receipt.get("request_id")
-    flight = _flight_by_rid(_load_flight(port)).get(rid, []) if rid else []
+    flight = _flight_by_rid(_load_flight(port, path=getattr(args, "flight_log", None))).get(rid, []) if rid else []
     samples = [e for e in flight if e.get("ev") == "s"]
     if args.json:
-        print(json.dumps({"receipt": receipt, "flight": flight}, indent=2))
+        from .trace_metrics import mtp_economics, sample_intervals
+        print(json.dumps({"receipt": receipt, "flight": flight,
+                          "economics": mtp_economics(receipt, getattr(args, "ar_tok_s", None)),
+                          "intervals": sample_intervals(flight)}, indent=2))
         return 0
 
     index = receipts.index(receipt)
@@ -677,7 +722,7 @@ def _cmd_request(args: argparse.Namespace) -> int:
                     val = json.dumps(val, separators=(",", ":"))
                 pairs.append((key, val))
         _print_kv_block(title, pairs)
-    rest = sorted(k for k in receipt.keys() if k not in shown)
+    rest = sorted(k for k in receipt if k not in shown)
     if rest and args.all:
         _print_kv_block("other", [(k, receipt[k]) for k in rest])
     elif rest:
@@ -856,5 +901,3 @@ def cmd_trace(args: argparse.Namespace) -> int:
         print(f"unknown trace action: {action}", file=sys.stderr)
         return 2
     return handler(args)
-
-

--- a/mtplx/commands/trace.py
+++ b/mtplx/commands/trace.py
@@ -323,6 +323,7 @@ def _join_session(
                 "receipt": receipt,
                 "join": ("exact Pi parent entry" if receipt and message.get("_parent_entry_id")
                          and receipt.get("request_client_entry_id") == message["_parent_entry_id"]
+                         and sum(r.get("request_client_entry_id") == message["_parent_entry_id"] for r in pool) == 1
                          else "exact client turn; request by time/tokens" if receipt and receipt.get("request_client_turn_id")
                          else "session/time/tokens"),
                 "flight": flight_rids.get(rid, []) if rid else [],
@@ -526,6 +527,8 @@ def _turn_row(turn: dict) -> dict:
     status = "ok"
     if message.get("error"):
         status = "CANCEL/ERR"
+    elif not receipt:
+        status = "missing receipt" if completed_s else "in progress"
     return {
         "turn": turn["turn"],
         "start": created_s,

--- a/mtplx/commands/trace.py
+++ b/mtplx/commands/trace.py
@@ -430,10 +430,10 @@ def _detect_pathologies(turns: list[dict]) -> list[str]:
         flags.append(f"CAP APPLIED on {caps} turn(s)")
 
     # think explosion after a small-think turn (re-derivation signature)
-    thinks = [
-        _msg_tokens(t["message"])["reasoning"] for t in assistant
-    ]
+    thinks = [(t["message"].get("tokens") or {}).get("reasoning") for t in assistant]
     for i in range(1, len(thinks)):
+        if thinks[i] is None or thinks[i - 1] is None:
+            continue
         if thinks[i] > 20_000 and thinks[i] > 5 * max(thinks[i - 1], 1):
             flags.append(
                 f"THINK EXPLOSION turn {assistant[i]['turn']}: {_fmt_tok(thinks[i])} reasoning tokens "
@@ -441,15 +441,18 @@ def _detect_pathologies(turns: list[dict]) -> list[str]:
             )
             break
 
-    # cache walls: warm turns paying big new prefill
+    # New file/tool content legitimately requires prefill. Flag a reduction
+    # in reused prefix separately; a large suffix alone is not a cache fault.
     walls = [
         (t["turn"], int(t["receipt"].get("new_prefill_tokens") or 0))
-        for t in assistant[1:]
+        for previous, t in zip(assistant, assistant[1:])
         if int(t["receipt"].get("new_prefill_tokens") or 0) > 1_000
+        and t["receipt"].get("cached_tokens") is not None
+        and int(t["receipt"]["cached_tokens"]) < int(previous["receipt"].get("prompt_tokens") or 0)
     ]
     if walls:
         flags.append(
-            "CACHE WALLS (new_prefill>1k on warm turns): "
+            "REDUCED PREFIX REUSE (inspect history edits, compaction and cache receipts): "
             + ", ".join(f"t{n}={_fmt_tok(w)}" for n, w in walls[:8])
         )
     return flags

--- a/mtplx/commands/trace.py
+++ b/mtplx/commands/trace.py
@@ -329,8 +329,9 @@ def _join_session(
                 "flight": flight_rids.get(rid, []) if rid else [],
             }
         )
+    modes = {t["join"] for t in turns if t["kind"] == "assistant" and t.get("receipt")}
     return {"session": session, "turns": turns, "receipt_pool_scoped": bool(scoped),
-            "join_mode": "exact session; requests matched by time and tokens" if scoped else "time+token fallback",
+            "join_mode": next(iter(modes)) if len(modes) == 1 else "mixed joins; see per-request evidence",
             "unmatched_receipts": [r for i, r in enumerate(pool) if i not in used]}
 
 
@@ -534,13 +535,16 @@ def _turn_row(turn: dict) -> dict:
         "start": created_s,
         "wall_s": (completed_s - created_s) if completed_s and created_s else None,
         "status": status,
+        "join": turn.get("join"),
+        "tool_errors": sum(p.get("state", {}).get("status") == "error"
+                           for p in message.get("_parts", []) if p.get("type") == "tool"),
         "prompt_tokens": receipt.get("prompt_tokens"),
         "cached_tokens": receipt.get("cached_tokens"),
         "new_prefill_tokens": receipt.get("new_prefill_tokens"),
         "cache_source": receipt.get("cache_source"),
         "cache_miss_reason": receipt.get("cache_miss_reason"),
         "completion_tokens": receipt.get("completion_tokens"),
-        "client_reasoning_tokens": tokens["reasoning"],
+        "client_reasoning_tokens": None if message.get("_client") == "pi" else tokens["reasoning"],
         "client_output_tokens": tokens["output"],
         "client_cache_read": tokens["cache_read"],
         "decode_tok_s": receipt.get("decode_tok_s"),
@@ -585,7 +589,8 @@ def _cmd_session(args: argparse.Namespace) -> int:
         "join_mode": joined["join_mode"],
         "warm_cache_reuse": round(reuse, 4) if reuse is not None else None,
         "total_completion_tokens": sum(r["completion_tokens"] or 0 for r in rows),
-        "total_client_reasoning_tokens": sum(r["client_reasoning_tokens"] or 0 for r in rows),
+        "total_client_reasoning_tokens": (None if any(r["client_reasoning_tokens"] is None for r in rows)
+                                          else sum(r["client_reasoning_tokens"] for r in rows)),
         "pathologies": flags,
     }
     if args.json:

--- a/mtplx/commands/trace.py
+++ b/mtplx/commands/trace.py
@@ -526,7 +526,7 @@ def _turn_row(turn: dict) -> dict:
     canon = receipt.get("committed_reasoning_canonicalization") or {}
     samples = [e for e in turn.get("flight", []) if e.get("ev") == "s"]
     status = "ok"
-    if message.get("error"):
+    if message.get("error") or message.get("stopReason") in {"error", "aborted"}:
         status = "CANCEL/ERR"
     elif not receipt:
         status = "missing receipt" if completed_s else "in progress"

--- a/mtplx/commands/trace_clients.py
+++ b/mtplx/commands/trace_clients.py
@@ -58,7 +58,7 @@ def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
             else:
                 parts.append(part)
         messages.append({
-            **message, "_id": record["id"], "_parts": parts,
+            **message, "_id": record["id"], "_parts": parts, "_client": "pi",
             "_parent_entry_id": record.get("parentId"),
             "_time_created_s": float(stamp) / 1000,
             "time": {"created": stamp},

--- a/mtplx/commands/trace_clients.py
+++ b/mtplx/commands/trace_clients.py
@@ -1,0 +1,60 @@
+"""Normalize local harness transcripts without changing their history."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+
+def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
+    records = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                records.append(json.loads(line))
+    header = next((r for r in records if r.get("type") == "session"), {})
+    # Pi is an append-only tree. Follow the current leaf's ancestors, so a
+    # fork or rewind does not quietly include abandoned turns in the report.
+    entries = {r["id"]: r for r in records if r.get("id") and r.get("type") != "session"}
+    lineage, seen = [], set()
+    current = next((r for r in reversed(records) if r.get("id") in entries), None)
+    while current and current["id"] not in seen:
+        seen.add(current["id"])
+        lineage.append(current)
+        current = entries.get(current.get("parentId"))
+    messages = []
+    for record in reversed(lineage):
+        if record.get("type") != "message":
+            continue
+        message = dict(record.get("message") or {})
+        if message.get("role") not in {"user", "assistant"}:
+            continue
+        stamp = message.get("timestamp")
+        if stamp is None:
+            stamp = datetime.datetime.fromisoformat(record["timestamp"]).timestamp() * 1000
+        usage = message.get("usage") or {}
+        content = message.get("content") or []
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+        parts = []
+        for part in content:
+            kind = part.get("type")
+            if kind == "thinking":
+                parts.append({"type": "reasoning", "text": part.get("thinking", "")})
+            elif kind == "toolCall":
+                parts.append({"type": "tool", "tool": part.get("name"), "callID": part.get("id"),
+                              "state": {"input": part.get("arguments")}})
+            else:
+                parts.append(part)
+        messages.append({
+            **message, "_id": record["id"], "_parts": parts,
+            "_parent_entry_id": record.get("parentId"),
+            "_time_created_s": float(stamp) / 1000,
+            "time": {"created": stamp},
+            "tokens": {"input": usage.get("input", 0), "output": usage.get("output", 0),
+                       "cache": {"read": usage.get("cacheRead", 0)}},
+            "finish": message.get("stopReason"),
+        })
+    return {"id": header.get("id"), "directory": header.get("cwd"),
+            "title": path.stem, "client": "pi", "transcript_path": str(path)}, messages

--- a/mtplx/commands/trace_clients.py
+++ b/mtplx/commands/trace_clients.py
@@ -36,6 +36,9 @@ def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
         if stamp is None:
             stamp = datetime.datetime.fromisoformat(record["timestamp"]).timestamp() * 1000
         usage = message.get("usage") or {}
+        completed = (datetime.datetime.fromisoformat(record["timestamp"]).timestamp() * 1000
+                     if message.get("role") == "assistant" and message.get("stopReason")
+                     and record.get("timestamp") else None)
         content = message.get("content") or []
         if isinstance(content, str):
             content = [{"type": "text", "text": content}]
@@ -61,7 +64,7 @@ def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
             **message, "_id": record["id"], "_parts": parts, "_client": "pi",
             "_parent_entry_id": record.get("parentId"),
             "_time_created_s": float(stamp) / 1000,
-            "time": {"created": stamp},
+            "time": {"created": stamp, "completed": completed},
             "tokens": {"input": usage.get("input", 0), "output": usage.get("output", 0),
                        "cache": {"read": usage.get("cacheRead", 0)}},
             "finish": message.get("stopReason"),

--- a/mtplx/commands/trace_clients.py
+++ b/mtplx/commands/trace_clients.py
@@ -23,6 +23,8 @@ def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
         seen.add(current["id"])
         lineage.append(current)
         current = entries.get(current.get("parentId"))
+    tool_results = {r["message"]["toolCallId"]: r["message"] for r in lineage
+                    if r.get("message", {}).get("role") == "toolResult"}
     messages = []
     for record in reversed(lineage):
         if record.get("type") != "message":
@@ -43,8 +45,16 @@ def load_pi_session(path: Path) -> tuple[dict, list[dict]]:
             if kind == "thinking":
                 parts.append({"type": "reasoning", "text": part.get("thinking", "")})
             elif kind == "toolCall":
+                result = tool_results.get(part.get("id"))
+                state = {"input": part.get("arguments")}
+                if result is not None:
+                    state.update(
+                        status="error" if result.get("isError") else "completed",
+                        output=result.get("content"),
+                        metadata={"result_timestamp_ms": result.get("timestamp")},
+                    )
                 parts.append({"type": "tool", "tool": part.get("name"), "callID": part.get("id"),
-                              "state": {"input": part.get("arguments")}})
+                              "state": state})
             else:
                 parts.append(part)
         messages.append({

--- a/mtplx/commands/trace_metrics.py
+++ b/mtplx/commands/trace_metrics.py
@@ -1,0 +1,92 @@
+"""Pure arithmetic for recorded decode economics; never estimates an AR baseline."""
+
+from __future__ import annotations
+
+import math
+from itertools import pairwise
+from typing import Any
+
+
+def _number(value: Any) -> float | None:
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) and value >= 0 else None
+
+
+def mtp_economics(receipt: dict, ar_tok_s: float | None = None) -> dict:
+    """Compare actual delivered tokens / full decode time with a matched AR run.
+
+    For fixed depth D, q = accepted / drafted is UNCONDITIONAL across all
+    proposed positions. Away from terminal/bonus boundaries, tokens/round is
+    1 + D*q. Conditional per-position acceptance instead gives
+    1 + p1 + p1*p2 + ...; these two definitions must not be confused.
+    Production conclusions use actual delivered tokens, including overhead.
+    """
+    tokens = _number(receipt.get("completion_tokens"))
+    elapsed = _number(receipt.get("decode_elapsed_s"))
+    rounds = _number(receipt.get("verify_calls"))
+    acc = receipt.get("accepted_by_depth") or []
+    drafted = receipt.get("drafted_by_depth") or []
+    accepted = sum(float(x) for x in acc)
+    proposed = sum(float(x) for x in drafted)
+    result: dict[str, Any] = {
+        "acceptance_definition": "accepted draft tokens / all proposed draft tokens",
+        "acceptance": accepted / proposed if proposed else None,
+        "tokens_per_verify": tokens / rounds if tokens and rounds else None,
+        "decode_ms_per_token": 1000 * elapsed / tokens if elapsed and tokens else None,
+        "verify_ms_per_round": (
+            1000 * float(receipt.get("verify_time_s") or 0) / rounds if rounds else None
+        ),
+        "draft_ms_per_round": (
+            1000 * float(receipt.get("draft_time_s") or 0) / rounds if rounds else None
+        ),
+        "cycle_ms": 1000 * elapsed / rounds if elapsed and rounds else None,
+        "ar_tok_s": ar_tok_s,
+        "speedup_vs_ar": None,
+        "break_even_acceptance": None,
+        "status": "matched_ar_measurement_required",
+    }
+    ar = _number(ar_tok_s)
+    if ar and tokens and elapsed:
+        result["speedup_vs_ar"] = (tokens / elapsed) / ar
+        result["status"] = "measured_comparison_requires_matched_workload"
+        fixed = rounds and drafted and all(float(n) == rounds for n in drafted)
+        if fixed and not receipt.get("context_copy_accepted_tokens"):
+            # Do not clamp: >1 means even perfect acceptance cannot amortize
+            # this observed cycle cost; <0 means the cycle is already cheaper.
+            result["break_even_acceptance"] = (elapsed / rounds * ar - 1) / len(drafted)
+    return result
+
+
+def sample_intervals(events: list[dict]) -> list[dict]:
+    """Difference cumulative counters; leave missing observations missing.
+
+    A gap is an observation gap, not an invented sequence of zero-TPS samples.
+    A negative delta is a counter reset and is never rendered as performance.
+    """
+    samples = sorted((e for e in events if e.get("ev") == "s"), key=lambda e: e.get("ts", 0))
+    result = []
+    for prev, cur in pairwise(samples):
+        duration = float(cur["ts"]) - float(prev["ts"])
+        if duration <= 0:
+            continue
+        row = {"start_s": prev["ts"], "end_s": cur["ts"], "duration_s": duration,
+               "observation_gap": duration > 2.5, "context_tokens": cur.get("ctx")}
+        for key in ("gen", "vc", "vt", "dt", "at", "ct", "rt", "st", "bt", "cct"):
+            before, after = _number(prev.get(key)), _number(cur.get(key))
+            row[key] = after - before if before is not None and after is not None and after >= before else None
+        for key in ("acc", "drf"):
+            before, after = prev.get(key), cur.get(key)
+            row[key] = ([b-a for a, b in zip(before, after)]
+                        if isinstance(before, list) and isinstance(after, list)
+                        and len(before) == len(after) and all(b >= a for a, b in zip(before, after)) else None)
+        row["tok_s"] = row["gen"] / duration if row["gen"] is not None else None
+        denominator = sum(row["drf"]) if row["drf"] is not None else 0
+        row["acceptance"] = sum(row["acc"]) / denominator if row["acc"] is not None and denominator else None
+        row["active_memory_bytes"] = cur.get("mem_active")
+        row["cache_memory_bytes"] = cur.get("mem_cache")
+        row["peak_memory_bytes"] = cur.get("mem_peak")
+        result.append(row)
+    return result

--- a/mtplx/commands/trace_metrics.py
+++ b/mtplx/commands/trace_metrics.py
@@ -31,16 +31,18 @@ def mtp_economics(receipt: dict, ar_tok_s: float | None = None) -> dict:
     drafted = receipt.get("drafted_by_depth") or []
     accepted = sum(float(x) for x in acc)
     proposed = sum(float(x) for x in drafted)
+    verify = _number(receipt.get("verify_time_s"))
+    draft = _number(receipt.get("draft_time_s"))
     result: dict[str, Any] = {
         "acceptance_definition": "accepted draft tokens / all proposed draft tokens",
         "acceptance": accepted / proposed if proposed else None,
         "tokens_per_verify": tokens / rounds if tokens and rounds else None,
         "decode_ms_per_token": 1000 * elapsed / tokens if elapsed and tokens else None,
         "verify_ms_per_round": (
-            1000 * float(receipt.get("verify_time_s") or 0) / rounds if rounds else None
+            1000 * verify / rounds if verify is not None and rounds else None
         ),
         "draft_ms_per_round": (
-            1000 * float(receipt.get("draft_time_s") or 0) / rounds if rounds else None
+            1000 * draft / rounds if draft is not None and rounds else None
         ),
         "cycle_ms": 1000 * elapsed / rounds if elapsed and rounds else None,
         "ar_tok_s": ar_tok_s,

--- a/mtplx/commands/trace_metrics.py
+++ b/mtplx/commands/trace_metrics.py
@@ -76,7 +76,7 @@ def sample_intervals(events: list[dict]) -> list[dict]:
             continue
         row = {"start_s": prev["ts"], "end_s": cur["ts"], "duration_s": duration,
                "observation_gap": duration > 2.5, "context_tokens": cur.get("ctx")}
-        for key in ("gen", "vc", "vt", "dt", "at", "ct", "rt", "st", "bt", "cct"):
+        for key in ("gen", "vc", "vt", "dt", "at", "ct", "rt", "st", "bt", "cct", "cv", "evc"):
             before, after = _number(prev.get(key)), _number(cur.get(key))
             row[key] = after - before if before is not None and after is not None and after >= before else None
         for key in ("acc", "drf"):
@@ -90,5 +90,6 @@ def sample_intervals(events: list[dict]) -> list[dict]:
         row["active_memory_bytes"] = cur.get("mem_active")
         row["cache_memory_bytes"] = cur.get("mem_cache")
         row["peak_memory_bytes"] = cur.get("mem_peak")
+        row["verify_route"] = cur.get("route")
         result.append(row)
     return result

--- a/mtplx/commands/trace_metrics.py
+++ b/mtplx/commands/trace_metrics.py
@@ -50,6 +50,10 @@ def mtp_economics(receipt: dict, ar_tok_s: float | None = None) -> dict:
         "break_even_acceptance": None,
         "status": "matched_ar_measurement_required",
     }
+    if receipt.get("repetition_stop_triggered"):
+        result.update(status="guard_stopped_invalid_quality_sample",
+                      guard_reason=receipt.get("repetition_stop_reason"))
+        return result
     ar = _number(ar_tok_s)
     if ar and tokens and elapsed:
         result["speedup_vs_ar"] = (tokens / elapsed) / ar

--- a/mtplx/commands/trace_report.py
+++ b/mtplx/commands/trace_report.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import html
+import json
 import math
 import subprocess
 import sys
@@ -33,17 +34,16 @@ from typing import Any
 from .trace import (
     METRICS_DIR,
     _detect_pathologies,
-    _detect_port,
     _fmt_dur,
     _fmt_tok,
-    _join_session,
     _load_flight,
+    _load_joined,
     _load_receipts,
-    _opencode_connect,
     _opencode_parts,
-    _resolve_session_arg,
+    _source_port,
     _turn_row,
 )
+from .trace_metrics import mtp_economics, sample_intervals
 
 # dataviz reference palette, light mode (validated with validate_palette.js)
 _MUT, _AXIS, _SURF = "#898781", "#c3c2b7", "#fcfcfb"
@@ -537,7 +537,7 @@ def _sec_digest(digest: list[dict]) -> str:
 def _user_snippet(conn: Any, message: dict) -> str | None:
     texts: list[str] = []
     try:
-        for part in _opencode_parts(conn, message.get("_id") or ""):
+        for part in (message["_parts"] if "_parts" in message else _opencode_parts(conn, message.get("_id") or "")):
             if part.get("type") == "text" and part.get("text"):
                 texts.append(str(part["text"]))
         if not texts:
@@ -554,11 +554,61 @@ def _user_snippet(conn: Any, message: dict) -> str | None:
 
 def _part_chars(conn: Any, message: dict) -> tuple[int | None, int | None]:
     try:
-        parts = _opencode_parts(conn, message.get("_id") or "")
+        parts = message["_parts"] if "_parts" in message else _opencode_parts(conn, message.get("_id") or "")
         return (sum(len(p.get("text") or "") for p in parts if p.get("type") == "reasoning"),
                 sum(len(p.get("text") or "") for p in parts if p.get("type") == "text"))
     except Exception:  # noqa: BLE001
         return None, None
+
+
+def _sec_inspector(joined: dict, conn: Any, ar_tok_s: float | None) -> str:
+    """One request selector and time scrubber over the original evidence."""
+    requests = []
+    for turn in joined["turns"]:
+        if turn["kind"] != "assistant":
+            continue
+        receipt = turn.get("receipt") or {}
+        message = turn["message"]
+        parts = (message["_parts"] if "_parts" in message
+                 else _opencode_parts(conn, message.get("_id") or ""))
+        requests.append({"turn": turn["turn"], "request_id": receipt.get("request_id"),
+                         "join": turn.get("join"), "receipt": receipt,
+                         "economics": mtp_economics(receipt, ar_tok_s),
+                         "intervals": sample_intervals(turn.get("flight", [])),
+                         "flight": turn.get("flight", []),
+                         "tools": [p for p in parts if p.get("type") == "tool"]})
+    evidence = {"session": joined["session"], "requests": requests,
+                "unmatched_receipts": joined.get("unmatched_receipts", [])}
+    payload = json.dumps(evidence, ensure_ascii=False).replace("<", "\\u003c")
+    options = ''.join(f'<option value="{i}">Step {r["turn"]} · {_esc(r["request_id"] or "unmatched")}</option>'
+                      for i, r in enumerate(requests))
+    return _card("Request inspector", (
+        '<p class="quiet">Choose an engine step, then scrub its recorded intervals. '
+        'Missing samples remain missing; a long gap is not fabricated zero throughput. '
+        'Verify/draft counters can overlap GPU work and must not be summed as exclusive wall time. '
+        'AR comparisons require a separately measured, matching baseline.</p>'
+        '<label>Engine step <select id="inspect-request">'+options+'</select></label> '
+        '<button id="inspect-export" type="button">Export evidence JSON</button>'
+        '<p id="inspect-summary"></p>'
+        '<label>Recorded interval <input id="inspect-time" type="range" min="0" value="0" step="1"></label>'
+        '<pre id="inspect-sample" style="white-space:pre-wrap"></pre>'
+        '<details><summary>Tool calls and their timing</summary><pre id="inspect-tools" style="white-space:pre-wrap"></pre></details>'
+        '<details><summary>Full engine receipt and MTP economics</summary><pre id="inspect-receipt" style="white-space:pre-wrap"></pre></details>'
+        f'<script type="application/json" id="inspect-data">{payload}</script>'
+        '<script>(()=>{const data=JSON.parse(document.getElementById("inspect-data").textContent);'
+        'const select=document.getElementById("inspect-request"),slider=document.getElementById("inspect-time");'
+        'const put=(id,v)=>document.getElementById(id).textContent=JSON.stringify(v,null,2);'
+        'function render(reset){const r=data.requests[Number(select.value)];if(!r)return;'
+        'slider.max=Math.max(0,r.intervals.length-1);slider.disabled=!r.intervals.length;if(reset)slider.value=0;'
+        'document.getElementById("inspect-summary").textContent="Join: "+r.join+" · "+r.intervals.length+" recorded intervals";'
+        'put("inspect-sample",r.intervals[Number(slider.value)]||{status:"No interval samples"});'
+        'put("inspect-tools",r.tools);put("inspect-receipt",{economics:r.economics,receipt:r.receipt});}'
+        'select.addEventListener("change",()=>render(true));slider.addEventListener("input",()=>render(false));'
+        'document.getElementById("inspect-export").onclick=()=>{const a=document.createElement("a");'
+        'const u=URL.createObjectURL(new Blob([JSON.stringify(data,null,2)],{type:"application/json"}));'
+        'a.href=u;a.download="mtplx-trace-evidence.json";a.click();setTimeout(()=>URL.revokeObjectURL(u),1000);};'
+        'render(true);})();</script>'
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -622,21 +672,18 @@ _JS = (
 
 
 def cmd_trace_report(args: argparse.Namespace) -> int:
-    conn = _opencode_connect(Path(args.db))
-    if conn is None:
-        print(f"opencode db not found: {args.db}", file=sys.stderr)
-        return 1
-    session_id = _resolve_session_arg(conn, getattr(args, "session", None))
-    if not session_id:
-        print("no opencode sessions found", file=sys.stderr)
-        return 1
-    port = _detect_port(args.port)
+    port = _source_port(args)
     if port is None:
         print("no request logs found under ~/.mtplx/logs", file=sys.stderr)
         return 1
-    receipts = _load_receipts(port)
-    flight = _load_flight(port)
-    joined = _join_session(conn, session_id, receipts, flight)
+    receipts = _load_receipts(port, path=getattr(args, "request_log", None))
+    flight = _load_flight(port, path=getattr(args, "flight_log", None))
+    try:
+        conn, joined = _load_joined(args, receipts, flight)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    session_id = joined["session"]["id"]
     a_turns = [t for t in joined["turns"] if t["kind"] == "assistant"]
     rows = [_enrich(t) for t in a_turns]
     flags = _detect_pathologies(joined["turns"])
@@ -663,7 +710,7 @@ def cmd_trace_report(args: argparse.Namespace) -> int:
         ("Wall time (turns)", _fmt_dur(sum(r["wall_s"] or 0 for r in rows))),
         ("Mean decode", f"{mean_dec:.1f} tok/s" if mean_dec else "-"),
     ]
-    join_mode = "exact session_id" if joined["receipt_pool_scoped"] else "time+token fallback"
+    join_mode = joined["join_mode"]
     session = joined["session"]
     header = (f'<h1>mtplx trace report</h1><p class="meta"><b>{_esc(session_id)}</b>'
               f' · {_esc(session.get("title") or "untitled")}<br>{_esc(session.get("directory") or "-")}'
@@ -688,7 +735,8 @@ def cmd_trace_report(args: argparse.Namespace) -> int:
             '<meta name="viewport" content="width=device-width,initial-scale=1">'
             f"<title>mtplx trace — {_esc(session_id)}</title><style>" + _CSS + "</style></head><body><main>"
             + header + pathology + _sec_timeline(rows) + _sec_cache(rows) + _sec_tps(rows)
-            + _sec_mtp(rows) + _sec_scatter(receipts, session_ids, port) + _sec_digest(digest)
+            + _sec_mtp(rows) + _sec_inspector(joined, conn, getattr(args, "ar_tok_s", None))
+            + _sec_scatter(receipts, session_ids, port) + _sec_digest(digest)
             + '</main><div id="tip"></div><script>' + _JS + "</script></body></html>")
 
     out_path = Path(args.out).expanduser() if args.out else METRICS_DIR / "reports" / f"{session_id}.html"

--- a/mtplx/commands/trace_report.py
+++ b/mtplx/commands/trace_report.py
@@ -139,6 +139,8 @@ def _row_dur(r: dict) -> float:
 
 
 def _share(r: dict) -> str:
+    if r["client_reasoning_tokens"] is None:
+        return ""
     think = r["client_reasoning_tokens"] or 0
     denom = r["completion_tokens"] or (think + (r["client_output_tokens"] or 0))
     return f"{think / denom * 100:.0f}% think" if denom else ""
@@ -706,7 +708,8 @@ def cmd_trace_report(args: argparse.Namespace) -> int:
         ("Turns", str(len(rows))),
         ("Warm cache reuse", f"{reuse * 100:.1f}%" if reuse is not None else "-"),
         ("Completion tokens", _fmt_tok(sum(r["completion_tokens"] or 0 for r in rows))),
-        ("Client think tokens", _fmt_tok(sum(r["client_reasoning_tokens"] or 0 for r in rows))),
+        ("Client think tokens", _fmt_tok(None if any(r["client_reasoning_tokens"] is None for r in rows)
+                                         else sum(r["client_reasoning_tokens"] for r in rows))),
         ("Wall time (turns)", _fmt_dur(sum(r["wall_s"] or 0 for r in rows))),
         ("Mean decode", f"{mean_dec:.1f} tok/s" if mean_dec else "-"),
     ]

--- a/mtplx/commands/trace_report.py
+++ b/mtplx/commands/trace_report.py
@@ -710,7 +710,8 @@ def cmd_trace_report(args: argparse.Namespace) -> int:
         ("Completion tokens", _fmt_tok(sum(r["completion_tokens"] or 0 for r in rows))),
         ("Client think tokens", _fmt_tok(None if any(r["client_reasoning_tokens"] is None for r in rows)
                                          else sum(r["client_reasoning_tokens"] for r in rows))),
-        ("Wall time (turns)", _fmt_dur(sum(r["wall_s"] or 0 for r in rows))),
+        ("Wall time (turns)", _fmt_dur(None if any(r["wall_s"] is None for r in rows)
+                                      else sum(r["wall_s"] for r in rows))),
         ("Mean decode", f"{mean_dec:.1f} tok/s" if mean_dec else "-"),
     ]
     join_mode = joined["join_mode"]

--- a/mtplx/commands/trace_report.py
+++ b/mtplx/commands/trace_report.py
@@ -412,8 +412,7 @@ def _mtp_accept_panel(rows: list[dict]) -> str:
 
 
 def _mtp_time_panel(rows: list[dict]) -> str:
-    """100%-normalized stacked bar per turn splitting decode_elapsed_s into
-    draft / verify / accept / other, absolute seconds always visible."""
+    """Recorded timer shares per turn, with overlaps explicitly labelled."""
     x0, x1, rh = 44.0, 640.0, 26.0
     have, skipped = [], []
     for r in rows:
@@ -447,7 +446,8 @@ def _mtp_time_panel(rows: list[dict]) -> str:
                 body.append(f'<rect x="{cx:.1f}" y="{y}" width="{max(wseg - gap, 0.5):.1f}" height="12" fill="{col}"/>')
             cx += wseg
         ann = (f"draft {_fmt_dur(r['draft_time_s'])} · verify {_fmt_dur(r['verify_time_s'])}"
-               f" · accept {_fmt_dur(r['accept_time_s'])} · other {_fmt_dur(other)} of {_fmt_dur(total)}")
+               f" · accept {_fmt_dur(r['accept_time_s'])} · remainder {_fmt_dur(other)} · wall {_fmt_dur(total)}"
+               + (" (overlapping spans)" if d + v + a > total else ""))
         body.append(f'<text x="{x1 + 10:.1f}" y="{y + 10:.1f}" class="vlab">{_esc(ann)}</text>')
         tip_lines = [f"t{r['turn']} · decode {total:.2f}s"]
         tip_lines.extend(f"{nm} {sec:.2f}s ({sec / denom * 100:.1f}%)" for nm, sec, _c in segs)
@@ -456,10 +456,10 @@ def _mtp_time_panel(rows: list[dict]) -> str:
         tip = "\n".join(tip_lines)
         body.append(f'<rect x="0" y="{y - 3}" width="{_W}" height="{rh}" fill="transparent" data-tip="{_esc(tip)}" tabindex="0"/>')
     legend = _chips([(_BLUE, "draft"), (_ORANGE, "verify"), (_AQUA, "accept"), (_YELLOW, "other (unattributed decode)")])
-    note = _QUIET.format("each bar = that turn's decode_elapsed_s normalized to 100% · absolute seconds annotated per row")
+    note = _QUIET.format("recorded timer shares; when their sum exceeds wall time, spans overlap and the bar is normalized to that sum · absolute seconds and full wall time are shown")
     tail = _QUIET.format("omitted (receipt carries no draft/verify/accept timing): "
                          + ", ".join(skipped)) if skipped else ""
-    return ("<h3>Decode time split (draft / verify / accept / other)</h3>" + note + legend
+    return ("<h3>Recorded decode timers (draft / verify / accept / remainder)</h3>" + note + legend
             + f'<svg viewBox="0 0 {_W} {h}" role="img" aria-label="decode time split">'
             + _pct_grid(x0, x1, float(h)) + "".join(body) + "</svg>" + tail)
 
@@ -701,7 +701,7 @@ def cmd_trace_report(args: argparse.Namespace) -> int:
         lo = min(starts)
         hi = max(r["start"] + _row_dur(r) for r in rows if r["start"])
         day = _dt.datetime.fromtimestamp(lo, tz=_dt.UTC).astimezone()
-        span = f"{day:%Y-%m-%d} {_hms(lo)} → {_hms(hi)}"
+        span = f"{day:%Y-%m-%d} {_hms(lo)} → {_hms(hi)} {day:%Z %z}"
     cards = [
         ("Turns", str(len(rows))),
         ("Warm cache reuse", f"{reuse * 100:.1f}%" if reuse is not None else "-"),

--- a/mtplx/engine_session.py
+++ b/mtplx/engine_session.py
@@ -1673,7 +1673,19 @@ class EngineSessionManager:
         chat_id: str | None = None,
         conversation_id: str | None = None,
         prompt_ids: list[int] | tuple[int, ...] | None = None,
+        diagnostic_out: dict[str, Any] | None = None,
     ) -> tuple[str, str]:
+        # The caller owns its evidence even while another request resolves
+        # during a postcommit wait. The last value is only for health.
+        self.last_prefix_diagnostic = None
+        if diagnostic_out is not None:
+            diagnostic_out.clear()
+
+        def record(diagnostic: dict[str, Any]) -> None:
+            self.last_prefix_diagnostic = diagnostic
+            if diagnostic_out is not None:
+                diagnostic_out.update(diagnostic)
+
         headers = headers or {}
         metadata = metadata or {}
         lowered_headers = {
@@ -1708,11 +1720,11 @@ class EngineSessionManager:
         if prompt_ids:
             best = self.longest_prefix_session(prompt_ids)
             if best is not None:
-                self.last_prefix_diagnostic = self._prefix_diagnostic(
+                record(self._prefix_diagnostic(
                     prompt_ids,
                     selected=best,
                     exact=True,
-                )
+                ))
                 return best.session_id, "longest_prefix"
             pending, matched = self.pending_near_prefix_session(prompt_ids)
             if pending is not None:
@@ -1731,7 +1743,7 @@ class EngineSessionManager:
                         - int(matched),
                     }
                 )
-                self.last_prefix_diagnostic = diagnostic
+                record(diagnostic)
                 return pending.session_id, "pending_postcommit_near_prefix"
             best, matched = self.best_common_prefix_session(prompt_ids)
             if best is not None:
@@ -1748,9 +1760,9 @@ class EngineSessionManager:
                         "reason": "common_prefix_reuse",
                     }
                 )
-                self.last_prefix_diagnostic = diagnostic
+                record(diagnostic)
                 return best.session_id, "common_prefix_reuse"
-            self.last_prefix_diagnostic = self._prefix_diagnostic(prompt_ids)
+            record(self._prefix_diagnostic(prompt_ids))
         else:
             self.last_prefix_diagnostic = None
         return _new_anon_session_id(), "new"

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -11671,7 +11671,13 @@ def generate_mtpk(
 
         before_verify = None
         if a3b_target_prefix_route is None:
-            if _skip_verify_snapshot():
+            # The family capture lane commits by replaying the GDN recurrences
+            # from the pre-verify snapshot (commit_verified_window), so it needs
+            # that snapshot regardless of MTPLX_SKIP_VERIFY_SNAPSHOT -- the same
+            # rule the block round applies above. The lazy snapshot is
+            # zero-copy, so honouring the skip here only removes the commit's
+            # input and forces the rollback + re-forward fallback.
+            if _skip_verify_snapshot() and not family_capture_commit_active:
                 event["snapshot"] = "skipped_capture_commit_required"
             else:
                 started = time.perf_counter()

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1904,6 +1904,17 @@ class _DecodeTrace:
                             "verify_calls": totals.get("verify_calls"),
                             "verify_time_s": totals.get("verify_time_s"),
                             "draft_time_s": totals.get("draft_time_s"),
+                            "accept_time_s": totals.get("accept_time_s"),
+                            "commit_time_s": totals.get("commit_time_s"),
+                            "repair_time_s": totals.get("repair_time_s"),
+                            "snapshot_time_s": totals.get("snapshot_time_s"),
+                            "bonus_time_s": totals.get("bonus_time_s"),
+                            "capture_commit_time_s": totals.get("capture_commit_time_s"),
+                            # Host allocator counters only: no mx.eval or GPU
+                            # synchronization on this existing ~1 Hz hook.
+                            "active_memory_bytes": mx.get_active_memory(),
+                            "cache_memory_bytes": mx.get_cache_memory(),
+                            "peak_memory_bytes": mx.get_peak_memory(),
                         }
                     )
                 except Exception:

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -1953,6 +1953,9 @@ class _DecodeTrace:
                             "snapshot_time_s": totals.get("snapshot_time_s"),
                             "bonus_time_s": totals.get("bonus_time_s"),
                             "capture_commit_time_s": totals.get("capture_commit_time_s"),
+                            "verify_route": totals.get("verify_route"),
+                            "compiled_verify_calls": totals.get("compiled_verify_calls"),
+                            "eager_verify_calls": totals.get("eager_verify_calls"),
                             # Host allocator counters only: no mx.eval or GPU
                             # synchronization on this existing ~1 Hz hook.
                             "active_memory_bytes": mx.get_active_memory(),
@@ -9629,6 +9632,12 @@ def generate_mtpk(
             "trace_accounting_time_s": trace_accounting_time_s,
             "accepted_by_depth": list(accepted_by_depth),
             "drafted_by_depth": list(drafted_by_depth),
+            "verify_route": (compiled_verify_bank.last_dispatch_route()
+                             if compiled_verify_bank is not None else None),
+            "compiled_verify_calls": (compiled_verify_bank.stats["compiled_calls"]
+                                      if compiled_verify_bank is not None else None),
+            "eager_verify_calls": (compiled_verify_bank.stats["fallback_calls"]
+                                   if compiled_verify_bank is not None else None),
             "accept_probability_sum_by_depth": list(accept_probability_sum_by_depth),
             "draft_confidence_width_stops": draft_confidence_width_stops,
             "draft_confidence_sum_by_depth": list(draft_confidence_sum_by_depth),

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -10394,6 +10394,7 @@ def generate_mtpk(
                                 return_hidden=True,
                                 hidden_variant=base_hidden_variant,
                                 extended_window=True,
+                                committed_count=len(tokens) - 1,
                             )
                         )
                         event["verify_route"] = (
@@ -10401,6 +10402,12 @@ def generate_mtpk(
                         )
                     else:
                         event["verify_route"] = "ccopy_block"
+                        if compiled_verify_bank is not None:
+                            compiled_verify_bank.reserve_fixed_m4_window(
+                                cache,
+                                committed_count=len(tokens) - 1,
+                                window_tokens=_cc_T,
+                            )
                         _cc_logits, _cc_hidden, _cc_captures = rt.forward_ar_capture(
                             mx.array([[primary] + _cc_block]),
                             cache=cache,
@@ -11796,6 +11803,7 @@ def generate_mtpk(
                             cache=cache,
                             return_hidden=True,
                             hidden_variant=base_hidden_variant,
+                            committed_count=len(tokens) - 1,
                         )
                     )
                     event["verify_route"] = (
@@ -11893,6 +11901,7 @@ def generate_mtpk(
                         cache=cache,
                         return_hidden=True,
                         hidden_variant=base_hidden_variant,
+                        committed_count=len(tokens) - 1,
                     )
                 )
                 event["verify_route"] = (

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -354,6 +354,10 @@ def _qwen4_fixed_m4_compiled_verify_requested(
     max_tokens: int,
     cached_tokens: int,
     prompt_tokens: int,
+    speculative_depth: int = 3,
+    session_bank: Any | None = None,
+    prompt_ids: list[int] | None = None,
+    receipt: dict | None = None,
 ) -> bool:
     """Construction gate for the shape-specialized physical-M4 verifier."""
 
@@ -366,7 +370,21 @@ def _qwen4_fixed_m4_compiled_verify_requested(
         and int(max_tokens) > 0
     ):
         return False
-    return _qwen4_fixed_m4_lane_fits(rt, prompt_tokens=int(prompt_tokens))
+    if receipt is not None:
+        receipt.update(requested_depth=int(speculative_depth), engaged=False)
+    if int(speculative_depth) < 3:
+        # This bank has only a four-row compiled forward. D1/D2 otherwise
+        # pay the O(context) copy and memory twice, then run eager anyway.
+        if receipt is not None:
+            receipt["reason"] = "depth_below_compiled_window"
+        return False
+    fits = _qwen4_fixed_m4_lane_fits(
+        rt, prompt_tokens=int(prompt_tokens), session_bank=session_bank,
+        prompt_ids=prompt_ids, receipt=receipt,
+    )
+    if receipt is not None:
+        receipt.update(engaged=fits, reason="admitted" if fits else "memory_gate")
+    return fits
 
 
 # The prefill admission line (server _PREFILL_ADMISSION_PRESSURE_FRACTION).
@@ -456,7 +474,10 @@ def _announce_qwen4_fixed_m4_skip(reason: str) -> None:
         pass
 
 
-def _qwen4_fixed_m4_lane_fits(rt: Any, *, prompt_tokens: int) -> bool:
+def _qwen4_fixed_m4_lane_fits(
+    rt: Any, *, prompt_tokens: int, session_bank: Any | None = None,
+    prompt_ids: list[int] | None = None, receipt: dict | None = None,
+) -> bool:
     """Per-request memory gate for the strict fixed-M4 lane.
 
     The promotion copies every QSA layer's state into padded banks (about
@@ -490,6 +511,8 @@ def _qwen4_fixed_m4_lane_fits(rt: Any, *, prompt_tokens: int) -> bool:
     need = (prompt_tokens + _fixed_m4_initial_growth_reserve()) * per_token
     live = _mlx_live_memory_bytes()
     line = int(limit * _QWEN4_FIXED_M4_PRESSURE_FRACTION)
+    if receipt is not None:
+        receipt.update(live_bytes_before=live, promotion_bytes=need, threshold_bytes=line)
     if live + need <= line:
         return True
     # The allocator cache is free memory the allocator is holding; only
@@ -499,6 +522,26 @@ def _qwen4_fixed_m4_lane_fits(rt: Any, *, prompt_tokens: int) -> bool:
     released = _mlx_release_allocator_cache()
     if released > 0:
         live = _mlx_live_memory_bytes()
+        if live + need <= line:
+            return True
+    # Idle bank snapshots compete with the faster verifier. Reuse the same
+    # protected eviction order as prefill admission, then measure allocator
+    # bytes again: evicted logical bytes are not necessarily physical savings.
+    reclaim = getattr(session_bank, "shrink_for_admission", None)
+    if callable(reclaim) and prompt_ids:
+        bank_before = int(session_bank.total_nbytes)
+        deficit = max(0, live + need - line)
+        chain, terminal = reclaim(
+            max(0, bank_before - deficit), protect_tokens=prompt_ids,
+            reason="fixed_m4_admission",
+        )
+        _mlx_release_allocator_cache()
+        live = _mlx_live_memory_bytes()
+        if receipt is not None:
+            receipt.update(bank_bytes_before=bank_before,
+                           bank_bytes_after=int(session_bank.total_nbytes),
+                           chain_entries_evicted=chain, terminal_entries_evicted=terminal,
+                           live_bytes_after=live)
         if live + need <= line:
             return True
     _announce_qwen4_fixed_m4_skip(
@@ -2620,6 +2663,7 @@ class GenerationStats:
     speculative_depth: int = 0
     requested_speculative_depth: int = 0
     long_context_mtp_depth_policy: dict[str, object] = field(default_factory=dict)
+    fixed_m4_admission: dict[str, object] = field(default_factory=dict)
     accepted_by_depth: list[int] = field(default_factory=list)
     drafted_by_depth: list[int] = field(default_factory=list)
     accept_probability_sum_by_depth: list[float] = field(default_factory=list)
@@ -8567,6 +8611,7 @@ def generate_mtpk(
         and not exact_a3b_target_prefix
         and _env_truthy("MTPLX_COMPILED_TARGET_PREFIX")
     )
+    fixed_m4_admission: dict[str, object] = {}
     qwen4_fixed_m4_compiled_verify = (
         # M-RoPE tables slice by the host offset; the fixed bank carries a
         # tensor offset, so vision requests keep main's verify routes.
@@ -8578,6 +8623,10 @@ def generate_mtpk(
             max_tokens=max_tokens,
             cached_tokens=int(getattr(prompt_state, "cached_tokens", 0) or 0),
             prompt_tokens=len(prompt_ids),
+            speculative_depth=speculative_depth,
+            session_bank=session_bank,
+            prompt_ids=prompt_ids,
+            receipt=fixed_m4_admission,
         )
     )
     compiled_verify_bank = (
@@ -13290,6 +13339,7 @@ def generate_mtpk(
             _forkev_snapshot = {"enabled": True, "errors": _forkev.errors + 1}
     stats = GenerationStats(
         mode="mtpk",
+        fixed_m4_admission=fixed_m4_admission,
         forkev=_forkev_snapshot,
         constraint_active=constraint is not None,
         constraint_completed=(

--- a/mtplx/generation.py
+++ b/mtplx/generation.py
@@ -11595,7 +11595,13 @@ def generate_mtpk(
 
         before_verify = None
         if a3b_target_prefix_route is None:
-            if _skip_verify_snapshot():
+            # The family capture lane commits by replaying the GDN recurrences
+            # from the pre-verify snapshot (commit_verified_window), so it needs
+            # that snapshot regardless of MTPLX_SKIP_VERIFY_SNAPSHOT -- the same
+            # rule the block round applies above. The lazy snapshot is
+            # zero-copy, so honouring the skip here only removes the commit's
+            # input and forces the rollback + re-forward fallback.
+            if _skip_verify_snapshot() and not family_capture_commit_active:
                 event["snapshot"] = "skipped_capture_commit_required"
             else:
                 started = time.perf_counter()

--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -1122,11 +1122,11 @@ def _record_permanent_eager(reason: str, *, once: bool = False) -> None:
 # Process-global compiled verify callables, keyed by
 # (runtime id, capture backend, state spec, verify length, hidden variant,
 # bucket). The bank is per-generation; without sharing, every request pays a
-# fresh trace. Values are (compiled_fn, trace_host) where trace_host["bank"]
-# is re-pointed to the live bank before each dispatch so internal retraces
+# fresh trace. Values are (compiled_fn, trace_host, runtime_ref), where the
+# host's WEAK bank reference is re-pointed before each dispatch so retraces
 # (mx.compile re-traces on leaf-shape changes) always use live scratch
 # containers. See CompiledVerifyBank._shared_or_new_verify_step.
-_SHARED_VERIFY_STEPS: dict[tuple, tuple[Any, dict[str, Any]]] = {}
+_SHARED_VERIFY_STEPS: dict[tuple, tuple[Any, dict[str, Any], Any]] = {}
 
 
 def _prewarm_enabled() -> bool:
@@ -3249,10 +3249,13 @@ class CompiledVerifyBank:
             # id() can be recycled after a model swap frees the old runtime;
             # a stale callable would replay graphs bound to freed weights.
             if runtime_ref() is self.runtime:
-                host["bank"] = self
+                host["bank_ref"] = weakref.ref(self)
                 return fn
             _SHARED_VERIFY_STEPS.pop(global_key, None)
-        host = {"bank": self}
+        # Programs may outlive requests. Keeping the bank here also keeps its
+        # shadow KV and traced state alive after the request/session is gone.
+        # The dispatch owns the bank; the process cache owns only the program.
+        host = {"bank_ref": weakref.ref(self)}
         fn = mx.compile(
             self._make_verify_step(length, hidden_variant, trace_host=host)
         )
@@ -3267,15 +3270,14 @@ class CompiledVerifyBank:
     ):
         spec = list(self._spec or [])
         layout = self._capture_layout()
-        bank = self
-        static_host = {"bank": self}
+        static_host = {"bank_ref": weakref.ref(self)}
         host = trace_host if trace_host is not None else static_host
-
-        del bank
 
         def verify_step(input_ids, *args):
             # Python body executes at trace time only; replays skip it.
-            live = host["bank"]
+            live = host["bank_ref"]()
+            if live is None:
+                raise RuntimeError("compiled verifier traced without a live request bank")
             shadow = live._shadow
             if live._prepare_compiled_aux is not None:
                 compiled_aux, *state_in = args

--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -3270,7 +3270,16 @@ class CompiledVerifyBank:
         fn = mx.compile(
             self._make_verify_step(length, hidden_variant, trace_host=host)
         )
-        _SHARED_VERIFY_STEPS[global_key] = (fn, host, weakref.ref(self.runtime))
+        def release_program(reference, *, key=global_key):
+            # Compiled graphs may hold weight arrays even after their Python
+            # runtime is gone. Drop them at unload, not only on id() reuse.
+            entry = _SHARED_VERIFY_STEPS.get(key)
+            if entry is not None and entry[2] is reference:
+                _SHARED_VERIFY_STEPS.pop(key, None)
+
+        _SHARED_VERIFY_STEPS[global_key] = (
+            fn, host, weakref.ref(self.runtime, release_program)
+        )
         return fn
 
     def _make_verify_step(

--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -1999,26 +1999,31 @@ class CompiledVerifyBank:
                 flush=True,
             )
 
-    def _transition_fixed_m4_generation(
+    def reserve_fixed_m4_window(
         self,
         cache: Any,
         *,
-        committed_count: int,
+        committed_count: int | None = None,
+        window_tokens: int = 4,
     ) -> None:
-        """Grow or reroute one installed fixed-M4 capacity generation.
+        """Reserve every target write into an installed fixed-capacity bank.
 
-        The decision is host-owned: ``committed_count`` advances with the
-        accepted completion prefix, so this boundary check never evaluates a
-        device offset. Within a generation, replay stays branch-free.
+        D1/D2 and copy windows use these same buffers even when their forward
+        runs eager. They must renew capacity before writing, too. Generation
+        supplies its host ledger to avoid a device sync; standalone callers
+        without that ledger use the live cache offset. Generic banks are
+        unchanged. Keep four rows reserved for a possible lazy bonus write.
         """
 
         dispatch = self._fixed_m4_dispatch
-        assert dispatch is not None
-        required_end = (
-            int(dispatch["base_offset"])
-            + max(0, int(committed_count))
-            + 4
+        if dispatch is None:
+            return
+        logical_start = (
+            int(dispatch["base_offset"]) + max(0, int(committed_count))
+            if committed_count is not None
+            else dispatch["qsa_entries"][0].size()
         )
+        required_end = logical_start + max(4, int(window_tokens))
         capacity_needed = required_end > int(dispatch["capacity"])
         route_transition_at = dispatch["route_transition_at"]
         route_needed = (
@@ -2107,7 +2112,7 @@ class CompiledVerifyBank:
     ):
         dispatch = self._fixed_m4_dispatch
         assert dispatch is not None
-        self._transition_fixed_m4_generation(
+        self.reserve_fixed_m4_window(
             cache,
             committed_count=committed_count,
         )
@@ -2221,6 +2226,7 @@ class CompiledVerifyBank:
         return_hidden: bool = True,
         hidden_variant: str | None = None,
         extended_window: bool = False,
+        committed_count: int | None = None,
     ):
         """Compiled verify dispatch.
 
@@ -2241,6 +2247,11 @@ class CompiledVerifyBank:
         global _PREWARM_DONE
         if self._fixed_m4_dispatch is not None:
             self.stats["calls"] += 1
+            self.reserve_fixed_m4_window(
+                cache,
+                committed_count=committed_count,
+                window_tokens=_decode_length(input_ids),
+            )
             if _decode_length(input_ids) == 4:
                 # Without host-owned n-gram inputs (any caller other than the
                 # generation loop's forward_fixed_m4 entrypoint, for example a

--- a/mtplx/kernel_selfcheck.py
+++ b/mtplx/kernel_selfcheck.py
@@ -212,17 +212,17 @@ def _check_qwen_combine_tail_m1_m2(mx, dtype) -> float:
     return 0.0
 
 
-def _check_gqa_packed(mx, dtype) -> float:
+def _check_gqa_packed(mx, dtype, kernel=None, *, d=128, q_len=4) -> float:
     from .kernels.sdpa_gqa_packed import sdpa_gqa_packed_tail
 
-    hq, hk, d = 8, 2, 128
-    capacity, offset, q_len = 512, 200, 4
+    hq, hk = (24, 4) if d == 256 else (8, 2)
+    capacity, offset = 512, 200
     scale = d**-0.5
     mx.random.seed(11)
     queries = (mx.random.normal((1, hq, q_len, d), dtype=mx.float32) * 0.5).astype(dtype)
     keys = (mx.random.normal((1, hk, capacity, d), dtype=mx.float32) * 0.5).astype(dtype)
     values = (mx.random.normal((1, hk, capacity, d), dtype=mx.float32) * 0.5).astype(dtype)
-    out = sdpa_gqa_packed_tail(
+    out = (kernel or sdpa_gqa_packed_tail)(
         queries=queries,
         keys=keys,
         values=values,
@@ -665,6 +665,25 @@ def run_kernel_selfcheck(dtype, bits: int, group_size: int) -> dict[str, Any]:
         _record("gqa_packed_sdpa", _SDPA_TOLERANCE, lambda: _check_gqa_packed(mx, dtype))
     else:
         lanes["gqa_packed_sdpa"] = _STATUS_SKIPPED
+
+    # NAX attention has its own kernels: validating the scalar packed lane
+    # cannot certify these. Probe both physical geometries before serving,
+    # and retain the established packed route on non-G17 GPUs / older macOS.
+    from .kernels.sdpa_nax_flash import sdpa_nax_flash
+    from .kernels.sdpa_nax_flash_dsplit import sdpa_nax_flash_dsplit
+    from .kernels.sdpa_nax_tile import sdpa_nax_tile
+
+    for lane, env, kernel, rows in (
+        ("nax_flash_sdpa", "MTPLX_NAX_FLASH_ROUTE", sdpa_nax_flash, 8),
+        ("nax_flash_dsplit_sdpa", "MTPLX_NAX_FLASH_ROUTE", sdpa_nax_flash_dsplit, 4),
+        ("nax_tile_sdpa", "MTPLX_NAX_TILE_ROUTE", sdpa_nax_tile, 8),
+    ):
+        if _env_on("MTPLX_GQA_PACKED_SDPA") and _env_on(env) and nax_verify.nax_available():
+            _record(lane, _SDPA_TOLERANCE,
+                    lambda kernel=kernel, rows=rows: _check_gqa_packed(
+                        mx, dtype, kernel, d=256, q_len=rows))
+        else:
+            lanes[lane] = _STATUS_SKIPPED
 
     if _env_on("MTPLX_FUSE_POST_NORM_RESIDUAL"):
         # Bitwise gate: this lane's contract is exact identity with the

--- a/mtplx/kernels/qsa_prefill_direct.py
+++ b/mtplx/kernels/qsa_prefill_direct.py
@@ -120,15 +120,15 @@ def _import_extension():
     """Import the optional native module; never raise."""
 
     native_path = _extension_dir()
-    if native_path.is_dir() and str(native_path) not in sys.path:
+    built = native_path / "mtplx_qsa_kernels"
+    if any(built.glob("_ext*.so")) and str(native_path) not in sys.path:
         # Source-tree builds live beside the sources (the house pattern used
-        # by mtplx/kernels/native_gdn_tail.py); an installed wheel is found
-        # on the normal path and this insert is a no-op.
+        # by mtplx/kernels/native_gdn_tail.py). An unbuilt source directory
+        # must not shadow a working installed wheel with its empty package.
         sys.path.insert(0, str(native_path))
     try:
         import mtplx_qsa_kernels  # type: ignore
     except Exception as exc:  # pragma: no cover - depends on a local build
-        built = native_path / "mtplx_qsa_kernels"
         if built.is_dir() and any(built.glob("_ext*.so")):
             # A built extension that fails to load is a real defect (usually
             # an unresolved @rpath to the mlx wheel's libmlx.dylib). Leave a

--- a/mtplx/kernels/sdpa_nax_flash.py
+++ b/mtplx/kernels/sdpa_nax_flash.py
@@ -29,7 +29,10 @@ from functools import lru_cache
 
 import mlx.core as mx
 
+from ..nax_verify import nax_available
 from .sdpa_gqa_packed import _paged_reduce_kernel
+
+nax_flash_bail_counts: dict[str, int] = {}
 
 _HEADER = r"""
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
@@ -340,6 +343,7 @@ def _nax_flash_kernel():
 
 
 def _bail(reason: str):
+    nax_flash_bail_counts[reason] = nax_flash_bail_counts.get(reason, 0) + 1
     if os.environ.get("MTPLX_NAX_FLASH_DEBUG"):
         print(f"[nax-flash bail] {reason}")
     return None
@@ -368,6 +372,8 @@ def sdpa_nax_flash(
         return _bail("env_disabled")
     if not mx.metal.is_available():
         return _bail("metal_unavailable")
+    if not nax_available():
+        return _bail("gpu_family_or_os")
     if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
         return _bail("ndim")
     bsz, hq, q_len, d = (int(x) for x in queries.shape)

--- a/mtplx/kernels/sdpa_nax_flash_dsplit.py
+++ b/mtplx/kernels/sdpa_nax_flash_dsplit.py
@@ -24,6 +24,10 @@ from functools import lru_cache
 
 import mlx.core as mx
 
+from ..nax_verify import nax_available
+
+nax_flash_dsplit_bail_counts: dict[str, int] = {}
+
 from .sdpa_gqa_packed import _paged_reduce_kernel
 from .sdpa_nax_flash import _HEADER
 
@@ -271,6 +275,7 @@ def _nax_flash_dsplit_kernel():
 
 
 def _bail(reason: str):
+    nax_flash_dsplit_bail_counts[reason] = nax_flash_dsplit_bail_counts.get(reason, 0) + 1
     if os.environ.get("MTPLX_NAX_FLASH_DEBUG"):
         print(f"[nax-flash-dsplit bail] {reason}")
     return None
@@ -301,6 +306,8 @@ def sdpa_nax_flash_dsplit(
         return _bail("env_disabled")
     if not mx.metal.is_available():
         return _bail("metal_unavailable")
+    if not nax_available():
+        return _bail("gpu_family_or_os")
     if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
         return _bail("ndim")
     bsz, hq, q_len, d = (int(x) for x in queries.shape)

--- a/mtplx/kernels/sdpa_nax_flash_dsplit.py
+++ b/mtplx/kernels/sdpa_nax_flash_dsplit.py
@@ -25,11 +25,10 @@ from functools import lru_cache
 import mlx.core as mx
 
 from ..nax_verify import nax_available
-
-nax_flash_dsplit_bail_counts: dict[str, int] = {}
-
 from .sdpa_gqa_packed import _paged_reduce_kernel
 from .sdpa_nax_flash import _HEADER
+
+nax_flash_dsplit_bail_counts: dict[str, int] = {}
 
 # Template params: InT, D, QL, GQA_F.
 _SOURCE = r"""

--- a/mtplx/kernels/sdpa_nax_tile.py
+++ b/mtplx/kernels/sdpa_nax_tile.py
@@ -29,6 +29,10 @@ from functools import lru_cache
 
 import mlx.core as mx
 
+from ..nax_verify import nax_available
+
+nax_tile_bail_counts: dict[str, int] = {}
+
 from .sdpa_gqa_packed import _blocks_for_capacity, _paged_reduce_kernel
 
 _HEADER = r"""
@@ -311,6 +315,7 @@ def _nax_tile_kernel():
 
 
 def _bail(reason: str):
+    nax_tile_bail_counts[reason] = nax_tile_bail_counts.get(reason, 0) + 1
     if os.environ.get("MTPLX_NAX_TILE_DEBUG"):
         print(f"[nax-tile bail] {reason}")
     return None
@@ -329,6 +334,8 @@ def sdpa_nax_tile(
         return _bail("env_disabled")
     if not mx.metal.is_available():
         return _bail("metal_unavailable")
+    if not nax_available():
+        return _bail("gpu_family_or_os")
     if queries.ndim != 4 or keys.ndim != 4 or values.ndim != 4:
         return _bail("ndim")
     bsz, hq, q_len, d = (int(x) for x in queries.shape)

--- a/mtplx/kernels/sdpa_nax_tile.py
+++ b/mtplx/kernels/sdpa_nax_tile.py
@@ -30,10 +30,9 @@ from functools import lru_cache
 import mlx.core as mx
 
 from ..nax_verify import nax_available
+from .sdpa_gqa_packed import _blocks_for_capacity, _paged_reduce_kernel
 
 nax_tile_bail_counts: dict[str, int] = {}
-
-from .sdpa_gqa_packed import _blocks_for_capacity, _paged_reduce_kernel
 
 _HEADER = r"""
 #include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1475,8 +1475,18 @@ def _qsa_prefill_enabled() -> bool:
         # cannot compile the MPP pipelines (macOS 27, issue #404): honoring
         # the env verbatim there turns into a guaranteed mid-request 500.
         # The probe prints its own diagnostic when it says no.
-        return _qsa_prefill_mpp_compile_ok()
-    return qsa_prefill_lane_auto_supported() and _qsa_prefill_mpp_compile_ok()
+        return _qsa_prefill_producer_compile_ok()
+    return qsa_prefill_lane_auto_supported() and _qsa_prefill_producer_compile_ok()
+
+
+def _qsa_prefill_producer_compile_ok() -> bool:
+    from mtplx.kernels.qsa_indexer_select import qsa_indexer_select_nax_available
+
+    # The portable producer uses bounded MLX score tiles when NAX is absent
+    # (qsa_indexer_prefill_metal). It never dispatches the MPP score kernel.
+    # Requiring that unrelated kernel to compile disables the Steel consumer
+    # on M1-M4 even after a valid native extension has been installed.
+    return not qsa_indexer_select_nax_available() or _qsa_prefill_mpp_compile_ok()
 
 
 def _qsa_prefill_mpp_compile_ok() -> bool:

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1595,14 +1595,17 @@ def _qsa_large_prefill_enabled(rows: int, total_tokens: int) -> bool:
     # existing exact cache path and reserves this matrix-shaped lane for the
     # prompt/SSD-restored prefill it was designed to accelerate.
     return (
-        _qsa_prefill_enabled()
-        and current_attention_phase() == "prefill"
+        current_attention_phase() == "prefill"
         and int(rows) >= _qsa_prefill_min_rows()
         # Gate on the earliest query in the chunk, not its final T.  A large
         # restored/SSD chunk may straddle the crossover; routing it by final T
         # would make its early rows pay the exact fixed-cost pathology this
         # guard exists to avoid.
         and int(total_tokens) - int(rows) >= _qsa_prefill_min_context()
+        # Capability/pipeline resolution is only useful for eligible prefill
+        # chunks. Never pay its imports and native readiness checks on every
+        # AR or speculative decode layer, especially on portable consumers.
+        and _qsa_prefill_enabled()
     )
 
 

--- a/mtplx/opencode.py
+++ b/mtplx/opencode.py
@@ -74,6 +74,9 @@ export const MTPLXSessionHeaders = async () => ({
     if (input?.sessionID) {
       output.headers["x-mtplx-session-id"] = String(input.sessionID);
     }
+    if (input?.message?.id) {
+      output.headers["x-mtplx-client-turn-id"] = String(input.message.id);
+    }
   },
   "chat.params": async (input, output) => {
     const providerID = mtplxProviderID(input);

--- a/mtplx/pi.py
+++ b/mtplx/pi.py
@@ -23,9 +23,8 @@ PI_LOCAL_API_KEY = "mtplx-local"
 PI_NPM_PACKAGE = "@earendil-works/pi-coding-agent"
 PI_DEFAULT_CONTEXT_WINDOW = 131_072
 PI_DEFAULT_MAX_TOKENS: int | None = None
-# Pi serializes a 16,384 output ceiling for models whose metadata omits
-# maxTokens. The extension strips exactly this value; any other cap is a
-# deliberate client choice and must reach MTPLX intact.
+# Legacy Pi fallback when model metadata omits maxTokens. Configured models
+# pass their advertised value to the bridge instead of assuming this value.
 PI_INJECTED_DEFAULT_MAX_TOKENS = 16_384
 PI_REQUEST_POLICY_EXTENSION_NAME = "mtplx-request-policy.ts"
 # Connection identity MTPLX must keep correct for the integration to work at
@@ -64,11 +63,12 @@ def build_pi_request_policy_extension_source(
     model_id: str,
     *,
     uncapped: bool,
+    injected_max_tokens: int = PI_INJECTED_DEFAULT_MAX_TOKENS,
 ) -> str:
     """Build Pi's request/session bridge for the configured MTPLX model.
 
-    Pi defaults omitted ``maxTokens`` metadata to 16,384 and serializes that
-    default on every request. The extension removes only Pi's generated output
+    Pi serializes the model's advertised ``maxTokens`` (or its legacy default)
+    on every request. The extension removes only Pi's generated output
     ceiling for the exact MTPLX model while leaving explicit user caps alone.
     It also gives MTPLX Pi's real session id so prompt-cache reuse is stable.
     """
@@ -81,7 +81,7 @@ def build_pi_request_policy_extension_source(
 // the mtplx identifiers below are gone from it.
 const mtplxModelID = {model_literal};
 const mtplxUncapped = {uncapped_literal};
-const mtplxPiInjectedDefaultMaxTokens = {PI_INJECTED_DEFAULT_MAX_TOKENS};
+const mtplxPiInjectedDefaultMaxTokens = {int(injected_max_tokens)};
 
 export default function (pi: any) {{
   pi.on("before_provider_headers", (event: any, ctx: any) => {{
@@ -125,12 +125,15 @@ def write_pi_request_policy_extension(
     *,
     model_id: str,
     uncapped: bool,
+    injected_max_tokens: int = PI_INJECTED_DEFAULT_MAX_TOKENS,
     path: str | Path | None = None,
 ) -> Path:
     """Install the small Pi bridge owned by the MTPLX provider config."""
 
     extension_path = pi_request_policy_extension_path(path)
-    source = build_pi_request_policy_extension_source(model_id, uncapped=uncapped)
+    source = build_pi_request_policy_extension_source(
+        model_id, uncapped=uncapped, injected_max_tokens=injected_max_tokens,
+    )
     if extension_path.exists():
         try:
             current = extension_path.read_text(encoding="utf-8")
@@ -475,6 +478,7 @@ def write_pi_models_config(
     request_policy_extension_path = write_pi_request_policy_extension(
         model_id=model_id,
         uncapped=max_tokens is None,
+        injected_max_tokens=int(provider_config["models"][0]["maxTokens"]),
         path=config_path,
     )
     return {

--- a/mtplx/pi.py
+++ b/mtplx/pi.py
@@ -94,6 +94,8 @@ export default function (pi: any) {{
     event.headers["x-mtplx-session-id"] = String(
       ctx.sessionManager.getSessionId(),
     );
+    const leaf = ctx.sessionManager.getLeafId();
+    if (leaf) event.headers["x-mtplx-client-entry-id"] = String(leaf);
   }});
 
   pi.on("before_provider_request", (event: any) => {{

--- a/mtplx/server/flight_recorder.py
+++ b/mtplx/server/flight_recorder.py
@@ -42,6 +42,14 @@ _TEXT_CAPTURE_MAX_CHARS = 4_000_000
 _TAIL_CHARS = 400
 _SAMPLE_INTERVAL_S = 1.0
 _TPS_WINDOW = 48
+_LIVE_FIELDS = (
+    ("accepted_by_depth", "acc"), ("drafted_by_depth", "drf"),
+    ("verify_calls", "vc"), ("verify_time_s", "vt"), ("draft_time_s", "dt"),
+    ("accept_time_s", "at"), ("commit_time_s", "ct"), ("repair_time_s", "rt"),
+    ("snapshot_time_s", "st"), ("bonus_time_s", "bt"),
+    ("capture_commit_time_s", "cct"), ("active_memory_bytes", "mem_active"),
+    ("cache_memory_bytes", "mem_cache"), ("peak_memory_bytes", "mem_peak"),
+)
 
 
 class FlightRecord:
@@ -309,14 +317,9 @@ class FlightRecorder:
             }
             depth = record.live_depth
             if depth:
-                for src, dst in (
-                    ("accepted_by_depth", "acc"),
-                    ("drafted_by_depth", "drf"),
-                    ("verify_time_s", "vt"),
-                    ("draft_time_s", "dt"),
-                ):
+                for src, dst in _LIVE_FIELDS:
                     value = depth.get(src)
-                    if value:
+                    if value is not None:
                         sample[dst] = (
                             round(value, 3) if isinstance(value, float) else value
                         )
@@ -364,14 +367,9 @@ class FlightRecorder:
                 # stall. trace derives its curve from gen deltas regardless.
                 sample["tps"] = round(record.tps_window(), 2)
                 sample["tps_avg"] = round(record.tps_avg(now), 2)
-            for src, dst in (
-                ("accepted_by_depth", "acc"),
-                ("drafted_by_depth", "drf"),
-                ("verify_time_s", "vt"),
-                ("draft_time_s", "dt"),
-            ):
+            for src, dst in _LIVE_FIELDS:
                 value = payload.get(src)
-                if value:
+                if value is not None:
                     sample[dst] = round(value, 3) if isinstance(value, float) else value
             self._emit(sample)
 

--- a/mtplx/server/flight_recorder.py
+++ b/mtplx/server/flight_recorder.py
@@ -49,6 +49,8 @@ _LIVE_FIELDS = (
     ("snapshot_time_s", "st"), ("bonus_time_s", "bt"),
     ("capture_commit_time_s", "cct"), ("active_memory_bytes", "mem_active"),
     ("cache_memory_bytes", "mem_cache"), ("peak_memory_bytes", "mem_peak"),
+    ("verify_route", "route"), ("compiled_verify_calls", "cv"),
+    ("eager_verify_calls", "evc"),
 )
 
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -17435,6 +17435,18 @@ def _prefill_admission_min_miss_tokens() -> int:
         return 4096
 
 
+def _prefill_admission_live_prefix_enabled() -> bool:
+    return os.environ.get(
+        "MTPLX_PREFILL_ADMISSION_LIVE_PREFIX", "1"
+    ).strip().lower() not in {"0", "off", "false", "no"}
+
+
+def _prefill_admission_chain_shed_enabled() -> bool:
+    return os.environ.get(
+        "MTPLX_PREFILL_ADMISSION_CHAIN_SHED", "1"
+    ).strip().lower() not in {"0", "off", "false", "no"}
+
+
 # Same line as _allocator_pressure_level's WARNING edge: at >=97% of the
 # Metal limit the next growth step swaps.
 _PREFILL_ADMISSION_PRESSURE_FRACTION = 0.97
@@ -17555,6 +17567,56 @@ def _prefill_admission_shed(
                 if block_tokens > reused_tokens:
                     reused_tokens = block_tokens
                     reused_mode = "block_prefix"
+        # The bank is not the only holder of reusable state: the engine's
+        # live sessions serve a committed prefix directly (that is what a
+        # warm turn's cached_tokens reads), and a live frontier can be
+        # unbanked — a refused snapshot (retokenized-history mismatch)
+        # banks nothing while the live KV still serves. Estimating from
+        # the bank alone read a warm 212k-token session as a full miss,
+        # cleared its snapshots as "superseded", and every client retry
+        # was then a 211,807-token cold miss that could never be admitted
+        # until a server restart (#447).
+        if _prefill_admission_live_prefix_enabled():
+            sessions = getattr(state, "sessions", None)
+            live_tokens = 0
+            if sessions is not None:
+                # Ask the same ladder session resolution asks (exact, then
+                # pending-postcommit near prefix, then best common prefix),
+                # with the non-exact answers rewound to the block floor the
+                # bank estimate above uses — the reuse a request achieves
+                # is never more optimistic than resolution's own match.
+                try:
+                    exact_fn = getattr(sessions, "longest_prefix_session", None)
+                    live = exact_fn(prompt_ids) if callable(exact_fn) else None
+                    if live is not None:
+                        live_tokens = len(
+                            getattr(live, "committed_token_ids", ()) or ()
+                        )
+                    if live_tokens <= 0:
+                        near_fn = getattr(
+                            sessions, "pending_near_prefix_session", None
+                        )
+                        if callable(near_fn):
+                            near, matched = near_fn(prompt_ids)
+                            if near is not None:
+                                live_tokens = _block_restorable_prefix_tokens(
+                                    int(matched)
+                                )
+                    if live_tokens <= 0:
+                        common_fn = getattr(
+                            sessions, "best_common_prefix_session", None
+                        )
+                        if callable(common_fn):
+                            shared, matched = common_fn(prompt_ids)
+                            if shared is not None:
+                                live_tokens = _block_restorable_prefix_tokens(
+                                    int(matched)
+                                )
+                except Exception:
+                    live_tokens = 0
+            if live_tokens > reused_tokens:
+                reused_tokens = int(live_tokens)
+                reused_mode = "live_session"
         miss_tokens = max(0, prompt_tokens - reused_tokens)
         if miss_tokens < _prefill_admission_min_miss_tokens():
             return None
@@ -17601,6 +17663,38 @@ def _prefill_admission_shed(
                             protect_active=True,
                         )
                     )
+                # Escalation between the protected LRU pass and giving up
+                # (#447): a deep session's sibling snapshots — forked
+                # generations of the same conversation that no put()-time
+                # supersede collapses — are active-protected above, so a
+                # 12.6 GiB bank served a 7 GiB deficit with zero evictions
+                # and the request died on the sustained-pressure 507. Walk
+                # those chain prefixes (never a session's terminal entry,
+                # never the entry this prompt restores from; the SSD cold
+                # tier keeps every eviction restorable) before letting the
+                # prefill start into a projection that crosses the line.
+                if _prefill_admission_chain_shed_enabled():
+                    bank_bytes_now = int(session_bank.total_nbytes)
+                    remaining = deficit - max(
+                        0, bank_bytes_before - bank_bytes_now
+                    )
+                    chain_fn = getattr(
+                        session_bank, "shrink_for_admission", None
+                    )
+                    if (
+                        remaining > 0
+                        and bank_bytes_now > 0
+                        and callable(chain_fn)
+                    ):
+                        chain_evicted, terminal_evicted = chain_fn(
+                            max(0, bank_bytes_now - remaining),
+                            protect_tokens=prompt_ids,
+                            reason="prefill_admission_chain",
+                        )
+                        receipt["chain_entries_evicted"] = int(chain_evicted)
+                        receipt["terminal_entries_evicted"] = int(
+                            terminal_evicted
+                        )
                 receipt["bank_bytes_after"] = int(session_bank.total_nbytes)
             except Exception as exc:
                 receipt["bank_error"] = repr(exc)

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -17454,8 +17454,8 @@ def _prefill_admission_chain_shed_enabled() -> bool:
     ).strip().lower() not in {"0", "off", "false", "no"}
 
 
-# Same line as _allocator_pressure_level's WARNING edge: at >=97% of the
-# Metal limit the next growth step swaps.
+# Same line as _allocator_pressure_level's WARNING edge. This is an early
+# allocation-budget signal, not proof that the operating system is swapping.
 _PREFILL_ADMISSION_PRESSURE_FRACTION = 0.97
 
 
@@ -17498,10 +17498,12 @@ def _prefill_admission_shed(
 
     Projects the miss-prefill footprint against the live allocator state
     and, only when the projection crosses the guard's WARNING line, frees
-    in escalation order: superseded same-session bank entries (the prefix
+    in escalation order: unused allocator cache, superseded same-session
+    bank entries (the prefix
     was rewritten, so they can never be restored by this lineage again),
-    then LRU idle entries with every active session protected, then the
-    allocator cache. Never raises; returns the receipt when it acted.
+    then LRU idle entries with every active session protected, then sibling
+    and terminal snapshots while protecting the incoming restore source.
+    Never raises; returns the receipt when it acted.
     """
 
     if not _prefill_admission_shed_enabled():
@@ -17642,8 +17644,28 @@ def _prefill_admission_shed(
             "threshold_bytes": int(threshold),
             "limit_bytes": int(limit),
         }
-        deficit = projected - threshold
-        if session_bank is not None:
+        # The allocator pool is free storage, whereas session snapshots
+        # avoid real re-prefill/SSD work. Reclaim the pool and remeasure
+        # before choosing any snapshot victims. Counting it as an admission
+        # deficit evicted useful conversations even when active KV fitted.
+        try:
+            import mlx.core as _mx
+
+            _mx.clear_cache()
+            receipt["cache_cleared"] = True
+        except Exception as exc:
+            receipt["cache_cleared"] = False
+            receipt["cache_clear_error"] = repr(exc)
+        after_cache = _mlx_memory_stats_live()
+        if int(after_cache.get("active_memory_bytes") or 0) > 0:
+            projected = (
+                int(after_cache["active_memory_bytes"])
+                + int(after_cache.get("cache_memory_bytes") or 0)
+                + miss_tokens * per_token + transients
+            )
+        receipt["projected_bytes_after_cache_clear"] = int(projected)
+        deficit = max(0, projected - threshold)
+        if session_bank is not None and deficit > 0:
             try:
                 bank_bytes_before = int(session_bank.total_nbytes)
                 receipt["bank_bytes_before"] = bank_bytes_before
@@ -17705,13 +17727,16 @@ def _prefill_admission_shed(
                 receipt["bank_bytes_after"] = int(session_bank.total_nbytes)
             except Exception as exc:
                 receipt["bank_error"] = repr(exc)
-        try:
-            import mlx.core as _mx
+        if deficit > 0:
+            # Evicted leaves may now sit in the allocator pool. Return that
+            # storage before the final physical-memory receipt as well.
+            try:
+                import mlx.core as _mx
 
-            _mx.clear_cache()
-            receipt["cache_cleared"] = True
-        except Exception:
-            receipt["cache_cleared"] = False
+                _mx.clear_cache()
+                receipt["cache_cleared"] = True
+            except Exception as exc:
+                receipt["cache_clear_error"] = repr(exc)
         after = _mlx_memory_stats_live()
         receipt["active_bytes_after"] = int(after.get("active_memory_bytes") or 0)
         receipt["cache_bytes_after"] = int(after.get("cache_memory_bytes") or 0)
@@ -17740,8 +17765,8 @@ def _allocator_pressure_level(state: "ServerState") -> tuple[int, float]:
     macOS's kern.memorystatus level fires only once the system is already
     compressing/swapping — on a 48 GB Mac that is minutes into the death
     spiral (#305: 61.8/48.0 GB before the first signal). The allocator
-    knows earlier: active+cache at >=97% of the configured Metal memory
-    limit means the next growth step swaps, so treat it as WARNING (2);
+    knows its allocation envelope earlier: active+cache at >=97% of the
+    configured Metal memory limit is treated as WARNING (2);
     past the limit is CRITICAL-equivalent (4). Returns (level, fraction).
     """
     caps = getattr(state, "metal_memory_caps", None)

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -15591,6 +15591,8 @@ def _metrics_envelope(
         "mtp_history_policy": str(stats.get("mtp_history_policy") or ""),
         "mtp_history_window_tokens": int(stats.get("mtp_history_window_tokens") or 0),
         "mtp_history_position_base": int(stats.get("mtp_history_position_base") or 0),
+        **({"fixed_m4_admission": stats["fixed_m4_admission"]}
+           if stats.get("fixed_m4_admission") else {}),
         **_maintenance_timing_stats(stats),
         "session_cache_hit": bool(session_cache_hit),
         "cache_miss_reason": cache_miss_reason,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -16519,6 +16519,9 @@ def _health_degradation_payload(state: Any) -> dict[str, Any]:
         for module_name, attr_name in (
             ("mtplx.kernels.sdpa_gqa_packed", "gqa_packed_bail_counts"),
             ("mtplx.attention_split", "gqa_packed_route_bail_counts"),
+            ("mtplx.kernels.sdpa_nax_flash", "nax_flash_bail_counts"),
+            ("mtplx.kernels.sdpa_nax_flash_dsplit", "nax_flash_dsplit_bail_counts"),
+            ("mtplx.kernels.sdpa_nax_tile", "nax_tile_bail_counts"),
         ):
             try:
                 from importlib import import_module

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -2346,17 +2346,18 @@ def _apply_metal_memory_caps(
     total_ram_bytes: int | None = None,
     minimum_resident_bytes: int | None = None,
 ) -> dict[str, Any]:
-    """Pin MLX Metal allocator caps at startup to avoid wired-memory swap-out
-    pathologies under sustained long-context inference.
+    """Set MLX allocation and wired-residency budgets at startup.
 
     On Apple Silicon, MLX's Metal allocator can grow the wired pool past safe
     headroom under back-to-back >30 K-token requests. When the OS starts
     swapping, decode collapses ~10x (50 t/s -> 2.5 t/s) and the kernel may kill
-    the process. Setting both caps at startup keeps the allocator inside a
-    fixed budget; ``clear_cache`` periodically drops idle pool memory.
+    the process. The allocation limit is MLX's working-set guideline, not an
+    instantaneous hard ceiling: a single operation can exceed it. Admission
+    and request pressure guards remain necessary. ``clear_cache`` releases
+    unused allocator buffers; it does not clear the session bank.
 
     Operators can override via env:
-      MTPLX_MEMORY_LIMIT_BYTES   - hard cap, default 75% of total RAM,
+      MTPLX_MEMORY_LIMIT_BYTES   - allocation budget, default 75% of total RAM,
                                    capped at 192 GiB on very large Macs
       MTPLX_WIRED_LIMIT_BYTES    - wired (resident) cap, default 60% of total
                                    RAM, capped at 160 GiB on very large Macs

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -15593,6 +15593,8 @@ def _metrics_envelope(
         "mtp_history_position_base": int(stats.get("mtp_history_position_base") or 0),
         **({"fixed_m4_admission": stats["fixed_m4_admission"]}
            if stats.get("fixed_m4_admission") else {}),
+        **({"compiled_verify": stats["graphbank"]["compiled_verify"]}
+           if (stats.get("graphbank") or {}).get("compiled_verify") else {}),
         **_maintenance_timing_stats(stats),
         "session_cache_hit": bool(session_cache_hit),
         "cache_miss_reason": cache_miss_reason,
@@ -30217,6 +30219,7 @@ def create_app(state: ServerState) -> FastAPI:
         )
         resolved_session_id: str | None = None
         resolved_session_source: str | None = None
+        resolved_session_diagnostic: dict[str, Any] = {}
         early_postcommit_handled = False
         early_postcommit_wait: dict[str, Any] | None = None
         early_cross_session_yield: dict[str, Any] | None = None
@@ -30243,6 +30246,7 @@ def create_app(state: ServerState) -> FastAPI:
                         chat_id=_request_extra(request, "chat_id"),
                         conversation_id=_request_extra(request, "conversation_id"),
                         prompt_ids=prompt_ids,
+                        diagnostic_out=resolved_session_diagnostic,
                     )
                 )
             except Exception:
@@ -30558,6 +30562,7 @@ def create_app(state: ServerState) -> FastAPI:
                     chat_id=_request_extra(request, "chat_id"),
                     conversation_id=_request_extra(request, "conversation_id"),
                     prompt_ids=prompt_ids,
+                    diagnostic_out=resolved_session_diagnostic,
                 )
             session = state.sessions.get_or_create(session_id)
             session.last_cache_miss_reason = cache_miss_reason
@@ -30591,10 +30596,9 @@ def create_app(state: ServerState) -> FastAPI:
             _record_tool_parse_event(state, event="tool_template_fallback")
         if request_observability.get("request_client_hint") == "android_studio":
             _record_tool_parse_event(state, event="android_studio_request_detected")
-        prefix_diagnostic = getattr(state.sessions, "last_prefix_diagnostic", None)
-        if isinstance(prefix_diagnostic, dict):
+        if resolved_session_diagnostic:
             request_observability["request_session_prefix_diagnostic"] = (
-                prefix_diagnostic
+                resolved_session_diagnostic
             )
         session_keep_live_ref = _session_keep_live_refs_for_request(
             session_source=session_source,

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -19626,7 +19626,13 @@ def _request_observability(
             "x-mtplx-request-id",
         }
     }
+    client_links = {}
+    for name in ("turn", "entry"):
+        value = str(headers.get(f"x-mtplx-client-{name}-id") or "")
+        if _CLIENT_REQUEST_ID_RE.fullmatch(value):
+            client_links[f"request_client_{name}_id"] = value
     return {
+        **client_links,
         "request_message_count": len(request.messages),
         "request_message_roles": [message.role for message in request.messages],
         "request_message_chars": [

--- a/mtplx/session_bank.py
+++ b/mtplx/session_bank.py
@@ -2759,6 +2759,111 @@ class SessionBank:
             evicted += 1
         return evicted
 
+    def shrink_for_admission(
+        self,
+        target_bytes: int,
+        *,
+        protect_tokens: list[int] | tuple[int, ...] | None = None,
+        reason: str = "prefill_admission_chain",
+    ) -> tuple[int, int]:
+        """Escalating eviction for the admission shed (#447).
+
+        Runs only when the pre-prefill projection says the request in front
+        of us is likely to die on the sustained-pressure abort, after the
+        superseded clear and the ``protect_active`` LRU pass both came up
+        short: a deep session's sibling snapshots — forked generations of
+        the same conversation whose retokenized histories diverge, so
+        ``_supersede_contained_prefixes`` never collapses them — are all
+        active-protected there. A 12.6 GiB bank served a 7 GiB deficit
+        with zero evictions and the request 507'd.
+
+        Phase 1 walks non-terminal entries (any session keeps its highest
+        ``prefix_len`` entry — the one the protected-terminal order guards).
+        Phase 2, only if the deficit stands, takes remaining entries in the
+        take-anything order of real memory pressure (active sessions last).
+        Both phases spare the entry the imminent prompt restores from
+        (``protect_tokens``), and every eviction is RAM-only: the SSD cold
+        tier still restores a walked entry, so the worst case is a disk
+        read on some session's next turn, not this request's abort.
+        Returns ``(non_terminal_evicted, terminal_evicted)``.
+        """
+        target = max(0, int(target_bytes))
+        protected_keys: set[tuple[int, ...]] = set()
+        if protect_tokens:
+            tokens = tuple(int(token) for token in protect_tokens)
+            best_key = None
+            best_common = 0
+            for key, entry in self._entries.items():
+                common = common_prefix_len(tokens, entry.token_ids)
+                if common > best_common:
+                    best_common = common
+                    best_key = key
+            if best_key is not None:
+                protected_keys.add(best_key)
+
+        def _walk(candidates_fn, order_key) -> int:
+            evicted = 0
+            while self._entries and self.total_nbytes > target:
+                candidates = candidates_fn()
+                if not candidates:
+                    break
+                victim = min(candidates, key=order_key)
+                before = len(self._entries)
+                self._evict_entry(victim, reason=reason)
+                if len(self._entries) >= before:
+                    break
+                evicted += 1
+            return evicted
+
+        def _evictable(entry) -> bool:
+            # Entries holding a live cache reference are the live session's
+            # own arrays (the same bar _supersede_contained_prefixes sets);
+            # walking one frees nothing and costs the running session its
+            # state. Measured: the first decode after such an eviction ran
+            # at 15 tok/s against 63 stock.
+            return entry.cache_ref is None and not entry.live_ref_only
+
+        def _non_terminal_candidates():
+            terminal: dict[str, int] = {}
+            for entry in self._entries.values():
+                lineage = entry.session_id or ""
+                if entry.prefix_len > terminal.get(lineage, -1):
+                    terminal[lineage] = entry.prefix_len
+            return [
+                entry
+                for key, entry in self._entries.items()
+                if key not in protected_keys
+                and _evictable(entry)
+                and entry.prefix_len < terminal.get(entry.session_id or "", -1)
+            ]
+
+        non_terminal = _walk(
+            _non_terminal_candidates,
+            lambda entry: (
+                entry.last_access_s,
+                -entry.nbytes,
+                entry.created_at_s,
+            ),
+        )
+        if self.total_nbytes <= target:
+            return non_terminal, 0
+
+        active = self._active_session_ids()
+        terminal_evicted = _walk(
+            lambda: [
+                entry
+                for key, entry in self._entries.items()
+                if key not in protected_keys and _evictable(entry)
+            ],
+            lambda entry: (
+                entry.session_id in active,
+                entry.last_access_s,
+                -entry.nbytes,
+                entry.created_at_s,
+            ),
+        )
+        return non_terminal, terminal_evicted
+
     def _evict_entry(self, entry: SessionBankEntry, *, reason: str) -> None:
         entry.eviction_reason = reason
         if self._entries.pop(entry.token_ids, None) is None:

--- a/native_extensions/qsa_kernels/README.md
+++ b/native_extensions/qsa_kernels/README.md
@@ -61,6 +61,22 @@ venv's Python, ABI and macOS tags to choose between them; the app's installed
 fingerprint follows that selected artifact. macOS14 retains the pure wheel.
 This packaging does not establish performance on an unmeasured GPU family.
 
+The app installer can be exercised without opening its UI. Set
+`MTPLX_QA_WHEEL` to the staged pure wheel (with `Native/` and the selector
+beside it), `MTPLX_QA_PYTHON` to the bundled Python, and `MTPLX_QA_HOME` to
+a new, isolated test directory. Then run:
+
+```sh
+swift test --package-path apps/MTPLXApp \
+  --filter RuntimeBundledArtifactTests.testFreshArtifactInstallAndReuse
+```
+
+`MTPLX_QA_EXPECT_WHEEL` optionally asserts the selected wheel's filename.
+The test installs through the production bootstrapper, verifies its health
+and fingerprint, checks reuse, and preserves an `artifact-install-receipt.json`
+in the test directory. It skips when the three required inputs are absent.
+Run native pipeline/model checks under the project's verified fan procedure.
+
 ## Things that break it
 
 * **nanobind drift.** `nanobind>=2` at the MTPLX root is a floor, not a pin.

--- a/native_extensions/qsa_kernels/README.md
+++ b/native_extensions/qsa_kernels/README.md
@@ -46,6 +46,21 @@ PY
 `otool -L mtplx_qsa_kernels/_ext*.so` must resolve `libmlx.dylib` to the mlx
 wheel in this venv, not to a build-tree absolute path.
 
+## Release artifacts
+
+`scripts/bundle_native_runtime_wheel.py` combines a pure MTPLX wheel and
+this extension's wheel into one platform-tagged MTPLX wheel. It verifies
+both input RECORDs, preserves the native licenses and NOTICE, records the
+input hashes, and carries the exact MLX runtime dependency into the result.
+The ordinary pure wheel remains available for unsupported Python/OS cells.
+
+The macOS release script builds with the app's bundled Python and a macOS15
+deployment target. The app carries the pure wheel in `Runtime/` and the
+native wheel in `Runtime/Native/`. `select_runtime_wheel.py` uses the actual
+venv's Python, ABI and macOS tags to choose between them; the app's installed
+fingerprint follows that selected artifact. macOS14 retains the pure wheel.
+This packaging does not establish performance on an unmeasured GPU family.
+
 ## Things that break it
 
 * **nanobind drift.** `nanobind>=2` at the MTPLX root is a floor, not a pin.
@@ -56,8 +71,8 @@ wheel in this venv, not to a build-tree absolute path.
   it: `BUILT_AGAINST_MLX` is compared against the imported version at
   readiness, and a mismatch warns once and disables the lane, so the symptom
   is "the direct lane stopped engaging", not a crash. Rebuild here.
-  `pyproject.toml` pins the BUILD to `mlx==0.32.2` so a PEP 517 isolated
-  build cannot quietly pick a different 0.32.x than the serving venv holds.
+  Both build and native-wheel runtime metadata pin `mlx==0.32.2` so a
+  resolver cannot silently combine a different wheel with this extension.
 * **Metallib name or location.** The C++ resolves `mtplx_qsa_kernels` from the
   directory of the loaded `.so`. Renaming or moving either one turns a symbol
   that imports fine into an `mx.eval`-time pipeline failure. That is what

--- a/native_extensions/qsa_kernels/setup.py
+++ b/native_extensions/qsa_kernels/setup.py
@@ -43,4 +43,6 @@ if __name__ == "__main__":
         },
         zip_safe=False,
         python_requires=">=3.11",
+        # This extension uses MLX's private C++ ABI; runtime must match build.
+        install_requires=["mlx==0.32.2"],
     )

--- a/scripts/bundle_native_runtime_wheel.py
+++ b/scripts/bundle_native_runtime_wheel.py
@@ -6,11 +6,13 @@ This builds a local artifact only; it never uploads or installs anything.
 """
 
 import argparse
+from email.parser import BytesParser
 import hashlib
 import json
 from pathlib import Path
 
 from packaging.tags import Tag
+from packaging.requirements import Requirement
 from packaging.utils import parse_wheel_filename
 from wheel.wheelfile import WheelFile
 
@@ -35,6 +37,12 @@ def main():
     if output.exists():
         parser.error(f"Refusing to overwrite {output}")
     with WheelFile(args.runtime) as core, WheelFile(args.native) as native:
+        metadata_name = next(n for n in native.namelist() if n.endswith(".dist-info/METADATA"))
+        native_metadata = BytesParser().parsebytes(native.read(metadata_name))
+        native_requirements = native_metadata.get_all("Requires-Dist", [])
+        mlx_pins = [Requirement(r) for r in native_requirements if Requirement(r).name == "mlx"]
+        if len(mlx_pins) != 1 or not str(mlx_pins[0].specifier).startswith("=="):
+            parser.error("Native wheel must declare its exact MLX runtime ABI dependency")
         members = [n for n in native.namelist() if n.startswith("mtplx_qsa_kernels/")]
         for required in ("NOTICE", "LICENSE.txt", "MLX_LICENSE.txt"):
             if f"mtplx_qsa_kernels/{required}" not in members:
@@ -57,6 +65,12 @@ def main():
                         data = ("\n".join([*lines, "Root-Is-Purelib: false", f"Tag: {tag}", ""])).encode()
                     elif archive is core and name.endswith(".dist-info/top_level.txt"):
                         data += b"mtplx_qsa_kernels\n"
+                    elif archive is core and name.endswith(".dist-info/METADATA"):
+                        metadata = BytesParser().parsebytes(data)
+                        for requirement in native_requirements:
+                            if requirement not in metadata.get_all("Requires-Dist", []):
+                                metadata["Requires-Dist"] = requirement
+                        data = metadata.as_bytes()
                     bundled.writestr(archive.getinfo(name), data)
             bundled.writestr("mtplx/native_build_receipt.json", json.dumps(provenance, indent=2))
             # WheelFile writes a new RECORD for the complete distribution.

--- a/scripts/bundle_native_runtime_wheel.py
+++ b/scripts/bundle_native_runtime_wheel.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Package the tested QSA extension inside a platform-specific MTPLX wheel.
+
+The pure Python wheel remains the fallback for other Python/OS platforms.
+This builds a local artifact only; it never uploads or installs anything.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from packaging.tags import Tag
+from packaging.utils import parse_wheel_filename
+from wheel.wheelfile import WheelFile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runtime", type=Path)
+    parser.add_argument("native", type=Path)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    name, version, _, core_tags = parse_wheel_filename(args.runtime.name)
+    native_name, _, _, native_tags = parse_wheel_filename(args.native.name)
+    if name != "mtplx" or core_tags != frozenset({Tag("py3", "none", "any")}):
+        parser.error("The runtime input must be the pure Python MTPLX wheel")
+    if native_name.replace("-", "_") != "mtplx_qsa_kernels" or len(native_tags) != 1:
+        parser.error("Expected one tested mtplx_qsa_kernels platform wheel")
+    tag = next(iter(native_tags))
+    if not tag.platform.startswith("macosx_") or not tag.platform.endswith("_arm64"):
+        parser.error("The native wheel must target Apple Silicon")
+    args.out.mkdir(parents=True, exist_ok=True)
+    output = args.out / f"mtplx-{version}-{tag}.whl"
+    if output.exists():
+        parser.error(f"Refusing to overwrite {output}")
+    with WheelFile(args.runtime) as core, WheelFile(args.native) as native:
+        members = [n for n in native.namelist() if n.startswith("mtplx_qsa_kernels/")]
+        for required in ("NOTICE", "LICENSE.txt", "MLX_LICENSE.txt"):
+            if f"mtplx_qsa_kernels/{required}" not in members:
+                parser.error(f"Native attribution is missing: {required}")
+        if not any(n.endswith(".metallib") for n in members) or not any(n.endswith(".so") for n in members):
+            parser.error("Native wheel lacks its extension or Metal library")
+        provenance = {p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+                      for p in (args.runtime, args.native)}
+        with WheelFile(output, "w") as bundled:
+            for archive, names in ((core, core.namelist()), (native, members)):
+                for name in names:
+                    if name.endswith("/") or name.endswith(".dist-info/RECORD"):
+                        continue
+                    if name.startswith("/") or ".." in Path(name).parts:
+                        raise ValueError(f"Unsafe archive path: {name}")
+                    data = archive.read(name)  # WheelFile verifies source RECORD hashes.
+                    if archive is core and name.endswith(".dist-info/WHEEL"):
+                        lines = [line for line in data.decode().splitlines()
+                                 if not line.startswith(("Tag:", "Root-Is-Purelib:"))]
+                        data = ("\n".join([*lines, "Root-Is-Purelib: false", f"Tag: {tag}", ""])).encode()
+                    elif archive is core and name.endswith(".dist-info/top_level.txt"):
+                        data += b"mtplx_qsa_kernels\n"
+                    bundled.writestr(archive.getinfo(name), data)
+            bundled.writestr("mtplx/native_build_receipt.json", json.dumps(provenance, indent=2))
+            # WheelFile writes a new RECORD for the complete distribution.
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bundle_native_runtime_wheel.py
+++ b/scripts/bundle_native_runtime_wheel.py
@@ -7,6 +7,7 @@ This builds a local artifact only; it never uploads or installs anything.
 
 import argparse
 from email.parser import BytesParser
+from email.policy import compat32
 import hashlib
 import json
 from pathlib import Path
@@ -70,7 +71,10 @@ def main():
                         for requirement in native_requirements:
                             if requirement not in metadata.get_all("Requires-Dist", []):
                                 metadata["Requires-Dist"] = requirement
-                        data = metadata.as_bytes()
+                        # Core Metadata requirements must stay on one line;
+                        # email's default folding inserts a newline inside
+                        # environment markers that wheel validators reject.
+                        data = metadata.as_bytes(policy=compat32.clone(max_line_length=0))
                     bundled.writestr(archive.getinfo(name), data)
             bundled.writestr("mtplx/native_build_receipt.json", json.dumps(provenance, indent=2))
             # WheelFile writes a new RECORD for the complete distribution.

--- a/scripts/hygiene_scan.sh
+++ b/scripts/hygiene_scan.sh
@@ -76,6 +76,14 @@ record_model_artifact() {
     apps/MTPLXApp/Sources/MTPLXAppCore/Resources/*|./apps/MTPLXApp/Sources/MTPLXAppCore/Resources/*)
       return 0
       ;;
+    # The shipped FR-Spec lookup is 65,536 int32 vocabulary token IDs,
+    # not model parameters. Only these reviewed bytes are exempt; a changed
+    # table or any other NPY still requires review and fails this check.
+    mtplx/data/qwen38_code_ranked_64k.npy|./mtplx/data/qwen38_code_ranked_64k.npy)
+      if [[ "$(shasum -a 256 "$path" | cut -d ' ' -f 1)" == "922a4d0570ce0a79e03c1e1ecb25e6c8c1e9cae943b2c0d5ce11874d42d74a17" ]]; then
+        return 0
+      fi
+      ;;
     # The deepseek_v4 parity suite gates the whole forward against a 2.3 MB
     # deterministic golden (toy dims, float32 arrays, no pickled objects) —
     # a test fixture, not a checkpoint. Exempted by exact path; everything

--- a/scripts/mtp_cost_probe.py
+++ b/scripts/mtp_cost_probe.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Replay an uncapped request at AR and fixed MTP depths, retaining evidence.
+
+Use an isolated, already-running daemon with request logging and verified
+max fans. The request JSON supplies the real task and native sampler; no
+output/reasoning limit or stop string is inserted by this tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import statistics
+import subprocess
+import time
+import urllib.request
+
+from mtplx.commands.trace_metrics import mtp_economics
+
+
+def read_json(url):
+    with urllib.request.urlopen(url, timeout=10) as response:
+        return json.load(response)
+
+
+def fans(command):
+    state = json.loads(subprocess.check_output([command, "status"], text=True))
+    rows = state.get("fans", [])
+    if not rows or not all(r["mode"] != "auto" and
+                           r["actual_rpm"] >= .95 * r["max_rpm"] for r in rows):
+        raise RuntimeError("Max-fan ramp is not verified")
+    return state
+
+
+def request(base, body, path):
+    req = urllib.request.Request(base + "/v1/chat/completions",
+        data=json.dumps(body).encode(), headers={"Content-Type": "application/json",
+        "x-mtplx-allow-client-controls": "true"})
+    started = time.time()
+    first = last = None
+    gap = 0.
+    rid = finish = None
+    usage = {}
+    with urllib.request.urlopen(req, timeout=900) as response, path.open("w") as sink:
+        for line in response:
+            if not line.startswith(b"data: "):
+                continue
+            payload = line[6:].strip()
+            if payload == b"[DONE]":
+                break
+            event = json.loads(payload)
+            now = time.time()
+            sink.write(json.dumps({"ts": now, "event": event}, ensure_ascii=False) + "\n")
+            sink.flush()
+            if "error" in event:
+                raise RuntimeError(event["error"])
+            rid = event.get("id", rid)
+            usage = event.get("usage") or usage
+            for choice in event.get("choices", []):
+                delta = choice.get("delta", {})
+                if any(delta.get(k) for k in ("content", "reasoning_content", "reasoning", "tool_calls")):
+                    first = first or now
+                    if last is not None:
+                        gap = max(gap, now-last)
+                    last = now
+                finish = choice.get("finish_reason") or finish
+    if finish in (None, "error", "length"):
+        raise RuntimeError(f"Request did not complete naturally: {finish}")
+    return {"request_id": rid, "started_s": started, "wall_s": time.time()-started,
+            "ttft_s": first-started if first else None, "max_emit_gap_s": gap,
+            "finish_reason": finish, "usage": usage}
+
+
+def receipt(path, rid):
+    deadline = time.monotonic()+15
+    while True:
+        if path.exists():
+            for line in path.read_text().splitlines():
+                row = json.loads(line)
+                if row.get("request_id") == rid:
+                    return row
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"No durable receipt for {rid}")
+        time.sleep(.2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("request", type=Path)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8211")
+    parser.add_argument("--request-log", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--depths", default="0,1,2,3")
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--fan-command", default=shutil.which("thermalforge"))
+    args = parser.parse_args()
+    depths = [int(d) for d in args.depths.split(",")]
+    if not depths or min(depths) < 0 or args.repeats < 1 or not args.fan_command:
+        parser.error("Need nonnegative depths, positive repeats, and thermalforge")
+    raw = args.request.read_bytes()
+    body = json.loads(raw)
+    args.out.mkdir(parents=True, exist_ok=False)
+    health = read_json(args.base_url + "/health")
+    model = read_json(args.base_url + "/v1/models")["data"][0]["id"]
+    if health.get("active_requests"):
+        raise RuntimeError("Daemon is busy; run the probe after the active client finishes")
+    identity = {"request_sha256": hashlib.sha256(raw).hexdigest(), "health": health, "model": model,
+                "fans": fans(args.fan_command), "depths": depths, "repeats": args.repeats}
+    (args.out / "identity.json").write_text(json.dumps(identity, indent=2))
+    rows = []
+    for repeat in range(args.repeats):
+        for depth in (depths if repeat % 2 == 0 else depths[::-1]):
+            label = f"r{repeat+1}-d{depth}"
+            sent = {**body, "model": model, "stream": True,
+                    "stream_options": {"include_usage": True},
+                    "generation_mode": "ar" if depth == 0 else "mtp", "depth": depth}
+            fan = fans(args.fan_command)
+            (args.out / f"{label}-request.json").write_text(json.dumps(sent, indent=2))
+            row = request(args.base_url, sent, args.out / f"{label}-stream.jsonl")
+            rec = receipt(args.request_log, row["request_id"])
+            if rec.get("generation_mode") != sent["generation_mode"] or (depth and rec.get("mtp_depth") != depth):
+                raise RuntimeError("The daemon did not honor the requested generation mode/depth")
+            row.update(label=label, depth=depth, repeat=repeat+1, receipt=rec, fans=fan)
+            rows.append(row)
+            (args.out / f"{label}-result.json").write_text(json.dumps(row, indent=2))
+            print(json.dumps({"label": label, "wall_s": row["wall_s"],
+                              "decode_tok_s": rec.get("decode_tok_s"),
+                              "tokens": rec.get("completion_tokens")}), flush=True)
+    ar = [r["receipt"]["decode_tok_s"] for r in rows if r["depth"] == 0]
+    ar_median = statistics.median(ar) if ar else None
+    for row in rows:
+        row["economics"] = mtp_economics(row["receipt"], ar_median)
+    (args.out / "summary.json").write_text(json.dumps({"ar_median_tok_s": ar_median,
+        "caveat": "Sampled outputs vary. Compare repeated matched workloads and full task completion, not a single ratio.",
+        "runs": rows}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mtp_cost_probe.py
+++ b/scripts/mtp_cost_probe.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-from pathlib import Path
 import shutil
 import statistics
 import subprocess
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 from mtplx.commands.trace_metrics import mtp_economics
 
@@ -102,6 +102,8 @@ def main():
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument("--depths", default="0,1,2,3")
     parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--seed-map", type=Path,
+                        help="JSON mapping run labels (r1-d0, ...) to baseline resolved seeds")
     parser.add_argument("--fan-command", default=shutil.which("thermalforge"))
     args = parser.parse_args()
     depths = [int(d) for d in args.depths.split(",")]
@@ -109,13 +111,15 @@ def main():
         parser.error("Need nonnegative depths, positive repeats, and thermalforge")
     raw = args.request.read_bytes()
     body = json.loads(raw)
+    seeds = json.loads(args.seed_map.read_text()) if args.seed_map else {}
     args.out.mkdir(parents=True, exist_ok=False)
     health = read_json(args.base_url + "/health")
     model = read_json(args.base_url + "/v1/models")["data"][0]["id"]
     if health.get("active_requests"):
         raise RuntimeError("Daemon is busy; run the probe after the active client finishes")
     identity = {"request_sha256": hashlib.sha256(raw).hexdigest(), "health": health, "model": model,
-                "fans": fans(args.fan_command), "depths": depths, "repeats": args.repeats}
+                "fans": fans(args.fan_command), "depths": depths, "repeats": args.repeats,
+                "seed_map": seeds}
     (args.out / "identity.json").write_text(json.dumps(identity, indent=2))
     rows = []
     for repeat in range(args.repeats):
@@ -124,6 +128,8 @@ def main():
             sent = {**body, "model": model, "stream": True,
                     "stream_options": {"include_usage": True},
                     "generation_mode": "ar" if depth == 0 else "mtp", "depth": depth}
+            if args.seed_map:
+                sent["seed"] = int(seeds[label])
             fan = fans(args.fan_command)
             (args.out / f"{label}-request.json").write_text(json.dumps(sent, indent=2))
             row = request(args.base_url, sent, args.out / f"{label}-stream.jsonl")

--- a/scripts/mtp_cost_probe.py
+++ b/scripts/mtp_cost_probe.py
@@ -130,19 +130,23 @@ def main():
             rec = receipt(args.request_log, row["request_id"])
             if rec.get("generation_mode") != sent["generation_mode"] or (depth and rec.get("mtp_depth") != depth):
                 raise RuntimeError("The daemon did not honor the requested generation mode/depth")
-            row.update(label=label, depth=depth, repeat=repeat+1, receipt=rec, fans=fan)
+            row.update(label=label, depth=depth, repeat=repeat+1, receipt=rec, fans=fan,
+                       guard_passed=not bool(rec.get("repetition_stop_triggered")))
             rows.append(row)
             (args.out / f"{label}-result.json").write_text(json.dumps(row, indent=2))
             print(json.dumps({"label": label, "wall_s": row["wall_s"],
                               "decode_tok_s": rec.get("decode_tok_s"),
                               "tokens": rec.get("completion_tokens")}), flush=True)
-    ar = [r["receipt"]["decode_tok_s"] for r in rows if r["depth"] == 0]
+    ar = [r["receipt"]["decode_tok_s"] for r in rows if r["depth"] == 0 and r["guard_passed"]]
     ar_median = statistics.median(ar) if ar else None
     for row in rows:
         row["economics"] = mtp_economics(row["receipt"], ar_median)
     (args.out / "summary.json").write_text(json.dumps({"ar_median_tok_s": ar_median,
-        "caveat": "Sampled outputs vary. Compare repeated matched workloads and full task completion, not a single ratio.",
+        "guard_passed": all(r["guard_passed"] for r in rows),
+        "caveat": "Sampled outputs vary. Guard-stopped samples are invalid; passing this guard does not validate the generated code. Compare repeated matched workloads and full task completion.",
         "runs": rows}, indent=2))
+    if not all(r["guard_passed"] for r in rows):
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/mtp_cost_probe.py
+++ b/scripts/mtp_cost_probe.py
@@ -16,6 +16,7 @@ import shutil
 import statistics
 import subprocess
 import time
+import urllib.error
 import urllib.request
 
 from mtplx.commands.trace_metrics import mtp_economics
@@ -44,7 +45,13 @@ def request(base, body, path):
     gap = 0.
     rid = finish = None
     usage = {}
-    with urllib.request.urlopen(req, timeout=900) as response, path.open("w") as sink:
+    try:
+        response = urllib.request.urlopen(req, timeout=900)
+    except urllib.error.HTTPError as exc:
+        error_path = path.with_suffix(".http-error.json")
+        error_path.write_bytes(exc.read())
+        raise RuntimeError(f"HTTP {exc.code}; response saved to {error_path}") from exc
+    with response, path.open("w") as sink:
         for line in response:
             if not line.startswith(b"data: "):
                 continue

--- a/scripts/release_macos_v1.sh
+++ b/scripts/release_macos_v1.sh
@@ -205,6 +205,26 @@ if [[ ! -x "$PBS_EXTRACT_DIR/bin/python3" ]]; then
   exit 1
 fi
 
+# Build the optional sparse-prefill consumer for the exact bundled Python.
+# Keep the pure wheel beside it: pip/app tag selection declines this binary
+# on older macOS or a different Python ABI rather than breaking installation.
+NATIVE_BUILD_VENV="$OUT_ROOT/native-build-venv"
+NATIVE_DIST="$OUT_ROOT/native-wheels"
+"$PBS_EXTRACT_DIR/bin/python3" -m venv "$NATIVE_BUILD_VENV"
+"$NATIVE_BUILD_VENV/bin/python" -m pip install \
+  build wheel setuptools 'cmake>=3.27' 'mlx==0.32.2' 'nanobind==2.15.0'
+MACOSX_DEPLOYMENT_TARGET=15.0 "$NATIVE_BUILD_VENV/bin/python" -m build \
+  --wheel --no-isolation "$ROOT/native_extensions/qsa_kernels" --outdir "$NATIVE_DIST"
+NATIVE_WHEELS=("$NATIVE_DIST"/mtplx_qsa_kernels-*.whl)
+if [[ "${#NATIVE_WHEELS[@]}" != "1" || ! -f "${NATIVE_WHEELS[0]}" ]]; then
+  echo "error: expected exactly one native QSA wheel" >&2
+  exit 1
+fi
+NATIVE_RUNTIME_WHEEL="$("$NATIVE_BUILD_VENV/bin/python" \
+  "$ROOT/scripts/bundle_native_runtime_wheel.py" "$PYTHON_WHEEL" \
+  "${NATIVE_WHEELS[0]}" --out "$PYTHON_DIST")"
+"$PYTOOLS_VENV/bin/python" -m twine check "$NATIVE_RUNTIME_WHEEL"
+
 echo "Building signed MTPLX.app"
 MTPLX_APP_PUBLIC_RELEASE=1 \
 MTPLX_APP_VERSION="$VERSION" \
@@ -212,6 +232,7 @@ MTPLX_APP_BUILD="$APP_BUILD" \
 MTPLX_APP_BUNDLE_DIR="$APP_BUNDLE" \
 MTPLX_APP_EMBED_LOCAL_RUNTIME_WRAPPER=0 \
 MTPLX_RUNTIME_WHEEL="$PYTHON_WHEEL" \
+MTPLX_NATIVE_RUNTIME_WHEEL="$NATIVE_RUNTIME_WHEEL" \
 MTPLX_REQUIRE_RUNTIME_WHEEL_RESOURCE=1 \
 MTPLX_BUNDLED_PYTHON_DIR="$PBS_EXTRACT_DIR" \
 MTPLX_REQUIRE_BUNDLED_PYTHON_RESOURCE=1 \

--- a/scripts/select_runtime_wheel.py
+++ b/scripts/select_runtime_wheel.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Select a bundled runtime with pip's real Python/ABI/macOS compatibility tags."""
+
+from pathlib import Path
+import sys
+
+try:
+    from packaging.tags import sys_tags
+    from packaging.utils import parse_wheel_filename
+except ImportError:  # A fresh app venv has ensurepip before its dependencies.
+    from pip._vendor.packaging.tags import sys_tags
+    from pip._vendor.packaging.utils import parse_wheel_filename
+
+
+def select_runtime_wheel(fallback: Path, native_dir: Path, tags=None) -> Path:
+    name, version, _, _ = parse_wheel_filename(fallback.name)
+    if name != "mtplx":
+        raise ValueError("Expected an MTPLX fallback wheel")
+    ranking = {tag: i for i, tag in enumerate(sys_tags() if tags is None else tags)}
+    matches = []
+    for path in [fallback, *sorted(native_dir.glob("mtplx-*.whl"))]:
+        candidate_name, candidate_version, _, candidate_tags = parse_wheel_filename(path.name)
+        if candidate_name != name or candidate_version != version:
+            raise ValueError(f"Bundled runtime versions disagree: {path.name}")
+        ranks = [ranking[tag] for tag in candidate_tags if tag in ranking]
+        if ranks:
+            matches.append((min(ranks), path))
+    if not matches:
+        raise ValueError("No bundled runtime matches this Python and macOS")
+    return min(matches, key=lambda item: item[0])[1]
+
+
+if __name__ == "__main__":
+    print(select_runtime_wheel(Path(sys.argv[1]), Path(sys.argv[2])))

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -4,6 +4,20 @@ from mtplx.adaptive import AdaptiveDepthPolicy, ExpectedValueDepthPolicy
 from mtplx.benchmarks.runners import mtp_adaptive
 
 
+def test_expected_value_does_not_charge_early_rejection_again_at_later_positions():
+    policy = ExpectedValueDepthPolicy(
+        max_depth=3, accept_priors=(1.0, 1.0, 1.0), ewma_alpha=0.5,
+        confidence_weight=0.0, warmup_full_depth_cycles=0, exploration_interval=0,
+    )
+    policy.observe(attempted_depth=3, accepted_depths=3)
+    policy.observe(attempted_depth=3, accepted_depths=0)
+    decision = policy.should_continue_after_draft(
+        drafted_depth=2, max_depth=3, draft_metrics={})
+    # Half the first-position estimate, with perfect later acceptance when
+    # reached, means p(accept third) = .5, not .5 * .5 * .5 = .125.
+    assert decision["expected_extra_accept"] == 0.5
+
+
 def test_adaptive_policy_increases_after_full_accept_streak():
     policy = AdaptiveDepthPolicy(max_depth=4, start_depth=2, increase_after=2)
 

--- a/tests/test_descriptors_qwen4_exp_tune.py
+++ b/tests/test_descriptors_qwen4_exp_tune.py
@@ -1,0 +1,42 @@
+"""Tune is enabled for the Qwen 3.8 Flash-Next family (qwen4_exp).
+
+qwen4-next ships backend qwen4_exp with can_run_verified=True and the forged
+packs record mtp_depth_max 3, yet the family never reached tune: the allowlist
+stopped at qwen3_8, so `mtplx tune` reported the model unsupported and no
+depth could be measured or chosen for the geometry that 2.11 made its headline
+decode lane.
+"""
+
+from __future__ import annotations
+
+from mtplx.backends.descriptors import (
+    model_family_from_inspection,
+    tune_policy_for_model,
+)
+
+FLASH_NEXT_INSPECTION = {
+    "model_type": "qwen4_exp_text",
+    "architecture": "Qwen4ExpForConditionalGeneration",
+    "mtp_arch": "qwen4-next",
+    "num_hidden_layers": 48,
+    "mtp_num_hidden_layers": 1,
+}
+
+
+def test_flash_next_resolves_to_the_qwen4_exp_family():
+    assert model_family_from_inspection(FLASH_NEXT_INSPECTION) == "qwen4_exp"
+
+
+def test_tune_is_supported_for_flash_next():
+    assert tune_policy_for_model(inspection=FLASH_NEXT_INSPECTION).supported is True
+
+
+def test_flash_next_offers_depths_one_to_three():
+    policy = tune_policy_for_model(inspection=FLASH_NEXT_INSPECTION)
+    assert policy.candidates == ("AR", "D1", "D2", "D3")
+
+
+def test_the_family_does_not_ride_the_dense_qwen3_8_contract():
+    # Flash-Next carries "3.8" in its public name; it must resolve to its own
+    # family, not the dense-27B qwen3_8 behaviour contract.
+    assert model_family_from_inspection({"model_type": "qwen4_exp_text"}) != "qwen3_8"

--- a/tests/test_engine_session_concurrency.py
+++ b/tests/test_engine_session_concurrency.py
@@ -12,6 +12,21 @@ from mtplx.engine_session import (
 )
 
 
+def test_prefix_receipt_belongs_to_the_request_even_after_another_resolution():
+    manager = EngineSessionManager()
+    anonymous = {}
+    manager.resolve_session_id(prompt_ids=[1, 2, 3], diagnostic_out=anonymous)
+    assert anonymous["prompt_len"] == 3
+    explicit = {}
+    manager.resolve_session_id(headers={"x-mtplx-session-id": "opencode"},
+                               diagnostic_out=explicit)
+    assert explicit == {}
+    assert manager.last_prefix_diagnostic is None
+    # The awaiting anonymous request keeps its own original evidence.
+    manager.resolve_session_id(prompt_ids=[4, 5], diagnostic_out={})
+    assert anonymous["prompt_len"] == 3
+
+
 def test_busy_implicit_session_forks_to_fresh_anonymous_session():
     manager = EngineSessionManager()
     shared = manager.get_or_create("anon-shared")

--- a/tests/test_graphbank_trace_lifetime.py
+++ b/tests/test_graphbank_trace_lifetime.py
@@ -1,0 +1,58 @@
+"""Shared compiled programs must not own a completed request's cache buffers."""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import mtplx.graphbank as graphbank
+
+
+class Runtime:
+    pass
+
+
+def _bank(runtime, marker):
+    bank = object.__new__(graphbank.CompiledVerifyBank)
+    bank.runtime = runtime
+    bank.capture_backend = "linear_gdn_from_conv_tape"
+    bank._capture_layout_override = ()
+    bank._extra_capture_layout = ()
+    bank._prepare_compiled_aux = None
+    bank._spec = []
+    bank._shadow = []
+    bank.stats = {"traces": 0}
+    bank._runtime_forward = lambda *args, **kwargs: (marker, "hidden", {})
+    return bank
+
+
+def test_shared_compiled_trace_does_not_own_completed_bank(monkeypatch):
+    # The retention defect is Python ownership, independent of MLX execution.
+    monkeypatch.setattr(graphbank.mx, "compile", lambda fn: fn)
+    monkeypatch.setattr(graphbank, "_SHARED_VERIFY_STEPS", {})
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_SHARED_TRACES", "1")
+    runtime = Runtime()
+    first = _bank(runtime, "first")
+    reference = weakref.ref(first)
+    fn = first._shared_or_new_verify_step((4, "default", 8192), 4, None)
+    assert fn(SimpleNamespace(shape=(1, 4))) == ("first", "hidden")
+    del first
+    gc.collect()
+    assert reference() is None, "process-global trace retains a completed request's shadow cache"
+
+    second = _bank(runtime, "second")
+    second_fn = second._shared_or_new_verify_step((4, "default", 8192), 4, None)
+    assert second_fn is fn
+    assert second_fn(SimpleNamespace(shape=(1, 4))) == ("second", "hidden")
+    assert second.stats["traces"] == 1
+
+
+def test_unshared_callable_does_not_create_a_bank_cycle(monkeypatch):
+    monkeypatch.setattr(graphbank.mx, "compile", lambda fn: fn)
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_SHARED_TRACES", "0")
+    bank = _bank(Runtime(), "unshared")
+    reference = weakref.ref(bank)
+    fn = bank._shared_or_new_verify_step((4, "default", 8192), 4, None)
+    assert fn(SimpleNamespace(shape=(1, 4))) == ("unshared", "hidden")
+    del bank
+    gc.collect()
+    assert reference() is None

--- a/tests/test_graphbank_trace_lifetime.py
+++ b/tests/test_graphbank_trace_lifetime.py
@@ -4,7 +4,7 @@ import gc
 import weakref
 from types import SimpleNamespace
 
-import mtplx.graphbank as graphbank
+from mtplx import graphbank
 
 
 class Runtime:

--- a/tests/test_graphbank_trace_lifetime.py
+++ b/tests/test_graphbank_trace_lifetime.py
@@ -56,3 +56,20 @@ def test_unshared_callable_does_not_create_a_bank_cycle(monkeypatch):
     del bank
     gc.collect()
     assert reference() is None
+
+
+def test_model_unload_releases_its_shared_programs(monkeypatch):
+    monkeypatch.setattr(graphbank.mx, "compile", lambda fn: fn)
+    monkeypatch.setattr(graphbank, "_SHARED_VERIFY_STEPS", {})
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_SHARED_TRACES", "1")
+    runtime = Runtime()
+    bank = _bank(runtime, "model")
+    fn = bank._shared_or_new_verify_step((4, "default", 8192), 4, None)
+    program = weakref.ref(fn)
+    del fn, bank
+    gc.collect()
+    assert program() is not None, "A live model should retain its reusable program"
+    del runtime
+    gc.collect()
+    assert not graphbank._SHARED_VERIFY_STEPS, "Unloaded models leave permanent compiled entries"
+    assert program() is None

--- a/tests/test_issue_404_macos27_mpp_compat.py
+++ b/tests/test_issue_404_macos27_mpp_compat.py
@@ -20,6 +20,8 @@ Two layers of protection are gated here:
 
 from __future__ import annotations
 
+import ast
+import os
 import re
 from pathlib import Path
 
@@ -82,19 +84,23 @@ def test_probe_exists_and_is_cached_once() -> None:
     )
 
 
-def test_enable_path_routes_through_probe_both_ways() -> None:
-    """Explicit ON and AUTO must both fail closed through the compile probe."""
+def test_enable_path_routes_through_probe_both_ways(monkeypatch) -> None:
+    """Explicit ON and AUTO must obey the selected producer's compile verdict.
 
-    text = (ROOT / "mtplx/models/qwen4_exp.py").read_text()
-    start = text.find("def _qsa_prefill_enabled")
-    assert start != -1
-    end = text.find("\ndef ", start + 1)
-    body = text[start:end]
-    assert body.count("_qsa_prefill_mpp_compile_ok()") >= 2, (
-        "_qsa_prefill_enabled must consult the #404 compile probe on both "
-        "the explicit-on and AUTO paths; honoring MTPLX_QSA_PREFILL=1 "
-        "verbatim on a refusing SDK is a guaranteed mid-request 500"
-    )
-    assert "return True" not in body, (
-        "no unconditional True path may remain in _qsa_prefill_enabled"
-    )
+    Execute the small resolver without importing MLX, retaining this gate on
+    non-Mac CI. The producer wrapper selects MPP only on NAX hardware; its
+    hardware routing is covered separately by test_qsa_portable_producer_gate.
+    """
+    tree = ast.parse((ROOT / "mtplx/models/qwen4_exp.py").read_text())
+    node = next(n for n in tree.body if isinstance(n, ast.FunctionDef)
+                and n.name == "_qsa_prefill_enabled")
+    calls = []
+    scope = {"os": os, "qsa_prefill_lane_auto_supported": lambda: True,
+             "_qsa_prefill_producer_compile_ok": lambda: calls.append(True) or allowed}
+    exec(compile(ast.Module(body=[node], type_ignores=[]), "<prefill-resolver>", "exec"), scope)
+    for raw in ("1", "auto"):
+        monkeypatch.setenv("MTPLX_QSA_PREFILL", raw)
+        for allowed in (False, True):
+            calls.clear()
+            assert scope["_qsa_prefill_enabled"]() is allowed
+            assert calls == [True]

--- a/tests/test_kernel_selfcheck.py
+++ b/tests/test_kernel_selfcheck.py
@@ -29,6 +29,8 @@ def _clean_selfcheck_state():
 def test_selfcheck_passes_on_this_machine(monkeypatch, dtype, bits) -> None:
     monkeypatch.setenv("MTPLX_NAX_VERIFY", "1")
     monkeypatch.setenv("MTPLX_GQA_PACKED_SDPA", "1")
+    monkeypatch.setenv("MTPLX_NAX_FLASH_ROUTE", "1")
+    monkeypatch.setenv("MTPLX_NAX_TILE_ROUTE", "1")
     report = run_kernel_selfcheck(dtype, bits, 64)
     lanes = report["lanes"]
     checked = {lane: s for lane, s in lanes.items() if s != "skipped"}
@@ -41,6 +43,24 @@ def test_selfcheck_passes_on_this_machine(monkeypatch, dtype, bits) -> None:
     assert lanes["qmm_m4"] == "ok"
     assert lanes["qmm_m6"] == "ok"
     assert lanes["gqa_packed_sdpa"] == "ok"
+    for lane in ("nax_flash_sdpa", "nax_flash_dsplit_sdpa", "nax_tile_sdpa"):
+        assert lanes[lane] == ("ok" if nax_verify.nax_available() else "skipped")
+
+
+def test_nax_attention_selfcheck_failure_is_local_to_its_lane(monkeypatch) -> None:
+    if not nax_verify.nax_available():
+        pytest.skip("NAX hardware/OS unavailable")
+    from mtplx.kernels import sdpa_nax_flash_dsplit as module
+
+    monkeypatch.setenv("MTPLX_NAX_VERIFY", "0")
+    monkeypatch.setenv("MTPLX_GQA_PACKED_SDPA", "1")
+    monkeypatch.setenv("MTPLX_NAX_FLASH_ROUTE", "1")
+    monkeypatch.setattr(module, "sdpa_nax_flash_dsplit", lambda **kwargs: None)
+    report = run_kernel_selfcheck(mx.bfloat16, 4, 64)
+    assert report["lanes"]["nax_flash_dsplit_sdpa"] == "fallback"
+    assert lane_disabled("nax_flash_dsplit_sdpa")
+    assert report["lanes"]["nax_flash_sdpa"] == "ok"
+    assert report["lanes"]["gqa_packed_sdpa"] == "ok"
 
 
 def test_selfcheck_mismatch_disables_lane_and_surfaces_in_health(monkeypatch) -> None:

--- a/tests/test_mtp_depth_sweep.py
+++ b/tests/test_mtp_depth_sweep.py
@@ -3,6 +3,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from mtplx.benchmarks.runners import mtp_depth_sweep
+import pytest
+
+
+def test_draft_cycle_mean_uses_proposals_when_event_recording_is_disabled():
+    # Actual installed-artifact tune receipts had events=[] and incorrectly
+    # reported 333 / 370 accepted drafts per cycle from 512 generated tokens.
+    mean = mtp_depth_sweep._accepted_drafts_per_cycle
+    assert mean(333, [178, 178]) == pytest.approx(333 / 178)
+    assert mean(370, [139, 139, 138]) == pytest.approx(370 / 139)
+    assert mean(0, []) is None
+    assert mean(0, [0, 0]) is None
 
 
 def test_depth_sweep_uses_packaged_draft_lm_head_helper(monkeypatch, tmp_path) -> None:

--- a/tests/test_nax_attention_hardware.py
+++ b/tests/test_nax_attention_hardware.py
@@ -1,0 +1,24 @@
+"""Hardware admission must precede tensor access or Metal compilation."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name,function_name,counter", [
+    ("sdpa_nax_flash", "sdpa_nax_flash", "nax_flash_bail_counts"),
+    ("sdpa_nax_flash_dsplit", "sdpa_nax_flash_dsplit", "nax_flash_dsplit_bail_counts"),
+    ("sdpa_nax_tile", "sdpa_nax_tile", "nax_tile_bail_counts"),
+])
+def test_unsupported_nax_attention_declines_before_touching_tensors(
+    monkeypatch, module_name, function_name, counter
+):
+    module = importlib.import_module("mtplx.kernels." + module_name)
+    monkeypatch.setattr(module.mx.metal, "is_available", lambda: True)
+    monkeypatch.setattr(module, "nax_available", lambda: False)
+    counts = getattr(module, counter)
+    before = counts.get("gpu_family_or_os", 0)
+    assert getattr(module, function_name)(
+        queries=None, keys=None, values=None, offset=1, scale=.0625
+    ) is None
+    assert counts["gpu_family_or_os"] == before + 1

--- a/tests/test_prefill_admission_shed.py
+++ b/tests/test_prefill_admission_shed.py
@@ -327,3 +327,281 @@ class TestBlockPrefixRestorableEntries:
         assert receipt is not None
         assert receipt["reusable_prefix_tokens"] == 0
         assert bank.cleared_sessions == ["gate"]
+
+
+class _LiveSession:
+    def __init__(self, committed):
+        self.committed_token_ids = tuple(int(t) for t in committed)
+
+
+def _state_with_live(committed, *, near=None, common=None):
+    """Fake EngineSessionManager exposing the resolution ladder: exact
+    containment, then (near, matched) / (common, matched) tuples."""
+    state = _state()
+    live = _LiveSession(committed)
+
+    def longest_prefix_session(token_ids):
+        tokens = tuple(int(t) for t in token_ids)
+        prefix = live.committed_token_ids
+        if prefix and len(prefix) <= len(tokens) and tokens[: len(prefix)] == prefix:
+            return live
+        return None
+
+    state.sessions = SimpleNamespace(
+        longest_prefix_session=longest_prefix_session,
+        pending_near_prefix_session=lambda token_ids: near or (None, 0),
+        best_common_prefix_session=lambda token_ids: common or (None, 0),
+    )
+    return state
+
+
+class TestLiveSessionPrefix:
+    """#447, receipt 2: a warm 212k session whose newest turns were never
+    banked (snapshot commits refused on retokenized-history mismatch) read
+    as a full miss, was cleared as "superseded", and every client retry was
+    a 211,807-token cold miss. The engine's live sessions are the state the
+    request actually reuses; the shed must ask them too."""
+
+    def test_live_prefix_under_the_miss_floor_leaves_the_guard_inert(
+        self, monkeypatch
+    ):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:97_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        assert _shed(state, prompt, bank, "warm") is None
+        assert bank.cleared_sessions == []
+        assert entry in bank.entries
+
+    def test_live_prefix_pins_instead_of_clearing(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:60_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        assert receipt["reusable_prefix_tokens"] == 60_000
+        assert receipt["miss_tokens"] == 40_000
+        assert bank.cleared_sessions == []
+        assert "warm" in bank.touched
+
+    def test_live_prefix_yields_to_the_export(self, monkeypatch):
+        monkeypatch.setenv("MTPLX_PREFILL_ADMISSION_LIVE_PREFIX", "0")
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(prompt[:60_000])
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+        assert bank.cleared_sessions == ["warm"]
+
+    def test_state_without_sessions_keeps_the_bank_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        entry = _Entry(list(range(500_000, 500_040)), "warm", 4 * GIB)
+        bank = _Bank([entry])
+        receipt = _shed(_state(), prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+        assert bank.cleared_sessions == ["warm"]
+
+
+class _ChainBank(_Bank):
+    """Active-protecting bank: shrink_to_bytes honors protect_active the way
+    the real bank does (touched sessions are the active set), and the chain
+    walk keeps each session's longest entry plus the protect_tokens match."""
+
+    def __init__(self, entries):
+        super().__init__(entries)
+        self.chain_calls: list[tuple[int, str]] = []
+
+    def shrink_to_bytes(self, target_bytes, *, reason="", protect_active=False):
+        self.shrink_calls.append((int(target_bytes), reason, protect_active))
+        evicted = 0
+        active = set(self.touched)
+        while self.entries and self.total_nbytes > int(target_bytes):
+            candidates = [
+                e
+                for e in self.entries
+                if not (protect_active and e.session_id in active)
+            ]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            evicted += 1
+        return evicted
+
+    def shrink_for_admission(self, target_bytes, *, protect_tokens=None, reason=""):
+        self.chain_calls.append((int(target_bytes), reason))
+        protected = set()
+        if protect_tokens:
+            tokens = tuple(int(t) for t in protect_tokens)
+            best, best_common = None, 0
+            for e in self.entries:
+                common = 0
+                for left, right in zip(tokens, e.token_ids):
+                    if left != right:
+                        break
+                    common += 1
+                if common > best_common:
+                    best, best_common = e, common
+            if best is not None:
+                protected.add(id(best))
+        non_terminal = 0
+        while self.entries and self.total_nbytes > int(target_bytes):
+            terminal = {}
+            for e in self.entries:
+                key = e.session_id or ""
+                terminal[key] = max(terminal.get(key, -1), len(e.token_ids))
+            candidates = [
+                e
+                for e in self.entries
+                if id(e) not in protected
+                and len(e.token_ids) < terminal.get(e.session_id or "", -1)
+            ]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            non_terminal += 1
+        terminals = 0
+        while self.entries and self.total_nbytes > int(target_bytes):
+            candidates = [e for e in self.entries if id(e) not in protected]
+            if not candidates:
+                break
+            self.entries.remove(candidates[0])
+            terminals += 1
+        return non_terminal, terminals
+
+
+class TestChainPrefixEscalation:
+    """#447, receipt 1: 12.6 GiB of a deep session's own sibling snapshots
+    were active-protected, the LRU pass evicted nothing, and a warm turn
+    with a 23k miss died on the sustained-pressure 507."""
+
+    def _fixture(self):
+        prompt = list(range(100_000))
+        exact = _Entry(prompt[:50_000], "deep", 2 * GIB)
+        terminal = _Entry(prompt[:49_000] + list(range(700_000, 711_000)), "deep", 3 * GIB)
+        sibling = _Entry(prompt[:30_000] + list(range(800_000, 800_400)), "deep", 6 * GIB)
+        return prompt, exact, terminal, sibling
+
+    def test_sibling_snapshots_are_walked_when_lru_is_protected(
+        self, monkeypatch
+    ):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _ChainBank([exact, terminal, sibling])
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert receipt["reusable_prefix_tokens"] == 50_000
+        assert receipt["lru_entries_evicted"] == 0
+        assert receipt["chain_entries_evicted"] == 1
+        assert receipt["terminal_entries_evicted"] == 0
+        assert sibling not in bank.entries
+        assert exact in bank.entries
+        assert terminal in bank.entries
+        assert receipt["bank_bytes_after"] == 5 * GIB
+
+    def test_chain_walk_yields_to_the_export(self, monkeypatch):
+        monkeypatch.setenv("MTPLX_PREFILL_ADMISSION_CHAIN_SHED", "0")
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _ChainBank([exact, terminal, sibling])
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert "chain_entries_evicted" not in receipt
+        assert bank.chain_calls == []
+        assert sibling in bank.entries
+
+    def test_bank_without_the_method_is_tolerated(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt, exact, terminal, sibling = self._fixture()
+        bank = _Bank([exact, terminal, sibling])
+        bank.shrink_to_bytes = lambda *a, **k: 0
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert "chain_entries_evicted" not in receipt
+
+
+class TestLiveSessionLadder:
+    """The resolution ladder: a mutated history (retokenized turns, the
+    #446 fork shape) misses exact containment but is still served by the
+    pending-near-prefix and best-common lookups; the shed's estimate must
+    follow the same ladder or it reads a warm engine as a full miss."""
+
+    def test_pending_near_prefix_serves_the_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live((), near=(_LiveSession(prompt[:60_000]), 60_000))
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        expected = srv._block_restorable_prefix_tokens(60_000)
+        assert receipt["reusable_prefix_tokens"] == expected
+        assert bank.cleared_sessions == []
+
+    def test_best_common_serves_the_estimate(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live((), common=(_LiveSession(prompt[:60_000]), 60_000))
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "live_session"
+        assert receipt["reusable_prefix_tokens"] == srv._block_restorable_prefix_tokens(60_000)
+
+    def test_exact_wins_over_the_tolerant_rungs(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state_with_live(
+            prompt[:60_000], common=(_LiveSession(prompt[:10_000]), 10_000)
+        )
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_tokens"] == 60_000
+
+    def test_ladder_exceptions_never_cost_the_request(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        state = _state()
+
+        def boom(token_ids):
+            raise RuntimeError("probe blew up")
+
+        state.sessions = SimpleNamespace(
+            longest_prefix_session=boom,
+            pending_near_prefix_session=boom,
+            best_common_prefix_session=boom,
+        )
+        bank = _Bank([])
+        receipt = _shed(state, prompt, bank, "warm")
+        assert receipt is not None
+        assert receipt["reusable_prefix_mode"] == "none"
+
+
+class TestTerminalPhase:
+    """Phase 2 (#447): when non-terminal walking cannot cover the deficit
+    (every fork is its own session's terminal — the post-#446 shape), the
+    walk takes remaining entries rather than letting the request die, but
+    never the entry the imminent prompt restores from."""
+
+    def test_other_terminals_fall_when_siblings_are_not_enough(self, monkeypatch):
+        _pin_live_stats(monkeypatch, active=92 * GIB, cache=GIB // 2)
+        prompt = list(range(100_000))
+        exact = _Entry(prompt[:50_000], "deep", 2 * GIB)
+        fork = _Entry(prompt[:20_000] + list(range(900_000, 950_000)), "fork-session", 6 * GIB)
+        bank = _ChainBank([exact, fork])
+        bank.touched.append("fork-session")  # recently active: LRU pass skips it
+        receipt = _shed(_state(), prompt, bank, "deep")
+        assert receipt is not None
+        assert receipt["chain_entries_evicted"] == 0
+        assert receipt["terminal_entries_evicted"] == 1
+        assert fork not in bank.entries
+        assert exact in bank.entries

--- a/tests/test_prefill_admission_shed.py
+++ b/tests/test_prefill_admission_shed.py
@@ -9,8 +9,8 @@ mid-prefill and the sustained-pressure guard killed the request with a
 structured 507 ~30 s later.
 
 These tests pin the admission guard that sheds BEFORE the prefill:
-superseded same-session entries first, then LRU idle entries with active
-sessions protected, then the allocator cache — and stays perfectly inert
+unused allocator storage first, then superseded same-session entries and
+LRU idle entries with active sessions protected — and stays perfectly inert
 when memory is healthy.
 """
 
@@ -151,6 +151,20 @@ class TestInertWhenHealthy:
 
 class TestIncidentShape:
     """The #415 timeline: cache-miss prefill + superseded resident snapshot."""
+
+    def test_allocator_cache_reclaims_without_evicting_useful_sessions(self, monkeypatch):
+        import mlx.core as mx
+
+        live = {"ok": True, "active_memory_bytes": 85 * GIB,
+                "cache_memory_bytes": 8 * GIB}
+        monkeypatch.setattr(srv, "_mlx_memory_stats_live", lambda: dict(live))
+        monkeypatch.setattr(mx, "clear_cache", lambda: live.update(cache_memory_bytes=0))
+        bank = _Bank([_Entry(range(900, 1000), "pi", 6 * GIB)])
+        receipt = _shed(_state(), list(range(40_000)), bank, "pi")
+        assert receipt["cache_cleared"] is True
+        assert bank.cleared_sessions == []
+        assert bank.shrink_calls == []
+        assert bank.total_nbytes == 6 * GIB
 
     def test_superseded_session_snapshot_released_first(self, monkeypatch):
         _pin_live_stats(monkeypatch, active=93 * GIB, cache=2 * GIB)

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -3552,19 +3552,21 @@ def test_pi_models_config_merge_preserves_other_providers(tmp_path):
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
-def test_pi_extension_cap_guard_three_payload_shapes(tmp_path):
+@pytest.mark.parametrize("configured_cap", [None, 8192])
+def test_pi_extension_cap_guard_three_payload_shapes(tmp_path, configured_cap):
     """Execute the Pi request-policy handler under node for the three payload
     shapes: injected default (stripped), explicit cap (preserved), no cap
     (untouched)."""
 
-    from mtplx.pi import (
-        PI_INJECTED_DEFAULT_MAX_TOKENS,
-        build_pi_request_policy_extension_source,
-    )
+    from mtplx.pi import write_pi_models_config
 
-    source = build_pi_request_policy_extension_source(
-        "mtplx-test-model", uncapped=True
+    config = tmp_path / "models.json"
+    result = write_pi_models_config(
+        base_url="http://127.0.0.1:8211/v1", model_id="mtplx-test-model",
+        path=config, context_window=262144, max_tokens=configured_cap,
     )
+    injected_cap = json.loads(config.read_text())["providers"]["mtplx"]["models"][0]["maxTokens"]
+    source = Path(result["request_policy_extension_path"]).read_text()
     # The extension is TypeScript only by annotation; strip ": any" so node
     # can execute the real handler logic unchanged.
     module = tmp_path / "extension.mjs"
@@ -3577,7 +3579,7 @@ const handlers = {{}};
 register({{ on: (name, fn) => {{ handlers[name] = fn; }} }});
 const run = (payload) => handlers["before_provider_request"]({{ payload }});
 const results = {{
-  injected: run({{ model: "mtplx-test-model", max_tokens: {PI_INJECTED_DEFAULT_MAX_TOKENS} }}) ?? null,
+  injected: run({{ model: "mtplx-test-model", max_tokens: {injected_cap} }}) ?? null,
   explicit: run({{ model: "mtplx-test-model", max_tokens: 8192 }}) ?? null,
   absent: run({{ model: "mtplx-test-model" }}) ?? null,
 }};
@@ -3590,8 +3592,11 @@ console.log(JSON.stringify(results));
     )
     results = json.loads(proc.stdout)
     # Injected default: handler returns an override with the cap removed.
-    assert results["injected"] is not None
-    assert "max_tokens" not in results["injected"]
+    if configured_cap is None:
+        assert results["injected"] is not None
+        assert "max_tokens" not in results["injected"]
+    else:
+        assert results["injected"] is None
     # Explicit cap: no override returned — the deliberate cap flows through.
     assert results["explicit"] is None
     # No cap at all: nothing to strip, no override.

--- a/tests/test_qsa_portable_producer_gate.py
+++ b/tests/test_qsa_portable_producer_gate.py
@@ -1,0 +1,26 @@
+"""The startup probe must test the producer the hardware will actually run."""
+
+import pytest
+
+from mtplx.kernels import qsa_indexer_select
+from mtplx.models import qwen4_exp
+
+
+@pytest.mark.parametrize("nax,consumer,mpp,expected", [
+    (False, True, False, True),
+    (False, False, False, False),
+    (True, True, False, False),
+    (True, True, True, True),
+])
+def test_auto_gate_keeps_portable_lane_and_rejects_broken_mpp(
+    monkeypatch, nax, consumer, mpp, expected,
+):
+    monkeypatch.delenv("MTPLX_QSA_PREFILL", raising=False)
+    monkeypatch.setattr(qsa_indexer_select, "qsa_indexer_select_nax_available", lambda: nax)
+    monkeypatch.setattr(qwen4_exp, "qsa_prefill_lane_auto_supported", lambda: consumer)
+    calls = []
+    monkeypatch.setattr(qwen4_exp, "_qsa_prefill_mpp_compile_ok", lambda: calls.append(True) or mpp)
+    assert qwen4_exp._qsa_prefill_enabled() is expected
+    assert bool(calls) is (nax and consumer)
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", "0")
+    assert qwen4_exp._qsa_prefill_enabled() is False

--- a/tests/test_qsa_portable_producer_gate.py
+++ b/tests/test_qsa_portable_producer_gate.py
@@ -4,6 +4,7 @@ import pytest
 
 from mtplx.kernels import qsa_indexer_select
 from mtplx.models import qwen4_exp
+from mtplx.attention_context import attention_phase
 
 
 @pytest.mark.parametrize("nax,consumer,mpp,expected", [
@@ -12,15 +13,31 @@ from mtplx.models import qwen4_exp
     (True, True, False, False),
     (True, True, True, True),
 ])
+@pytest.mark.parametrize("mode", ["auto", "1"])
 def test_auto_gate_keeps_portable_lane_and_rejects_broken_mpp(
-    monkeypatch, nax, consumer, mpp, expected,
+    monkeypatch, nax, consumer, mpp, expected, mode,
 ):
-    monkeypatch.delenv("MTPLX_QSA_PREFILL", raising=False)
+    monkeypatch.setenv("MTPLX_QSA_PREFILL", mode)
     monkeypatch.setattr(qsa_indexer_select, "qsa_indexer_select_nax_available", lambda: nax)
     monkeypatch.setattr(qwen4_exp, "qsa_prefill_lane_auto_supported", lambda: consumer)
     calls = []
     monkeypatch.setattr(qwen4_exp, "_qsa_prefill_mpp_compile_ok", lambda: calls.append(True) or mpp)
-    assert qwen4_exp._qsa_prefill_enabled() is expected
-    assert bool(calls) is (nax and consumer)
+    assert qwen4_exp._qsa_prefill_enabled() is (expected if mode == "auto" else (not nax or mpp))
+    assert bool(calls) is (nax and (consumer or mode == "1"))
     monkeypatch.setenv("MTPLX_QSA_PREFILL", "0")
     assert qwen4_exp._qsa_prefill_enabled() is False
+
+
+@pytest.mark.parametrize("phase,rows,total", [
+    ("ar_decode", 1, 100000), ("decode_verify", 4, 100000),
+    ("prefill", 1, 100000), ("prefill", 2048, 2048),
+])
+def test_decode_and_small_chunks_do_not_resolve_prefill_pipelines(monkeypatch, phase, rows, total):
+    calls = []
+    monkeypatch.setattr(qwen4_exp, "_qsa_prefill_enabled", lambda: calls.append(True) or True)
+    with attention_phase(phase):
+        assert qwen4_exp._qsa_large_prefill_enabled(rows, total) is False
+    assert not calls
+    with attention_phase("prefill"):
+        assert qwen4_exp._qsa_large_prefill_enabled(2048, 100000) is True
+    assert len(calls) == 1

--- a/tests/test_qsa_prefill_direct_numeric.py
+++ b/tests/test_qsa_prefill_direct_numeric.py
@@ -11,6 +11,7 @@ results.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -257,54 +258,39 @@ def test_early_prefix_matches_gather_with_upstream_bound(native_lane):
     assert err <= _EARLY_BOUND, err
 
 
-def test_missing_metallib_fails_preflight_in_a_fresh_process(native_lane):
+def test_missing_metallib_fails_preflight_in_a_fresh_process(native_lane, tmp_path):
     """FAILED is process-wide, so this drill cannot share the pytest process."""
 
-    ext_dir = Path(direct.__file__).resolve().parents[2] / "native_extensions" / "qsa_kernels"
-    metallibs = list((ext_dir / "mtplx_qsa_kernels").glob("*.metallib"))
+    ext_dir = Path(direct._EXT.__file__).resolve().parent
+    metallibs = list(ext_dir.glob("*.metallib"))
     assert metallibs, f"no metallib next to the extension in {ext_dir}"
-    metallib = metallibs[0]
+    # Exercise the installed artifact, without hiding files from a live
+    # runtime or assuming that an in-place source build exists.
+    shutil.copytree(ext_dir, tmp_path / "mtplx_qsa_kernels",
+                    ignore=shutil.ignore_patterns("*.metallib"))
     child = r"""
-import os, sys, traceback
+import os, sys
+sys.path.insert(0, os.environ["MTPLX_TEST_NATIVE"])
+import mlx.core as mx
+import mtplx_qsa_kernels
+assert mtplx_qsa_kernels.__file__.startswith(os.environ["MTPLX_TEST_NATIVE"])
 sys.path.insert(0, os.environ["MTPLX_SRC"])
-# Hide the metallib before the extension's first eval.
-src = os.environ["METALLIB"]
-dst = src + ".hidden"
-os.rename(src, dst)
-try:
-    import mlx.core as mx  # noqa: F401
-    from mtplx.kernels.qsa_prefill_direct import (
-        qsa_prefill_direct_preflight,
-        qsa_prefill_direct_ready,
-    )
-    ok = qsa_prefill_direct_preflight()
-    ready = qsa_prefill_direct_ready()
-    print(f"preflight={ok} ready={ready}")
-    sys.exit(0 if (ok is False and ready is False) else 2)
-except Exception:
-    traceback.print_exc()
-    sys.exit(2)
-finally:
-    if os.path.exists(dst) and not os.path.exists(src):
-        os.rename(dst, src)
+from mtplx.kernels import qsa_prefill_direct as direct
+assert direct._EXT is not None, direct._IMPORT_ERROR
+ok = direct.qsa_prefill_direct_preflight()
+ready = direct.qsa_prefill_direct_ready()
+print(f"preflight={ok} ready={ready}")
+sys.exit(0 if (ok is False and ready is False) else 2)
 """
     env = os.environ.copy()
     src_root = str(Path(direct.__file__).resolve().parents[2])
     env["MTPLX_SRC"] = src_root
-    env["METALLIB"] = str(metallib)
+    env["MTPLX_TEST_NATIVE"] = str(tmp_path)
     env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
-    hidden = Path(str(metallib) + ".hidden")
-    try:
-        proc = subprocess.run(
-            [sys.executable, "-c", child],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-    finally:
-        if hidden.is_file() and not metallib.is_file():
-            hidden.rename(metallib)
-    assert metallib.is_file(), "child must restore the metallib"
+    proc = subprocess.run(
+        [sys.executable, "-c", child], env=env, capture_output=True,
+        text=True, timeout=120,
+    )
+    assert all(p.is_file() for p in metallibs), "installed artifact must remain intact"
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "preflight=False ready=False" in proc.stdout

--- a/tests/test_qwen4_exp_capture_commit.py
+++ b/tests/test_qwen4_exp_capture_commit.py
@@ -811,6 +811,63 @@ def test_fixed_m4_capacity_grows_without_leaving_the_installed_lane(
     assert int(pooled.shape[1]) == logical_end // cache[qsa_index].ratio
 
 
+@pytest.mark.parametrize("width", [2, 3, 4, 9])
+def test_fixed_bank_eager_windows_grow_and_preserve_state(tm, monkeypatch, width):
+    """Adaptive and copy windows must renew the same banks as D3 replay.
+
+    Compare every logit and committed state with an unpromoted cache across
+    the initial allocation boundary, then return to the compiled D3 lane.
+    """
+    import mtplx.graphbank as graphbank
+    from mtplx.qwen4_fixed_verify import install_qwen4_fixed_verify_route
+
+    class TinyRuntime:
+        pass
+
+    runtime = TinyRuntime()
+    runtime.model = SimpleNamespace(language_model=tm)
+    install_qwen4_fixed_verify_route(runtime)
+    monkeypatch.setattr(graphbank, "_PREWARM_DONE", True)
+    monkeypatch.setattr(graphbank, "_compiled_verify_bits_gate_ok", lambda _rt: True)
+    monkeypatch.setenv("MTPLX_COMPILED_VERIFY_GROWTH_RESERVE", "4")
+    monkeypatch.setenv("MTPLX_QSA_GATHER", "1")
+    monkeypatch.setenv("MTPLX_QSA_GATHER_MIN_CONTEXT", "18")
+    prefill = _ids(PREFILL, seed=51)
+    cache, golden_cache = tm.make_cache(), tm.make_cache()
+    tm(prefill, cache=cache)
+    tm(prefill, cache=golden_cache)
+    bank = graphbank.CompiledVerifyBank(runtime, max_verify_len=4, request_max_tokens=100)
+    bank.install_fixed_m4(cache, prompt_ids=_host_ids(prefill), hidden_variant=None)
+    completion = []
+    for ordinal in range(10):
+        ids = _ids(width, seed=52 + ordinal)
+        snap = snapshot_untrimmable_cache_lazy(cache)
+        golden_snap = snapshot_untrimmable_cache_lazy(golden_cache)
+        ledger = {"committed_count": ordinal} if ordinal % 2 else {}
+        if width > 4 and ordinal % 3 == 1:
+            # The copy route can bypass compiled dispatch, but still owns
+            # promoted buffers and must reserve before its eager forward.
+            bank.reserve_fixed_m4_window(cache, window_tokens=width, **ledger)
+            actual, hidden, _ = runtime.forward_ar_capture(ids, cache=cache)
+        else:
+            actual, hidden, _ = bank.forward_ar_capture(
+                ids, cache=cache, extended_window=width > 4, **ledger
+            )
+        expected, golden_hidden, _ = runtime.forward_ar_capture(ids, cache=golden_cache)
+        mx.eval(actual, expected, hidden, golden_hidden)
+        assert mx.allclose(actual, expected, atol=2e-5, rtol=2e-5).item(), ordinal
+        assert tm.model.commit_verified_window(cache, snap.states, keep_tokens=1, verified_tokens=width)
+        assert tm.model.commit_verified_window(golden_cache, golden_snap.states, keep_tokens=1, verified_tokens=width)
+        completion.extend(_host_ids(ids[:, :1]))
+    assert bank.stats["fixed_m4_capacity_transitions"] > 0
+    ids = _ids(4, seed=70)
+    actual, _, _ = bank.forward_fixed_m4(ids, host_input_ids=_host_ids(ids),
+        completion_tokens=completion, committed_count=len(completion), cache=cache)
+    expected, _, _ = runtime.forward_ar_capture(ids, cache=golden_cache)
+    assert mx.allclose(actual, expected, atol=2e-5, rtol=2e-5).item()
+    assert bank.last_dispatch_route() == "compiled_bank"
+
+
 def test_fixed_m4_bank_fails_loud_instead_of_falling_back(tm, monkeypatch):
     import mtplx.graphbank as graphbank
     from mtplx.qwen4_fixed_verify import install_qwen4_fixed_verify_route

--- a/tests/test_qwen4_fixed_m4_gate_cache.py
+++ b/tests/test_qwen4_fixed_m4_gate_cache.py
@@ -64,3 +64,50 @@ def test_nothing_cached_means_no_second_read(monkeypatch) -> None:
     assert fits is False
     assert releases == 1  # asked, nothing to release
     assert "released" not in announced[0]
+
+
+def test_shallow_depth_does_not_promote_or_evict(monkeypatch):
+    def unexpected(*args, **kwargs):
+        raise AssertionError("a depth with no compiled forward must not enter memory admission")
+
+    monkeypatch.setattr(gen, "_qwen4_fixed_m4_lane_fits", unexpected)
+    for depth in (1, 2):
+        receipt = {}
+        assert not gen._qwen4_fixed_m4_compiled_verify_requested(
+            SimpleNamespace(qwen4_fixed_m4_compiled_verify=True),
+            verify_strategy="batched", compiled_mode="on", max_tokens=10000,
+            cached_tokens=0, prompt_tokens=128000, speculative_depth=depth,
+            receipt=receipt,
+        )
+        assert receipt["reason"] == "depth_below_compiled_window"
+
+
+def test_idle_bank_yields_but_logical_eviction_is_not_proof_of_freed_memory(monkeypatch):
+    state = {"live": 99 * GB}
+    monkeypatch.setattr(gen, "_mlx_live_memory_bytes", lambda: state["live"])
+    monkeypatch.setattr(gen, "_mlx_release_allocator_cache", lambda: 0)
+    monkeypatch.setattr(gen, "_qwen4_fixed_m4_promotion_bytes_per_token", lambda rt: 28416)
+    monkeypatch.setattr(gen, "_metal_memory_limit_bytes", lambda rt: 103079215104)
+    monkeypatch.setattr(gen, "_fixed_m4_initial_growth_reserve", lambda: 4096)
+    monkeypatch.delenv("MTPLX_QWEN4_FIXED_M4_MAX_CONTEXT", raising=False)
+
+    class Bank:
+        total_nbytes = 8 * GB
+        physical_reclaim = False
+
+        def shrink_for_admission(self, target, *, protect_tokens, reason):
+            assert protect_tokens == [1, 2, 3]
+            assert reason == "fixed_m4_admission"
+            self.total_nbytes = target
+            if self.physical_reclaim:
+                state["live"] = 90 * GB
+            return 1, 0
+
+    bank = Bank()
+    assert not gen._qwen4_fixed_m4_lane_fits(SimpleNamespace(), prompt_tokens=128000,
+                                          session_bank=bank, prompt_ids=[1, 2, 3])
+    bank.physical_reclaim = True
+    receipt = {}
+    assert gen._qwen4_fixed_m4_lane_fits(SimpleNamespace(), prompt_tokens=128000,
+                                      session_bank=bank, prompt_ids=[1, 2, 3], receipt=receipt)
+    assert receipt["live_bytes_after"] == 90 * GB

--- a/tests/test_sdpa_nax_flash.py
+++ b/tests/test_sdpa_nax_flash.py
@@ -14,11 +14,12 @@ import pytest
 from mtplx.kernels.sdpa_gqa_packed import sdpa_gqa_packed_tail
 from mtplx.kernels.sdpa_nax_flash import _nax_flash_kernel, sdpa_nax_flash
 from mtplx.kernels.sdpa_nax_flash_dsplit import sdpa_nax_flash_dsplit
+from mtplx.nax_verify import nax_available
 
 HQ, HKV, D = 24, 4, 256
 
 pytestmark = pytest.mark.skipif(
-    not mx.metal.is_available() or _nax_flash_kernel() is None,
+    not mx.metal.is_available() or not nax_available() or _nax_flash_kernel() is None,
     reason="TensorOps kernel unavailable on this toolchain",
 )
 

--- a/tests/test_sdpa_nax_tile.py
+++ b/tests/test_sdpa_nax_tile.py
@@ -12,6 +12,9 @@ import pytest
 
 from mtplx.kernels.sdpa_gqa_packed import sdpa_gqa_packed_tail
 from mtplx.kernels.sdpa_nax_tile import sdpa_nax_tile
+from mtplx.nax_verify import nax_available
+
+pytestmark = pytest.mark.skipif(not nax_available(), reason="NAX hardware/OS unavailable")
 
 HQ, HKV, D = 24, 4, 256
 

--- a/tests/test_select_runtime_wheel.py
+++ b/tests/test_select_runtime_wheel.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import importlib.util
+
+import pytest
+from packaging.tags import Tag
+
+spec = importlib.util.spec_from_file_location(
+    "select_runtime_wheel", Path(__file__).parents[1] / "scripts/select_runtime_wheel.py")
+selector = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(selector)
+
+
+@pytest.mark.parametrize("python,os_major,native", [
+    ("cp314", 15, True), ("cp314", 26, True),
+    ("cp314", 14, False), ("cp313", 26, False),
+])
+def test_compatible_native_or_pure_fallback(tmp_path, python, os_major, native):
+    fallback = tmp_path / "mtplx-2.11.1-py3-none-any.whl"
+    binary_dir = tmp_path / "Native"
+    binary_dir.mkdir()
+    binary = binary_dir / "mtplx-2.11.1-cp314-cp314-macosx_15_0_arm64.whl"
+    binary.touch()
+    tags = [Tag(python, python, f"macosx_{major}_0_arm64")
+            for major in range(os_major, 10, -1)] + [Tag("py3", "none", "any")]
+    selected = selector.select_runtime_wheel(fallback, binary_dir, tags)
+    assert selected == (binary if native else fallback)
+
+
+def test_mixed_release_artifacts_fail_instead_of_installing_wrong_version(tmp_path):
+    binary = tmp_path / "mtplx-2.10.2-cp314-cp314-macosx_15_0_arm64.whl"
+    binary.touch()
+    with pytest.raises(ValueError, match="versions disagree"):
+        selector.select_runtime_wheel(tmp_path / "mtplx-2.11.1-py3-none-any.whl", tmp_path)

--- a/tests/test_session_bank_chain_shed.py
+++ b/tests/test_session_bank_chain_shed.py
@@ -1,0 +1,129 @@
+"""#447: SessionBank.shrink_for_admission — escalating eviction for the
+admission shed. Phase 1 walks non-terminal chain entries (every session
+keeps its highest-prefix entry); phase 2, only if the deficit stands,
+takes remaining entries in take-anything order with active sessions last.
+Both phases spare the entry the imminent prompt restores from.
+
+Pure host tests -- synthetic entries, ``cache=[]`` plus ``nbytes_override``,
+no MLX, no model, no Metal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from mtplx.session_bank import SessionBank
+
+
+RUNTIME = SimpleNamespace(model_path=Path("models/example"), mtp_enabled=True)
+
+
+def _bank(**kwargs) -> SessionBank:
+    defaults = dict(max_entries=16, max_bytes=10_000, per_session_max_bytes=10_000)
+    defaults.update(kwargs)
+    return SessionBank(**defaults)
+
+
+def _put(bank: SessionBank, tokens, *, session_id: str, nbytes: int):
+    return bank.put(
+        runtime=RUNTIME,
+        token_ids=list(tokens),
+        cache=[],
+        logits=None,
+        hidden=None,
+        session_id=session_id,
+        nbytes_override=nbytes,
+    )
+
+
+def _keys(bank: SessionBank):
+    return set(bank._entries.keys())
+
+
+def test_phase_one_evicts_the_sibling_and_stops():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)      # sibling fork
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)  # terminal of a
+    _put(bank, (7, 7, 7), session_id="b", nbytes=50)         # terminal of b
+    assert bank.shrink_for_admission(150) == (1, 0)
+    assert _keys(bank) == {(1, 2, 3, 4, 5), (7, 7, 7)}
+
+
+def test_phase_two_takes_terminals_when_siblings_are_not_enough():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    _put(bank, (7, 7, 7), session_id="b", nbytes=50)
+    non_terminal, terminal = bank.shrink_for_admission(
+        0, protect_tokens=(1, 2, 3, 4, 5, 6)
+    )
+    assert non_terminal == 1
+    assert terminal == 1
+    # The imminent prompt's restore source survives both phases.
+    assert _keys(bank) == {(1, 2, 3, 4, 5)}
+
+
+def test_protect_tokens_shields_the_restore_source():
+    bank = _bank()
+    _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    non_terminal, terminal = bank.shrink_for_admission(
+        0, protect_tokens=(1, 2, 9, 9, 10)
+    )
+    # The shorter fork is what this prompt restores from: phase 1 skips it,
+    # phase 2 takes the session's terminal instead.
+    assert (non_terminal, terminal) == (0, 1)
+    assert _keys(bank) == {(1, 2, 9, 9)}
+
+
+def test_phase_two_takes_active_sessions_last():
+    import time
+
+    bank = _bank()
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    _put(bank, (7, 7), session_id="b", nbytes=100)
+    # put() stamps the active pin for both; age b out of the TTL so only
+    # a is active when phase 2 orders its victims.
+    bank._session_last_active["b"] = time.monotonic() - 100_000
+    non_terminal, terminal = bank.shrink_for_admission(100)
+    assert (non_terminal, terminal) == (0, 1)
+    assert _keys(bank) == {(1, 2, 3)}
+
+
+def test_lru_order_among_siblings():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)            # oldest sibling
+    _put(bank, (1, 8, 8), session_id="a", nbytes=60)         # newer sibling
+    _put(bank, (1, 2, 3, 4, 5, 6), session_id="a", nbytes=100)
+    assert bank.shrink_for_admission(160) == (1, 0)
+    assert (1, 9) not in _keys(bank)
+    assert (1, 8, 8) in _keys(bank)
+
+
+def test_target_already_met_is_a_no_op():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    assert bank.shrink_for_admission(1_000) == (0, 0)
+    assert len(bank._entries) == 2
+
+
+def test_eviction_reason_is_recorded():
+    bank = _bank()
+    _put(bank, (1, 9), session_id="a", nbytes=60)
+    _put(bank, (1, 2, 3), session_id="a", nbytes=100)
+    bank.shrink_for_admission(100, reason="prefill_admission_chain")
+    assert bank.eviction_log[-1]["reason"] == "prefill_admission_chain"
+
+
+def test_live_referenced_entries_are_never_victims():
+    bank = _bank()
+    fork = _put(bank, (1, 2, 9, 9), session_id="a", nbytes=80)
+    _put(bank, (1, 2, 3, 4, 5), session_id="a", nbytes=100)
+    # The fork's arrays are the live session's own state (a live-ref lease):
+    # walking it frees nothing and costs the running session its state.
+    fork.cache_ref = object()
+    assert bank.shrink_for_admission(0) == (0, 1)
+    assert (1, 2, 9, 9) in _keys(bank)
+    assert (1, 2, 3, 4, 5) not in _keys(bank)

--- a/tests/test_trace_diagnostics.py
+++ b/tests/test_trace_diagnostics.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 
 import pytest
 
-from mtplx.commands.trace import _load_receipts, _match_receipt, _source_port
+from mtplx.commands.trace import _detect_pathologies, _load_receipts, _match_receipt, _source_port
 from mtplx.commands.trace_clients import load_pi_session
 from mtplx.commands.trace_metrics import mtp_economics, sample_intervals
 
@@ -74,3 +74,16 @@ def test_exact_pi_parent_beats_nearby_time_match_and_cannot_be_reused():
     used = set()
     assert _match_receipt(message, receipts, used) is receipts[1]
     assert used == {1}
+
+
+def test_new_tool_content_and_unknown_reasoning_are_not_false_regressions():
+    turns = [
+        {"kind": "assistant", "turn": 1, "message": {"tokens": {}},
+         "receipt": {"prompt_tokens": 17513, "completion_tokens": 227}},
+        {"kind": "assistant", "turn": 2, "message": {"tokens": {"reasoning": 25000}},
+         "receipt": {"prompt_tokens": 25819, "cached_tokens": 17740,
+                     "new_prefill_tokens": 8079, "completion_tokens": 26000}},
+    ]
+    assert _detect_pathologies(turns) == []
+    turns[1]["receipt"]["cached_tokens"] = 1024
+    assert any("REDUCED PREFIX REUSE" in flag for flag in _detect_pathologies(turns))

--- a/tests/test_trace_diagnostics.py
+++ b/tests/test_trace_diagnostics.py
@@ -1,0 +1,73 @@
+import json
+from argparse import Namespace
+
+import pytest
+
+from mtplx.commands.trace import _load_receipts, _match_receipt, _source_port
+from mtplx.commands.trace_clients import load_pi_session
+from mtplx.commands.trace_metrics import mtp_economics, sample_intervals
+
+
+def test_economics_distinguishes_aggregate_acceptance_from_conditional_probability():
+    receipt = {"completion_tokens": 250, "decode_elapsed_s": 4.0, "verify_calls": 100,
+               "accepted_by_depth": [80, 50, 20], "drafted_by_depth": [100, 100, 100],
+               "verify_time_s": 3, "draft_time_s": .8}
+    result = mtp_economics(receipt, ar_tok_s=50)
+    assert result["acceptance"] == .5
+    assert result["tokens_per_verify"] == 2.5
+    assert result["speedup_vs_ar"] == 1.25
+    assert result["break_even_acceptance"] == pytest.approx(1/3)
+    assert mtp_economics(receipt)["speedup_vs_ar"] is None
+    # A copy route or mixed depths invalidates the fixed-depth threshold.
+    assert mtp_economics({**receipt, "context_copy_accepted_tokens": 12}, 50)["break_even_acceptance"] is None
+    assert mtp_economics({**receipt, "drafted_by_depth": [100, 80, 20]}, 50)["break_even_acceptance"] is None
+
+
+def test_intervals_preserve_zero_and_missing_counters_and_expose_gaps():
+    rows = sample_intervals([
+        {"ev": "s", "ts": 1, "gen": 10, "vt": 0, "acc": [0], "drf": [0]},
+        {"ev": "s", "ts": 2, "gen": 20, "vt": .4, "acc": [3], "drf": [5]},
+        {"ev": "s", "ts": 9, "gen": 2, "vt": 0},
+    ])
+    assert rows[0]["vt"] == .4
+    assert rows[0]["acceptance"] == .6
+    assert rows[0]["dt"] is None
+    assert rows[1]["observation_gap"] is True
+    assert rows[1]["gen"] is None
+    assert rows[1]["tok_s"] is None
+
+
+def test_custom_logs_include_rotations_without_silently_using_latest_daemon(tmp_path):
+    path = tmp_path / "receipts.jsonl"
+    path.write_text('{"request_id":"new"}\n')
+    (tmp_path / "receipts.jsonl.1").write_text('{"request_id":"old"}\n')
+    assert [r["request_id"] for r in _load_receipts(0, path=str(path))] == ["old", "new"]
+    assert _source_port(Namespace(port=None, request_log=str(path))) == 0
+
+
+def test_pi_reader_follows_active_branch_and_keeps_correlation(tmp_path):
+    rows = [{"type": "session", "id": "session", "cwd": str(tmp_path)},
+            {"type": "message", "id": "u", "parentId": None,
+             "message": {"role": "user", "timestamp": 1000, "content": "Build it"}},
+            {"type": "message", "id": "abandoned", "parentId": "u",
+             "message": {"role": "assistant", "timestamp": 2000, "content": []}},
+            {"type": "message", "id": "current", "parentId": "u",
+             "message": {"role": "assistant", "timestamp": 3000,
+                         "content": [{"type": "thinking", "thinking": "inspect"}],
+                         "usage": {"output": 20, "cacheRead": 12}}}]
+    path = tmp_path / "pi.jsonl"
+    path.write_text('\n'.join(json.dumps(r) for r in rows))
+    session, messages = load_pi_session(path)
+    assert session["id"] == "session"
+    assert [m["_id"] for m in messages] == ["u", "current"]
+    assert messages[-1]["_parent_entry_id"] == "u"
+    assert messages[-1]["_parts"] == [{"type": "reasoning", "text": "inspect"}]
+
+
+def test_exact_pi_parent_beats_nearby_time_match_and_cannot_be_reused():
+    message = {"_parent_entry_id": "right", "time": {"created": 1000}}
+    receipts = [{"request_client_entry_id": "wrong", "logged_at_s": 1},
+                {"request_client_entry_id": "right", "logged_at_s": 5}]
+    used = set()
+    assert _match_receipt(message, receipts, used) is receipts[1]
+    assert used == {1}

--- a/tests/test_trace_diagnostics.py
+++ b/tests/test_trace_diagnostics.py
@@ -21,6 +21,9 @@ def test_economics_distinguishes_aggregate_acceptance_from_conditional_probabili
     # A copy route or mixed depths invalidates the fixed-depth threshold.
     assert mtp_economics({**receipt, "context_copy_accepted_tokens": 12}, 50)["break_even_acceptance"] is None
     assert mtp_economics({**receipt, "drafted_by_depth": [100, 80, 20]}, 50)["break_even_acceptance"] is None
+    failed = mtp_economics({**receipt, "repetition_stop_triggered": True}, 50)
+    assert failed["status"] == "guard_stopped_invalid_quality_sample"
+    assert failed["speedup_vs_ar"] is None
 
 
 def test_intervals_preserve_zero_and_missing_counters_and_expose_gaps():

--- a/tests/test_tune_qwen4_exp_verify_strategy.py
+++ b/tests/test_tune_qwen4_exp_verify_strategy.py
@@ -11,6 +11,10 @@ Flash-Next hyper-connection layers. The server already coerces qwen4_exp to
 from __future__ import annotations
 
 import json
+import os
+from types import SimpleNamespace
+
+import pytest
 
 from mtplx.commands.public import _model_config_is_qwen4_exp
 
@@ -39,3 +43,70 @@ def test_missing_or_unreadable_config_is_not_flash_next(tmp_path):
     assert _model_config_is_qwen4_exp(str(tmp_path)) is False
     (tmp_path / "config.json").write_text("{not json")
     assert _model_config_is_qwen4_exp(str(tmp_path)) is False
+
+
+@pytest.mark.parametrize("exports", [
+    {},
+    {"MTPLX_QWEN4_FIXED_M4_VERIFY": "0", "MTPLX_FRSPEC_DRAFT": "0"},
+    {"MTPLX_COMPILED_GDN": "0", "MTPLX_SKIP_VERIFY_SNAPSHOT": "1"},
+])
+def test_tune_uses_serve_contract_without_manual_family_exports(tmp_path, monkeypatch, exports):
+    from mtplx.commands import public
+    from mtplx.profiles import apply_profile_env, get_profile
+    from mtplx.server import openai
+
+    for key in list(os.environ):
+        if key.startswith("MTPLX_"):
+            monkeypatch.delenv(key)
+    for key, value in exports.items():
+        monkeypatch.setenv(key, value)
+    model = _write(tmp_path, {"model_type": "qwen4_exp", "text_config": {
+        "model_type": "qwen4_exp_text", "hidden_size": 2560,
+        "num_hidden_layers": 48, "hc_count": 4, "hc_lowrank": 320,
+        "indexer_compress_ratio": 4, "linear_num_key_heads": 16,
+        "linear_num_value_heads": 48, "linear_key_head_dim": 128,
+        "linear_value_head_dim": 128, "ple_layer_ids": [2], "ngram_size": 3,
+        "ngram_vocab_size_base": 20000000, "heads_per_ngram": 8,
+        "ple_embed_dim": 2560, "ngram_sidecar": True, "num_experts": 512,
+        "num_experts_per_tok": 10, "moe_intermediate_size": 640, "vocab_size": 248320,
+    }})
+    # This pack-level override must survive profile defaults too.
+    pack = {"MTPLX_QSA_GATHER_MAX_ROWS": "24"}
+    monkeypatch.setattr(openai, "load_runtime_contract", lambda _: (
+        SimpleNamespace(runtime_env_overrides=pack), None))
+    profile = get_profile("turbo")
+    before = dict(os.environ)
+    resolved = public._runtime_env_with_model_contract_overrides(
+        profile.env_dict(), {}, profile, model=model)
+    assert dict(os.environ) == before
+    expected = dict(os.environ)
+    family = openai._server_runtime_env_overrides(
+        SimpleNamespace(model=model, generation_mode="mtp", verify_strategy="batched"), pack)
+    apply_profile_env("turbo", environ=expected, runtime_env_overrides=family)
+    for key, value in resolved.items():
+        assert value == expected.get(key), key
+    assert resolved["MTPLX_FAMILY_CAPTURE_COMMIT"] == "1"
+    assert resolved["MTPLX_SKIP_VERIFY_SNAPSHOT"] == "0"
+    assert resolved["MTPLX_NAX_VERIFY"] == "0"
+    assert resolved["MTPLX_QSA_GATHER_MAX_ROWS"] == "24"
+    if not exports:
+        assert resolved["MTPLX_QWEN4_FIXED_M4_VERIFY"] == "1"
+        assert resolved["MTPLX_BATCH_TARGET_ARRAYS"] == "1"
+        assert resolved["MTPLX_LAZY_TARGET_DISTRIBUTIONS"] == "0"
+
+
+def test_family_environment_restored_if_memory_preflight_refuses(tmp_path, monkeypatch):
+    from mtplx.commands import public
+    from mtplx.server import openai
+
+    key = "MTPLX_QWEN4_FIXED_M4_VERIFY"
+    monkeypatch.delenv(key, raising=False)
+    before = dict(os.environ)
+    def refuse(**kwargs):
+        assert os.environ[key] == "1"
+        raise RuntimeError("memory preflight refused")
+    monkeypatch.setattr(openai, "apply_memory_caps_preflight", refuse)
+    with pytest.raises(RuntimeError, match="memory preflight refused"):
+        public._depth_sweep_native60(model=str(tmp_path), prompt_suite="unused",
+            max_tokens=1, limit=1, seed=0, runtime_env={key: "1"})
+    assert dict(os.environ) == before

--- a/tests/test_tune_qwen4_exp_verify_strategy.py
+++ b/tests/test_tune_qwen4_exp_verify_strategy.py
@@ -1,0 +1,41 @@
+"""The tune candidate runner reads the pack config to pick the verify lane.
+
+_depth_sweep_native60 hardcoded verify_strategy="capture_commit" and the
+linear-gdn-from-conv-tape capture backend for every candidate. Those are
+qwen3-next structure lanes: their capture stack introspects the qwen3-next
+DecoderLayer layout (input_layernorm et al.) and raises AttributeError on
+Flash-Next hyper-connection layers. The server already coerces qwen4_exp to
+'batched' at boot; the candidate runner now applies the same predicate.
+"""
+
+from __future__ import annotations
+
+import json
+
+from mtplx.commands.public import _model_config_is_qwen4_exp
+
+
+def _write(tmp_path, config):
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    return str(tmp_path)
+
+
+def test_flash_next_pack_is_recognised_from_its_text_config(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen4_exp", "text_config": {"model_type": "qwen4_exp_text"}})
+    assert _model_config_is_qwen4_exp(path) is True
+
+
+def test_top_level_model_type_alone_is_enough(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen4_exp_text"})
+    assert _model_config_is_qwen4_exp(path) is True
+
+
+def test_dense_qwen3_5_pack_keeps_the_capture_commit_lane(tmp_path):
+    path = _write(tmp_path, {"model_type": "qwen3_5", "text_config": {"model_type": "qwen3_5_text"}})
+    assert _model_config_is_qwen4_exp(path) is False
+
+
+def test_missing_or_unreadable_config_is_not_flash_next(tmp_path):
+    assert _model_config_is_qwen4_exp(str(tmp_path)) is False
+    (tmp_path / "config.json").write_text("{not json")
+    assert _model_config_is_qwen4_exp(str(tmp_path)) is False


### PR DESCRIPTION
Long Flash-Next coding sessions could discard useful prefixes or fail admission under memory pressure. Short speculative and copy windows could also write past a promoted verifier's reserved capacity, corrupting later output. This change repairs those paths, completes Flash-Next tuning, and makes the runtime's behavior inspectable without raising memory limits.

- Integrate #453 by @nomishbhardwaj: account for live prefixes and reclaim bank entries in a protected order. Release unused allocator storage first, then evict only for the remaining measured deficit.
- Reserve fixed-verifier capacity before every write, including shallow and copy windows. Avoid promoting fixed D1/D2 requests into an unusable four-row lane. Release request banks and unloaded runtimes' shared verifier programs through explicit weak ownership.
- Gate the NAX attention routes by GPU/OS eligibility and individual startup checks. Keep portable QSA production independent of the NAX-only producer probe and exclude prefill capability resolution from decode.
- Integrate all four original #457 commits by @stooit, then complete the missing serving-family environment contract in tuning children. Correct draft-cycle and context reporting and the expected-value policy's conditional acceptance estimates.
- Join OpenCode and Pi turns/tools to request receipts and per-second verifier, acceptance, cache, memory and stall evidence. Keep missing observations, ambiguous joins, tool failures and invalid generations visible. Add an uncapped request replay and measured-AR break-even calculations.
- Package the existing native sparse-prefill consumer into an optional platform wheel, preserving attribution and its exact MLX ABI dependency. The app selects by the actual Python/macOS tags and retains the pure wheel on unsupported cells.

Validation completed so far: before/after capacity and ownership reproducers; cache/admission/native/CLI/trace suites; native-sampled uncapped 100K AR/D1/D2/D3 generation; a growing conversation through 206K at unchanged 96 GiB allocation / 83.334 GiB wired settings; a 6,529-token coding response at 206K; an actual 42-request OpenCode edit session with independently passing game checks; actual Pi transcript joins; Swift build and isolated real runtime-bootstrapper install/reuse/upgrade; installed-wheel BF16/FP16 native preflight and public tuning at temperature 1, top-p .95, top-k 20.

Final validation: all four GitHub checks pass at dba84f4d (runtime smoke, wheel, hygiene, attribution). The final 100K repeat measured AR 33.82 TPS versus the preceding stock 32.70, and D3 53.81 TPS; the matched historical sequence measured D3 46.91 → 53.09 TPS with essentially unchanged prefill. Native adaptive mixed Chinese/code completed with 584 D2 and 1,266 D3 draft cycles, 52.03 TPS versus AR 38.23; generated modules passed 17/20 checks and a corrective followup passed 9 checks plus independent framing assertions. These are scoped M5 measurements, not a universal performance claim.

The final platform wheel was installed and validated through the actual app bootstrapper, with native FP16/BF16 checks. Its SHA-256 is 258b8979f90ec695aa730368421051b430b1c9f40603c84c88301f3d541ddacf. An import-order cleanup changed no kernel source or function bodies; 79 targeted hardware/numerical checks passed after it.

M1–M4 long-context measurements, the separate 40K-plus continuous-response comparison, and final signed release/distribution QA remain release gates. No memory/wired limits are raised, no global runtime is repointed, and this PR does not tag or publish a release.

Human authorship from #453 and #457 is preserved. The two #453 commits were replayed with their human author identities and only their prohibited AI co-author footers removed; original commits remain in a local checkpoint. The original #457 ancestry is retained. The earlier #444 SSD restoration fix by @softpudding is already on main; this branch reconciles with that merge. The new native packaging retains the existing Steel/MLX licenses and notices from the consumer contributed in #423 by @humanrouter.

Repository hygiene now accepts only the exact reviewed bytes of the existing 65,536-entry integer vocabulary lookup; changed tables and other NPY artifacts remain rejected. Positive and negative gate replays passed.
