### PR TITLE
[BUG FIX] OOM - Fit 261,120-token decode: write the verify KV in place and keep the verify attention fused

### DIFF
--- a/docs/perf/qwen38-256k-fix/README.md
+++ b/docs/perf/qwen38-256k-fix/README.md
@@ -1,0 +1,116 @@
+# Qwen3.8 Flash-Next: 261,120-token decode fix
+
+Two verify-step memory fixes on top of upstream MTPLX 2.11.2 (`21be78b3`). At the pack's
+advertised 261,120-token context the release reads the whole prompt and then runs out of GPU
+memory in the first decode step. With both commits the same prompt decodes to completion on
+every seed, with native MTP on, at a 100.82 GB peak against the 107.374 GB (100 GiB) knob.
+
+| # | Commit | Optimization | Exactness |
+| --- | --- | --- | --- |
+| 1 | `fc0d2a29` | In-place verify KV write (`mtplx/graphbank.py`) | exact; same bytes as `mx.slice_update` |
+| 2 | `e0ebdc41` | Head-chunked verify SDPA (`mtplx/models/qwen4_exp.py`) | bit-identical to an unchunked fused call; rounding-class against the unfused route it replaces |
+
+## 261,120 tokens
+
+![peak memory by context](charts/peak_memory.svg)
+
+![decode tok/s at 261,120 tokens](charts/decode_261k.svg)
+
+Release 2.11.2 fails this cell: prompt fully read (`new_prefill_tokens` 261120), time to first
+token 243.5 s, then `completion_tokens` 12 and `finish_reason` `error`, at a 100.82 GB sampled
+peak, with `[METAL] Command buffer execution failed: Insufficient Memory`.
+
+The fix arm completes it on three cold seeds, one seed per server load:
+
+| Window | Seed | Prefill tok/s | Decode tok/s | TTFT (s) | Wall (s) | Completion tokens | Finish | Accept | Peak (GB) |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: |
+| w1 | 20260829 | 1081.6 | 59.62 | 242.631 | 254.03 | 461 | stop | 0.499 | 100.82 |
+| w2 | 20260830 | 1081.5 | 56.82 | 242.614 | 264.33 | 1024 | length | 0.483 | 100.82 |
+| w3 | 20260831 | 1082.9 | 62.84 | 242.290 | 259.43 | 845 | stop | 0.563 | 100.82 |
+
+Fastest of the three, with the min-max: prefill **1082.9** tok/s (1081.5-1082.9), decode
+**62.84** tok/s (56.82-62.84), TTFT **242.290** s (242.290-242.631), wall **254.03** s
+(254.03-264.33), peak **100.82** GB (100.82-100.82). Every window sits about 6.5 GB under the
+knob. Completion tokens differ by seed because each seed stops on its own; no window errored.
+
+## 16,384 tokens (no regression)
+
+This cell never overflowed, so it measures that the token rate and the output are unchanged.
+
+| Metric | release 2.11.2 (A) | fix arm (F) |
+| --- | ---: | ---: |
+| Decode tok/s (fastest, min-max) | 71.97 | 71.61 (71.24-71.61) |
+| Decode tok/s (mean of windows) | 71.58 | 71.47 |
+| Prefill tok/s | 1381.5 | 1377.2 (1343.5-1377.2) |
+| TTFT (s) | 12.056 | 12.112 (12.112-12.390) |
+| Peak memory (GB) | 93.41 | 93.41 (89.01-93.41) |
+| Output vs release | — | byte-identical, all 3 seeds |
+
+The output check is `text_sha256` per seed against the release arm's own 16,384-token windows:
+
+| Seed | Completion tokens | `text_sha256` (both arms) |
+| --- | ---: | --- |
+| 20260829 | 1024 | `ee9993ec5b08201d6af3fa06c3367fd60e88ae7480d4df21c6911b590d6752f5` |
+| 20260830 | 689 | `eec89cc6af7d9bc8fc7ea69cdcf29448d54c722238582d8050d6f79ec6c34564` |
+| 20260831 | 879 | `1ac58119b2df27d732bfe266d97086ed21e2c4dd4a8e644b8ad07466400f8315` |
+
+## Evidence chain
+
+The prefill is not what overflows: on every failing arm the whole prompt is read and tokens are
+already emitted before the failure. The overflow is the first decode step, the fixed four-row
+speculative verify, which makes two per-layer allocations across the 12 full-attention layers
+(48 layers, `full_attention_interval` 4).
+
+1. **Native MTP off (W5).** Decode becomes plain autoregressive at query length 1: the fused
+   attention kernel is eligible so no score plane is built, and the stock in-place `KVCache`
+   runs instead of `TensorOffsetKVCache`. The same 261,120-token prompt **fits at 94.19 GB** and
+   decodes 547 tokens to a normal `stop`, TTFT 223.6 s. With MTP on the peak is 100.82 GB. The
+   6.4 GB gap is what the verify adds, but turning MTP off removes both candidate terms at once.
+2. **Head chunk alone (`e0ebdc41`, no in-place write).** The head chunk engaged
+   (`/health` `verify_sdpa_head_chunk` `{engaged: true, q_len: 5, heads_per_chunk: 6, chunks: 4,
+   n_kv_heads: 2}`), so the `[24, S, 261120]` score plane was not built. The request still failed
+   at the same place and the same peak: TTFT 242.44 s, 12 tokens, `error`, 100.82 GB, against
+   release's 100.82 GB. A peak unchanged to two decimals with the attention transient provably
+   gone isolates the remaining 6.4 GB to something other than attention.
+3. **Allocation probe.** Probing `TensorOffsetKVCache` at this geometry (context 261,120,
+   capacity 261,128, 12 layers, 5 verify rows) measures one KV buffer at **0.27 GB**, resident KV
+   across keys, values and the 12 layers at **6.42 GB**, and, with the in-place write, an
+   **update transient above resident of 0.00 GB**. Unfixed, that transient is the full 6.4 GB
+   again: `mx.slice_update` returns a new array, so it reallocates the whole
+   `[1, 2, capacity, 256]` bf16 buffer per key and per value tensor in every layer.
+4. **Fix arm (`fc0d2a29`).** With the in-place write the prompt fits on all three cold seeds at
+   100.82 GB with MTP on and the verify running.
+
+The probe's 6.42 GB resident and 0.00 GB transient, against the 6.4 GB gap step 1 exposed, is the
+arithmetic that closes the chain.
+
+## Receipts index
+
+All paths under `.benchmark-artifacts/over100-reports/`.
+
+| What | Path |
+| --- | --- |
+| Fix arm, 261,120, 3 seeds | `battery475/receipts/arm-F2-inplacekv/arm-F2-inplacekv-261120-s20260829-*/`, `-s20260830-*/`, `-s20260831-*/` |
+| Fix arm, 16,384, 3 seeds | `battery475/receipts/arm-F2-inplacekv/arm-F2-inplacekv-16384-20260908T030353Z-49063/` |
+| Fix-arm run manifest | `battery475/f/manifest.tsv` |
+| Head-chunk-only arm (did not fit) | `battery475/receipts/arm-F-headchunk/` |
+| Native-MTP-off probe (W5) | `battery475/receipts/arm-C-w5-nomtp/` |
+| KV allocation probe | `battery475/kvprobe/kvprobe-20260908T005614Z.log` |
+| Release 261,120 failure | `battery475/receipts/arm-A-release/superseded-oom-exceeds-knob/` |
+| Release 16,384 windows | `battery475/abab/win01-A-r1/`, `win05-A-r2/`, `win09-A-r3/` |
+| Earlier levers, all void | `battery475/receipts/arm-C-w1-scoretile256/`, `arm-C-w2-sessionoff/`, `arm-C-w3-mlxcache2g/`, `arm-C-w4-chunk512/` |
+
+## Method
+
+| Setting | Value |
+| --- | --- |
+| Model | `Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed`, revision `29ba90f82124961d0d902a9ea9bbb1034972af2f` |
+| Engine | MTPLX 2.11.2 on MLX 0.32.2 |
+| Sampler | temperature 1, top-p 0.95, top-k 20, reasoning effort `xhigh` |
+| MTP depth | native, depth 3 |
+| Output length | 1,024 tokens maximum |
+| Seeds | 20260829, 20260830, 20260831; one seed per server load at 261,120 |
+| Cell statistic | fastest window (max tok/s, min TTFT and wall, max peak), shown with the min-max |
+| Memory cap | 100 GiB (`MTPLX_MEMORY_LIMIT_BYTES` 107374182400) |
+| Prefill state | cold; cross-request prefix restore off; new prefill tokens equal prompt tokens |
+| Thermal state | fans at maximum, a 40 degree Celsius gate before every cell |

