### PR TITLE
Allow removing stale custom models from picker

### DIFF
--- a/apps/MTPLXApp/Sources/MTPLXAppCore/Models/AppConfiguration.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppCore/Models/AppConfiguration.swift
@@ -556,6 +556,13 @@ public struct MTPLXAppConfiguration: Codable, Equatable, Sendable {
         customModels.append(option)
     }
 
+    @discardableResult
+    public mutating func removeCustomModel(id: String) -> Bool {
+        let originalCount = customModels.count
+        customModels.removeAll { $0.id == id }
+        return customModels.count != originalCount
+    }
+
     /// Persist a locally-forged model into the picker. Called by the
     /// Forge wizard's Registered stage when the build completes;
     /// dedup is by id (same branded name re-forged) AND by local

--- a/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Forge/ForgeMineView.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Forge/ForgeMineView.swift
@@ -323,7 +323,12 @@ struct ForgeMineView: View {
     private func removeFromPicker(entryID: String) {
         guard let entry = entries.first(where: { $0.id == entryID }) else { return }
         var config = backend.configuration
-        config.customModels.removeAll { $0.localCandidates.contains(entry.localPath) }
+        let modelIDs = config.customModels
+            .filter { $0.localCandidates.contains(entry.localPath) }
+            .map(\.id)
+        for modelID in modelIDs {
+            config.removeCustomModel(id: modelID)
+        }
         try? backend.saveSettings(config)
         reload()
         if selectedID == entryID {

--- a/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Models/ModelPickerOverlay.swift
+++ b/apps/MTPLXApp/Sources/MTPLXAppHost/Views/Models/ModelPickerOverlay.swift
@@ -58,6 +58,7 @@ struct ModelPickerOverlay: View, Equatable {
     @State private var rowsVisibleCount: Int = 0
     @State private var applyingModelID: String? = nil
     @State private var errorMessage: String? = nil
+    @State private var pendingRemoveID: String?
     @State private var addRowExpanded: Bool = false
     @State private var customRepoInput: String = ""
     /// The input the visible verdict (probe or error) was produced for.
@@ -120,6 +121,23 @@ struct ModelPickerOverlay: View, Equatable {
             // updates; the store throttles to one network check per 6 h.
             guard presented else { return }
             await backend.refreshModelUpdates()
+        }
+        .confirmationDialog(
+            tr("Remove this model from MTPLX?"),
+            isPresented: removePresented,
+            titleVisibility: .visible
+        ) {
+            Button(tr("Remove from picker"), role: .destructive) {
+                if let id = pendingRemoveID {
+                    removeFromPicker(id: id)
+                }
+                pendingRemoveID = nil
+            }
+            Button(tr("Cancel"), role: .cancel) {
+                pendingRemoveID = nil
+            }
+        } message: {
+            Text(tr("This unregisters the model from the picker only — the files on disk stay intact. Delete the folder from Finder if you want to free the space."))
         }
     }
 
@@ -315,7 +333,9 @@ struct ModelPickerOverlay: View, Equatable {
             disabled: applyingModelID != nil || checkingCustomRepo || isTransitioning,
             visible: visible,
             motionEnabled: motionEnabled,
-            action: { select(row) }
+            action: { select(row) },
+            canRemoveFromPicker: row.canRemoveFromPicker,
+            removeAction: { pendingRemoveID = row.id }
         )
     }
 
@@ -562,6 +582,19 @@ struct ModelPickerOverlay: View, Equatable {
         }
     }
 
+    private var removePresented: Binding<Bool> {
+        Binding(
+            get: { pendingRemoveID != nil },
+            set: { if !$0 { pendingRemoveID = nil } }
+        )
+    }
+
+    private func removeFromPicker(id: String) {
+        var next = backend.configuration
+        guard next.removeCustomModel(id: id) else { return }
+        try? backend.saveSettings(next)
+    }
+
     private func checkAndAddCustomModel() {
         guard !checkingCustomRepo, applyingModelID == nil, !isTransitioning else { return }
         // A path is checked on disk; anything else is a Hugging Face id.
@@ -803,7 +836,11 @@ struct ModelPickerOverlay: View, Equatable {
                     hardware: hardware
                 )
                 .map { option in
-                    ModelPickerPreparedOption(option: option, currentModel: currentModel)
+                    ModelPickerPreparedOption(
+                        option: option,
+                        currentModel: currentModel,
+                        customModels: customModels
+                    )
                 }
             }.value
 
@@ -846,7 +883,7 @@ private struct ModelPickerCatalogSignature: Equatable, Sendable {
     let hardware: DetectedHardware?
 }
 
-private struct ModelPickerPreparedOption: Equatable, Identifiable, Sendable {
+struct ModelPickerPreparedOption: Equatable, Identifiable, Sendable {
     let option: MTPLXModelOption
     let id: String
     let displayName: String
@@ -854,9 +891,17 @@ private struct ModelPickerPreparedOption: Equatable, Identifiable, Sendable {
     let isInstalled: Bool
     let selected: Bool
     let resolvedReference: String
+    let canRemoveFromPicker: Bool
 
-    init(option: MTPLXModelOption, currentModel: String) {
+    init(option: MTPLXModelOption, currentModel: String, customModels: [MTPLXModelOption]) {
         let installedLocalPath = option.installedLocalPath
+        let selected = Self.matches(
+            option: option,
+            model: currentModel,
+            resolvedReference: installedLocalPath ?? option.hfModelID
+        )
+        let isOfficial = MTPLXModelOption.officialCatalog.contains { $0.id == option.id }
+        let isPersistedCustom = !isOfficial && customModels.contains { $0.id == option.id }
 
         self.option = option
         self.id = option.id
@@ -864,11 +909,8 @@ private struct ModelPickerPreparedOption: Equatable, Identifiable, Sendable {
         self.detail = option.detail
         self.isInstalled = installedLocalPath != nil
         self.resolvedReference = installedLocalPath ?? option.hfModelID
-        self.selected = Self.matches(
-            option: option,
-            model: currentModel,
-            resolvedReference: installedLocalPath ?? option.hfModelID
-        )
+        self.selected = selected
+        self.canRemoveFromPicker = isPersistedCustom && installedLocalPath == nil && !selected
     }
 
     func matches(_ model: String) -> Bool {
@@ -930,6 +972,8 @@ private struct ModelRowView: View {
     let visible: Bool
     let motionEnabled: Bool
     let action: () -> Void
+    let canRemoveFromPicker: Bool
+    let removeAction: () -> Void
 
     @State private var hovering = false
 
@@ -973,6 +1017,11 @@ private struct ModelRowView: View {
             }
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            if canRemoveFromPicker {
+                Button(tr("Remove from picker"), role: .destructive, action: removeAction)
+            }
+        }
         .disabled(disabled)
         .opacity(visible ? 1 : 0)
         .offset(y: visible ? 0 : 8)

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/MTPLXAppCoreTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/MTPLXAppCoreTests.swift
@@ -4322,6 +4322,51 @@ final class MTPLXAppCoreTests: XCTestCase {
         )
     }
 
+    func testRemoveCustomModelByIDPreservesUnrelatedModelsAndOfficialCatalog() throws {
+        var config = MTPLXAppConfiguration()
+        config.rememberCustomModel(repoID: "Foo/Bar")
+        config.rememberCustomModel(repoID: "Foo/Baz")
+        let officialIDs = Set(MTPLXModelOption.officialCatalog.map(\.id))
+        let removedID = try XCTUnwrap(config.customModels.first?.id)
+
+        XCTAssertTrue(config.removeCustomModel(id: removedID))
+        XCTAssertFalse(config.customModels.contains { $0.id == removedID })
+        XCTAssertEqual(config.customModels.map(\.hfModelID), ["Foo/Baz"])
+        XCTAssertEqual(Set(MTPLXModelOption.officialCatalog.map(\.id)), officialIDs)
+        XCTAssertFalse(config.removeCustomModel(id: "missing-model"))
+    }
+
+    func testRemovingCustomModelDoesNotDeleteItsLocalFiles() throws {
+        let directory = temporaryDirectory().appendingPathComponent("custom-model", isDirectory: true)
+        let file = directory.appendingPathComponent("weights.bin")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data([1, 2, 3]).write(to: file)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        var config = MTPLXAppConfiguration()
+        config.rememberForgedModel(brandedName: "Custom", localPath: directory.path)
+        let modelID = try XCTUnwrap(config.customModels.first?.id)
+
+        XCTAssertTrue(config.removeCustomModel(id: modelID))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    func testRemovingCurrentCustomRegistrationPreservesCurrentModelSynthesis() throws {
+        var config = MTPLXAppConfiguration()
+        config.rememberCustomModel(repoID: "Foo/Current")
+        config.model = "Foo/Current"
+        let modelID = try XCTUnwrap(config.customModels.first?.id)
+
+        XCTAssertTrue(config.removeCustomModel(id: modelID))
+        let catalog = MTPLXModelOption.pickerCatalog(
+            customModels: config.customModels,
+            currentModel: config.model
+        )
+
+        XCTAssertTrue(catalog.contains { $0.matches(config.model) })
+    }
+
     func testCommandBuilderEmitsBatchingRuntimeSettings() throws {
         let fake = try makeExecutable(named: "mtplx")
         let builder = MTPLXCommandBuilder(environment: ["PATH": fake.deletingLastPathComponent().path])

--- a/apps/MTPLXApp/Tests/MTPLXAppCoreTests/SettingsRecoveryTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppCoreTests/SettingsRecoveryTests.swift
@@ -139,6 +139,20 @@ final class SettingsRecoveryTests: XCTestCase {
         XCTAssertEqual(result.degradedFields.map(\.path).sorted(), ["custom_models", "embedding_models"])
     }
 
+    func testRemovedCustomModelStaysRemovedAfterSaveAndLoad() throws {
+        let store = makeStore()
+        var configuration = MTPLXAppConfiguration()
+        configuration.rememberCustomModel(repoID: "Foo/Bar")
+        configuration.rememberCustomModel(repoID: "Foo/Baz")
+        let removedID = try XCTUnwrap(configuration.customModels.first?.id)
+
+        XCTAssertTrue(configuration.removeCustomModel(id: removedID))
+        try store.save(configuration)
+
+        let loaded = try store.load()
+        XCTAssertEqual(loaded.customModels.map(\.hfModelID), ["Foo/Baz"])
+    }
+
     // MARK: - Unreadable file
 
     func testNonJSONFileIsKeptBesideItselfWithDatedSuffixAndNoticeSet() throws {

--- a/apps/MTPLXApp/Tests/MTPLXAppHostTests/ModelPickerOverlayTests.swift
+++ b/apps/MTPLXApp/Tests/MTPLXAppHostTests/ModelPickerOverlayTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import MTPLXAppCore
+
+@testable import MTPLXAppHost
+
+final class ModelPickerOverlayTests: XCTestCase {
+    func testMissingPersistedCustomModelCanBeRemoved() throws {
+        let option = try XCTUnwrap(MTPLXModelOption.customHuggingFaceModel(repoID: "Foo/Bar"))
+        let row = ModelPickerPreparedOption(
+            option: option,
+            currentModel: "Other/Model",
+            customModels: [option]
+        )
+
+        XCTAssertFalse(row.isInstalled)
+        XCTAssertTrue(row.canRemoveFromPicker)
+    }
+
+    func testInstalledPersistedCustomModelCannotBeRemoved() throws {
+        let directory = temporaryDirectory().appendingPathComponent("installed-model", isDirectory: true)
+        try makeCompleteModelFolder(at: directory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let option = MTPLXModelOption(
+            id: "custom-installed",
+            displayName: "Installed Custom",
+            shortName: "Installed Custom",
+            detail: "Test model",
+            hfModelID: "Foo/Installed",
+            localCandidates: [directory.path]
+        )
+        let row = ModelPickerPreparedOption(
+            option: option,
+            currentModel: "Other/Model",
+            customModels: [option]
+        )
+
+        XCTAssertTrue(row.isInstalled)
+        XCTAssertFalse(row.canRemoveFromPicker)
+    }
+
+    func testOfficialModelCannotBeRemoved() throws {
+        let option = try XCTUnwrap(MTPLXModelOption.officialCatalog.first)
+        let row = ModelPickerPreparedOption(
+            option: option,
+            currentModel: "Other/Model",
+            customModels: [option]
+        )
+
+        XCTAssertFalse(row.canRemoveFromPicker)
+    }
+
+    func testCurrentSynthesizedModelCannotBeRemovedAndRemainsRepresentable() throws {
+        let option = try XCTUnwrap(MTPLXModelOption.customHuggingFaceModel(repoID: "Foo/Current"))
+        let row = ModelPickerPreparedOption(
+            option: option,
+            currentModel: option.hfModelID,
+            customModels: []
+        )
+
+        XCTAssertTrue(row.selected)
+        XCTAssertFalse(row.canRemoveFromPicker)
+        XCTAssertEqual(row.resolvedReference, option.hfModelID)
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtplx-model-picker-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func makeCompleteModelFolder(at folder: URL) throws {
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try "{}".write(to: folder.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try "{}".write(to: folder.appendingPathComponent("tokenizer.json"), atomically: true, encoding: .utf8)
+        try Data([0]).write(to: folder.appendingPathComponent("model.safetensors"))
+    }
+}


### PR DESCRIPTION
## Summary
* Allow stale persisted custom models to be removed from the model picker.
* Reuse the existing `removeCustomModel(id:)` configuration API.
* Keep installed, official, and currently selected models non-removable.
* Removing a model only unregisters it from the picker; model files on disk are left untouched.
* Add focused tests for removal behavior and picker eligibility.

## Removal eligibility
* Only persisted custom models that are no longer installed can be removed.
* Official catalog models are never removable.
* Installed custom models are not removable.
* The currently selected model is not removable.
* Removal only unregisters the model from the picker and does not delete files from disk.

## Testing
* Added unit tests covering stale, installed, official, and current models.
* Manually verified the model picker in the macOS app: a stale custom model exposes `Remove from picker` via the row context menu and requires confirmation before removal.
* `git diff --check` passes.