### PR TITLE
Fix Flash-Next FP8 n-gram scalar scales

### DIFF
--- a/scripts/convert_qwen4_exp_fp8.py
+++ b/scripts/convert_qwen4_exp_fp8.py
@@ -163,11 +163,15 @@ class SourceReader:
         if dtype == "F8_E4M3":
             w = mx.array(fp8_e4m3_lut()[np.ascontiguousarray(arr)])
             scale_name = name.replace(".weight", ".weight_scale_inv")
+            if scale_name not in self.weight_map and ".ngram_embedding.shard_" in name:
+                scale_name = name.split(".ngram_embedding.shard_", 1)[0] + ".ngram_embedding.weight_scale"
             s_arr, s_dtype = self.raw(scale_name)
             scale = mx.array(np.ascontiguousarray(s_arr))
             if s_dtype in ("BF16", "F16"):
                 scale = scale.view(mx.bfloat16 if s_dtype == "BF16" else mx.float16)
             scale = scale.astype(mx.float32)
+            if tuple(scale.shape) == (1,):
+                return (w * scale).astype(mx.bfloat16)
             R, C = w.shape
             br, bc = scale.shape
             scale = mx.repeat(mx.repeat(scale, 128, axis=0)[:R], 128, axis=1)[:, :C]
@@ -438,6 +442,9 @@ def main():
             if (i + 1) % 16 == 0:
                 print(f"[ngram] {i + 1}/{len(shard_names)}", flush=True)
         ng.close()
+        global_scale_name = ple_prefix + ".ple_embedding.ngram_embedding.weight_scale"
+        if global_scale_name in reader.weight_map:
+            accounted[global_scale_name] = "ngram-scale"
 
     # ---- 2. numbered experts -> stacked switch_mlp (trunk + mtp) ------------
     expert_re = re.compile(r"^(.*)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$")

--- a/tests/test_convert_qwen4_exp_fp8_scales.py
+++ b/tests/test_convert_qwen4_exp_fp8_scales.py
@@ -1,0 +1,75 @@
+"""Regression coverage for Qwen3.8 Flash-Next FP8 scale layouts."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "convert_qwen4_exp_fp8.py"
+
+
+@pytest.fixture
+def converter(monkeypatch):
+    """Load the converter with a small NumPy-backed MLX stand-in.
+
+    The converter itself only needs these array operations for dequantization,
+    which keeps this focused regression runnable on non-macOS CI.
+    """
+    fake_mx = types.SimpleNamespace(
+        array=np.asarray,
+        repeat=np.repeat,
+        bfloat16=np.float32,
+        float16=np.float16,
+        float32=np.float32,
+    )
+    fake_mlx = types.ModuleType("mlx")
+    fake_mlx.core = fake_mx
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mx)
+
+    spec = importlib.util.spec_from_file_location("qwen4_exp_fp8_converter_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reader(module, tensors: dict[str, tuple[np.ndarray, str]]):
+    reader = object.__new__(module.SourceReader)
+    reader.weight_map = {name: "synthetic.safetensors" for name in tensors}
+    reader.raw = lambda name: tensors[name]
+    return reader
+
+
+def test_bf16_uses_per_block_weight_scale_inv_for_ordinary_fp8_weight(converter) -> None:
+    weight_name = "model.layers.0.mlp.gate_proj.weight"
+    scale_name = "model.layers.0.mlp.gate_proj.weight_scale_inv"
+    reader = _reader(
+        converter,
+        {
+            weight_name: (np.full((2, 3), 0x38, dtype=np.uint8), "F8_E4M3"),
+            scale_name: (np.array([[2.0]], dtype=np.float32), "F32"),
+        },
+    )
+
+    np.testing.assert_allclose(reader.bf16(weight_name), np.full((2, 3), 2.0))
+
+
+def test_bf16_uses_shared_scalar_weight_scale_for_ngram_fp8_shard(converter) -> None:
+    weight_name = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_0.weight"
+    scale_name = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.weight_scale"
+    reader = _reader(
+        converter,
+        {
+            weight_name: (np.full((2, 3), 0x38, dtype=np.uint8), "F8_E4M3"),
+            scale_name: (np.array([0.5], dtype=np.float32), "F32"),
+        },
+    )
+
+    np.testing.assert_allclose(reader.bf16(weight_name), np.full((2, 3), 0.5))


### PR DESCRIPTION
## Summary

The stock converter fails on the official Qwen/Qwen3.8-Flash-Next-FP8 revision 236dfdf285828023ca3bcd3f37366c58a3469b13 because its 128 PLE n-gram FP8 shards share one BF16 scalar weight_scale rather than providing per-weight weight_scale_inv tensors.

This narrow fix falls back to that shared scalar only for n-gram shards, broadcasts it during FP8 dequantization, and accounts for the shared source tensor in fail-closed accounting. Ordinary block-scale weight_scale_inv conversion remains unchanged.

## Validation

- Added synthetic regression coverage for both ordinary 128x128 block weight_scale_inv and official n-gram shared scalar weight_scale layouts.
- Targeted regression tests pass on Linux with a NumPy-backed MLX stand-in; native MLX execution is not available on this host.
- Completed the full 185.6 GB official-source conversion, Forge verification, and model-load verification on Nexus. The verified patched converter SHA-256 is 4ecc6eb37366739ba214778adea7ba6aeacf133817d5162cba684abc8f1a8b73.