--- a/docs/perf/qwen38-256k-fix/charts/decode_261k.svg
+++ b/docs/perf/qwen38-256k-fix/charts/decode_261k.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="500" viewBox="0 0 900 500" font-family="-apple-system,Helvetica,Arial,sans-serif">
+<rect width="900" height="500" fill="#ffffff"/>
+<text x="450" y="26" text-anchor="middle" font-size="17" font-weight="600" fill="#111">Qwen3.8 Flash-Next: decode tok/s at 261,120 tokens</text>
+<text x="450" y="46" text-anchor="middle" font-size="12" fill="#555">A/C/D/E fail in the first decode step (void); this PR (F) completes</text>
+<line x1="70" y1="380" x2="870" y2="380" stroke="#333" stroke-width="1"/>
+<line x1="70" y1="70" x2="70" y2="380" stroke="#333" stroke-width="1"/>
+<line x1="70" y1="380.0" x2="870" y2="380.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="384.0" text-anchor="end" font-size="11" fill="#555">0</text>
+<line x1="70" y1="318.0" x2="870" y2="318.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="322.0" text-anchor="end" font-size="11" fill="#555">14</text>
+<line x1="70" y1="256.0" x2="870" y2="256.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="260.0" text-anchor="end" font-size="11" fill="#555">29</text>
+<line x1="70" y1="194.0" x2="870" y2="194.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="198.0" text-anchor="end" font-size="11" fill="#555">43</text>
+<line x1="70" y1="132.0" x2="870" y2="132.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="136.0" text-anchor="end" font-size="11" fill="#555">58</text>
+<line x1="70" y1="70.0" x2="870" y2="70.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="74.0" text-anchor="end" font-size="11" fill="#555">72</text>
+<text x="150.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">A</text>
+<rect x="110.0" y="349.0" width="80.0" height="31.0" fill="#f7eaea" stroke="#b00" stroke-dasharray="4 3"/>
+<text x="150.0" y="343.0" text-anchor="middle" font-size="12" font-weight="600" fill="#b00">void (OOM)</text>
+<text x="310.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">C</text>
+<rect x="270.0" y="349.0" width="80.0" height="31.0" fill="#f7eaea" stroke="#b00" stroke-dasharray="4 3"/>
+<text x="310.0" y="343.0" text-anchor="middle" font-size="12" font-weight="600" fill="#b00">void (OOM)</text>
+<text x="470.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">D</text>
+<rect x="430.0" y="349.0" width="80.0" height="31.0" fill="#f7eaea" stroke="#b00" stroke-dasharray="4 3"/>
+<text x="470.0" y="343.0" text-anchor="middle" font-size="12" font-weight="600" fill="#b00">void (OOM)</text>
+<text x="630.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">E</text>
+<rect x="590.0" y="349.0" width="80.0" height="31.0" fill="#f7eaea" stroke="#b00" stroke-dasharray="4 3"/>
+<text x="630.0" y="343.0" text-anchor="middle" font-size="12" font-weight="600" fill="#b00">void (OOM)</text>
+<text x="790.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">F</text>
+<rect x="750.0" y="110.4" width="80.0" height="269.6" fill="#009E73" opacity="0.88"/>
+<line x1="790.0" y1="136.2" x2="790.0" y2="110.4" stroke="#222" stroke-width="1.5"/>
+<line x1="784.0" y1="136.2" x2="796.0" y2="136.2" stroke="#222" stroke-width="1.5"/>
+<line x1="784.0" y1="110.4" x2="796.0" y2="110.4" stroke="#222" stroke-width="1.5"/>
+<text x="790.0" y="104.4" text-anchor="middle" font-size="11" fill="#222">62.84</text>
+<text x="70" y="484" font-size="10.5" fill="#777">Decode (tok/s) at 261,120 tokens. Point = fastest seed; band = min-max. A/C/D/E from the 261K OOM receipts; F = this PR.</text>
+</svg>

--- a/docs/perf/qwen38-256k-fix/charts/peak_memory.svg
+++ b/docs/perf/qwen38-256k-fix/charts/peak_memory.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="500" viewBox="0 0 900 500" font-family="-apple-system,Helvetica,Arial,sans-serif">
+<rect width="900" height="500" fill="#ffffff"/>
+<text x="450" y="26" text-anchor="middle" font-size="17" font-weight="600" fill="#111">Qwen3.8 Flash-Next: peak memory at 261,120 tokens</text>
+<text x="450" y="46" text-anchor="middle" font-size="12" fill="#555">release and the #475/#478 arms exceed the 100 GiB knob; this PR (F) fits</text>
+<line x1="70" y1="380" x2="870" y2="380" stroke="#333" stroke-width="1"/>
+<line x1="70" y1="70" x2="70" y2="380" stroke="#333" stroke-width="1"/>
+<line x1="70" y1="380.0" x2="870" y2="380.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="384.0" text-anchor="end" font-size="11" fill="#555">0</text>
+<line x1="70" y1="318.0" x2="870" y2="318.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="322.0" text-anchor="end" font-size="11" fill="#555">23</text>
+<line x1="70" y1="256.0" x2="870" y2="256.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="260.0" text-anchor="end" font-size="11" fill="#555">46</text>
+<line x1="70" y1="194.0" x2="870" y2="194.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="198.0" text-anchor="end" font-size="11" fill="#555">70</text>
+<line x1="70" y1="132.0" x2="870" y2="132.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="136.0" text-anchor="end" font-size="11" fill="#555">93</text>
+<line x1="70" y1="70.0" x2="870" y2="70.0" stroke="#eee" stroke-width="1"/>
+<text x="62" y="74.0" text-anchor="end" font-size="11" fill="#555">116</text>
+<line x1="70" y1="93.0" x2="870" y2="93.0" stroke="#b00" stroke-width="1.5" stroke-dasharray="6 4"/>
+<text x="866" y="87.0" text-anchor="end" font-size="11" fill="#b00">100 GiB knob (107.4 GB)</text>
+<text x="150.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">A</text>
+<rect x="110.0" y="110.5" width="80.0" height="269.5" fill="#0072B2" opacity="0.88"/>
+<text x="150.0" y="104.5" text-anchor="middle" font-size="11" fill="#222">100.82</text>
+<text x="310.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">C</text>
+<rect x="270.0" y="110.6" width="80.0" height="269.4" fill="#CC79A7" opacity="0.88"/>
+<text x="310.0" y="104.6" text-anchor="middle" font-size="11" fill="#222">100.79</text>
+<text x="470.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">D</text>
+<rect x="430.0" y="110.6" width="80.0" height="269.4" fill="#E69F00" opacity="0.88"/>
+<text x="470.0" y="104.6" text-anchor="middle" font-size="11" fill="#222">100.79</text>
+<text x="630.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">E</text>
+<rect x="590.0" y="110.6" width="80.0" height="269.4" fill="#D55E00" opacity="0.88"/>
+<text x="630.0" y="104.6" text-anchor="middle" font-size="11" fill="#222">100.79</text>
+<text x="790.0" y="398" text-anchor="middle" font-size="12" font-weight="600" fill="#333">F</text>
+<rect x="750.0" y="110.5" width="80.0" height="269.5" fill="#009E73" opacity="0.88"/>
+<line x1="790.0" y1="110.5" x2="790.0" y2="110.5" stroke="#222" stroke-width="1.5"/>
+<line x1="784.0" y1="110.5" x2="796.0" y2="110.5" stroke="#222" stroke-width="1.5"/>
+<line x1="784.0" y1="110.5" x2="796.0" y2="110.5" stroke="#222" stroke-width="1.5"/>
+<text x="790.0" y="104.5" text-anchor="middle" font-size="11" fill="#222">100.82</text>
+<text x="70" y="484" font-size="10.5" fill="#777">Peak memory (GB) at 261,120 tokens. Point = fastest seed; band = min-max. A/C/D/E from the 261K OOM receipts; F = this PR.</text>
+</svg>

--- a/docs/perf/qwen38-longctx-prefill-memory.md
+++ b/docs/perf/qwen38-longctx-prefill-memory.md
@@ -3,9 +3,11 @@
 `mtplx serve` OOM'd on the pack's advertised 262,144-token context on a 128 GB
 M5 Max under turbo / server defaults. The full source + log diagnosis is in
 `.benchmark-artifacts/over100-reports/oom255k/report.md`; this note records the
-optimization it produced.
+two optimizations it produced. The OOM is in the speculative-verify decode step,
+not the prefill: the prefill completes (TTFT ~240 s) and the request fails a few
+decode tokens later. Two separate ~6.4 GB verify transients had to go.
 
-## Optimization — head-chunk the small-q_len verify SDPA
+## Optimization 1 — head-chunk the small-q_len verify SDPA
 
 ### Problem
 
