### PR TITLE
Fix remote Qwen detection and keep AR-only sources out of speculative Forge

### DIFF
--- a/mtplx/backends/registry.py
+++ b/mtplx/backends/registry.py
@@ -1766,14 +1766,7 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
             # A dir with no TRUNK weights at all is a different failure — no
             # model, not a missing head — and keeps a clean human refusal
             # instead of a FileNotFoundError deep in the loader.
-            try:
-                trunk_weights_exist = any(
-                    path.name != "mtp.safetensors"
-                    for path in Path(model_dir).glob("*.safetensors")
-                )
-            except OSError:
-                trunk_weights_exist = False
-            if not trunk_weights_exist:
+            if not _trunk_weights_present(inspection):
                 return CompatibilityVerdict(
                     tier=TIER_ARCH_COMPATIBLE_UNVERIFIED,
                     arch_id=detected_arch_id,
@@ -1807,8 +1800,9 @@ def compatibility_for_inspection(inspection: Any) -> CompatibilityVerdict:
                     "tensors (mtp.safetensors or embedded mtp.* / "
                     "language_model.mtp.* weights). mtp_heads not found -> "
                     "mtp_off: MTPLX will serve this model autoregressive, "
-                    "without speculative decode acceleration. Build and verify "
-                    "an MTP artifact with Forge for full speed."
+                    "without speculative decode acceleration. Speculative "
+                    "acceleration requires a checkpoint with compatible "
+                    "trained MTP weights; Forge cannot create missing heads."
                 ),
                 recommended_backend="qwen3_next",
                 recommended_profile=DEFAULT_PROFILE_NAME,

--- a/mtplx/commands/forge.py
+++ b/mtplx/commands/forge.py
@@ -437,8 +437,8 @@ def _probe_runtime_mtp_evidence(
     except Exception as exc:
         return False, str(exc), {}
     compatibility = getattr(inspection, "compatibility", {}) or {}
-    if bool(compatibility.get("can_run")):
-        return True, None, compatibility
+    # Runtime compatibility includes autoregressive trunks without a draft
+    # head. Forge's speculative build requires actual MTP weight evidence.
     mtp = getattr(inspection, "mtp", None)
     tensor_count = int(getattr(mtp, "tensor_count", 0) or 0) if mtp is not None else 0
     if tensor_count > 0 or _inspection_has_mtp_weight_evidence(inspection):
@@ -461,10 +461,10 @@ def _no_mtp_probe_message(diagnostic: str | None, *, config_only: bool = False) 
         )
     return (
         "Source has no MTP head, and Forge currently builds speculative "
-        "MTP artifacts only. This does NOT block running the model: MTPLX "
-        "serves MTP-less checkpoints autoregressive directly (mtplx run / "
-        "mtplx serve — MTP unavailable, mtp_off). AR-only Forge "
-        "conversion/quantization lands in a later update."
+        "MTP artifacts only; it cannot create missing trained MTP weights. "
+        "AR-only Forge conversion/quantization is not supported yet. "
+        "For runtime-compatible checkpoints, use mtplx run / mtplx serve "
+        "directly with MTP disabled (mtp_off)."
     )
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2318,6 +2318,50 @@ def test_hf_verified_contract_passes_metadata_gate(monkeypatch):
     assert result.runtime_contract_path == "/tmp/mtplx_runtime.json"
 
 
+@pytest.mark.parametrize("has_trunk", [True, False])
+def test_hf_qwen_declared_mtp_without_head_distinguishes_trunk(monkeypatch, has_trunk):
+    from mtplx import artifacts
+
+    # Nex-N2.5-mini declares one MTP layer but publishes only trunk/vision
+    # tensors. Remote shard evidence must not require a local download.
+    files = {"config.json", "model.safetensors.index.json"}
+    if has_trunk:
+        files.add("model-00001-of-00016.safetensors")
+    config = {
+        "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        "model_type": "qwen3_5_moe",
+        "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "mtp_num_hidden_layers": 1,
+            "num_hidden_layers": 40,
+            "hidden_size": 2048,
+        },
+    }
+    monkeypatch.setattr(artifacts, "_hf_list_repo_files", lambda _: (files, None))
+
+    def fake_json(_repo_id, filename):
+        if filename == "config.json":
+            return config, "/tmp/config.json", None
+        assert filename == "mtplx_runtime.json"
+        return None, None, "404 Client Error: not found"
+
+    monkeypatch.setattr(artifacts, "_hf_download_json", fake_json)
+    monkeypatch.setattr(
+        artifacts,
+        "_hf_model_weight_keys",
+        lambda *_: (("model.language_model.layers.39.self_attn.q_proj.weight",), None),
+    )
+
+    result = inspect_model("nex-agi/Nex-N2.5-mini")
+
+    assert result.mtp.exists is False
+    assert result.compatibility["can_run"] is has_trunk
+    assert result.compatibility["mtp_supported"] == "no"
+    assert result.compatibility["runtime_compatibility"] == (
+        "native-ar-only-missing-mtp" if has_trunk else "missing-model-weights"
+    )
+
+
 def test_hf_llama_without_mtp_is_no_mtp(monkeypatch):
     from mtplx import artifacts
 

--- a/tests/test_forge_cli.py
+++ b/tests/test_forge_cli.py
@@ -391,6 +391,23 @@ def test_probe_refuses_no_mtp_sources(tmp_path):
     assert payload["has_mtp_weights"] is False
 
 
+def test_probe_does_not_treat_runnable_qwen_trunk_as_mtp_evidence(tmp_path):
+    _write_json(tmp_path / "config.json", _mtp_config())
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"),
+        {"model.language_model.layers.0.mlp.down_proj.weight": mx.zeros((1, 1))},
+    )
+
+    payload = forge.probe_source(str(tmp_path))
+
+    assert payload["verdict"] == "no_mtp_heads"
+    assert payload["forgeable"] is False
+    assert payload["has_mtp_weights"] is False
+    assert payload["runtime_compatibility"] == "native-ar-only-missing-mtp"
+    assert payload["diagnostic"] == "native-ar-only-missing-mtp"
+    assert "AR-only Forge" in payload["message"]
+
+
 def test_probe_refuses_config_only_mtp_sources(tmp_path):
     _write_json(
         tmp_path / "config.json",


### PR DESCRIPTION
Remote Qwen checkpoints without MTP weights, including `nex-agi/Nex-N2.5-mini`, were reported as `missing-model-weights` even when the Hugging Face listing contained all trunk shards. Use the existing local/remote trunk check so runtime inspection recognizes these as autoregressive checkpoints with MTP disabled. Separately, require MTP weight evidence for Forge: `can_run` also includes AR-only models and must not admit those into speculative conversion.

The guidance now explains that Forge cannot create missing trained heads. AR-only Forge conversion remains unsupported; this change fixes detection and guidance, not conversion support or model qualification.

Validation:
- New regressions reproduced both defects before the fix; config-only sources remain refused.
- All 180 artifact and Forge tests passed natively on macOS; Ruff and `git diff --check` passed.
- Live metadata-only probe of `nex-agi/Nex-N2.5-mini` at `87420286149d9cce9bd46cd335ef9bda33c37c1b` sees 16 shards, `can_run=true`, `mtp_supported=no`, and `native-ar-only-missing-mtp`; Forge still refuses speculative conversion.
- No full model download, load, inference, or performance qualification was performed.