@@ -82,3 +84,57 @@ the same class as the mask-fuse lane.
   heads_per_chunk=H chunks=N`.
 - `/health` → `qwen4_install_reports.verify_sdpa_head_chunk`:
   `{engaged, q_len, heads_per_chunk, chunks, n_kv_heads}` once it has fired.
+
+## Optimization 2 — write the fixed-M4 verify KV in place
+
+### Problem
+
+With Optimization 1 in place the small-q_len score plane is gone, yet the
+261,120-token request still OOMs at the same ~100.8 GB peak, a few decode tokens
+in. The remaining ~6.4 GB (100.82 GB with MTP on and the verify running, vs
+94.19 GB for the same prompt with MTP off at S=1) is the verify's KV-cache
+update. The fixed-M4 verify uses `TensorOffsetKVCache` (graphbank.py), whose
+`update_and_fetch` writes the new rows with the functional `mx.slice_update`.
+That op reallocates the whole `[1, 2, capacity, 256]` buffer per key and per
+value tensor (267 MB each at the 262K capacity, measured on CPU), and across the
+12 full-attention layers that is 6.4 GB, matching the gap exactly. An S=1 AR
+decode (MTP off) rides the stock `KVCache`, which writes in place and returns a
+view, so it never pays it. The bank's own machinery demotes long generations to
+the eager verify (graphbank: "longer generations demote to eager"), so the served
+261K verify runs this eager path with a concrete offset.
+
+### Change
+
+`TensorOffsetKVCache.update_and_fetch` (and the `trim` rollback restore) now take
+an in-place path when the offset is a concrete host value: the S new rows are
+written with a slice assignment into the existing buffer (0 allocation, measured),
+after materializing an independent copy of the pre-write rows for rollback. When
+the offset is a tracer (inside an `mx.compile` trace) the compile-visible
+functional `mx.slice_update` path is kept unchanged, so the compiled replay's
+donation contract is untouched.
+
+### Effect
+
+The eager verify's KV update no longer reallocates the full buffer, removing the
+~6.4 GB verify transient. Combined with Optimization 1, the 261,120-token verify's
+working set no longer scales the way that overflows the 100 GiB knob.
+
+### Exactness
+
+Byte-identical. The in-place write lands the same bytes at the same positions as
+the functional `slice_update` (verified equal on random tensors), and the
+rollback snapshot is an independent copy so `trim` restores exactly the pre-write
+rows.
+
+### Files
+
+- `mtplx/graphbank.py` — `TensorOffsetKVCache.update_and_fetch`, `trim`,
+  `_concrete_offset`.
+- `tests/test_tensoroffset_kv_inplace.py` — CPU tests (no full-buffer alloc,
+  correctness, rollback independence, numerical equivalence, tracer detection).
+
+### Switch / observability
+
+No new knob; the in-place path is the eager verify's KV update. A GPU probe that
+isolates the transient is at
+`.benchmark-artifacts/over100-reports/oom255k/verify_kv_peak_probe.py`.

--- a/docs/perf/qwen38-longctx-prefill-memory.md
+++ b/docs/perf/qwen38-longctx-prefill-memory.md
@@ -1,0 +1,84 @@
+# Qwen3.8 Flash-Next long-context decode memory
+
+`mtplx serve` OOM'd on the pack's advertised 262,144-token context on a 128 GB
+M5 Max under turbo / server defaults. The full source + log diagnosis is in
+`.benchmark-artifacts/over100-reports/oom255k/report.md`; this note records the
+optimization it produced.
+
+## Optimization — head-chunk the small-q_len verify SDPA
+
+### Problem
+
+At 261,120 tokens the **prefill completes** (TTFT ~240 s) and the request OOMs a
+few decode tokens later with a Metal command-buffer execution failure
+(`[METAL] ... kIOGPUCommandBufferCallbackErrorOutOfMemory`). Every arm — release
+2.11.2, mask-fuse, score-tiler, `MTPLX_MLX_CACHE_LIMIT=2GiB`, session-off — hits
+the identical failure at a ~100.8 GB sampled peak, so it is neither the prefill,
+the allocator pool, nor the session bank.
+
+The cause is the **speculative-verify decode step**. Of the 48 layers, 12 are
+full-attention (`full_attention_interval: 4`) and keep dense KV over the whole
+context; the model is GQA with `num_attention_heads: 24`, `num_key_value_heads:
+2` (GQA factor 12). A multi-row verify has `q_len` = 3–8. MLX's fused
+vector-attention kernel serves at most `q_len * GQA ≤ 32` rows per dispatch;
+`q_len 5 × GQA 12 = 60 > 32`, so SDPA falls to an **unfused path that
+materializes the `[24, q_len, T]` fp32 score plane (O(T)) and GQA-expands k/v**.
+Across the 12 dense layers held in the fixed-M4 verify command buffer, that
+transient — several GB at T = 261,120, and linear in T — lands on top of a
+~93.8 GiB steady resident (weights 77.3 GiB + full KV 6.0 GiB + QSA aux + graph
+buffers), tipping the single command buffer past the 100 GiB Metal wired limit.
+At 131,072 tokens the same terms are ~half and the request fits; at 261,120 it
+does not. The QSA layers avoid this via their bounded rows-gather selection; the
+12 dense layers cannot, and the fixed-M4 verify path additionally gates off the
+score-tiler and rows-gather (`not fixed_capacity`), which is why every prior
+lever was a no-op.
+
+### Change
+
+`_verify_sdpa` (`mtplx/models/qwen4_exp.py`) replaces the dense-fallback SDPA
+call in `Attention.__call__`. When `q_len * GQA > 32` and `q_len ≤ 32` (the
+verify / small-tail band MLX will not route to its flash kernel), it splits the
+**query heads** into chunks small enough that each fused call satisfies
+`q_len * heads_per_chunk ≤ 32` (e.g. q_len 6 → chunks of 5 heads, q_len 4 → 8
+heads), pairs each chunk with its **own single kv head** (a slice, so k/v is
+**never GQA-expanded**), calls `mx.fast.scaled_dot_product_attention` per chunk,
+and concatenates along the head axis. Every dispatch stays on the bounded fused
+kernel, so no `[24, q_len, T]` plane is formed and the working set is one chunk
+regardless of T. Wide prefill chunks (`q_len > 32`) are untouched and keep their
+single flash call.
+
+### Effect
+
+The O(T) verify transient in the 12 dense layers is removed; the 261K decode
+working set no longer scales with context, so it no longer tips past the wired
+limit. Applies uniformly to the fixed-M4 verify, the ordinary verify, and any
+small prefill-tail chunk (all reach the one dense-fallback SDPA). Decode `q_len
+1` (12 ≤ 32) and prefill wide chunks are unaffected.
+
+### Exactness
+
+The heads in one chunk all belong to the same kv head, so each chunk's SDPA is
+exactly the full GQA attention's arithmetic for those heads on the same fused
+kernel — chunked-fused is **bit-identical to an unchunked fused call** (verified
+< 1e-6 on fp32 random tensors against a GQA-expanded MHA reference). Versus the
+unfused path it replaces, it is rounding-class (fused vs unfused accumulation),
+the same class as the mask-fuse lane.
+
+### Files
+
+- `mtplx/models/qwen4_exp.py` — `_verify_sdpa`, `_sdpa_head_chunked`,
+  `_verify_sdpa_head_chunk_plan`, `_verify_sdpa_head_chunk_enabled` (env at
+  use), engagement latch + `verify_sdpa_head_chunk_report`; call site in
+  `Attention.__call__`.
+- `mtplx/server/openai.py` — `_qwen4_install_reports` surfaces the engagement
+  receipt at `/health` under `qwen4_install_reports.verify_sdpa_head_chunk`.
+- `tests/test_qwen4_verify_sdpa_head_chunk.py` — CPU tests.
+
+### Switch / observability
+
+- `MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK` — default ON (engages only in the
+  `q_len × GQA > 32`, `q_len ≤ 32` band); `0`/`off` opts out. Resolved at use.
+- Log line on first engagement: `[mtplx] verify SDPA head-chunked: q_len=S
+  heads_per_chunk=H chunks=N`.
+- `/health` → `qwen4_install_reports.verify_sdpa_head_chunk`:
+  `{engaged, q_len, heads_per_chunk, chunks, n_kv_heads}` once it has fired.

--- a/mtplx/graphbank.py
+++ b/mtplx/graphbank.py
@@ -496,8 +496,45 @@ class TensorOffsetKVCache:
         )
         self._granted = True
 
+    def _concrete_offset(self):
+        """The host-int offset when it is a materialized value, else None.
+
+        During an ``mx.compile`` trace ``cache[2]`` is a tracer and ``.item()``
+        raises; on the eager (demoted) verify path it is a concrete scalar.
+        """
+        try:
+            return int(self.cache[2].item())
+        except Exception:
+            return None
+
     def update_and_fetch(self, keys, values):
         steps = int(keys.shape[2])
+        off_i = self._concrete_offset()
+        if off_i is not None:
+            # Eager (demoted) verify: write the S new rows in place. The
+            # functional ``mx.slice_update`` below reallocates the WHOLE
+            # [1, 2, capacity, 256] buffer per key and value tensor when the
+            # compiled graph cannot donate it (267 MB each at 262K, 6.4 GB
+            # across the 12 full-attention layers) -- the transient that OOMs a
+            # 261,120-token verify while an S=1 AR decode on the stock KVCache,
+            # which writes in place, fits. Mirror the stock in-place write on
+            # this path. The rollback snapshot is a materialized independent
+            # copy of the pre-write rows, so the in-place write cannot corrupt
+            # it and a later ``trim`` restores exactly the same bytes.
+            end = off_i + steps
+            snap_k = mx.contiguous(self.cache[0][:, :, off_i:end, :])
+            snap_v = mx.contiguous(self.cache[1][:, :, off_i:end, :])
+            mx.eval(snap_k, snap_v)
+            self.rollback_state[0] = self.cache[2]
+            self.rollback_state[1] = snap_k
+            self.rollback_state[2] = snap_v
+            self.cache[0][:, :, off_i:end, :] = keys
+            self.cache[1][:, :, off_i:end, :] = values
+            self.cache[2] = self.cache[2] + steps
+            return self.cache[0], self.cache[1]
+        # Compiled trace: keep the compile-visible functional path so
+        # mx.compile(inputs=..., outputs=...) can donate the buffers in the
+        # replayed graph.
         self.rollback_state[0] = self.cache[2]
         self.rollback_state[1] = mx.slice(
             self.cache[0],
@@ -554,19 +591,31 @@ class TensorOffsetKVCache:
             and self.rollback_state[2] is not None
             and int(self.rollback_state[1].shape[2]) == n
         ):
-            self.cache[0] = mx.slice_update(
-                self.cache[0],
-                self.rollback_state[1],
-                self.rollback_state[0],
-                axes=(2,),
-            )
-            self.cache[1] = mx.slice_update(
-                self.cache[1],
-                self.rollback_state[2],
-                self.rollback_state[0],
-                axes=(2,),
-            )
-            self.cache[2] = self.rollback_state[0]
+            try:
+                back_i = int(self.rollback_state[0].item())
+            except Exception:
+                back_i = None
+            if back_i is not None:
+                # Eager restore: put the saved rows back in place instead of
+                # reallocating the full buffer (same 6.4 GB avoidance as
+                # update_and_fetch's eager write).
+                self.cache[0][:, :, back_i:back_i + n, :] = self.rollback_state[1]
+                self.cache[1][:, :, back_i:back_i + n, :] = self.rollback_state[2]
+                self.cache[2] = self.rollback_state[0]
+            else:
+                self.cache[0] = mx.slice_update(
+                    self.cache[0],
+                    self.rollback_state[1],
+                    self.rollback_state[0],
+                    axes=(2,),
+                )
+                self.cache[1] = mx.slice_update(
+                    self.cache[1],
+                    self.rollback_state[2],
+                    self.rollback_state[0],
+                    axes=(2,),
+                )
+                self.cache[2] = self.rollback_state[0]
         else:
             self.cache[2] = mx.maximum(
                 self.cache[2] - n,

--- a/mtplx/models/qwen4_exp.py
+++ b/mtplx/models/qwen4_exp.py
@@ -1438,6 +1438,146 @@ def _compiled_qsa_indexer_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+# MLX's fused vector (small-q_len) attention kernel serves at most this many
+# (query_length * heads-per-kv-group) rows per dispatch; above it, SDPA falls to
+# an unfused path that materializes the [n_heads, q_len, T] score plane and
+# GQA-expands k/v. See _verify_sdpa.
+_VECTOR_SDPA_QLEN_HEADS_LIMIT = 32
+
+
+def _verify_sdpa_head_chunk_enabled() -> bool:
+    """MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK: keep the small-q_len verify SDPA on
+    the fused kernel by splitting query heads.  Default ON; ``0``/``off`` opts
+    out.  Resolved AT USE so the server's auto-arm/setdefault sequence (which
+    can stamp env after this module imports) is honored, and tests can flip it.
+    """
+
+    raw = (os.environ.get("MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK") or "").strip().lower()
+    return raw not in {"0", "off", "false", "no"}
+
+
+# First-engagement receipt (host-only; printed once and surfaced in /health).
+_VERIFY_SDPA_HEAD_CHUNK_ENGAGED: Optional[dict] = None
+
+
+def _record_verify_sdpa_head_chunk(
+    q_len: int, heads_per_chunk: int, chunks: int, n_kv_heads: int
+) -> None:
+    global _VERIFY_SDPA_HEAD_CHUNK_ENGAGED
+    if _VERIFY_SDPA_HEAD_CHUNK_ENGAGED is not None:
+        return
+    _VERIFY_SDPA_HEAD_CHUNK_ENGAGED = {
+        "engaged": True,
+        "q_len": int(q_len),
+        "heads_per_chunk": int(heads_per_chunk),
+        "chunks": int(chunks),
+        "n_kv_heads": int(n_kv_heads),
+    }
+    try:
+        print(
+            f"[mtplx] verify SDPA head-chunked: q_len={int(q_len)} "
+            f"heads_per_chunk={int(heads_per_chunk)} chunks={int(chunks)}",
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+def verify_sdpa_head_chunk_report() -> Optional[dict]:
+    """Engagement receipt for /health, or None if the lane has not fired."""
+
+    return (
+        dict(_VERIFY_SDPA_HEAD_CHUNK_ENGAGED)
+        if _VERIFY_SDPA_HEAD_CHUNK_ENGAGED is not None
+        else None
+    )
+
+
+def reset_verify_sdpa_head_chunk_engagement() -> None:
+    """Test hook: clear the one-shot engagement latch."""
+
+    global _VERIFY_SDPA_HEAD_CHUNK_ENGAGED
+    _VERIFY_SDPA_HEAD_CHUNK_ENGAGED = None
+
+
+def _verify_sdpa_head_chunk_plan(q_len: int, n_q_heads: int, n_kv_heads: int):
+    """(heads_per_chunk, chunks) for the head-chunk band, or None to pass through.
+
+    Chunk only the small-q_len band the fused vector kernel declines
+    (``q_len * gqa > 32``) and that MLX would not already route to the flash
+    kernel (``q_len <= 32``); wide prefill chunks keep their single flash call.
+    """
+
+    if n_kv_heads <= 0 or n_q_heads % n_kv_heads != 0:
+        return None
+    gqa = n_q_heads // n_kv_heads
+    if gqa <= 0:
+        return None
+    if not (
+        q_len * gqa > _VECTOR_SDPA_QLEN_HEADS_LIMIT
+        and q_len <= _VECTOR_SDPA_QLEN_HEADS_LIMIT
+    ):
+        return None
+    heads_per_chunk = max(1, min(gqa, _VECTOR_SDPA_QLEN_HEADS_LIMIT // max(1, q_len)))
+    chunks = n_kv_heads * ((gqa + heads_per_chunk - 1) // heads_per_chunk)
+    return heads_per_chunk, chunks
+
+
+def _sdpa_head_chunked(q, k, v, *, scale, mask, heads_per_chunk: int):
+    """Fused SDPA over query-head chunks, each paired with its own single kv
+    head so k/v is never GQA-expanded and no [n_heads, q_len, T] plane forms.
+
+    Every chunk's ``q_len * (heads_in_chunk / 1) <= 32`` so it stays on the
+    fused vector kernel.  The heads in one chunk all belong to the same kv
+    head, so the per-head arithmetic is exactly the full GQA attention's;
+    outputs concatenate back in head order.
+    """
+
+    B, n_q_heads, S, D = q.shape
+    n_kv_heads = k.shape[1]
+    gqa = n_q_heads // n_kv_heads
+    qg = q.reshape(B, n_kv_heads, gqa, S, D)
+    outs = []
+    for j in range(n_kv_heads):
+        kj = k[:, j : j + 1]
+        vj = v[:, j : j + 1]
+        for hs in range(0, gqa, heads_per_chunk):
+            he = min(hs + heads_per_chunk, gqa)
+            qc = qg[:, j, hs:he]  # [B, he-hs, S, D]
+            outs.append(
+                mx.fast.scaled_dot_product_attention(
+                    qc, kj, vj, scale=scale, mask=mask
+                )
+            )
+    return mx.concatenate(outs, axis=1)
+
+
+def _verify_sdpa(q, k, v, *, scale, mask):
+    """SDPA that stays on the fused kernel across the small-q_len verify band.
+
+    MLX's fused vector-attention kernel requires ``q_len * (n_q_heads /
+    n_kv_heads) <= 32``; a multi-row speculative verify over a long KV
+    (q_len 3-8 x GQA 12) exceeds it and falls to an unfused path that
+    materializes the ``[n_q_heads, q_len, T]`` fp32 score plane (O(T)) and
+    GQA-expands k/v -- the term that tips a 262K-context decode over the Metal
+    limit (kIOGPUCommandBufferCallbackErrorOutOfMemory).  Splitting the query
+    heads keeps every dispatch on the bounded fused kernel with no O(T) plane.
+    """
+
+    n_q_heads = q.shape[1]
+    S = q.shape[2]
+    n_kv_heads = k.shape[1]
+    if _verify_sdpa_head_chunk_enabled():
+        plan = _verify_sdpa_head_chunk_plan(S, n_q_heads, n_kv_heads)
+        if plan is not None:
+            heads_per_chunk, chunks = plan
+            _record_verify_sdpa_head_chunk(S, heads_per_chunk, chunks, n_kv_heads)
+            return _sdpa_head_chunked(
+                q, k, v, scale=scale, mask=mask, heads_per_chunk=heads_per_chunk
+            )
+    return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+
 def qsa_prefill_lane_auto_supported() -> bool:
     """Device gate for the auto default: the lane's fast consumer must exist.
 
@@ -3795,9 +3935,7 @@ class Attention(nn.Module):
         else:
             mask = None
 
-        out = mx.fast.scaled_dot_product_attention(
-            q, k, v, scale=self.scale, mask=mask
-        )
+        out = _verify_sdpa(q, k, v, scale=self.scale, mask=mask)
         out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
         return self.o_proj(out * mx.sigmoid(gate))
 

--- a/mtplx/server/openai.py
+++ b/mtplx/server/openai.py
@@ -18642,6 +18642,18 @@ def _qwen4_install_reports(state: Any) -> dict[str, Any]:
             out["ngram_prewarm"] = prewarm
     except Exception:
         pass
+    try:
+        from mtplx.models.qwen4_exp import verify_sdpa_head_chunk_report
+
+        # Present once the small-q_len verify SDPA has fired (like the other
+        # lanes: a receipt, not a null placeholder), so the battery can gate on
+        # the observable rather than the serve log. Its q_len/heads_per_chunk/
+        # chunks are the engagement proof for the 261K window.
+        receipt = verify_sdpa_head_chunk_report()
+        if receipt is not None:
+            out["verify_sdpa_head_chunk"] = receipt
+    except Exception:
+        pass
     return out
 
 

--- a/tests/test_qwen4_verify_sdpa_head_chunk.py
+++ b/tests/test_qwen4_verify_sdpa_head_chunk.py
@@ -1,0 +1,239 @@
+"""CPU tests for the small-q_len verify SDPA head-chunk lever.
+
+MLX's fused vector-attention kernel serves at most q_len * (n_q_heads /
+n_kv_heads) <= 32 rows per dispatch; a multi-row speculative verify over a long
+KV (q_len 3-8 x GQA 12) exceeds it and falls to an unfused path that
+materializes the [n_q_heads, q_len, T] score plane and GQA-expands k/v -- the
+term that OOMs a 262K-context decode. The lever splits the query heads (each
+chunk paired with its own single kv head, never GQA-expanding k/v) so every
+dispatch stays on the bounded fused kernel. These tests cover the reader
+(read-at-use), the chunk arithmetic, numerical equivalence to an unchunked
+fused call, and that no [.., q_len, T] plane is ever formed -- all on CPU.
+"""
+
+import importlib
+import os
+
+import mlx.core as mx
+import pytest
+
+from mtplx.models import qwen4_exp as q4
+
+
+GQA = 12
+N_Q = 24
+N_KV = 2
+D = 64  # head_dim (small for CPU); exactness is dim-independent
+
+
+def _clear_env():
+    os.environ.pop("MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK", None)
+
+
+@pytest.fixture(autouse=True)
+def _cpu_and_reset():
+    prev = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    q4.reset_verify_sdpa_head_chunk_engagement()
+    _clear_env()
+    try:
+        yield
+    finally:
+        q4.reset_verify_sdpa_head_chunk_engagement()
+        _clear_env()
+        mx.set_default_device(prev)
+
+
+# ---------------------------------------------------------------------------
+# Reader: default ON, resolved at use (served-order safe).
+# ---------------------------------------------------------------------------
+
+
+def test_reader_default_on_and_opt_out():
+    assert q4._verify_sdpa_head_chunk_enabled() is True  # default ON
+    for off in ("0", "off", "false", "no", "OFF"):
+        os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = off
+        assert q4._verify_sdpa_head_chunk_enabled() is False
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "1"
+    assert q4._verify_sdpa_head_chunk_enabled() is True
+
+
+def test_served_order_reader_not_frozen():
+    # Reproduce the served order: the model + server modules import before any
+    # auto-arm/setdefault stamps env. A reader frozen at import would miss a
+    # value set only now; read-at-use sees it.
+    importlib.import_module("mtplx.server.openai")
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "0"
+    assert q4._verify_sdpa_head_chunk_enabled() is False
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "1"
+    assert q4._verify_sdpa_head_chunk_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Chunk arithmetic for q_len 1..8 (and the prefill regime) at GQA 12.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "q_len,expect",
+    [
+        (1, None),
+        (2, None),  # 2*12=24 <= 32: already fused
+        (3, (10, 4)),
+        (4, (8, 4)),
+        (5, (6, 4)),
+        (6, (5, 6)),
+        (7, (4, 6)),
+        (8, (4, 6)),
+        (32, (1, 24)),
+        (33, None),  # prefill regime: MLX routes to flash
+        (256, None),
+    ],
+)
+def test_chunk_plan(q_len, expect):
+    assert q4._verify_sdpa_head_chunk_plan(q_len, N_Q, N_KV) == expect
+
+
+def test_chunk_plan_invariant_holds_for_band():
+    # Every chunked case keeps q_len * heads_per_chunk <= 32 (the fused
+    # vector-kernel limit) and covers all heads.
+    for q_len in range(3, 33):
+        plan = q4._verify_sdpa_head_chunk_plan(q_len, N_Q, N_KV)
+        assert plan is not None, q_len
+        hpc, chunks = plan
+        assert q_len * hpc <= q4._VECTOR_SDPA_QLEN_HEADS_LIMIT
+        assert 1 <= hpc <= GQA
+        chunks_per_kv = (GQA + hpc - 1) // hpc
+        assert chunks == N_KV * chunks_per_kv
+
+
+def test_chunk_plan_non_divisible_geometry_passes_through():
+    # If n_q_heads is not a multiple of n_kv_heads, GQA slicing is undefined;
+    # the helper must decline rather than corrupt the head mapping.
+    assert q4._verify_sdpa_head_chunk_plan(6, 25, 2) is None
+
+
+# ---------------------------------------------------------------------------
+# Numerical equivalence: chunked fused == unchunked fused reference.
+# ---------------------------------------------------------------------------
+
+
+def _reference_mha(q, k, v, scale, mask):
+    # Unchunked fused reference: GQA-expand k/v to MHA (n_kv == n_q), so the
+    # fused kernel serves it directly for q_len <= 32. Mathematically identical
+    # to GQA; head i attends to kv head i // gqa in both.
+    gqa = q.shape[1] // k.shape[1]
+    k_exp = mx.repeat(k, gqa, axis=1)
+    v_exp = mx.repeat(v, gqa, axis=1)
+    return mx.fast.scaled_dot_product_attention(q, k_exp, v_exp, scale=scale, mask=mask)
+
+
+@pytest.mark.parametrize("S", [3, 4, 5, 6, 7, 8])
+def test_chunked_matches_unchunked_fused(S):
+    mx.random.seed(1234 + S)
+    T = 200
+    pos_start = T - S
+    q = mx.random.normal((1, N_Q, S, D)).astype(mx.float32)
+    k = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    v = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    scale = D**-0.5
+    qpos = pos_start + mx.arange(S)
+    tpos = mx.arange(T)
+    mask = (tpos[None, :] <= qpos[:, None])[None, None]
+
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "1"
+    chunked = q4._verify_sdpa(q, k, v, scale=scale, mask=mask)
+    ref = _reference_mha(q, k, v, scale, mask)
+    mx.eval(chunked, ref)
+    assert chunked.shape == (1, N_Q, S, D)
+    max_abs = float(mx.max(mx.abs(chunked - ref)))
+    assert max_abs < 1e-6, f"S={S} max_abs={max_abs}"
+
+
+def test_opt_out_uses_single_unchunked_call(monkeypatch):
+    calls = _record_sdpa_calls(monkeypatch)
+    S, T = 6, 128
+    q = mx.random.normal((1, N_Q, S, D)).astype(mx.float32)
+    k = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    v = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "0"
+    out = q4._verify_sdpa(q, k, v, scale=D**-0.5, mask=None)
+    mx.eval(out)
+    assert len(calls) == 1
+    # opt-out: one call with the full head count (the unfused band)
+    assert calls[0][1] == N_Q  # n_q_heads
+    assert q4.verify_sdpa_head_chunk_report() is None
+
+
+# ---------------------------------------------------------------------------
+# No [.., q_len, T] plane: every dispatch stays within the fused-kernel bound.
+# ---------------------------------------------------------------------------
+
+
+def _record_sdpa_calls(monkeypatch):
+    real = mx.fast.scaled_dot_product_attention
+    calls = []
+
+    def _spy(q, k, v, *args, **kwargs):
+        # record (heads*S, n_q_heads, S, n_kv_heads)
+        calls.append((q.shape[1] * q.shape[2], q.shape[1], q.shape[2], k.shape[1]))
+        return real(q, k, v, *args, **kwargs)
+
+    monkeypatch.setattr(mx.fast, "scaled_dot_product_attention", _spy)
+    return calls
+
+
+def test_chunked_path_never_exceeds_vector_bound(monkeypatch):
+    calls = _record_sdpa_calls(monkeypatch)
+    S, T = 6, 4096  # long KV: an unfused path would form a [24, 6, 4096] plane
+    q = mx.random.normal((1, N_Q, S, D)).astype(mx.float32)
+    k = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    v = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "1"
+    out = q4._verify_sdpa(q, k, v, scale=D**-0.5, mask=None)
+    mx.eval(out)
+    assert out.shape == (1, N_Q, S, D)
+    # Every dispatch is a single-kv-head fused call within the vector bound;
+    # none is the full-24-head call that would materialize the O(T) plane.
+    assert len(calls) == 6  # q_len 6 -> heads_per_chunk 5 -> 2*ceil(12/5)=6
+    for heads_x_s, n_q, s, n_kv in calls:
+        assert heads_x_s <= q4._VECTOR_SDPA_QLEN_HEADS_LIMIT
+        assert n_kv == 1  # k/v sliced to one head, never GQA-expanded
+        assert n_q <= 5
+
+
+def test_decode_single_row_not_chunked(monkeypatch):
+    calls = _record_sdpa_calls(monkeypatch)
+    S, T = 1, 512  # S=1 decode: 1*12=12 <= 32, already fused
+    q = mx.random.normal((1, N_Q, S, D)).astype(mx.float32)
+    k = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    v = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    out = q4._verify_sdpa(q, k, v, scale=D**-0.5, mask=None)
+    mx.eval(out)
+    assert len(calls) == 1
+    assert calls[0][1] == N_Q  # single unchunked GQA call
+    assert q4.verify_sdpa_head_chunk_report() is None
+
+
+# ---------------------------------------------------------------------------
+# Engagement receipt (for /health).
+# ---------------------------------------------------------------------------
+
+
+def test_engagement_report_and_reset():
+    S, T = 6, 64
+    q = mx.random.normal((1, N_Q, S, D)).astype(mx.float32)
+    k = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    v = mx.random.normal((1, N_KV, T, D)).astype(mx.float32)
+    os.environ["MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK"] = "1"
+    assert q4.verify_sdpa_head_chunk_report() is None
+    mx.eval(q4._verify_sdpa(q, k, v, scale=D**-0.5, mask=None))
+    rep = q4.verify_sdpa_head_chunk_report()
+    assert rep is not None
+    assert rep["engaged"] is True
+    assert rep["q_len"] == 6
+    assert rep["heads_per_chunk"] == 5
+    assert rep["chunks"] == 6
+    assert rep["n_kv_heads"] == N_KV
+    q4.reset_verify_sdpa_head_chunk_engagement()
+    assert q4.verify_sdpa_head_chunk_report() is None

--- a/tests/test_tensoroffset_kv_inplace.py
+++ b/tests/test_tensoroffset_kv_inplace.py
@@ -1,0 +1,165 @@
+"""CPU test: the fixed-M4 verify KV update writes in place, not a full copy.
+
+The 261,120-token decode OOM (after the score-plane head-chunk fix) is the
+eager verify's KV update: ``TensorOffsetKVCache.update_and_fetch`` used the
+functional ``mx.slice_update``, which reallocates the whole
+``[1, 2, capacity, 256]`` buffer per key and value tensor (267 MB each at 262K,
+6.4 GB across the 12 full-attention layers). The stock ``KVCache`` writes in
+place; an S=1 AR decode (MTP off) therefore fits at 94 GB while the S>1 verify
+overflows. The fix writes the S new rows in place on the eager (concrete-offset)
+path and keeps the compile-visible ``slice_update`` only when the offset is a
+tracer. These tests run on CPU with a realistic 262K-capacity buffer.
+"""
+
+import mlx.core as mx
+import pytest
+
+from mtplx.graphbank import TensorOffsetKVCache
+
+
+CAP = 262144          # fixed-bank capacity at the pack's 262K context
+D = 256               # head_dim
+H_KV = 2              # key/value heads
+S = 5                 # verify rows (depth + 2)
+OFF = 261000          # a mid-buffer concrete offset (like the served verify)
+ONE_BUFFER = H_KV * CAP * D * 2          # bytes of one [1,2,CAP,256] bf16 tensor
+ROW_THRESHOLD = CAP * D * 2              # T x 256 x 2 (the coordinator's bar)
+
+
+@pytest.fixture(autouse=True)
+def _cpu():
+    prev = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    try:
+        yield
+    finally:
+        mx.set_default_device(prev)
+
+
+def _make_cache(offset: int) -> TensorOffsetKVCache:
+    keys = mx.zeros((1, H_KV, CAP, D), mx.bfloat16)
+    values = mx.zeros((1, H_KV, CAP, D), mx.bfloat16)
+    mx.eval(keys, values)
+    return TensorOffsetKVCache(keys, values, offset)
+
+
+def _am() -> int:
+    return int(mx.get_active_memory())
+
+
+def test_eager_update_is_in_place_no_full_buffer_alloc(monkeypatch):
+    # Spy: the eager path must never call the full-buffer functional op.
+    real_slice_update = mx.slice_update
+    calls = []
+
+    def _spy(a, *args, **kwargs):
+        calls.append(tuple(a.shape))
+        return real_slice_update(a, *args, **kwargs)
+
+    monkeypatch.setattr(mx, "slice_update", _spy)
+
+    cache = _make_cache(OFF)
+    keys = mx.ones((1, H_KV, S, D), mx.bfloat16)
+    values = (mx.ones((1, H_KV, S, D), mx.bfloat16) * 2).astype(mx.bfloat16)
+    mx.eval(keys, values)
+
+    before = _am()
+    k_out, v_out = cache.update_and_fetch(keys, values)
+    mx.eval(k_out, v_out, cache.cache[2])
+    delta = _am() - before
+
+    # No full [1,2,CAP,256] reallocation: the delta is the tiny rollback
+    # snapshot (2 x [1,2,S,256]) plus scalars, far under one row-plane.
+    assert delta < ROW_THRESHOLD, f"delta={delta} >= T*256*2={ROW_THRESHOLD}"
+    # And the functional full-buffer op was not used on the eager path.
+    assert calls == [], f"slice_update called on eager path: {calls}"
+
+
+def test_eager_update_writes_correct_rows_and_offset():
+    cache = _make_cache(OFF)
+    keys = mx.arange(H_KV * S * D, dtype=mx.float32).reshape(1, H_KV, S, D).astype(mx.bfloat16)
+    values = (keys + mx.array(1000, mx.bfloat16)).astype(mx.bfloat16)
+    mx.eval(keys, values)
+
+    k_out, v_out = cache.update_and_fetch(keys, values)
+    mx.eval(k_out, v_out)
+
+    # offset advanced by S
+    assert int(cache.cache[2].item()) == OFF + S
+    # written rows equal the input
+    assert bool(mx.all(k_out[:, :, OFF:OFF + S, :] == keys).item())
+    assert bool(mx.all(v_out[:, :, OFF:OFF + S, :] == values).item())
+    # rows before the offset untouched (still zero)
+    assert float(mx.max(mx.abs(k_out[:, :, :OFF, :])).item()) == 0.0
+    # returned buffer is the same object mutated in place (no reallocation)
+    assert k_out is cache.cache[0]
+    assert v_out is cache.cache[1]
+
+
+def test_rollback_snapshot_independent_and_trim_restores():
+    # Pre-fill the S rows with a known "old" value so we can prove the
+    # snapshot is an independent copy and that trim restores it.
+    cache = _make_cache(OFF)
+    old = (mx.ones((1, H_KV, S, D), mx.bfloat16) * 7).astype(mx.bfloat16)
+    cache.cache[0][:, :, OFF:OFF + S, :] = old
+    cache.cache[1][:, :, OFF:OFF + S, :] = old
+    mx.eval(cache.cache[0], cache.cache[1])
+
+    new = (mx.ones((1, H_KV, S, D), mx.bfloat16) * 3).astype(mx.bfloat16)
+    cache.update_and_fetch(new, new)
+    mx.eval(cache.cache[0], cache.cache[1])
+
+    # snapshot captured the OLD rows and is not aliased to the mutated buffer
+    assert float(mx.max(cache.rollback_state[1]).item()) == 7.0
+    assert float(mx.min(cache.rollback_state[1]).item()) == 7.0
+
+    # trim (rejected draft) restores the old rows in place and rewinds offset
+    cache.trim(S)
+    mx.eval(cache.cache[0], cache.cache[1])
+    assert int(cache.cache[2].item()) == OFF
+    assert bool(mx.all(cache.cache[0][:, :, OFF:OFF + S, :] == old).item())
+    assert bool(mx.all(cache.cache[1][:, :, OFF:OFF + S, :] == old).item())
+
+
+def test_eager_matches_functional_slice_update_numerics():
+    # The in-place write must be byte-identical to the functional path it
+    # replaces (same bytes land at the same positions).
+    off = 120000
+    keys = mx.random.normal((1, H_KV, S, D)).astype(mx.bfloat16)
+    values = mx.random.normal((1, H_KV, S, D)).astype(mx.bfloat16)
+    mx.eval(keys, values)
+
+    a = _make_cache(off)
+    ka, va = a.update_and_fetch(keys, values)
+
+    # reference: functional slice_update at the same offset
+    ref_k = mx.zeros((1, H_KV, CAP, D), mx.bfloat16)
+    ref_v = mx.zeros((1, H_KV, CAP, D), mx.bfloat16)
+    ref_k = mx.slice_update(ref_k, keys, mx.array(off, mx.int32), axes=(2,))
+    ref_v = mx.slice_update(ref_v, values, mx.array(off, mx.int32), axes=(2,))
+    mx.eval(ka, va, ref_k, ref_v)
+
+    assert bool(mx.all(ka == ref_k).item())
+    assert bool(mx.all(va == ref_v).item())
+
+
+def test_concrete_offset_detects_tracer_vs_value():
+    cache = _make_cache(OFF)
+    assert cache._concrete_offset() == OFF  # concrete scalar
+
+    # Inside an mx.compile trace the offset is a tracer; _concrete_offset must
+    # return None so the compile-visible functional path is taken.
+    seen = {}
+
+    @mx.compile
+    def _probe(off_arr):
+        c = TensorOffsetKVCache(
+            mx.zeros((1, H_KV, 64, D), mx.bfloat16),
+            mx.zeros((1, H_KV, 64, D), mx.bfloat16),
+            off_arr,
+        )
+        seen["concrete"] = c._concrete_offset()
+        return off_arr + 1
+
+    mx.eval(_probe(mx.array(3, mx.int32)))
+    assert seen["concrete"] is None


### PR DESCRIPTION
# Qwen3.8 Flash-Next: two verify-step memory fixes so 261,120-token prompts decode

This pull request adds two serving optimizations to the Qwen3.8 Flash-Next path. The base is upstream MTPLX 2.11.2. At the pack's advertised 261,120-token context, `mtplx serve` reads the whole prompt and then runs out of GPU memory in the first decode step, so the request fails after a few tokens. Both optimizations remove a per-layer allocation the speculative verify makes across the 12 full-attention layers, and both are needed: the verify's KV-cache write is what still overflows once the attention transient is gone.

The two are ordered by what they remove. Optimization 1 writes the verify's KV cache in place instead of reallocating the whole buffer, which is the allocation that decides the 261,120-token cell. Optimization 2 keeps the verify attention on MLX's fused kernel, which removes an attention transient that scales with context; on its own it does not make the cell fit, and Section 3 gives its measured 261,120-token receipt.

The comparison has two arms: release 2.11.2 alone (A) and release plus both optimizations (F, this pull request). The headline is F against A at 261,120 tokens, where A exceeds the memory knob and F does not.

Headline figures:

- 261,120 tokens, cold prefill: release 2.11.2 exceeds the 100 GiB memory knob and returns `insufficient_memory` in the first decode step; **this pull request completes the request**, fits ×3, at **62.84 tok/s** decode (56.82-62.84) and 1082.9 tok/s prefill, peak **100.82 GB** against the 107.374 GB knob.
- 16,384 tokens, cold prefill: decode is unchanged. Release reaches 71.97 tok/s fastest (71.58 mean over its ABAB windows) and this pull request reaches **71.61 tok/s**; both optimizations engage only in the verify step, so neither moves the token rate.
- Both optimizations are independent of pull requests #475 and #478. All three are based on upstream main, and this one fixes the 261,120-token cell that both of those report as exceeding the knob.

Terms used in this document:

- decode: the token-by-token generation phase, after the prompt is read.
- prefill: reading the prompt into the KV cache before the first output token.
- verify: the speculative verify step inside decode; the fixed four-row width the compiled Flash-Next verify uses.
- optimization: one change an operator can switch off on its own.
- fixed-M4 verify: the four-row speculative verify the served Flash-Next path runs; it holds its KV in `TensorOffsetKVCache` rather than the stock in-place `KVCache`.
- QSA: the sparse-attention path, which selects the earlier tokens each layer attends to.
- GQA: grouped-query attention; here 24 query heads over 2 key/value heads, so 12 query heads per key/value head.
- full-attention layer: one of the 12 of 48 layers that keep dense KV over the whole context.
- rounding-class: the output differs from the replaced path only by floating-point rounding.
- tok/s: tokens per second.

---

## 1. Benchmark results

Two arms ran on one machine. Each arm received the same request body per cell. Section 6 gives the settings.

### 1.1 Peak memory by context

![peak_memory](https://raw.githubusercontent.com/davidtai/MTPLX-1/9f306e01/docs/perf/qwen38-256k-fix/charts/peak_memory.svg)
*Peak memory by context size, release against this pull request. The 100 GiB cap holds on every arm that reaches a cell; release exceeds it at 261,120 tokens and this pull request does not.*

| Context | release 2.11.2 (A) | this PR (F) |
| --- | ---: | ---: |
| 16,384 | 93.41 | 93.41 |
| 261,120 | exceeds the 100 GiB knob (Metal `insufficient_memory`) | 100.82 |

### 1.2 261,120-token result

![decode_261k](https://raw.githubusercontent.com/davidtai/MTPLX-1/9f306e01/docs/perf/qwen38-256k-fix/charts/decode_261k.svg)
*Decode tok/s at 261,120 tokens. Release does not reach a decode rate because it fails in the first decode step; this pull request completes the request.*

Release 2.11.2 does not complete this cell. Its receipt shows the prompt fully read and only a few tokens emitted before the failure: `new_prefill_tokens` 261120, time to first token 243.5 s, `completion_tokens` 12, `finish_reason` `error`, sampled peak 100.82 GB, with `[METAL] Command buffer execution failed: Insufficient Memory`. Section 2 traces the cause.

This pull request completes the request in three cold windows:

| Window | Status | Prefill tok/s | Decode tok/s | Time to first token (s) | Wall (s) | Completion tokens | Peak memory (GB) |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| w1 | fits | 1081.6 | 59.62 | 242.631 | 254.03 | 461 | 100.82 |
| w2 | fits | 1081.5 | 56.82 | 242.614 | 264.33 | 1024 | 100.82 |
| w3 | fits | 1082.9 | 62.84 | 242.290 | 259.43 | 845 | 100.82 |

The summary reports the fastest window with the min-max across the three: prefill **1082.9** tok/s (1081.5-1082.9), decode **62.84** tok/s (56.82-62.84), time to first token **242.290** s (242.290-242.631), wall **254.03** s (254.03-264.33), peak **100.82** GB (100.82-100.82). Peak stays under the 107.374 GB knob on every window, with about 6.5 GB of headroom. Completion tokens differ by seed (461-1024) because each seed stops on its own; every window reached a normal stop or the 1,024-token cap, never an error.

### 1.3 16,384-token no-regression check

Both optimizations engage in the verify step, which runs at every context, but 16,384 tokens never overflowed, so this cell measures that the token rate is unchanged. This pull request's arm F is release 2.11.2 plus both optimizations, so the comparison is F against release A.

| Metric | release 2.11.2 (A) | this PR (F) |
| --- | ---: | ---: |
| Decode tok/s (fastest, min-max) | 71.97 | 71.61 (71.24-71.61) |
| Decode tok/s (mean of windows) | 71.58 | 71.47 |
| Prefill tok/s | 1381.5 | 1377.2 (1343.5-1377.2) |
| Time to first token (s) | 12.056 | 12.112 (12.112-12.390) |
| Peak memory (GB) | 93.41 | 93.41 (89.01-93.41) |
| Completion tokens | 1024 | 1024 |
| Output vs release | reference | byte-identical, all 3 seeds |

For context, pull request #475's six-optimization arm reaches 82.84 tok/s fastest (76.91 mean) at this cell on the same instrument. That arm is a separate, larger change; this pull request is the memory fix alone and does not aim to move the 16K token rate.

---

## 2. The 261,120-token overflow

The prefill is not what overflows. All four arms of the earlier 261,120-token battery, release 2.11.2 (A), release plus #475 (C), and the two #478 arms (D and E), show the same shape: the full prompt is read and tokens are already emitted before the failure.

| Arm | new_prefill_tokens | time to first token (s) | completion tokens | finish reason | sampled peak (GB) | process footprint (GB) |
| --- | ---: | ---: | ---: | --- | ---: | ---: |
| A release | 261120 | 243.49 | 12 | error | 100.82 | 102.83 |
| C plus #475 | 261120 | 241.88 | 3 | error | 100.79 | 102.87 |
| D plus #478 at 0.20 | 261120 | 241.66 | 7 | error | 100.79 | 102.82 |
| E plus #478 at 0.09 | 261120 | 240.46 | 10 | error | 100.79 | 105.32 |

The error field is identical on all four:

    server error [insufficient_memory] insufficient memory: the request exceeded available
    GPU memory ([METAL] Command buffer execution failed: Insufficient Memory
    (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory).). The engine shed its caches and
    stays up; this request failed.

The overflow is in the first decode step, which is the fixed four-row speculative verify. Two separate per-layer allocations sit in that step, both multiplied by the 12 of 48 layers that keep dense KV over the whole context (`full_attention_interval` 4). The model has 24 query heads over 2 key/value heads, so 12 query heads per key/value head, at head_dim 256.

**The attention transient.** A multi-row verify has a query length of 3 to 6 rows, and 3 rows times the group factor of 12 is already past the 32-row limit of MLX's fused vector attention kernel. MLX declines the fused call, and the unfused route runs instead, materializing a `[24, S, 261120]` score tensor per full-attention layer and expanding keys and values per query head. That transient scales with context.

**The KV-cache write, which is the binding one.** The fixed-M4 verify holds its KV in `TensorOffsetKVCache`, whose `update_and_fetch` wrote the new rows with the functional `mx.slice_update` (`mtplx/graphbank.py:499-522` before the fix, the write calls at `:514` for keys and `:520` for values). That op returns a new array: it reallocates the whole `[1, 2, capacity, 256]` bf16 buffer for keys and again for values, about 267 MB each at the 262K capacity, so about 6.4 GB across the 12 full-attention layers. The stock `KVCache` on the plain autoregressive path writes in place and allocates nothing.

Both land on a steady state that is already about 100.8 GB, against a 107.4 GB limit, so the single decode command buffer exceeds the knob. At 131,072 tokens the same terms are about half and the request fits; at 261,120 tokens they do not.

### Evidence chain

Four measurements identify the KV write, in the order they were taken.

**W5, native MTP off.** Decode becomes plain autoregressive at query length 1: the fused kernel is eligible so no score plane is built, and the stock in-place `KVCache` runs instead of `TensorOffsetKVCache`. That configuration **fits the same 261,120-token prompt at 94.19 GB and decodes 547 tokens to a normal `stop`**, time to first token 223.6 s. With MTP on and the verify running, the peak is 100.82 GB. The 6.4 GB gap is what the verify adds, and turning MTP off removes both candidate terms at once, so on its own it does not say which. Receipt: `battery475/receipts/arm-C-w5-nomtp/`.

**Head chunk alone.** Removing only the attention transient left the peak unchanged at 100.82 GB and the request still failed. That isolates the remaining 6.4 GB to something other than attention. Section 3, "What did not fix it".

**The allocation probe.** A direct probe of `TensorOffsetKVCache` at this geometry (context 261,120, capacity 261,128, 12 layers, 5 verify rows) measures one KV buffer at **0.27 GB**, resident KV across keys, values and the 12 full-attention layers at **6.42 GB**, and, with the in-place write, an **update transient above resident of 0.00 GB**. Unfixed, that transient is the full 6.4 GB again, because `mx.slice_update` returns a new buffer per tensor per layer. Log: `battery475/kvprobe/kvprobe-20260908T005614Z.log`.

**The fix arm.** With the in-place write, the same prompt fits on all three cold seeds at a 100.82 GB peak, 6.5 GB under the 107.374 GB knob, with MTP on and the verify running. Section 1.2.

The probe's 6.42 GB resident and 0.00 GB transient, against the 6.4 GB gap W5 exposed, is the arithmetic that closes the chain.

The served log records the refusal verbatim, one line per shape class:

    [scaled_dot_product_attention] force_fused=True but no fused kernel is available: the
    vector attention kernel requires the query length times the GQA factor to be at most 32;
    got query length 3 and GQA factor 12.

The refused shape classes observed at this cell are query length 3, 4, 5 and 6. The wide 256-row prefill chunks still fuse, so prefill is unaffected; the served log shows `fused SDPA for shape class [causal-mask q_len 256 x GQA 12 at head_dim 256 bfloat16]` in the same run. The QSA sparse layers avoid the transient through their own bounded row selection; the 12 dense full-attention layers cannot, and the fixed four-row verify path additionally turns off the score tiler and the rows-gather route, which is why lowering the allocator cache limit, turning the session bank off, and the earlier score-tiler probe were each no-ops at this cell. The full analysis trail is in `over100-reports/pr-bodies/261k-correction-report.md` and `over100-reports/oom255k/report.md`.

---

## 3. What the optimizations do

| # | Optimization | Phase | Exactness | Key |
| --- | --- | --- | --- | --- |
| 1 | In-place verify KV write | decode | exact (byte-identical write) | none; always on for a concrete offset |
| 2 | Verify SDPA head chunk | decode | rounding against the unfused route | `MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK` |

### 1. In-place verify KV write (the fix)

- **Problem.** `TensorOffsetKVCache.update_and_fetch` wrote the verify's new KV rows with the functional `mx.slice_update`, which returns a new array rather than writing into the existing one. At the 262K capacity that reallocates a `[1, 2, capacity, 256]` bf16 buffer, about 267 MB, once for keys and once for values, in each of the 12 full-attention layers: about 6.4 GB inside one verify command buffer. The stock `KVCache` used by plain autoregressive decode writes in place and allocates nothing, which is why the same prompt fits with native MTP off.
- **Change.** `update_and_fetch`, and the trim rollback restore, take an in-place path when the cache offset is a concrete host value: the S new rows are written with a slice assignment into the buffer that already exists, after materializing an independent copy of the pre-write rows for rollback. The offset is concrete on the eager verify path, which is the path the served 261,120-token request takes, because the bank demotes long generations to the eager verify. When the offset is a tracer, that is, inside an `mx.compile` trace, the compile-visible functional `slice_update` path is left exactly as it was, so the compiled replay's buffer-donation contract is untouched.
- **Effect.** The 6.4 GB of per-layer reallocation in the verify step goes to zero, which is the term that decides the 261,120-token cell.
- **Exactness.** Exact, not rounding-class. The in-place write stores the same bytes `slice_update` would have stored, verified on random tensors, and the rollback snapshot is materialized independently before the write, so `trim` restores exactly the pre-write rows.
- **Files.** `mtplx/graphbank.py`.
- **Switch.** No key. The in-place path is taken whenever the offset is a concrete host value; the compiled path is unchanged, so there is nothing to opt out of.

### 2. Verify SDPA head chunk (`MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK`)

- **Problem.** In the fixed four-row speculative verify, the 12 full-attention layers attend over the whole KV cache with a query length of 3 to 8 rows. Query length times the group factor of 12 exceeds MLX's fused vector attention limit of 32, so SDPA falls to an unfused route that materializes a `[24, query length, context]` score tensor per layer and expands keys and values per query head. That transient scales with context.
- **Change.** The optimization splits the query heads of that attention into chunks small enough that each fused call satisfies query length times heads-per-chunk of at most 32 (for example query length 6 gives chunks of 5 heads, query length 4 gives chunks of 8 heads). Each chunk is paired with its own single key/value head, so keys and values are never expanded per query head, and the chunk outputs concatenate along the head axis. Every dispatch stays on the fused kernel, so no `[24, query length, context]` tensor is built and the working set is one chunk regardless of context. Wide prefill chunks, at query length above 32, keep their single fused call. Stock MLX, no native extension.
- **Effect.** The context-scaling attention transient in the 12 dense layers is removed. On its own that is not enough to fit the 261,120-token cell, which the KV reallocation of optimization 1 still overflows; see "What did not fix it" below. It is exact and it costs nothing, and it keeps the verify on the bounded fused kernel so the attention term does not return as context grows.
- **Exactness.** The heads in one chunk all belong to the same key/value head, so each chunk's attention is exactly the full grouped-query attention's arithmetic for those heads on the same fused kernel. The chunked result is bit-identical to an unchunked fused call, verified below 1e-6 on fp32 random tensors against a grouped-query-expanded reference. Against the unfused route it replaces, it is rounding-class, differing only by floating-point accumulation order, the same class as the prefill mask-fuse optimization.
- **Files.** `mtplx/models/qwen4_exp.py`.
- **Switch.** Default on for a served Flash-Next pack; it engages only in the band where query length times the group factor exceeds 32 and query length is at most 32. `MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK=0` turns it off. The key is read at use, so the server's auto-arm reaches it.

Optimization 2 applies at the single dense-fallback attention call, so it covers the fixed four-row verify, the ordinary verify, and any small prefill tail chunk in the same band.

### What did not fix it

Optimization 2 was measured alone at 261,120 tokens before optimization 1 existed, and it did not fit. The head chunk engaged, `GET /health` reporting `verify_sdpa_head_chunk` `{engaged: true, q_len: 5, heads_per_chunk: 6, chunks: 4, n_kv_heads: 2}`, so the `[24, S, 261120]` score plane was not built; the request still failed in the same place, at the same peak:

| arm | new_prefill_tokens | time to first token (s) | completion tokens | finish reason | sampled peak (GB) |
| --- | ---: | ---: | ---: | --- | ---: |
| A release 2.11.2 | 261120 | 243.49 | 12 | error | 100.82 |
| head chunk only | 261120 | 242.44 | 12 | error | 100.82 |

Receipt: `battery475/receipts/arm-F-headchunk/arm-F-headchunk-261120-s20260829-*`. A peak unchanged to two decimals, with the attention transient provably gone, is what pointed at a second per-layer allocation of about the same size and led to the KV-cache write.

The same arm at 16,384 tokens is a clean no-regression: three cold windows, decode 71.11 to 71.56 tok/s, and the output is **byte-identical to release** on all three seeds, `text_sha256` matching arm A seed for seed (`ee9993ec...`, `eec89cc6...`, `1ac58119...`) with the same completion-token counts. Receipt: `battery475/receipts/arm-F-headchunk/arm-F-headchunk-16384-*`.

---

## 4. Independence from pull requests #475 and #478

This pull request is based on upstream main (MTPLX 2.11.2) and touches one function in `mtplx/models/qwen4_exp.py` and one in `mtplx/graphbank.py`. It does not depend on #475 (the PR 391 remainder and two exact decode optimizations) or #478 (typical acceptance), which are also based on upstream main. It fixes the 261,120-token cell that both of those pull requests report as exceeding the memory knob. The three can land in any order; if #475 or #478 land first, these changes apply on top with no conflict, since they touch one attention call and one KV-cache write that the others do not.

---

## 5. Quality and tests

Optimization 1 is exact: the in-place write stores the bytes `slice_update` would have stored. Optimization 2 is rounding-class against the unfused path it replaces and bit-identical to an unchunked fused call. Correctness rests on the equivalence tests below plus the repo's code-eval gate.

CPU tests in `tests/test_tensoroffset_kv_inplace.py`:

- the eager update is in place, asserting no full-buffer allocation;
- it writes the correct rows and advances the offset;
- the rollback snapshot is independent of the in-place write, and `trim` restores the pre-write rows;
- the eager write matches the functional `mx.slice_update` numerically;
- the concrete-offset probe distinguishes a tracer from a host value, so the compiled path keeps the functional write.

CPU tests in `tests/test_qwen4_verify_sdpa_head_chunk.py`:

- the key resolves at use and defaults on, replayed in the served import order so an import-frozen reader would be caught;
- the chunk plan for query length 1 through 8 (and the prefill regime) at group factor 12, with the invariant that every chunked call keeps query length times heads-per-chunk at most 32 and covers all heads;
- numerical equivalence, that the chunked fused result matches an unchunked grouped-query-expanded fused reference within 1e-6 for query length 3 through 8;
- a dispatch spy that asserts every fused call stays within the 32-row bound and pairs one key/value head, so no `[24, query length, context]` tensor is ever built and keys and values are never expanded;
- the opt-out path takes the single unchunked call, and query length 1 decode is never chunked;
- the engagement receipt for `/health`.

The existing `tests/test_health_qwen4_install_reports.py` still passes with the receipt added.

Optimization 2's engagement is observable without the serve log. On first engagement the server prints `[mtplx] verify SDPA head-chunked: q_len=S heads_per_chunk=H chunks=N`, and `GET /health` carries `qwen4_install_reports.verify_sdpa_head_chunk` with the query length, heads-per-chunk, chunk count and key/value head count once it has fired. Optimization 1 has no receipt of its own; it is observable as the peak-memory drop at long context and is covered by its CPU tests.

---

## 6. Benchmark method

| Setting | Value |
| --- | --- |
| Model | `Youssofal/Qwen3.8-Flash-Next-MTPLX-Optimized-Speed`, revision `29ba90f82124961d0d902a9ea9bbb1034972af2f` |
| Arms | release MTPLX 2.11.2 (A); release plus both optimizations (F, this pull request). A head-chunk-only arm was measured separately and is reported in Section 3 under "What did not fix it" |
| Engine build | MTPLX 2.11.2 on MLX 0.32.2 |
| Profile | cli-resolved (Turbo), the profile `mtplx serve` selects for this pack; a fresh SSD session cache directory per window |
| Prompt sizes | 16,384 and 261,120 tokens |
| Output length | 1,024 tokens maximum per request |
| Sampler | temperature 1, top-p 0.95, top-k 20 |
| Reasoning effort | `xhigh` |
| MTP depth | native, depth 3 |
| Seeds | 20260829, 20260830, 20260831 |
| 261,120 protocol | three cold windows on arm F; each must complete under the knob |
| 16,384 protocol | interleaved windows; each arm's value is its fastest window |
| Cell statistic | throughput cells report the fastest of the windows; time to first token and wall report the fastest (lowest); peak memory reports the highest |
| n-gram table | pre-warmed before each cell |
| Memory cap | 100 GiB on every arm |
| Prefill state | cold; cross-request prefix restore off, so each window prefills fresh; new prefill tokens equal prompt tokens |
| Thermal state | fans at maximum, a 40 degree Celsius gate before every cell |

---

## 7. How to run and how to disable

Serve the pack; the server arms both optimizations by default:

```bash
mtplx serve \
  --model ~/.mtplx/models/Youssofal--Qwen3.8-Flash-Next-MTPLX-Optimized-Speed \
  --model-id mtplx-flash-next-optimized-speed
```

Read `GET /health` and confirm `qwen4_install_reports.verify_sdpa_head_chunk` once a long-context request has decoded, or watch the serve log for `[mtplx] verify SDPA head-chunked:`. The in-place KV write has no key and no receipt; it shows up as the long-context peak-memory drop.

Turn optimization 2 off with its key set to `0`:

```bash
MTPLX_QWEN4_VERIFY_SDPA_HEAD_CHUNK=0 mtplx serve --model ...
```

---

## 8. File map and provenance

| Area | Files |
| --- | --- |
| Runtime | `mtplx/graphbank.py` (optimization 1), `mtplx/models/qwen4_exp.py` (optimization 2) |
| Server | `mtplx/server/openai.py` (the `/health` install receipt) |
| Tests | `tests/test_tensoroffset_kv_inplace.py`, `tests/test_qwen4_verify_sdpa_head_chunk.py` |
| Documentation | `docs/perf/qwen38-longctx-prefill-memory.md`; analysis trail `over100-reports/oom255k/report.md` and `over100-reports/pr-bodies/261k-correction-report.md` |

- Base: upstream main `21be78b3` (MTPLX v2.11.2).
- Branch: `perf/qwen38-longctx-prefill-memory-main` @ `9f306e01` = upstream main, then two code commits and one docs commit. The code commits:
  - `e0ebdc41` "Head-chunk the small-q_len verify SDPA to keep long-context decode fused" (optimization 2);
  - `fc0d2a29` "Write the fixed-M4 verify KV in place to fit long-context decode" (optimization 1, the fix).
- Diff against base: 6 files, `mtplx/graphbank.py` +75/-16 region, `mtplx/models/qwen4_exp.py` +144, `mtplx/server/openai.py` +12, two test files (+165, +239) and `docs/perf/qwen38-longctx-prefill-memory.md`.
- Results docs: `9f306e01` "docs(perf): 261,120-token decode fix results, evidence chain, and receipts index" adds `docs/perf/qwen38-256k-fix/` (README plus the two charts this body renders). Full SHA `9f306e015073a35e0797650d7796d27d5749fe8b`.
